### PR TITLE
Stop the RabbitMQ tests colliding on shared broker names (GH-3763)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/durable_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/durable_compliance.cs
@@ -20,7 +20,7 @@ public class RabbitMqTransportFixture : TransportComplianceFixture, IAsyncLifeti
 
         await SenderIs(opts =>
         {
-            var listener = $"listener{RabbitTesting.Number}";
+            var listener = RabbitTesting.NextListenerName();
 
             opts.Durability.Mode = DurabilityMode.Solo;
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
@@ -23,28 +23,60 @@ namespace Wolverine.RabbitMQ.Tests;
 
 public static class RabbitTesting
 {
-    public static int Number;
+    /// <summary>
+    /// Unique per process. A bare counter is not: it restarts at zero in every process, and Bobcat
+    /// partitions this project across several worker PROCESSES by class. Two tests in different
+    /// processes therefore declared and bound the SAME queue and exchange names against the one
+    /// shared broker and consumed each other's messages -- and because xUnit does not fix the order
+    /// of tests within a class, which pair collided moved from run to run. That is why
+    /// use_direct_exchange_with_binding_key and use_fan_out_exchange failed "one or the other,
+    /// every run" while each passes alone.
+    ///
+    /// It also repeated across runs on a persistent broker, so a queue could inherit a binding from
+    /// a previous run, and it could collide with the literal "exchange1"/"exchange3" used by
+    /// auto_declaration_of_rabbit_resources and when_adding_bindings. GH-3763.
+    /// </summary>
+    private static readonly string Token = Guid.NewGuid().ToString("N")[..8];
+
+    private static int _number;
 
     public static string NextQueueName()
     {
-        return $"messages{++Number}";
+        return $"messages-{Token}-{Interlocked.Increment(ref _number)}";
     }
 
     public static string NextExchangeName()
     {
-        return $"exchange{++Number}";
+        return $"exchange-{Token}-{Interlocked.Increment(ref _number)}";
+    }
+
+    /// <summary>
+    /// The three compliance fixtures used to build "listener{RabbitTesting.Number}" by READING the
+    /// counter without advancing it, so all three asked for the same queue -- "listener0" in a
+    /// fresh process -- and collided with each other and with every other worker process.
+    /// </summary>
+    public static string NextListenerName()
+    {
+        return $"listener-{Token}-{Interlocked.Increment(ref _number)}";
     }
 }
 
-// GH-3763: stays tagged, and the ledger entry now has numbers behind it. Measured 2026-08-02, this class
-// alone against a fresh broker, three consecutive runs: 18/20 pass every time and TWO fail every time.
+// GH-3763: stays tagged, but the earlier triage on this class was wrong in two ways and is replaced.
 //
-//   send_message_to_and_receive_through_rabbitmq_with_routing_key   fails 3 of 3  (deterministic)
-//   use_direct_exchange_with_binding_key / use_fan_out_exchange     one or the other, every run
+// It cited "the exchange/binding-declaration race described in #2618" -- #2618 is a closed CI-stabilisation
+// tracer PR that describes nothing of the sort -- and it recorded
+// send_message_to_and_receive_through_rabbitmq_with_routing_key as failing 3 of 3. That test passes now.
 //
-// So this is one hard failure plus a genuine flake, not one flaky class. Both fail in under 500ms, which
-// is the exchange/binding-declaration race described in #2618 rather than anything timing out. Needs the
-// deterministic binding-readiness gate that issue calls for before it can come off the list.
+// What is actually true, measured 2026-08-03: use_fan_out_exchange and use_direct_exchange_with_binding_key
+// each pass ALONE (3 consecutive runs) and fail inside the class. They fail in ~500ms, nowhere near their
+// 30s tracked-session timeout, on a null ColorHistory -- which is possible because
+// WaitForMessageToBeReceivedAt is satisfied by MessageFailed as well as MessageSucceeded, so a message that
+// arrives and then fails completes the session and the test falls through to the assertion.
+//
+// Two real causes were found and fixed in this pass (see RabbitTesting above, and the GH-3521 pins on the
+// receiver hosts), and they are not enough on their own: both tests still fail in-class. What remains is
+// unidentified cross-test state, and the next step is to dump the tracked session on failure rather than
+// infer from the assertion.
 [Trait("Category", "Flaky")]
 public class end_to_end
 {
@@ -561,7 +593,7 @@ public class end_to_end
     [Fact]
     public async Task use_fan_out_exchange()
     {
-        var exchangeName = "fanout1";
+        var exchangeName = RabbitTesting.NextExchangeName();
         var queueName1 = RabbitTesting.NextQueueName() + "e23";
         var queueName2 = RabbitTesting.NextQueueName() + "e23";
         var queueName3 = RabbitTesting.NextQueueName() + "e23";
@@ -579,6 +611,14 @@ public class end_to_end
 
         var receiver1 = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName1);
@@ -587,6 +627,14 @@ public class end_to_end
 
         var receiver2 = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName2);
@@ -595,6 +643,14 @@ public class end_to_end
 
         var receiver3 = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName3);
@@ -644,6 +700,14 @@ public class end_to_end
 
         var receiver = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName);
@@ -697,6 +761,14 @@ public class end_to_end
 
         using var receiver1 = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName1);
@@ -705,6 +777,14 @@ public class end_to_end
 
         using var receiver2 = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName2);
@@ -713,6 +793,14 @@ public class end_to_end
 
         using var receiver3 = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName3);
@@ -750,6 +838,14 @@ public class end_to_end
 
         using var receiver = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName);
@@ -790,6 +886,14 @@ public class end_to_end
 
         using var receiver = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName);
@@ -828,6 +932,14 @@ public class end_to_end
 
         using var receiver = await WolverineHost.ForAsync(opts =>
         {
+            // GH-3521: the application assembly is a process-wide value pinned by whichever host
+            // started FIRST in the process. Without this, these receivers discovered NO handlers
+            // ("Wolverine found no handlers" in the log), ColorChosen failed for want of a handler,
+            // and WaitForMessageToBeReceivedAt completed anyway -- it is satisfied by MessageFailed
+            // as well as MessageSucceeded -- so the test fell through to a null ColorHistory in
+            // ~500ms rather than timing out. GH-3763.
+            opts.ApplicationAssembly = GetType().Assembly;
+
             opts.UseRabbitMq();
 
             opts.ListenToRabbitQueue(queueName);

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
@@ -78,7 +78,7 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
             {
                 opts.Policies.DisableConventionalLocalRouting();
                 opts.ServiceName = "one";
-                opts.UseRabbitMq(f => f.VirtualHost = "vh1").DisableDeadLetterQueueing();
+                opts.UseRabbitMq(f => f.VirtualHost = "vh1").AutoPurgeOnStartup().DisableDeadLetterQueueing();
                 opts.ListenToRabbitQueue("multi_incoming");
                 
                 opts.Services.AddResourceSetupOnStartup();
@@ -91,7 +91,7 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
             {
                 opts.Policies.DisableConventionalLocalRouting();
                 opts.ServiceName = "two";
-                opts.UseRabbitMq(f => f.VirtualHost = "vh2").DisableDeadLetterQueueing();
+                opts.UseRabbitMq(f => f.VirtualHost = "vh2").AutoPurgeOnStartup().DisableDeadLetterQueueing();
                 opts.ListenToRabbitQueue("multi_incoming");
                 
                 opts.Services.AddResourceSetupOnStartup();
@@ -102,7 +102,7 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
             {
                 opts.Policies.DisableConventionalLocalRouting();
                 opts.ServiceName = "three";
-                opts.UseRabbitMq(f => f.VirtualHost = "vh3").DisableDeadLetterQueueing();
+                opts.UseRabbitMq(f => f.VirtualHost = "vh3").AutoPurgeOnStartup().DisableDeadLetterQueueing();
                 opts.ListenToRabbitQueue("multi_incoming");
                 
                 opts.Services.AddResourceSetupOnStartup();
@@ -144,20 +144,26 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
     }
 }
 
-// GH-3763: kept tagged, but this is NOT flakiness and the tag should not be read as "sometimes fails".
-// `send_message_to_a_specific_tenant` is DETERMINISTIC in both directions, measured on 2026-08-02:
+// GH-3763: untagged 2026-08-03, but NOT yet clean -- read this before assuming it is.
 //
-//   this class alone                                    7/7 pass, 3 runs
-//   this class alongside the other Rabbit suites        fails every time, 3 runs
+// The previous note said untagging "would put a guaranteed red in CIRabbitMQ". That is no longer true:
+// measured twice, CIRabbitMQ is GREEN at 472 passed with send_message_to_a_specific_tenant failing its
+// first attempt and passing on the supervisor's retry. So it is now visible debt in the retry ledger
+// (GH-3787) rather than 7 tests running nowhere, which is the trade this file is making on purpose.
 //
-// It fails in ~100ms — far short of its own 15s tracked-session timeout — so nothing is timing out;
-// the send is rejected or misrouted immediately. That is cross-class state on a shared broker, which is
-// the #1 shape called out in #3763, and it needs the interfering suite identified rather than another
-// retry budget. Untagging it would put a guaranteed red in CIRabbitMQ.
+// Two collisions were found and fixed in this pass, and neither was sufficient:
+//   - RabbitTesting handed out queue and exchange names from a static counter that restarts at zero in
+//     every worker PROCESS, so classes in different processes declared and bound the same names. See
+//     the note on RabbitTesting in end_to_end.cs.
+//   - Main purged on startup but the three tenant hosts did not, so a MultiTenantMessage left in
+//     multi_incoming on vh1/vh2/vh3 by an earlier run could be received alongside the new one and make
+//     SingleRecord throw.
 //
-// The other eight Rabbit classes that carried this tag were untagged in the same pass: 5 consecutive
-// clean runs, 41 tests, zero failures.
-[Trait("Category", "Flaky")]
+// What remains: the class still passes 7/7 alone and still costs exactly one retry in-suite, every run.
+// The remaining interference is unidentified. Next step is to dump the tracked session on the FIRST
+// attempt rather than infer from the assertion -- the fixture's queues (Queue1, multi_response,
+// global_response, multi_incoming) are fixed names in the shared default vhost and are the first
+// suspects.
 public class multi_tenancy_through_virtual_hosts : IClassFixture<MultiTenantedRabbitFixture>
 {
     private readonly MultiTenantedRabbitFixture _fixture;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/process_inline_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/process_inline_compliance.cs
@@ -23,7 +23,7 @@ public class ProcessInlineFixture : TransportComplianceFixture, IAsyncLifetime
 
         await SenderIs(opts =>
         {
-            var listener = $"listener{RabbitTesting.Number}";
+            var listener = RabbitTesting.NextListenerName();
 
             opts.Durability.Mode = DurabilityMode.Solo;
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/quorum_queue_compliance.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/quorum_queue_compliance.cs
@@ -23,7 +23,7 @@ public class QuorumQueueFixture : TransportComplianceFixture, IAsyncLifetime
 
         await SenderIs(opts =>
         {
-            var listener = $"listener{RabbitTesting.Number}";
+            var listener = RabbitTesting.NextListenerName();
 
             opts.Durability.Mode = DurabilityMode.Solo;
 


### PR DESCRIPTION
The RabbitMQ pass of #3763, after #3791 (AWS) and #3794 (Kafka). **Partial** — one class stays tagged, and the class I did untag is not yet clean. Both are stated in the files rather than glossed.

## The widest-reach bug wasn't in either tagged class

`RabbitTesting` handed out queue and exchange names from a bare static counter:

```csharp
public static int Number;
public static string NextQueueName()    => $"messages{++Number}";
public static string NextExchangeName() => $"exchange{++Number}";
```

That counter **restarts at zero in every process**, and Bobcat partitions this project across worker *processes* by class. Two classes in different processes therefore declared and bound the **same** names against the one shared broker, and consumed each other's messages. It also repeated across runs on a persistent broker (a queue inheriting a binding from a previous run), and it could collide with the literal `"exchange1"`/`"exchange3"` used by `auto_declaration_of_rabbit_resources` and `when_adding_bindings`.

Names are now unique per process. Three compliance fixtures were worse — they built `listener{RabbitTesting.Number}` by **reading** the counter without advancing it, so all three asked for `listener0` in a fresh process. `use_fan_out_exchange` also had a hard-coded `"fanout1"`.

`RabbitTesting` is used by **18 test files**, so this reaches far beyond the two classes that carried the tag.

## `multi_tenancy_through_virtual_hosts` — untagged, with the trade stated

Its previous note said untagging "would put a guaranteed red in CIRabbitMQ". Measured twice, that is no longer true: **CIRabbitMQ is green at 472 passed**, with `send_message_to_a_specific_tenant` failing its first attempt and passing on the supervisor's retry.

So this is now **visible debt in the #3787 retry ledger** instead of 7 tests running nowhere. I also found and fixed a second cause — `Main` purged on startup but the three tenant hosts did not, so a `MultiTenantMessage` left in `multi_incoming` on vh1/vh2/vh3 could be received alongside the new one and make `SingleRecord` throw — and **it was not sufficient**. The remaining interference is unidentified, and the file says so with the next step.

If you'd rather not carry a deterministic one-retry cost, re-tagging it is a one-line revert.

## `end_to_end` — stays tagged, triage corrected

The existing note was wrong twice over:

- It cited *"the exchange/binding-declaration race described in #2618"*. #2618 is a closed CI-stabilisation tracer PR that describes nothing of the sort.
- It recorded `send_message_to_and_receive_through_rabbitmq_with_routing_key` as failing 3 of 3. **That test passes now.**

What is actually true: `use_fan_out_exchange` and `use_direct_exchange_with_binding_key` each pass **alone** (3 consecutive runs) and fail in-class in ~500ms on a null `ColorHistory` — nowhere near their 30s timeout. That is reachable because `WaitForMessageToBeReceivedAt` is satisfied by `MessageFailed` as well as `MessageSucceeded`, so a message that arrives and then *fails* completes the session and the test falls through to the assertion.

One cause found: **GH-3521**. The receiver hosts never pinned an application assembly, so handler discovery came up empty (`"Wolverine found no handlers"` in the log) and `ColorChosen` failed for want of a handler. Pinned on all ten receiver hosts — the warning count dropped, but both tests still fail in-class, so the tag stays with the corrected note.

## Verification

| | Result |
|---|---|
| CIRabbitMQ, run 1 | 472 passed, 1 retry, **exit 0** |
| CIRabbitMQ, run 2 | 472 passed, 1 retry, **exit 0** |

Repo flaky tags **17 → 16**. `wolverine.slnx` builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA