### PR TITLE
feat: Allow waiting for prefetched messages on drain

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/drain_wait_for_prefetch.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/drain_wait_for_prefetch.cs
@@ -1,0 +1,228 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Marten;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// Coverage for RabbitMqListenerConfiguration.DrainWaitForPrefetch(): with the flag on, listener
+// StopAsync sends basic.cancel WITHOUT nowait and awaits cancel-ok (plus a batch flush for durable
+// micro-batching) before returning, so prefetched-but-unprocessed deliveries are handed to the
+// receiver and durably persisted to the inbox instead of being abandoned to broker redelivery.
+// Without the flag, StopAsync sends a nowait cancel and returns immediately, and the listener is
+// disposed (tearing down the channel) right behind it -- any delivery still sitting in the
+// RabbitMQ client's own dispatch buffer at that instant is simply lost and left for the broker to
+// requeue. Note this is about persistence, not synchronous handling: once the receiver latches
+// mid-drain, any delivery that hasn't yet reached the handler pipeline is persisted and deferred
+// for the durability agent to recover rather than executed inline (pre-existing DurableReceiver
+// shutdown behavior) -- so the assertion here is "every prefetched delivery survives durably",
+// not "every prefetched delivery's handler ran before stop returned".
+public class drain_wait_for_prefetch : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _queueName = null!;
+    private GateFirstDeliveryMapper _mapper = null!;
+    private DrainPrefetchTracker _tracker = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _queueName = RabbitTesting.NextQueueName();
+        var schemaName = $"drain_prefetch_{Guid.NewGuid():N}";
+        _tracker = new DrainPrefetchTracker();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.LocalRoutingConventionDisabled = true;
+
+                opts.Services.AddSingleton(_tracker);
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = schemaName;
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine(x => x.MessageStorageSchemaName = schemaName);
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.PublishMessage<DrainPrefetchMessage>().ToRabbitQueue(_queueName);
+
+                // Durable + the default MaximumMessagesToReceive (100) is exactly the combination
+                // that turns on WorkerQueueMessageConsumer's micro-batching channel, so this
+                // exercises RabbitMqListener.StopAsync's DrainBatchedDeliveriesAsync call, not just
+                // the CancelOkReceived wait.
+                opts.ListenToRabbitQueue(_queueName)
+                    .UseDurableInbox()
+                    .DrainWaitForPrefetch()
+                    .PreFetchCount(100)
+                    .ConfigureQueue(q =>
+                    {
+                        var queue = (RabbitMqQueue)q;
+                        _mapper = new GateFirstDeliveryMapper(new RabbitMqEnvelopeMapper(queue, null!));
+                        queue.EnvelopeMapper = _mapper;
+                    });
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    // This is the test that would fail if StopAsync reverted to a fire-and-forget nowait cancel:
+    // the gated mapper guarantees 24 of the 25 published messages are still undispatched in the
+    // RabbitMQ client at the instant StopAndDrainAsync is called. Reverted to fire-and-forget, the
+    // channel tears down behind the nowait cancel before the client ever hands those 24 to
+    // HandleBasicDeliverAsync, so they'd never even reach the inbox -- durably persisting all 25
+    // (rather than only however many happened to race ahead of the cancel) is only possible
+    // because StopAsync waited for cancel-ok and drained the batching channel first.
+    [Fact]
+    public async Task prefetched_durable_batch_is_drained_through_on_stop()
+    {
+        const int messageCount = 25;
+
+        var bus = _host.MessageBus();
+        for (var i = 0; i < messageCount; i++)
+        {
+            await bus.PublishAsync(new DrainPrefetchMessage(Guid.NewGuid()));
+        }
+
+        // Wait until the FIRST delivery is blocking the client's single dispatch thread (default
+        // ConsumerDispatchConcurrency is 1) -- this guarantees no delivery has been dispatched
+        // past it yet. The broker still routes and pushes the other 24 onto the wire while that
+        // first delivery sits blocked, so give that a moment to land before stopping -- otherwise
+        // some of the 24 may still be in flight from the broker rather than already prefetched.
+        _mapper.Entered.WaitOne(10.Seconds())
+            .ShouldBeTrue("the first prefetched delivery never reached the gated mapper");
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
+
+        var runtime = _host.GetRuntime();
+        var agent = runtime.Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri($"rabbitmq://queue/{_queueName}"));
+
+        var stopTask = agent.StopAndDrainAsync().AsTask();
+
+        _mapper.Release();
+
+        await stopTask.WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        // The durable guarantee this feature makes: every prefetched delivery is captured in the
+        // inbox, so none of them silently vanish and rely on the broker to redeliver them. (A
+        // handful may still be sitting as "Incoming" rather than "Handled" -- the receiver latches
+        // partway through the drain and defers anything that arrives after that point to the
+        // durability recovery sweep instead of running it inline; that's pre-existing shutdown
+        // behavior, not something this feature changes.)
+        var incoming = await runtime.Storage.Admin.AllIncomingAsync();
+        var persistedCount = incoming.Count(x => x.MessageType == typeof(DrainPrefetchMessage).ToMessageTypeName());
+
+        persistedCount.ShouldBe(messageCount);
+
+        // And the ones that beat the receiver's shutdown latch ran through the actual handler,
+        // proving the drained deliveries reach the pipeline and not just the inbox table.
+        _tracker.Handled.Count.ShouldBeGreaterThan(0);
+    }
+}
+
+public record DrainPrefetchMessage(Guid Id);
+
+public class DrainPrefetchTracker
+{
+    public readonly ConcurrentBag<Guid> Handled = new();
+}
+
+public static class DrainPrefetchMessageHandler
+{
+    public static void Handle(DrainPrefetchMessage message, DrainPrefetchTracker tracker)
+    {
+        tracker.Handled.Add(message.Id);
+    }
+}
+
+/// <summary>
+/// Wraps the default mapper and blocks the FIRST incoming delivery's envelope mapping until
+/// released. Mapping happens synchronously inside WorkerQueueMessageConsumer.HandleBasicDeliverAsync,
+/// so with the default ConsumerDispatchConcurrency of 1 this blocks the RabbitMQ client's single
+/// dispatch thread, guaranteeing every other already-prefetched delivery is still sitting
+/// undispatched in the client.
+/// </summary>
+internal class GateFirstDeliveryMapper : IRabbitMqEnvelopeMapper
+{
+    private readonly IRabbitMqEnvelopeMapper _inner;
+    private readonly ManualResetEventSlim _entered = new(false);
+    private readonly ManualResetEventSlim _release = new(false);
+    private int _hits;
+
+    public GateFirstDeliveryMapper(IRabbitMqEnvelopeMapper inner)
+    {
+        _inner = inner;
+    }
+
+    public WaitHandle Entered => _entered.WaitHandle;
+
+    public void Release()
+    {
+        _release.Set();
+    }
+
+    public void MapIncomingToEnvelope(Envelope envelope, IReadOnlyBasicProperties incoming)
+    {
+        if (Interlocked.Increment(ref _hits) == 1)
+        {
+            _entered.Set();
+            _release.Wait(TimeSpan.FromSeconds(20));
+        }
+
+        _inner.MapIncomingToEnvelope(envelope, incoming);
+    }
+
+    public void MapEnvelopeToOutgoing(Envelope envelope, IBasicProperties outgoing)
+    {
+        _inner.MapEnvelopeToOutgoing(envelope, outgoing);
+    }
+}
+
+// Cheap parity check: a listener that never opts in keeps the old fire-and-forget behavior and
+// stops promptly, rather than picking up any waiting behavior by accident.
+public class drain_wait_for_prefetch_default_off
+{
+    [Fact]
+    public async Task listener_without_the_flag_still_stops_cleanly_and_promptly()
+    {
+        var queue = RabbitTesting.NextQueueName();
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+            opts.ListenToRabbitQueue(queue); // DrainWaitForPrefetch() not called -- default off
+        });
+
+        var runtime = host.GetRuntime();
+        var agent = runtime.Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri($"rabbitmq://queue/{queue}"));
+
+        var sw = Stopwatch.StartNew();
+        await agent.StopAndDrainAsync();
+        sw.Stop();
+
+        agent.Status.ShouldBe(ListeningStatus.Stopped);
+        sw.Elapsed.ShouldBeLessThan(5.Seconds());
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/drain_wait_for_prefetch.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/drain_wait_for_prefetch.cs
@@ -18,18 +18,12 @@ using Xunit;
 
 namespace Wolverine.RabbitMQ.Tests;
 
-// Coverage for RabbitMqListenerConfiguration.DrainWaitForPrefetch(): with the flag on, listener
-// StopAsync sends basic.cancel WITHOUT nowait and awaits cancel-ok (plus a batch flush for durable
-// micro-batching) before returning, so prefetched-but-unprocessed deliveries are handed to the
-// receiver and durably persisted to the inbox instead of being abandoned to broker redelivery.
-// Without the flag, StopAsync sends a nowait cancel and returns immediately, and the listener is
-// disposed (tearing down the channel) right behind it -- any delivery still sitting in the
-// RabbitMQ client's own dispatch buffer at that instant is simply lost and left for the broker to
-// requeue. Note this is about persistence, not synchronous handling: once the receiver latches
-// mid-drain, any delivery that hasn't yet reached the handler pipeline is persisted and deferred
-// for the durability agent to recover rather than executed inline (pre-existing DurableReceiver
-// shutdown behavior) -- so the assertion here is "every prefetched delivery survives durably",
-// not "every prefetched delivery's handler ran before stop returned".
+// With DrainWaitForPrefetch on, StopAsync cancels WITHOUT nowait and awaits cancel-ok (plus a batch
+// flush in durable micro-batching mode), so prefetched deliveries land in the inbox instead of being
+// abandoned to broker redelivery. This asserts durable survival, not synchronous handling: the
+// receiver latches mid-drain and defers late arrivals to the durability agent (existing
+// DurableReceiver behavior), so the guarantee is "every prefetched delivery persists", not "every
+// handler ran before stop returned".
 public class drain_wait_for_prefetch : IAsyncLifetime
 {
     private IHost _host = null!;
@@ -61,10 +55,9 @@ public class drain_wait_for_prefetch : IAsyncLifetime
 
                 opts.PublishMessage<DrainPrefetchMessage>().ToRabbitQueue(_queueName);
 
-                // Durable + the default MaximumMessagesToReceive (100) is exactly the combination
-                // that turns on WorkerQueueMessageConsumer's micro-batching channel, so this
-                // exercises RabbitMqListener.StopAsync's DrainBatchedDeliveriesAsync call, not just
-                // the CancelOkReceived wait.
+                // Durable + the default MaximumMessagesToReceive (100) turns on the micro-batching
+                // channel, so this exercises StopAsync's DrainBatchedDeliveriesAsync path, not just
+                // the cancel-ok wait.
                 opts.ListenToRabbitQueue(_queueName)
                     .UseDurableInbox()
                     .DrainWaitForPrefetch()
@@ -88,13 +81,10 @@ public class drain_wait_for_prefetch : IAsyncLifetime
         _host.Dispose();
     }
 
-    // This is the test that would fail if StopAsync reverted to a fire-and-forget nowait cancel:
-    // the gated mapper guarantees 24 of the 25 published messages are still undispatched in the
-    // RabbitMQ client at the instant StopAndDrainAsync is called. Reverted to fire-and-forget, the
-    // channel tears down behind the nowait cancel before the client ever hands those 24 to
-    // HandleBasicDeliverAsync, so they'd never even reach the inbox -- durably persisting all 25
-    // (rather than only however many happened to race ahead of the cancel) is only possible
-    // because StopAsync waited for cancel-ok and drained the batching channel first.
+    // Reverted to a fire-and-forget nowait cancel, this fails: the gated mapper keeps 24 of the 25
+    // messages undispatched in the client, and the channel would tear down before they reached
+    // HandleBasicDeliverAsync. Persisting all 25 is only possible because StopAsync awaited cancel-ok
+    // and drained the batching channel first.
     [Fact]
     public async Task prefetched_durable_batch_is_drained_through_on_stop()
     {
@@ -106,11 +96,9 @@ public class drain_wait_for_prefetch : IAsyncLifetime
             await bus.PublishAsync(new DrainPrefetchMessage(Guid.NewGuid()));
         }
 
-        // Wait until the FIRST delivery is blocking the client's single dispatch thread (default
-        // ConsumerDispatchConcurrency is 1) -- this guarantees no delivery has been dispatched
-        // past it yet. The broker still routes and pushes the other 24 onto the wire while that
-        // first delivery sits blocked, so give that a moment to land before stopping -- otherwise
-        // some of the 24 may still be in flight from the broker rather than already prefetched.
+        // Block on the first delivery in the client's single dispatch thread (ConsumerDispatchConcurrency
+        // 1), so nothing dispatches past it. The broker still pushes the other 24 onto the wire while it
+        // sits blocked; give them a moment to land so they're prefetched, not still in flight.
         _mapper.Entered.WaitOne(10.Seconds())
             .ShouldBeTrue("the first prefetched delivery never reached the gated mapper");
         await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
@@ -125,19 +113,16 @@ public class drain_wait_for_prefetch : IAsyncLifetime
 
         await stopTask.WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
 
-        // The durable guarantee this feature makes: every prefetched delivery is captured in the
-        // inbox, so none of them silently vanish and rely on the broker to redeliver them. (A
-        // handful may still be sitting as "Incoming" rather than "Handled" -- the receiver latches
-        // partway through the drain and defers anything that arrives after that point to the
-        // durability recovery sweep instead of running it inline; that's pre-existing shutdown
-        // behavior, not something this feature changes.)
+        // Every prefetched delivery is captured in the inbox rather than left to broker redelivery.
+        // Some may still be "Incoming" rather than "Handled": the receiver latches partway through the
+        // drain and defers later arrivals to the recovery sweep (pre-existing shutdown behavior).
         var incoming = await runtime.Storage.Admin.AllIncomingAsync();
         var persistedCount = incoming.Count(x => x.MessageType == typeof(DrainPrefetchMessage).ToMessageTypeName());
 
         persistedCount.ShouldBe(messageCount);
 
-        // And the ones that beat the receiver's shutdown latch ran through the actual handler,
-        // proving the drained deliveries reach the pipeline and not just the inbox table.
+        // And the ones that beat the shutdown latch ran through the handler, proving drained
+        // deliveries reach the pipeline, not just the inbox table.
         _tracker.Handled.Count.ShouldBeGreaterThan(0);
     }
 }
@@ -158,11 +143,9 @@ public static class DrainPrefetchMessageHandler
 }
 
 /// <summary>
-/// Wraps the default mapper and blocks the FIRST incoming delivery's envelope mapping until
-/// released. Mapping happens synchronously inside WorkerQueueMessageConsumer.HandleBasicDeliverAsync,
-/// so with the default ConsumerDispatchConcurrency of 1 this blocks the RabbitMQ client's single
-/// dispatch thread, guaranteeing every other already-prefetched delivery is still sitting
-/// undispatched in the client.
+/// Blocks the first incoming delivery's envelope mapping until released. Mapping runs synchronously in
+/// HandleBasicDeliverAsync, so at the default ConsumerDispatchConcurrency of 1 this blocks the client's
+/// single dispatch thread, keeping every other prefetched delivery undispatched.
 /// </summary>
 internal class GateFirstDeliveryMapper : IRabbitMqEnvelopeMapper
 {
@@ -200,8 +183,8 @@ internal class GateFirstDeliveryMapper : IRabbitMqEnvelopeMapper
     }
 }
 
-// Cheap parity check: a listener that never opts in keeps the old fire-and-forget behavior and
-// stops promptly, rather than picking up any waiting behavior by accident.
+// Parity check: a listener that never opts in keeps the old fire-and-forget behavior and stops
+// promptly.
 public class drain_wait_for_prefetch_default_off
 {
     [Fact]

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -150,9 +150,15 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         var channel = Channel;
         if (channel != null)
         {
+            var noWait = !Queue.DrainWaitForPrefetch;
             foreach (var consumerTag in consumer.ConsumerTags)
             {
-                await channel.BasicCancelAsync(consumerTag, true, default);
+                await channel.BasicCancelAsync(consumerTag, noWait, default);
+            }
+
+            if (!noWait)
+            {
+                await consumer.CancelOkReceived.WaitAsync(TimeSpan.FromSeconds(30));
             }
         }
     }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -164,9 +164,12 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
 
             // Cancel WITHOUT the nowait bit so the broker replies cancel-ok; the consumer dispatcher
             // raises that callback (CancelOkReceived) only after every prefetched delivery ahead of it
-            // in FIFO order has reached the receiver. Bound the whole wait and log-and-continue on
-            // timeout or broker error so an unreachable broker can't abort the caller's stop-and-drain,
-            // which still has to drain the receiver and dispose this listener.
+            // in FIFO order has been dispatched. In durable micro-batching mode "dispatched" only means
+            // the delivery reached the batching channel, so also drain that batch to the receiver before
+            // returning -- otherwise the caller latches the receiver first and the batch is deferred back
+            // to the broker (redelivered). Bound the whole wait and log-and-continue on timeout or broker
+            // error so an unreachable broker can't abort the caller's stop-and-drain, which still has to
+            // drain the receiver and dispose this listener.
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             try
             {
@@ -176,6 +179,7 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
                 }
 
                 await consumer.CancelOkReceived.WaitAsync(cts.Token);
+                await consumer.DrainBatchedDeliveriesAsync().WaitAsync(cts.Token);
             }
             catch (Exception e)
             {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -163,22 +163,25 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
             }
 
             // Cancel WITHOUT the nowait bit so the broker replies cancel-ok; the consumer dispatcher
-            // raises that callback (CancelOkReceived) only after every prefetched delivery ahead of it
-            // in FIFO order has been dispatched. In durable micro-batching mode "dispatched" only means
-            // the delivery reached the batching channel, so also drain that batch to the receiver before
-            // returning -- otherwise the caller latches the receiver first and the batch is deferred back
-            // to the broker (redelivered). Bound the whole wait and log-and-continue on timeout or broker
-            // error so an unreachable broker can't abort the caller's stop-and-drain, which still has to
-            // drain the receiver and dispose this listener.
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            // raises that callback (HandleBasicCancelOkAsync) only after every prefetched delivery ahead
+            // of it in FIFO order has been dispatched. In durable micro-batching mode "dispatched" only
+            // means the delivery reached the batching channel, so also drain that batch to the receiver
+            // before returning -- otherwise the caller latches the receiver first and the batch is
+            // deferred back to the broker (redelivered). Bound the whole wait on the same graceful-drain
+            // budget as the rest of shutdown and log-and-continue on timeout or broker error so an
+            // unreachable broker can't abort the caller's stop-and-drain, which still has to drain the
+            // receiver and dispose this listener.
+            using var cts = new CancellationTokenSource(_runtime.DurabilitySettings.DrainTimeout);
             try
             {
+                var cancelled = 0;
                 foreach (var consumerTag in consumer.ConsumerTags)
                 {
                     await channel.BasicCancelAsync(consumerTag, false, cts.Token);
+                    cancelled++;
                 }
 
-                await consumer.CancelOkReceived.WaitAsync(cts.Token);
+                await consumer.WaitForCancelOksAsync(cancelled, cts.Token);
                 await consumer.DrainBatchedDeliveriesAsync().WaitAsync(cts.Token);
             }
             catch (Exception e)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -152,8 +152,8 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         {
             if (!Queue.DrainWaitForPrefetch)
             {
-                // nowait cancel: the broker sends no cancel-ok, and any still-prefetched deliveries
-                // are left for the broker to requeue on channel close.
+                // nowait cancel: no cancel-ok, and still-prefetched deliveries are requeued by the
+                // broker on channel close.
                 foreach (var consumerTag in consumer.ConsumerTags)
                 {
                     await channel.BasicCancelAsync(consumerTag, true, default);
@@ -162,15 +162,12 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
                 return;
             }
 
-            // Cancel WITHOUT the nowait bit so the broker replies cancel-ok; the consumer dispatcher
-            // raises that callback (HandleBasicCancelOkAsync) only after every prefetched delivery ahead
-            // of it in FIFO order has been dispatched. In durable micro-batching mode "dispatched" only
-            // means the delivery reached the batching channel, so also drain that batch to the receiver
-            // before returning -- otherwise the caller latches the receiver first and the batch is
-            // deferred back to the broker (redelivered). Bound the whole wait on the same graceful-drain
-            // budget as the rest of shutdown and log-and-continue on timeout or broker error so an
-            // unreachable broker can't abort the caller's stop-and-drain, which still has to drain the
-            // receiver and dispose this listener.
+            // Cancel WITHOUT nowait so the broker replies cancel-ok, which the client dispatches only
+            // after every prefetched delivery ahead of it in FIFO order. In durable micro-batching mode
+            // that only means the deliveries reached the batching channel, so drain that batch too --
+            // otherwise the caller latches the receiver first and the batch is redelivered. Bound the
+            // wait on the shared drain budget and log-and-continue so an unreachable broker can't abort
+            // the caller's stop-and-drain.
             using var cts = new CancellationTokenSource(_runtime.DurabilitySettings.DrainTimeout);
             try
             {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -150,15 +150,38 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
         var channel = Channel;
         if (channel != null)
         {
-            var noWait = !Queue.DrainWaitForPrefetch;
-            foreach (var consumerTag in consumer.ConsumerTags)
+            if (!Queue.DrainWaitForPrefetch)
             {
-                await channel.BasicCancelAsync(consumerTag, noWait, default);
+                // nowait cancel: the broker sends no cancel-ok, and any still-prefetched deliveries
+                // are left for the broker to requeue on channel close.
+                foreach (var consumerTag in consumer.ConsumerTags)
+                {
+                    await channel.BasicCancelAsync(consumerTag, true, default);
+                }
+
+                return;
             }
 
-            if (!noWait)
+            // Cancel WITHOUT the nowait bit so the broker replies cancel-ok; the consumer dispatcher
+            // raises that callback (CancelOkReceived) only after every prefetched delivery ahead of it
+            // in FIFO order has reached the receiver. Bound the whole wait and log-and-continue on
+            // timeout or broker error so an unreachable broker can't abort the caller's stop-and-drain,
+            // which still has to drain the receiver and dispose this listener.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
             {
-                await consumer.CancelOkReceived.WaitAsync(TimeSpan.FromSeconds(30));
+                foreach (var consumerTag in consumer.ConsumerTags)
+                {
+                    await channel.BasicCancelAsync(consumerTag, false, cts.Token);
+                }
+
+                await consumer.CancelOkReceived.WaitAsync(cts.Token);
+            }
+            catch (Exception e)
+            {
+                Logger.LogWarning(e,
+                    "Timed out or errored waiting for prefetched messages to drain at {Uri} during listener stop; continuing shutdown",
+                    Address);
             }
         }
     }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -100,16 +100,13 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     }
 
     /// <summary>
-    /// When true, listener shutdown will wait for all prefetched messages in the RabbitMQ client's
-    /// internal dispatch buffer to be delivered to the consumer before closing the channel. This
-    /// prevents silent redeliveries of messages that were prefetched but not yet handed to the
-    /// handler pipeline. Default is false.
+    /// When true, listener shutdown waits for prefetched messages in the RabbitMQ client's dispatch
+    /// buffer to reach the consumer before closing the channel, preventing silent redeliveries of
+    /// messages that were prefetched but not yet handled. Default is false.
     ///
-    /// This is only a guarantee at <c>ConsumerDispatchConcurrency</c> of 1 (the default), where the
-    /// broker's cancel-ok reliably orders after every in-flight delivery. At higher dispatch
-    /// concurrency the client processes deliveries and the cancel-ok in parallel, so it degrades to
-    /// best-effort -- some prefetched messages may still be redelivered -- but remains better than
-    /// not waiting at all.
+    /// Only a hard guarantee at <c>ConsumerDispatchConcurrency</c> of 1 (the default). At higher
+    /// concurrency the client handles deliveries and cancel-ok in parallel, so it degrades to
+    /// best-effort -- some messages may still be redelivered, but fewer than without waiting.
     /// </summary>
     public bool DrainWaitForPrefetch { get; set; }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -104,6 +104,12 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     /// internal dispatch buffer to be delivered to the consumer before closing the channel. This
     /// prevents silent redeliveries of messages that were prefetched but not yet handed to the
     /// handler pipeline. Default is false.
+    ///
+    /// This is only a guarantee at <c>ConsumerDispatchConcurrency</c> of 1 (the default), where the
+    /// broker's cancel-ok reliably orders after every in-flight delivery. At higher dispatch
+    /// concurrency the client processes deliveries and the cancel-ok in parallel, so it degrades to
+    /// best-effort -- some prefetched messages may still be redelivered -- but remains better than
+    /// not waiting at all.
     /// </summary>
     public bool DrainWaitForPrefetch { get; set; }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -100,6 +100,14 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     }
 
     /// <summary>
+    /// When true, listener shutdown will wait for all prefetched messages in the RabbitMQ client's
+    /// internal dispatch buffer to be delivered to the consumer before closing the channel. This
+    /// prevents silent redeliveries of messages that were prefetched but not yet handed to the
+    /// handler pipeline. Default is false.
+    /// </summary>
+    public bool DrainWaitForPrefetch { get; set; }
+
+    /// <summary>
     ///     Use to override the dead letter queue for this queue
     /// </summary>
     public DeadLetterQueue? DeadLetterQueue { get; set; }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -78,10 +78,9 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     }
 
     /// <summary>
-    /// Wait until the broker has replied cancel-ok for <paramref name="count"/> cancelled consumer
-    /// tags. Each cancel-ok is dispatched by the client only after every prefetched delivery ahead of
-    /// it in the FIFO dispatcher queue has been processed, so once all are in the prefetch backlog has
-    /// drained (to the batching channel, in durable micro-batching mode).
+    /// Wait for the broker's cancel-ok on <paramref name="count"/> cancelled consumer tags. The client
+    /// dispatches each cancel-ok only after every prefetched delivery ahead of it in FIFO order, so once
+    /// all arrive the prefetch backlog has drained (to the batching channel, in micro-batching mode).
     /// </summary>
     internal async Task WaitForCancelOksAsync(int count, CancellationToken token)
     {
@@ -92,9 +91,9 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     }
 
     /// <summary>
-    /// Flush batched-but-undelivered envelopes to the receiver and await that flush. In durable
-    /// micro-batching mode basic.cancel-ok only guarantees deliveries reached the batching channel,
-    /// so a drain must await this or the receiver latches first and the batch is redelivered.
+    /// Flush any batched-but-undelivered envelopes to the receiver and await that flush. cancel-ok only
+    /// guarantees deliveries reached the batching channel, so without this the receiver latches first and
+    /// the batch is redelivered.
     /// </summary>
     internal async Task DrainBatchedDeliveriesAsync()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -84,6 +84,23 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     /// </summary>
     internal Task CancelOkReceived => _cancelOkReceived.Task;
 
+    /// <summary>
+    /// Flush batched-but-undelivered envelopes to the receiver and await that flush. In durable
+    /// micro-batching mode basic.cancel-ok only guarantees deliveries reached the batching channel,
+    /// so a drain must await this or the receiver latches first and the batch is redelivered.
+    /// </summary>
+    internal async Task DrainBatchedDeliveriesAsync()
+    {
+        if (_batching == null)
+        {
+            return;
+        }
+
+        _batching.TriggerBatch();
+        _batching.Complete();
+        await _batching.WaitForCompletionAsync();
+    }
+
     public override Task HandleBasicCancelOkAsync(string consumerTag, CancellationToken cancellationToken = default)
     {
         _cancelOkReceived.TrySetResult();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -15,7 +15,7 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     private readonly IRabbitMqEnvelopeMapper _mapper;
     private readonly IReceiver _workerQueue;
     private bool _latched;
-    private readonly TaskCompletionSource _cancelOkReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly SemaphoreSlim _cancelOks = new(0);
 
     // GH-3492: durable endpoints coalesce prefetched deliveries into Envelope[] batches so the
     // inbox persists them with one multi-VALUES insert instead of gating on one INSERT round
@@ -75,14 +75,21 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         // Push any accumulated-but-unflushed deliveries onward; anything genuinely in flight
         // is unacked and will be redelivered by the broker (and deduplicated by the inbox).
         _batching?.TriggerBatch();
-        _cancelOkReceived.TrySetResult();
     }
 
     /// <summary>
-    /// Completes when the broker's basic.cancel-ok has been dispatched by the client, meaning
-    /// all prefetched deliveries ahead of it in the FIFO dispatcher queue have been processed.
+    /// Wait until the broker has replied cancel-ok for <paramref name="count"/> cancelled consumer
+    /// tags. Each cancel-ok is dispatched by the client only after every prefetched delivery ahead of
+    /// it in the FIFO dispatcher queue has been processed, so once all are in the prefetch backlog has
+    /// drained (to the batching channel, in durable micro-batching mode).
     /// </summary>
-    internal Task CancelOkReceived => _cancelOkReceived.Task;
+    internal async Task WaitForCancelOksAsync(int count, CancellationToken token)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            await _cancelOks.WaitAsync(token);
+        }
+    }
 
     /// <summary>
     /// Flush batched-but-undelivered envelopes to the receiver and await that flush. In durable
@@ -103,7 +110,7 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
 
     public override Task HandleBasicCancelOkAsync(string consumerTag, CancellationToken cancellationToken = default)
     {
-        _cancelOkReceived.TrySetResult();
+        _cancelOks.Release();
         return base.HandleBasicCancelOkAsync(consumerTag, cancellationToken);
     }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -15,6 +15,7 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     private readonly IRabbitMqEnvelopeMapper _mapper;
     private readonly IReceiver _workerQueue;
     private bool _latched;
+    private readonly TaskCompletionSource _cancelOkReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     // GH-3492: durable endpoints coalesce prefetched deliveries into Envelope[] batches so the
     // inbox persists them with one multi-VALUES insert instead of gating on one INSERT round
@@ -74,6 +75,19 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         // Push any accumulated-but-unflushed deliveries onward; anything genuinely in flight
         // is unacked and will be redelivered by the broker (and deduplicated by the inbox).
         _batching?.TriggerBatch();
+        _cancelOkReceived.TrySetResult();
+    }
+
+    /// <summary>
+    /// Completes when the broker's basic.cancel-ok has been dispatched by the client, meaning
+    /// all prefetched deliveries ahead of it in the FIFO dispatcher queue have been processed.
+    /// </summary>
+    internal Task CancelOkReceived => _cancelOkReceived.Task;
+
+    public override Task HandleBasicCancelOkAsync(string consumerTag, CancellationToken cancellationToken = default)
+    {
+        _cancelOkReceived.TrySetResult();
+        return base.HandleBasicCancelOkAsync(consumerTag, cancellationToken);
     }
 
     //TODO do something with the token passed in here

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -112,7 +112,6 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
         return this;
     }
 
-    /// <summary>
     ///     Override the RabbitMQ client's consumer dispatch concurrency for just this endpoint's
     ///     listening channels. This governs how many deliveries the client hands to the consumer
     ///     at once: at the default of 1, an <c>Inline</c> listener runs strictly one message at a
@@ -128,6 +127,17 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
         }
 
         add(e => e.ConsumerDispatchConcurrency = concurrency);
+        return this;
+    }
+
+    /// <summary>
+    /// When enabled, listener shutdown will wait for all prefetched messages in the RabbitMQ
+    /// client's internal dispatch buffer to be fully delivered before closing the channel.
+    /// Prevents silent redeliveries of prefetched-but-unprocessed messages. Default is false.
+    /// </summary>
+    public RabbitMqListenerConfiguration DrainWaitForPrefetch()
+    {
+        add(e => e.DrainWaitForPrefetch = true);
         return this;
     }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -132,14 +132,12 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
     }
 
     /// <summary>
-    /// When enabled, listener shutdown will wait for all prefetched messages in the RabbitMQ
-    /// client's internal dispatch buffer to be fully delivered before closing the channel.
-    /// Prevents silent redeliveries of prefetched-but-unprocessed messages. Default is false.
+    /// When enabled, listener shutdown waits for prefetched messages in the RabbitMQ client's dispatch
+    /// buffer to be delivered before closing the channel, preventing silent redeliveries of
+    /// prefetched-but-unprocessed messages. Default is false.
     ///
-    /// Only a guarantee at a <c>ConsumerDispatchConcurrency</c> of 1 (the default). At higher
-    /// dispatch concurrency the client processes deliveries and the broker's cancel-ok in parallel,
-    /// so it degrades to best-effort -- some prefetched messages may still be redelivered -- but
-    /// remains better than not waiting at all.
+    /// Only a hard guarantee at <c>ConsumerDispatchConcurrency</c> of 1 (the default); at higher
+    /// concurrency it degrades to best-effort as deliveries and cancel-ok are handled in parallel.
     /// </summary>
     public RabbitMqListenerConfiguration DrainWaitForPrefetch()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -112,6 +112,7 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
         return this;
     }
 
+    /// <summary>
     ///     Override the RabbitMQ client's consumer dispatch concurrency for just this endpoint's
     ///     listening channels. This governs how many deliveries the client hands to the consumer
     ///     at once: at the default of 1, an <c>Inline</c> listener runs strictly one message at a

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/RabbitMqListenerConfiguration.cs
@@ -135,6 +135,11 @@ public class RabbitMqListenerConfiguration : InteroperableListenerConfiguration<
     /// When enabled, listener shutdown will wait for all prefetched messages in the RabbitMQ
     /// client's internal dispatch buffer to be fully delivered before closing the channel.
     /// Prevents silent redeliveries of prefetched-but-unprocessed messages. Default is false.
+    ///
+    /// Only a guarantee at a <c>ConsumerDispatchConcurrency</c> of 1 (the default). At higher
+    /// dispatch concurrency the client processes deliveries and the broker's cancel-ok in parallel,
+    /// so it degrades to best-effort -- some prefetched messages may still be redelivered -- but
+    /// remains better than not waiting at all.
     /// </summary>
     public RabbitMqListenerConfiguration DrainWaitForPrefetch()
     {


### PR DESCRIPTION
Adds an option to wait for prefetched messages in rabbitmq to be passed to the receiver before continuing with the shutdown process. Disabled by default to maintain parity in existing code, especially with the default 100 message prefetch (where this could be harmful).

There is a caviat where this won't necessarily handle parallel dispatch cleanly, as the cancel is handled in parallel with real messages, which has been documented.