### PR TITLE
Restore the Kafka tests the Flaky tag was hiding (GH-3763)

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_async.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_async.cs
@@ -7,7 +7,6 @@ using Wolverine.Tracking;
 using Xunit;
 namespace Wolverine.Kafka.Tests;
 
-[Trait("Category", "Flaky")]
 public class broadcast_to_topic_async : IAsyncLifetime
 {
     private readonly ITestOutputHelper _output;

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_rules.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/broadcast_to_topic_rules.cs
@@ -31,13 +31,29 @@ public class broadcast_to_topic_rules : IAsyncLifetime
                 opts.UseKafka(KafkaContainerFixture.ConnectionString)
                     .AutoProvision()
                     .ConfigureConsumers(c => c.AutoOffsetReset = AutoOffsetReset.Earliest);
-                opts.ListenToKafkaTopic("red").ConfigureConsumer(c =>
-                {
-                    c.GroupId = "crimson";
-                });
-                opts.ListenToKafkaTopic("green");
-                opts.ListenToKafkaTopic("blue");
-                opts.ListenToKafkaTopic("purple");
+                // Dedicated topics and consumer groups. RedMessage/GreenMessage and the topics
+                // "red"/"green"/"blue" are also used by configure_consumers_and_publishers, and
+                // "green"/"blue" fell into the DEFAULT group ("Wolverine.Kafka.Tests") that every
+                // other class in this assembly shares. Bobcat runs this project across worker
+                // PROCESSES partitioned by class, so those two classes consume the same topics in
+                // the same group concurrently and rebalance each other out mid-test. That is what
+                // "Flaky in CI due to Kafka consumer group timing issues" was half of.
+                //
+                // The other half: ExtendConsumerConfiguration, NOT ConfigureConsumer.
+                // ConfigureConsumer builds a new ConsumerConfig and replaces the parent's outright
+                // -- documented, but it meant the ConfigureConsumers(AutoOffsetReset.Earliest)
+                // above was silently discarded for any topic that set a GroupId. A brand-new
+                // consumer group then defaulted to Latest, so on a fresh broker the message was
+                // published before the group finished joining and was never delivered at all.
+                // GH-3763.
+                opts.ListenToKafkaTopic(BroadcastRulesTopics.Red)
+                    .ExtendConsumerConfiguration(c => c.GroupId = "crimson");
+                opts.ListenToKafkaTopic(BroadcastRulesTopics.Green)
+                    .ExtendConsumerConfiguration(c => c.GroupId = "broadcast-rules-green");
+                opts.ListenToKafkaTopic(BroadcastRulesTopics.Blue)
+                    .ExtendConsumerConfiguration(c => c.GroupId = "broadcast-rules-blue");
+                opts.ListenToKafkaTopic(BroadcastRulesTopics.Purple)
+                    .ExtendConsumerConfiguration(c => c.GroupId = "broadcast-rules-purple");
 
                 opts.ServiceName = "receiver";
 
@@ -64,35 +80,35 @@ public class broadcast_to_topic_rules : IAsyncLifetime
             }).StartAsync();
     }
 
-    [Fact(Skip = "Flaky in CI due to Kafka consumer group timing issues")]
+    [Fact]
     public async Task route_by_derived_topics_1()
     {
         var session = await _sender
             .TrackActivity()
             .AlsoTrack(_receiver)
             .Timeout(60.Seconds())
-            .WaitForMessageToBeReceivedAt<RedMessage>(_receiver)
-            .PublishMessageAndWaitAsync(new RedMessage("one"));
+            .WaitForMessageToBeReceivedAt<BroadcastRedMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new BroadcastRedMessage("one"));
 
-        var singleEnvelope = session.Received.SingleEnvelope<RedMessage>();
+        var singleEnvelope = session.Received.SingleEnvelope<BroadcastRedMessage>();
         singleEnvelope
-            .Destination.ShouldBe(new Uri("kafka://topic/red"));
+            .Destination.ShouldBe(new Uri($"kafka://topic/{BroadcastRulesTopics.Red}"));
 
         singleEnvelope.GroupId.ShouldBe("crimson");
     }
 
-    [Fact(Skip = "Flaky in CI due to Kafka consumer group timing issues")]
+    [Fact]
     public async Task route_by_derived_topics_2()
     {
         var session = await _sender
             .TrackActivity()
             .AlsoTrack(_receiver)
             .Timeout(60.Seconds())
-            .WaitForMessageToBeReceivedAt<GreenMessage>(_receiver)
-            .PublishMessageAndWaitAsync(new GreenMessage("one"));
+            .WaitForMessageToBeReceivedAt<BroadcastGreenMessage>(_receiver)
+            .PublishMessageAndWaitAsync(new BroadcastGreenMessage("one"));
 
-        session.Received.SingleEnvelope<GreenMessage>()
-            .Destination.ShouldBe(new Uri("kafka://topic/green"));
+        session.Received.SingleEnvelope<BroadcastGreenMessage>()
+            .Destination.ShouldBe(new Uri($"kafka://topic/{BroadcastRulesTopics.Green}"));
     }
 
     public async ValueTask DisposeAsync()
@@ -104,6 +120,24 @@ public class broadcast_to_topic_rules : IAsyncLifetime
     }
 }
 
+/// <summary>
+/// Topic names owned by broadcast_to_topic_rules alone, so nothing else in this assembly
+/// publishes to them or joins a consumer group on them. See GH-3763.
+/// </summary>
+public static class BroadcastRulesTopics
+{
+    public const string Red = "broadcast-rules-red";
+    public const string Green = "broadcast-rules-green";
+    public const string Blue = "broadcast-rules-blue";
+    public const string Purple = "broadcast-rules-purple";
+}
+
+[Topic(BroadcastRulesTopics.Red)]
+public record BroadcastRedMessage(string Name);
+
+[Topic(BroadcastRulesTopics.Green)]
+public record BroadcastGreenMessage(string Name);
+
 [Topic("red")]
 public record RedMessage(string Name);
 
@@ -114,4 +148,6 @@ public static class ColoredMessageHandler
 {
     public static void Handle(RedMessage m) => Debug.WriteLine("Got red " + m.Name);
     public static void Handle(GreenMessage m) => Debug.WriteLine("Got green " + m.Name);
+    public static void Handle(BroadcastRedMessage m) => Debug.WriteLine("Got red " + m.Name);
+    public static void Handle(BroadcastGreenMessage m) => Debug.WriteLine("Got green " + m.Name);
 }

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/duplicate_message_handling_with_postgres_inbox.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/duplicate_message_handling_with_postgres_inbox.cs
@@ -26,7 +26,6 @@ namespace Wolverine.Kafka.Tests;
 /// It does NOT exercise the batch-insert path -- that is covered by the
 /// MessageStoreCompliance tests for each RDBMS backend.
 /// </summary>
-[Trait("Category", "Flaky")]
 public class duplicate_message_handling_with_postgres_inbox : IAsyncLifetime
 {
     private IHost _host = null!;

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/end_to_end_with_CloudEvents.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/end_to_end_with_CloudEvents.cs
@@ -19,7 +19,6 @@ internal static class CloudEventsKafkaTestConstants
     public const string ColorMessageTypeAlias = "wolverine.kafka.tests.color";
 }
 
-[Trait("Category", "Flaky")]
 public class end_to_end_with_CloudEvents : IAsyncLifetime
 {
     private IHost _receiver = null!;
@@ -83,7 +82,6 @@ public class end_to_end_with_CloudEvents : IAsyncLifetime
     }
 }
 
-[Trait("Category", "Flaky")]
 public class inline_end_to_end_with_CloudEvents : IAsyncLifetime
 {
     private IHost _receiver = null!;

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/when_publishing_and_receiving_by_partition_key.cs
@@ -9,7 +9,6 @@ using Wolverine.Tracking;
 
 namespace Wolverine.Kafka.Tests;
 
-[Trait("Category", "Flaky")]
 public class when_publishing_and_receiving_by_partition_key : IAsyncLifetime
 {
     #region sample_publish_to_kafka_by_partition_key
@@ -92,11 +91,10 @@ public class when_publishing_and_receiving_by_partition_key : IAsyncLifetime
         singleEnvelope.Offset.ShouldBeGreaterThan(0);
     }
 
-    [Fact]
-    public async Task receive_message_with_group_id()
-    {
-
-    }
+    // receive_message_with_group_id used to live here with an empty body -- an always-green test
+    // that asserted nothing. Envelope.GroupId is really covered by
+    // configure_consumers_and_publishers.can_receive_the_group_id_for_the_consumer_on_the_envelope
+    // and by broadcast_to_topic_rules.route_by_derived_topics_1. GH-3763.
 
     [Fact]
     public async Task received_message_has_partition_id()


### PR DESCRIPTION
The Kafka half of the #3763 burn-down, after #3791 did AWS.

## Four tags were just wrong

`broadcast_to_topic_async`, `when_publishing_and_receiving_by_partition_key`, `end_to_end_with_CloudEvents` (two classes) and `duplicate_message_handling_with_postgres_inbox` were tagged `[Trait("Category", "Flaky")]` — three in the same 2026-03-20/21 bulk sweep that mis-tagged the AWS and ASB sets. **They all pass.** Untagged, `CIKafka` goes **293 → 300 with 0 retries**, twice in a row on a freshly recreated broker.

## Two more were hiding outside the ledger

`broadcast_to_topic_rules` had two `[Fact(Skip = "Flaky in CI due to Kafka consumer group timing issues")]` tests — invisible to the `Category=Flaky` count, so they never showed up as debt. Unlike the four above, these were genuinely broken, in two independent ways.

**1. A documented API used the wrong way, losing `AutoOffsetReset`.**

```csharp
.ConfigureConsumers(c => c.AutoOffsetReset = AutoOffsetReset.Earliest)   // transport level
opts.ListenToKafkaTopic("red").ConfigureConsumer(c => c.GroupId = "crimson");   // topic level
```

`ConfigureConsumer` builds a **new** `ConsumerConfig` and replaces the parent's outright — its own XML doc says so, and `ExtendConsumerConfiguration` exists for the additive case. So `AutoOffsetReset.Earliest` was silently discarded for any topic that also set a `GroupId`. A brand-new consumer group then fell back to `Latest`, and on a fresh broker the message was published before the group finished joining — never delivered at all.

`route_by_derived_topics_1` fails **deterministically, alone, on a clean broker**. The "timing" in the skip reason was real, but the diagnosis stopped one level short of the cause. Switched to `ExtendConsumerConfiguration`.

**2. Topics and a consumer group shared with another test class.**

`RedMessage`/`GreenMessage` and the topics `red`/`green`/`blue` are also used by `configure_consumers_and_publishers`, and `green`/`blue` fell into the **default** consumer group (`Wolverine.Kafka.Tests`) that every class in this assembly shares. Bobcat partitions a project across worker **processes** by class, so `CollectionPerAssembly` only serialises within one process — the two classes consume the same topics in the same group concurrently and rebalance each other out mid-test. `broadcast_to_topic_rules` now owns its topics and its groups.

## One deleted

`when_publishing_and_receiving_by_partition_key.receive_message_with_group_id` had an **empty body** and asserted nothing — an always-green placeholder. `Envelope.GroupId` is really covered by `configure_consumers_and_publishers.can_receive_the_group_id_for_the_consumer_on_the_envelope` and by `route_by_derived_topics_1`.

## Verification

| | Before | After |
|---|---|---|
| CIKafka | **293 passed** | **300 passed** |
| Retries | 0 | **0** |

Two consecutive runs on a recreated Kafka container, both 300/0. Repo flaky tags **21 → 17**. `wolverine.slnx` builds clean in Release.

## One observation, not a claim

While deliberately over-parallelising (the supervisor ended up spawning far more workers than the machine could carry), `InlineSendingAndReceivingCompliance.explicit_respond_to_sender` failed with an `AggregateException` carrying `DivideByZeroException`s — which are the *deliberate* exceptions `throwOnAttempt<DivideByZeroException>` registers in a sibling compliance test. That suggests a previous test's still-retrying messages can land inside the next test's tracking window on the shared `receiver.inline` topic. It did **not** reproduce at normal worker counts, so I'm recording it here rather than filing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA