### PR TITLE
Fix DistributeByGroupAffinity assigning a bumped projection version to nodes that cannot build it

### DIFF
--- a/src/Persistence/MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs
@@ -1,0 +1,232 @@
+using IntegrationTests;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Npgsql;
+using Shouldly;
+using JasperFx;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine.Runtime.Agents;
+
+namespace MartenTests.MultiTenancy;
+
+/// <summary>
+/// End-to-end cover for a projection version bump on a <b>multi-database</b> store, through the real
+/// <see cref="EventSubscriptionAgentFamily.EvaluateAssignmentsAsync"/> rather than
+/// <see cref="AssignmentGrid.DistributeByGroupAffinity(string, Func{Uri, string}, Func{Uri, bool})"/>
+/// directly — so it also covers the store-cardinality pass selection and
+/// <c>RetireSupersededAgentsAsync</c>, both of which sit between a leader and the placement.
+///
+/// <para>The scenario is a blue/green rollout: the "blue" fleet runs the store as it is deployed today
+/// and is <i>already running</i> its agents; the "green" fleet runs a build where one projection's
+/// <c>Version</c> is one higher. Both fleets are the same application over the same tenant databases,
+/// and the leader evaluating the assignments is a blue node — which is what makes the green fleet's
+/// agents reachable only through its persisted node capabilities.</para>
+/// </summary>
+public class blue_green_version_bump_assignment : IAsyncLifetime
+{
+    private const uint PreviousVersion = 2;
+    private const uint BumpedVersion = 3;
+
+    private readonly List<string> _tenants = ["bgtenant1", "bgtenant2", "bgtenant3"];
+
+    private DocumentStore _blue = null!;
+    private DocumentStore _green = null!;
+    private IReadOnlyList<Uri> _blueAgents = null!;
+    private IReadOnlyList<Uri> _greenAgents = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        var connectionStrings = new List<string>();
+        foreach (var tenant in _tenants)
+        {
+            connectionStrings.Add(await CreateDatabaseIfNotExists(conn, tenant));
+        }
+
+        await conn.CloseAsync();
+
+        _blue = StoreFor(PreviousVersion, connectionStrings);
+        _green = StoreFor(BumpedVersion, connectionStrings);
+
+        _blueAgents = await AdvertisedAgentsAsync(_blue);
+        _greenAgents = await AdvertisedAgentsAsync(_green);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _blue.DisposeAsync();
+        await _green.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task the_two_fleets_advertise_the_bumped_projection_under_disjoint_identities()
+    {
+        _blueAgents.ShouldNotBeEmpty();
+        _greenAgents.ShouldNotBeEmpty();
+
+        var blueBumped = AgentsFor(_blueAgents, "Trip");
+        var greenBumped = AgentsFor(_greenAgents, "Trip");
+
+        blueBumped.ShouldNotBeEmpty();
+        greenBumped.Count.ShouldBe(blueBumped.Count);
+        blueBumped.Intersect(greenBumped).ShouldBeEmpty(
+            "a version bump has to change the agent identity, or the leader has no way to tell the two fleets apart");
+
+        // The projection that was NOT bumped is one and the same agent on both fleets, which is what
+        // makes it declared by every node and therefore free to land anywhere.
+        AgentsFor(_greenAgents, "Passenger")
+            .OrderBy(x => x.ToString())
+            .ShouldBe(AgentsFor(_blueAgents, "Passenger").OrderBy(x => x.ToString()));
+    }
+
+    [Fact]
+    public async Task the_bumped_version_is_assigned_to_the_fleet_that_declares_it()
+    {
+        var (grid, blue, green) = BuildGrid();
+
+        // The leader is a blue node: its own family enumerates only the previous version, exactly as in
+        // production, so the green agents reach the grid solely through node capabilities.
+        await using var leader = new EventSubscriptionAgentFamily([_blue], []);
+        await leader.EvaluateAssignmentsAsync(grid);
+
+        foreach (var uri in AgentsFor(_greenAgents, "Trip"))
+        {
+            var host = grid.AgentFor(uri).AssignedNode;
+            host.ShouldNotBeNull($"{uri} was left unassigned, so nothing would build the new version");
+            green.ShouldContain(host!,
+                $"{uri} may only run on a node that declares it — BuildAgentAsync throws 'Unknown event projection or subscription' on the other fleet");
+        }
+
+        foreach (var uri in AgentsFor(_blueAgents, "Trip"))
+        {
+            var host = grid.AgentFor(uri).AssignedNode;
+            host.ShouldNotBeNull($"{uri} was left unassigned, so the fleet still serving would stop projecting");
+            blue.ShouldContain(host!, $"{uri} is the version the blue fleet serves and must stay there");
+        }
+    }
+
+    // The "one owner per version per database" bound that the sibling-partition preference exists for is
+    // asserted in CoreTests.Runtime.Agents.distribute_by_group_affinity instead. It needs agents to
+    // outnumber nodes the way they do in a real cluster (~5k agents over ~10 nodes); with three databases
+    // over four nodes the per-node ceiling binds first and legitimately spreads a group's third partition
+    // to balance load, which is the intended trade and not what this test is about.
+
+    private (AssignmentGrid Grid, List<AssignmentGrid.Node> Blue, List<AssignmentGrid.Node> Green) BuildGrid()
+    {
+        var grid = new AssignmentGrid();
+
+        var blue = new List<AssignmentGrid.Node>
+        {
+            grid.WithNode(1, Guid.NewGuid()).HasCapabilities(_blueAgents),
+            grid.WithNode(2, Guid.NewGuid()).HasCapabilities(_blueAgents)
+        };
+
+        var green = new List<AssignmentGrid.Node>
+        {
+            grid.WithNode(3, Guid.NewGuid()).HasCapabilities(_greenAgents),
+            grid.WithNode(4, Guid.NewGuid()).HasCapabilities(_greenAgents)
+        };
+
+        // Blue is already running what it advertises. That incumbency is the whole point: it is what
+        // keeps a blue node in the candidate set of a group it can only partly run.
+        for (var i = 0; i < blue.Count; i++)
+        {
+            blue[i].Running(_blueAgents.Where((_, index) => index % blue.Count == i).ToArray());
+        }
+
+        // Mirrors NodeAgentController.EvaluateAssignmentsAsync, which seeds the grid from the union of
+        // every node's persisted capabilities before handing it to the families.
+        grid.WithAgents(_blueAgents.Concat(_greenAgents).Distinct().ToArray());
+
+        return (grid, blue, green);
+    }
+
+    private static async Task<IReadOnlyList<Uri>> AdvertisedAgentsAsync(IEventStore store)
+    {
+        await using var family = new EventSubscriptionAgentFamily([store], []);
+        return await family.SupportedAgentsAsync();
+    }
+
+    private static DocumentStore StoreFor(uint tripVersion, IReadOnlyList<string> connectionStrings)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.DatabaseSchemaName = "bluegreen";
+
+            // Nothing here writes or projects; the test only asks the store what it would advertise.
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+
+            opts.MultiTenantedDatabases(tenancy =>
+            {
+                for (var i = 0; i < connectionStrings.Count; i++)
+                {
+                    tenancy.AddSingleTenantDatabase(connectionStrings[i], $"bgtenant{i + 1}");
+                }
+            });
+
+            opts.Projections.Add(new TripProjection { Version = tripVersion }, ProjectionLifecycle.Async);
+            opts.Projections.Add(new PassengerProjection(), ProjectionLifecycle.Async);
+        });
+    }
+
+    private static async Task<string> CreateDatabaseIfNotExists(NpgsqlConnection conn, string databaseName)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString);
+
+        if (!await conn.DatabaseExists(databaseName))
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+        }
+
+        builder.Database = databaseName;
+        return builder.ConnectionString;
+    }
+
+    private static List<Uri> AgentsFor(IEnumerable<Uri> agents, string projectionName) =>
+        agents.Where(uri => uri.Segments.Any(segment =>
+            segment.Trim('/').Equals(projectionName, StringComparison.OrdinalIgnoreCase))).ToList();
+
+    // The (type, name, databaseId) prefix of an agent URI, mirroring the internal
+    // EventSubscriptionAgentFamily.DatabaseKeyOf that group affinity keys on.
+    private static string DatabaseKeyOf(Uri uri) =>
+        uri.Segments.Length >= 3
+            ? $"{uri.Host}/{uri.Segments[1].Trim('/')}/{uri.Segments[2].Trim('/')}"
+            : uri.AbsoluteUri;
+}
+
+public record TripStarted(Guid Id, string Description);
+
+public record PassengerBoarded(Guid TripId, string Name);
+
+public class BlueGreenTrip
+{
+    public Guid Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+}
+
+public class BlueGreenPassengerCount
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class TripProjection : SingleStreamProjection<BlueGreenTrip, Guid>
+{
+    public TripProjection() => Name = "Trip";
+
+    public static BlueGreenTrip Create(TripStarted started) =>
+        new() { Id = started.Id, Description = started.Description };
+}
+
+public partial class PassengerProjection : SingleStreamProjection<BlueGreenPassengerCount, Guid>
+{
+    public PassengerProjection() => Name = "Passenger";
+
+    public static BlueGreenPassengerCount Create(PassengerBoarded boarded) =>
+        new() { Id = boarded.TripId, Count = 1 };
+}

--- a/src/Persistence/MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs
@@ -30,7 +30,11 @@ public class blue_green_version_bump_assignment : IAsyncLifetime
     private const uint PreviousVersion = 2;
     private const uint BumpedVersion = 3;
 
-    private readonly List<string> _tenants = ["bgtenant1", "bgtenant2", "bgtenant3"];
+    // Our shape, and the one that makes a group big enough to matter: several tenants share a shard
+    // database, and events are tenant-partitioned, so the daemon runs an agent per
+    // (database, tenant, projection version) rather than one per (database, version).
+    private static readonly string[] _databases = ["bgshard1", "bgshard2", "bgshard3"];
+    private static readonly string[] _tenantsPerDatabase = ["alpha", "beta", "gamma"];
 
     private DocumentStore _blue = null!;
     private DocumentStore _green = null!;
@@ -43,9 +47,9 @@ public class blue_green_version_bump_assignment : IAsyncLifetime
         await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         var connectionStrings = new List<string>();
-        foreach (var tenant in _tenants)
+        foreach (var database in _databases)
         {
-            connectionStrings.Add(await CreateDatabaseIfNotExists(conn, tenant));
+            connectionStrings.Add(await CreateDatabaseIfNotExists(conn, database));
         }
 
         await conn.CloseAsync();
@@ -66,8 +70,18 @@ public class blue_green_version_bump_assignment : IAsyncLifetime
     [Fact]
     public async Task the_two_fleets_advertise_the_bumped_projection_under_disjoint_identities()
     {
-        _blueAgents.ShouldNotBeEmpty();
-        _greenAgents.ShouldNotBeEmpty();
+        // Guard the shape this test exists for: agents are per (database, tenant, projection), so each
+        // shard database's group is tenants x projections deep. Without this, a change that stopped
+        // distributing per tenant would silently shrink every group to one agent per projection and this
+        // whole file would go on passing while testing something much weaker.
+        foreach (var database in _blueAgents.GroupBy(DatabaseKeyOf))
+        {
+            database.Count().ShouldBe(_tenantsPerDatabase.Length * 2,
+                $"{database.Key} must carry an agent per tenant for each of the two projections");
+        }
+
+        _blueAgents.Count.ShouldBe(_databases.Length * _tenantsPerDatabase.Length * 2);
+        _greenAgents.Count.ShouldBe(_blueAgents.Count);
 
         var blueBumped = AgentsFor(_blueAgents, "Trip");
         var greenBumped = AgentsFor(_greenAgents, "Trip");
@@ -161,13 +175,25 @@ public class blue_green_version_bump_assignment : IAsyncLifetime
             // Nothing here writes or projects; the test only asks the store what it would advertise.
             opts.AutoCreateSchemaObjects = AutoCreate.None;
 
+            // Sharded shape: every database holds several tenants, and the event tables are partitioned
+            // per tenant, which is what turns IEventStore.DistributesAgentsPerTenant on and produces the
+            // per-(database, tenant) agents a real shard database's group is made of.
+            opts.Events.TenancyStyle = JasperFx.MultiTenancy.TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.UseArchivedStreamPartitioning = false;
+
             opts.MultiTenantedDatabases(tenancy =>
             {
                 for (var i = 0; i < connectionStrings.Count; i++)
                 {
-                    tenancy.AddSingleTenantDatabase(connectionStrings[i], $"bgtenant{i + 1}");
+                    tenancy.AddMultipleTenantDatabase(connectionStrings[i], _databases[i])
+                        .ForTenants(_tenantsPerDatabase.Select(t => $"{_databases[i]}-{t}").ToArray());
                 }
             });
+
+            // Conjoined events require conjoined read models.
+            opts.Schema.For<BlueGreenTrip>().MultiTenanted();
+            opts.Schema.For<BlueGreenPassengerCount>().MultiTenanted();
 
             opts.Projections.Add(new TripProjection { Version = tripVersion }, ProjectionLifecycle.Async);
             opts.Projections.Add(new PassengerProjection(), ProjectionLifecycle.Async);

--- a/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
@@ -235,5 +235,38 @@ public class distribute_by_group_affinity
         grid.AgentFor(g2).AssignedNode.ShouldBe(node2, "an under-ceiling incumbent keeps its group");
         grid.AgentFor(g3).AssignedNode.ShouldBe(node3, "only the over-ceiling group moves, to the empty node");
     }
+
+    // event-subscriptions://{type}/{name}/{databaseId}/{projection}/{shardKey}/v{version}/{tenant}
+    // — the real EventSubscriptionAgentFamily.UriFor grammar, so the version sits in its own segment.
+    private static Uri VersionedAgent(string db, uint version, string tenant) =>
+        new($"event-subscriptions://marten/main/{db}/Proj/All/v{version}/{tenant}");
+
+    [Fact]
+    public void a_version_bump_splits_a_group_between_the_old_and_new_version_nodes()
+    {
+        // A projection version bump on a sharded store: one shard database's group spans the previous
+        // version's agent — declared by, and RUNNING on, the blue node — and the new version's agent,
+        // declared only by the green node. No node is capable of the whole group, so the members must
+        // fall back individually: the old version stays on blue, the new version goes to green.
+        //
+        // This is the intersection of the two cases above, and it is what a blue/green deployment of a
+        // sharded store looks like at every evaluation for the whole rollout, not just transiently.
+        var previous = VersionedAgent("db1", 22, "t1");
+        var bumped = VersionedAgent("db1", 23, "t1");
+
+        var grid = new AssignmentGrid();
+        var blue = grid.WithNode(1, Guid.NewGuid()).HasCapabilities(new[] { previous });
+        blue.Running(previous);
+        var green = grid.WithNode(2, Guid.NewGuid()).HasCapabilities(new[] { bumped });
+
+        grid.WithAgents(previous, bumped);
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+
+        grid.AgentFor(previous).AssignedNode.ShouldBe(blue,
+            "the previous version keeps running where it is");
+        grid.AgentFor(bumped).AssignedNode.ShouldBe(green,
+            "the new version's agent may only run on the node that declares it — the blue node cannot build it");
+    }
 }
 

--- a/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/distribute_by_group_affinity.cs
@@ -268,5 +268,52 @@ public class distribute_by_group_affinity
         grid.AgentFor(bumped).AssignedNode.ShouldBe(green,
             "the new version's agent may only run on the node that declares it — the blue node cannot build it");
     }
+
+    [Fact]
+    public void a_split_group_costs_only_as_many_nodes_as_the_capability_split_forces()
+    {
+        // The same version bump, now with the projections whose version did NOT change also in the group.
+        // Every node declares those, so nothing stops them landing on a third node — and what a shard
+        // database costs in connection pools is the number of DISTINCT nodes holding any of its agents, so
+        // a third host is a third pool set on that database. A split group must still occupy only as many
+        // nodes as the capability split forces: one per version.
+        var databases = new[] { "db1", "db2", "db3", "db4" };
+        var tenants = new[] { "t1", "t2" };
+
+        Uri Unchanged(string db, string tenant) =>
+            new($"event-subscriptions://marten/main/{db}/Other/All/v7/{tenant}");
+
+        Uri[] Across(Func<string, string, Uri> agent) =>
+            databases.SelectMany(db => tenants.Select(t => agent(db, t))).ToArray();
+
+        var previous = Across((db, t) => VersionedAgent(db, 22, t));
+        var bumped = Across((db, t) => VersionedAgent(db, 23, t));
+        var unchanged = Across(Unchanged);
+
+        var grid = new AssignmentGrid();
+        var blues = new[] { grid.WithNode(1, Guid.NewGuid()), grid.WithNode(2, Guid.NewGuid()) };
+        var greens = new[] { grid.WithNode(3, Guid.NewGuid()), grid.WithNode(4, Guid.NewGuid()) };
+
+        foreach (var blue in blues) blue.HasCapabilities(previous.Concat(unchanged));
+        foreach (var green in greens) green.HasCapabilities(bumped.Concat(unchanged));
+
+        grid.WithAgents(previous.Concat(bumped).Concat(unchanged).ToArray());
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+
+        foreach (var db in databases)
+        {
+            var hosts = tenants
+                .SelectMany(t => new[] { VersionedAgent(db, 22, t), VersionedAgent(db, 23, t), Unchanged(db, t) })
+                .Select(uri => grid.AgentFor(uri).AssignedNode)
+                .Distinct()
+                .ToList();
+
+            hosts.Count.ShouldBe(2,
+                $"{db} must sit on exactly two nodes — one per version — so it attracts two pool sets, not three");
+            hosts.ShouldContain(host => blues.Contains(host!), $"{db}'s previous version must be on a blue node");
+            hosts.ShouldContain(host => greens.Contains(host!), $"{db}'s new version must be on a green node");
+        }
+    }
 }
 

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -170,121 +170,153 @@ public partial class AssignmentGrid
         // node whole — groups are indivisible by design.
         var maximum = (int)Math.Ceiling((double)agents.Count / nodes.Count);
 
-        // A group is one placement unit — except under mixed capabilities, where members that are declared
-        // by disjoint sets of nodes cannot share a host at all. That is what a blue/green rollout of a
-        // multi-database store looks like: one shard database's group spans the previous version's agents
-        // (only the blue nodes can build them) and the new version's (only the green nodes can), so no node
-        // is capable of the whole group. Sub-partitioning by capability set keeps affinity inside a version
-        // — a database still has one owner per version, not one per agent — while letting the versions land
-        // on their own nodes. With homogeneous capabilities there is exactly one partition per group, so
-        // this is a no-op on the common path.
         var groups = agents
             .GroupBy(a => groupKey(a.Uri))
-            .SelectMany(group => sameCapabilities
-                ? [(Key: group.Key, Members: group.ToList())]
-                : group
-                    .GroupBy(CapabilityKey)
-                    .Select(partition => (Key: $"{group.Key}|{partition.Key}", Members: partition.ToList())))
-            .OrderByDescending(unit => unit.Members.Count)
-            .ThenBy(unit => unit.Key, StringComparer.Ordinal)
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
             .ToList();
 
         foreach (var group in groups)
         {
-            var members = group.Members;
+            // A group is one placement unit — except under mixed capabilities, where members declared by
+            // different sets of nodes cannot share a host at all. That is what a blue/green rollout of a
+            // multi-database store looks like: one shard database's group spans the previous version's
+            // agents (only the blue nodes can build them) and the new version's (only the green nodes can),
+            // so no node is capable of the whole group and the group has to split. Partitioning by
+            // capability set keeps affinity inside a version — a database still has one owner per version,
+            // not one per agent. With homogeneous capabilities there is exactly one partition, so the
+            // common path is unchanged.
+            var partitions = sameCapabilities
+                ? [group.ToList()]
+                : group
+                    .GroupBy(CapabilityKey)
+                    .OrderByDescending(partition => partition.Count())
+                    .ThenBy(partition => partition.Key, StringComparer.Ordinal)
+                    .Select(partition => partition.ToList())
+                    .ToList();
 
-            // Candidate nodes for the whole group: nodes capable of running every member (all nodes when
-            // capabilities are homogeneous) — plus any node that was already running part of the group
-            // when the grid was assembled. The grandfathering mirrors the even paths, which leave running
-            // agents in place regardless of declared capabilities: a node's capability snapshot is
-            // persisted once at node startup, so a node that started before (say) a tenant database was
-            // provisioned never declares that database's agents even though it is happily running them.
-            var candidates = sameCapabilities
-                ? nodes
-                : nodes.Where(n => members.All(m => m.CandidateNodes.Contains(n))
-                                   || members.Any(m => m.OriginalNode == n)).ToList();
+            // Partitions of one group prefer to land on the same node as their siblings: what a database
+            // costs in connection pools is the number of DISTINCT nodes hosting any of its agents, so a
+            // split group should still occupy as few nodes as its capability split forces — two during a
+            // version bump (one per version), not one per partition.
+            var siblingHosts = new List<Node>();
 
-            if (candidates.Count == 0)
+            foreach (var members in partitions)
             {
-                // GH-3341: a whole group whose members are all unassigned AND declared by no node is a
-                // stale-snapshot artifact, not a genuine blue/green gap. A node captures its
-                // event-subscription capabilities once at startup (StartLocalAgentProcessingAsync), so a
-                // shard database provisioned after every surviving node started is absent from all their
-                // snapshots even though every node can run it — the agents are still enumerated as
-                // supported by AllKnownAgentsAsync. When such a group's incumbent was a departed node, the
-                // OriginalNode grandfathering above cannot rescue it, and the per-member fallback below
-                // would park every member: the shard silently stops projecting with no running agent, no
-                // log, and no self-heal until a restart refreshes the snapshots. Treat the whole group as
-                // assignable to any node so it always has a home, kept together to preserve the
-                // connection-pool affinity this method exists to provide.
-                if (members.All(m => m.AssignedNode == null && m.CandidateNodes.Count == 0))
-                {
-                    candidates = nodes;
-                }
-                else
-                {
-                    // Mixed capabilities (genuine blue/green): an already-running member stays where it is
-                    // (minimal disruption), an unassigned member with a capable node goes to its
-                    // least-loaded one, and an unassigned member no node declares falls back to the
-                    // least-loaded node overall rather than being silently stranded (GH-3341).
-                    foreach (var member in members)
-                    {
-                        if (member.AssignedNode != null)
-                        {
-                            load[member.AssignedNode] = load.GetValueOrDefault(member.AssignedNode) + 1;
-                            continue;
-                        }
+                // Candidate nodes for the whole partition: nodes capable of running every member (all nodes
+                // when capabilities are homogeneous) — plus any node that was already running part of it
+                // when the grid was assembled. The grandfathering mirrors the even paths, which leave
+                // running agents in place regardless of declared capabilities: a node's capability snapshot
+                // is persisted once at node startup, so a node that started before (say) a tenant database
+                // was provisioned never declares that database's agents even though it is happily running
+                // them.
+                var candidates = sameCapabilities
+                    ? nodes
+                    : nodes.Where(n => members.All(m => m.CandidateNodes.Contains(n))
+                                       || members.Any(m => m.OriginalNode == n)).ToList();
 
-                        var candidate = member.CandidateNodes
-                            .OrderBy(n => load.GetValueOrDefault(n))
-                            .ThenBy(n => n.IsLeader)
-                            .ThenBy(n => n.AssignedId)
-                            .FirstOrDefault()
-                            ?? nodes
+                if (candidates.Count == 0)
+                {
+                    // GH-3341: a whole group whose members are all unassigned AND declared by no node is a
+                    // stale-snapshot artifact, not a genuine blue/green gap. A node captures its
+                    // event-subscription capabilities once at startup (StartLocalAgentProcessingAsync), so a
+                    // shard database provisioned after every surviving node started is absent from all their
+                    // snapshots even though every node can run it — the agents are still enumerated as
+                    // supported by AllKnownAgentsAsync. When such a group's incumbent was a departed node,
+                    // the OriginalNode grandfathering above cannot rescue it, and the per-member fallback
+                    // below would park every member: the shard silently stops projecting with no running
+                    // agent, no log, and no self-heal until a restart refreshes the snapshots. Treat the
+                    // whole group as assignable to any node so it always has a home, kept together to
+                    // preserve the connection-pool affinity this method exists to provide.
+                    if (members.All(m => m.AssignedNode == null && m.CandidateNodes.Count == 0))
+                    {
+                        candidates = nodes;
+                    }
+                    else
+                    {
+                        // An already-running member stays where it is (minimal disruption), an unassigned
+                        // member with a capable node goes to its least-loaded one, and an unassigned member
+                        // no node declares falls back to the least-loaded node overall rather than being
+                        // silently stranded (GH-3341).
+                        foreach (var member in members)
+                        {
+                            if (member.AssignedNode != null)
+                            {
+                                load[member.AssignedNode] = load.GetValueOrDefault(member.AssignedNode) + 1;
+                                Remember(siblingHosts, member.AssignedNode);
+                                continue;
+                            }
+
+                            var candidate = member.CandidateNodes
                                 .OrderBy(n => load.GetValueOrDefault(n))
                                 .ThenBy(n => n.IsLeader)
                                 .ThenBy(n => n.AssignedId)
-                                .First();
+                                .FirstOrDefault()
+                                ?? nodes
+                                    .OrderBy(n => load.GetValueOrDefault(n))
+                                    .ThenBy(n => n.IsLeader)
+                                    .ThenBy(n => n.AssignedId)
+                                    .First();
 
-                        candidate.Assign(member);
-                        load[candidate] += 1;
+                            candidate.Assign(member);
+                            load[candidate] += 1;
+                            Remember(siblingHosts, candidate);
+                        }
+
+                        continue;
                     }
+                }
 
+                // Minimal disruption, mirroring DistributeEvenly: the node already running the WHOLE
+                // partition keeps it as long as that doesn't push the node past the ceiling. Without this,
+                // every evaluation reshuffles groups from scratch and a node whose stale capability snapshot
+                // keeps it out of the capability candidates can be starved permanently across evaluations.
+                var incumbent = members[0].AssignedNode;
+                if (incumbent != null && members.Any(m => m.AssignedNode != incumbent))
+                {
+                    incumbent = null;
+                }
+
+                if (incumbent != null && candidates.Contains(incumbent) &&
+                    load[incumbent] + members.Count <= maximum)
+                {
+                    load[incumbent] += members.Count;
+                    Remember(siblingHosts, incumbent);
                     continue;
                 }
-            }
 
-            // Minimal disruption, mirroring DistributeEvenly: the node already running the WHOLE group
-            // keeps it as long as that doesn't push the node past the ceiling. Without this, every
-            // evaluation reshuffles groups from scratch and a node whose stale capability snapshot keeps
-            // it out of the capability candidates can be starved permanently across evaluations.
-            var incumbent = members[0].AssignedNode;
-            if (incumbent != null && members.Any(m => m.AssignedNode != incumbent))
+                // Otherwise the least-loaded candidate hosts the whole partition — preferring a node that
+                // already hosts a sibling partition of this same group, so a split group still costs as few
+                // connection pools per database as its capability split allows (tie-breaks: non-leader
+                // first, then node id).
+                var node = candidates
+                    .Where(n => siblingHosts.Contains(n) && load[n] + members.Count <= maximum)
+                    .OrderBy(n => load[n])
+                    .ThenBy(n => n.IsLeader)
+                    .ThenBy(n => n.AssignedId)
+                    .FirstOrDefault()
+                    ?? candidates
+                        .OrderBy(n => load[n])
+                        .ThenBy(n => n.IsLeader)
+                        .ThenBy(n => n.AssignedId)
+                        .First();
+
+                foreach (var agent in members)
+                {
+                    node.Assign(agent);
+                }
+
+                load[node] += members.Count;
+                Remember(siblingHosts, node);
+            }
+        }
+
+        static void Remember(List<Node> hosts, Node node)
+        {
+            if (!hosts.Contains(node))
             {
-                incumbent = null;
+                hosts.Add(node);
             }
-
-            if (incumbent != null && candidates.Contains(incumbent) &&
-                load[incumbent] + members.Count <= maximum)
-            {
-                load[incumbent] += members.Count;
-                continue;
-            }
-
-            // Otherwise the least-loaded candidate hosts the whole group (tie-breaks: non-leader first,
-            // then node id).
-            var node = candidates
-                .OrderBy(n => load[n])
-                .ThenBy(n => n.IsLeader)
-                .ThenBy(n => n.AssignedId)
-                .First();
-
-            foreach (var agent in members)
-            {
-                node.Assign(agent);
-            }
-
-            load[node] += members.Count;
         }
     }
 

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -189,7 +189,7 @@ public partial class AssignmentGrid
             var partitions = sameCapabilities
                 ? [group.ToList()]
                 : group
-                    .GroupBy(CapabilityKey)
+                    .GroupBy(capabilityKey)
                     .OrderByDescending(partition => partition.Count())
                     .ThenBy(partition => partition.Key, StringComparer.Ordinal)
                     .Select(partition => partition.ToList())
@@ -243,7 +243,7 @@ public partial class AssignmentGrid
                             if (member.AssignedNode != null)
                             {
                                 load[member.AssignedNode] = load.GetValueOrDefault(member.AssignedNode) + 1;
-                                Remember(siblingHosts, member.AssignedNode);
+                                remember(siblingHosts, member.AssignedNode);
                                 continue;
                             }
 
@@ -260,7 +260,7 @@ public partial class AssignmentGrid
 
                             candidate.Assign(member);
                             load[candidate] += 1;
-                            Remember(siblingHosts, candidate);
+                            remember(siblingHosts, candidate);
                         }
 
                         continue;
@@ -281,7 +281,7 @@ public partial class AssignmentGrid
                     load[incumbent] + members.Count <= maximum)
                 {
                     load[incumbent] += members.Count;
-                    Remember(siblingHosts, incumbent);
+                    remember(siblingHosts, incumbent);
                     continue;
                 }
 
@@ -307,11 +307,11 @@ public partial class AssignmentGrid
                 }
 
                 load[node] += members.Count;
-                Remember(siblingHosts, node);
+                remember(siblingHosts, node);
             }
         }
 
-        static void Remember(List<Node> hosts, Node node)
+        static void remember(List<Node> hosts, Node node)
         {
             if (!hosts.Contains(node))
             {
@@ -327,7 +327,7 @@ public partial class AssignmentGrid
     /// blue/green split. An agent no node declares gets the empty key, so those stay together and keep the
     /// GH-3341 whole-group rescue.
     /// </summary>
-    private static string CapabilityKey(Agent agent) =>
+    private static string capabilityKey(Agent agent) =>
         string.Join(",", agent.CandidateNodes.Select(n => n.AssignedId).OrderBy(id => id));
 
     public bool AllNodesHaveSameCapabilities(string scheme)

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -170,15 +170,28 @@ public partial class AssignmentGrid
         // node whole — groups are indivisible by design.
         var maximum = (int)Math.Ceiling((double)agents.Count / nodes.Count);
 
+        // A group is one placement unit — except under mixed capabilities, where members that are declared
+        // by disjoint sets of nodes cannot share a host at all. That is what a blue/green rollout of a
+        // multi-database store looks like: one shard database's group spans the previous version's agents
+        // (only the blue nodes can build them) and the new version's (only the green nodes can), so no node
+        // is capable of the whole group. Sub-partitioning by capability set keeps affinity inside a version
+        // — a database still has one owner per version, not one per agent — while letting the versions land
+        // on their own nodes. With homogeneous capabilities there is exactly one partition per group, so
+        // this is a no-op on the common path.
         var groups = agents
             .GroupBy(a => groupKey(a.Uri))
-            .OrderByDescending(g => g.Count())
-            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .SelectMany(group => sameCapabilities
+                ? [(Key: group.Key, Members: group.ToList())]
+                : group
+                    .GroupBy(CapabilityKey)
+                    .Select(partition => (Key: $"{group.Key}|{partition.Key}", Members: partition.ToList())))
+            .OrderByDescending(unit => unit.Members.Count)
+            .ThenBy(unit => unit.Key, StringComparer.Ordinal)
             .ToList();
 
         foreach (var group in groups)
         {
-            var members = group.ToList();
+            var members = group.Members;
 
             // Candidate nodes for the whole group: nodes capable of running every member (all nodes when
             // capabilities are homogeneous) — plus any node that was already running part of the group
@@ -274,6 +287,16 @@ public partial class AssignmentGrid
             load[node] += members.Count;
         }
     }
+
+    /// <summary>
+    /// Stable identity of the set of nodes that declare an agent as a capability, used to sub-partition a
+    /// group in <see cref="DistributeByGroupAffinity(string, Func{Uri, string}, Func{Uri, bool})" />. Agents
+    /// with the same key can share a host; agents with different keys generally cannot, which is exactly the
+    /// blue/green split. An agent no node declares gets the empty key, so those stay together and keep the
+    /// GH-3341 whole-group rescue.
+    /// </summary>
+    private static string CapabilityKey(Agent agent) =>
+        string.Join(",", agent.CandidateNodes.Select(n => n.AssignedId).OrderBy(id => id));
 
     public bool AllNodesHaveSameCapabilities(string scheme)
     {


### PR DESCRIPTION
`DistributeByGroupAffinity` documents itself as mirroring `DistributeEvenlyWithBlueGreenSemantics`, but on a real blue/green rollout of a multi-database store it does the opposite of that: it assigns the **new** version's agents to a node that cannot build them, and the new version then never starts anywhere.

Test first — the failing one in this PR is the intersection of two tests that already exist, which is why it slipped through.

## What happens

Take one shard database mid-rollout. Its group (group key is the database, `EventSubscriptionAgentFamily.DatabaseKeyOf`) contains:

| members of the group | declared by |
|---|---|
| `Proj/All/v22/{tenant}` — previous version, **currently running** | blue nodes |
| `Proj/All/v23/{tenant}` — new version | green nodes |
| agents of projections whose version did not change | all nodes |

`AllNodesHaveSameCapabilities` is false, so the capability-matching branch runs. No node is capable of the *whole* group, so `members.All(m => m.CandidateNodes.Contains(n))` is false everywhere — and the per-member fallback below is exactly the right behaviour for this.

It never runs. The `|| members.Any(m => m.OriginalNode == n)` grandfathering keeps the incumbent blue node in `candidates`, so `candidates.Count == 0` is false, the fallback is skipped, and:

- `incumbent` resolves to null (the v23 members are unassigned, so not all members share one `AssignedNode`);
- "the least-loaded candidate hosts the whole group" assigns **every** member to the blue node, v23 included;
- `EventSubscriptionAgentFamily.BuildAgentAsync` throws `Unknown event projection or subscription` there, because that node's store registers v22, not v23;
- green is never assigned anything, and the new version's tables stay empty.

`Node.Assign` has no capability check and `MatchAgentsToCapableNodesFor` is only consulted to build `CandidateNodes`, so nothing downstream catches it.

Single-database stores are unaffected — they take `DistributeEvenlyWithBlueGreenSemantics`, which matches per agent.

## Where it came from

Both on 2026-07-06, in order:

- `afe02783a` "Blue/green capability matching inside DistributeByGroupAffinity" — correct.
- `748762a42` "Group placement: minimal disruption + grandfathering for stale capability snapshots" — adds the `OriginalNode` clause, which subsumes the genuine blue/green case as a side effect.

The grandfathering is right and this PR keeps it. `a_group_lands_only_on_a_node_capable_of_running_it` and `a_node_already_running_a_groups_agents_stays_a_candidate_despite_a_stale_capability_snapshot` both still pass; neither covers the case where both conditions hold at once, which is what a rollout looks like at *every* evaluation for its whole duration rather than transiently.

## The fix, in two steps

**1. A group is only a single placement unit when its members can actually share a host.** Members are sub-partitioned by the set of nodes that declare them, and each partition placed whole. That preserves what the method exists for — affinity *inside* a version, so a shard database keeps one owner per version and pools scale with databases rather than nodes x databases (jasperfx#486 / marten#4806). "Just always take the per-member fallback" is not the fix: it scatters one database's agents across every capable node, which is the pool explosion this method was written to prevent.

**2. Partitions of one group prefer a node already hosting a sibling partition.** Step 1 alone can make the pool budget worse than before. A database's group during a bump has *three* partitions, not two: previous version (blue-only), new version (green-only), and every projection whose version did not change — and that last one is declared by every node, so it is free to land on a third node and add a third pool set to that database. What a database costs is the number of distinct nodes holding any of its agents, so partitions now prefer a sibling's host, bounded by the same per-node ceiling the incumbent rule already respects.

With homogeneous capabilities there is exactly one partition per group and no sibling to prefer, so the common path is unchanged.

```
before:  Failed: 1, Passed: 8    (distribute_by_group_affinity)
after:   Passed: 10
         Passed: 287             (all of CoreTests.Runtime.Agents, net9.0 + net10.0)
```

Both new tests fail without their respective half — the second asserts the number of *hosts* per database rather than a specific placement, and without the sibling preference four databases across two blue and two green nodes spread onto three nodes each.

## Scale context

This is the same 512-shard-database, ~854-tenant deployment as #3746 / #3747 and jasperfx#594. The rollout shape we need is a second Deployment on the new image that builds the bumped projection version off the load balancer and then takes over serving, which leaves the cluster in mixed-capability state for the *whole* build — an hour or more, not the seconds a rolling update spends there. The pool arithmetic is why step 2 matters to us specifically: at 512 databases, two owners per database is affordable and three is not.

I have not run this on the cluster yet; the evidence here is the tests and the code path. If it helps, I can put a build of this on our canary (production snapshot, all 512 shards) and report what assignment actually does with a real version bump — that is the measurement loop you asked for, and the one thing this class of bug cannot get from a dev-scale reproduction.

One judgement call worth your eye: the partition key is the ordered set of declaring node ids, so two members share a partition only when the *same* nodes declare them. That is stricter than strictly necessary — members with overlapping-but-unequal candidate sets could sometimes still share a capable host — but it never assigns to an incapable node, and the sibling preference recovers most of what the strictness would otherwise cost. Happy to relax it to "group by whether a common capable node exists" if you prefer coarser partitions.
