### PR TITLE
Restore 55 Pulsar tests and skip only the four behaviours that are missing (GH-3763)

### DIFF
--- a/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
@@ -578,7 +578,7 @@ public abstract class TransportCompliance<T> : IAsyncLifetime where T : Transpor
     }
 
     [Fact]
-    public async Task can_schedule_retry()
+    public virtual async Task can_schedule_retry()
     {
         throwOnAttempt<BadImageFormatException>(1);
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
@@ -40,5 +40,22 @@ public class InlinePulsarTransportFixture : TransportComplianceFixture, IAsyncLi
 }
 
 [Collection("acceptance")]
-[Trait("Category", "Flaky")]
-public class InlinePulsarTransportComplianceTests : TransportCompliance<InlinePulsarTransportFixture>;
+public class InlinePulsarTransportComplianceTests : TransportCompliance<InlinePulsarTransportFixture>
+{
+    // GH-3763. These four are not flaky -- they fail deterministically, every run, in all three Pulsar
+    // compliance fixtures, with "No ending activity detected" / "Expected ending activity was not
+    // detected". They are the requeue, retry-scheduling and dead-letter behaviours the transport has not
+    // implemented. Skipping just these restores the other 55 tests in this file's three fixtures, which
+    // pass; the whole classes used to be excluded for them. See GH-3797.
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_requeue_and_increment_attempts() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task can_schedule_retry() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_move_to_dead_letter_queue_without_any_exception_match() => Task.CompletedTask;
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
@@ -43,5 +43,22 @@ public class PulsarTransportFixture : TransportComplianceFixture, IAsyncLifetime
 }
 
 [Collection("acceptance")]
-[Trait("Category", "Flaky")]
-public class PulsarTransportComplianceTests : TransportCompliance<PulsarTransportFixture>;
+public class PulsarTransportComplianceTests : TransportCompliance<PulsarTransportFixture>
+{
+    // GH-3763. These four are not flaky -- they fail deterministically, every run, in all three Pulsar
+    // compliance fixtures, with "No ending activity detected" / "Expected ending activity was not
+    // detected". They are the requeue, retry-scheduling and dead-letter behaviours the transport has not
+    // implemented. Skipping just these restores the other 55 tests in this file's three fixtures, which
+    // pass; the whole classes used to be excluded for them. See GH-3797.
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_requeue_and_increment_attempts() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task can_schedule_retry() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_move_to_dead_letter_queue_without_any_exception_match() => Task.CompletedTask;
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
@@ -48,7 +48,6 @@ public class PulsarWithCloudEventsFixture : TransportComplianceFixture, IAsyncLi
 }
 
 [Collection("acceptance")]
-[Trait("Category", "Flaky")]
 public class with_cloud_events : TransportCompliance<PulsarWithCloudEventsFixture>
 {
     // This test uses ErrorCausingMessage which contains a Dictionary<int, Exception>.
@@ -56,8 +55,20 @@ public class with_cloud_events : TransportCompliance<PulsarWithCloudEventsFixtur
     // which CloudEvents uses internally. The test message's Errors dictionary gets
     // corrupted during serialization, causing the wrong exception type to be thrown.
     // This is a test infrastructure limitation, not a CloudEvents functionality issue.
-    public override Task will_move_to_dead_letter_queue_with_exception_match()
-    {
-        return Task.CompletedTask;
-    }
+    //
+    // Skip rather than an empty body: an override that just returns Task.CompletedTask reports as a
+    // PASS, so the suite counted a test that never ran anything. GH-3763.
+    [Fact(Skip = "CloudEvents' System.Text.Json serialization corrupts ErrorCausingMessage's Dictionary<int, Exception>, so the wrong exception type is thrown -- a test-infrastructure limit, not a CloudEvents defect.")]
+    public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
+
+    // GH-3763. Deterministic failures shared with the other two Pulsar compliance fixtures -- the
+    // requeue, retry-scheduling and dead-letter behaviours the transport has not implemented. See GH-3797.
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_requeue_and_increment_attempts() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task can_schedule_retry() => Task.CompletedTask;
+
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
+    public override Task will_move_to_dead_letter_queue_without_any_exception_match() => Task.CompletedTask;
 }


### PR DESCRIPTION
The Pulsar pass of #3763, after #3791 (AWS), #3794 (Kafka) and #3795 (RabbitMQ).

## An exclusion with no recorded reason, and far too broad

Commit `02f531842` on 2026-06-08 — message *"Disable Pulsar compliance tests"*, no other rationale — tagged all three Pulsar compliance classes `Category=Flaky`. That is **66 of the project's 224 tests**; `CIPulsar` has been running 158.

Untagged: **213 pass, 11 fail** — and the 11 are the *same four behaviours* repeated across the three fixtures.

| Test | Failure |
|---|---|
| `will_requeue_and_increment_attempts` | `Expected ending activity was not detected` |
| `can_schedule_retry` | `Expected ending activity was not detected` |
| `will_move_to_dead_letter_queue_without_any_exception_match` | `No ending activity detected` |
| `will_move_to_dead_letter_queue_with_exception_match` | `No ending activity detected` |

They are **not flaky** — they fail deterministically, every run, alone or in a suite, and they look like genuinely unimplemented transport behaviour: native requeue with attempt tracking, scheduled retry, and dead-letter routing. Filed as **#3797**.

## So: all three classes come off the ledger, only those four are skipped

Each skip carries the reason and the issue number, so what's missing is greppable instead of buried under three blanket exclusions. `can_schedule_retry` had to become `virtual` in `TransportCompliance` to be overridable; the other three already were.

`with_cloud_events` already opted out of `will_move_to_dead_letter_queue_with_exception_match` by overriding it with a bare `return Task.CompletedTask` — which **reports as a PASS**, so the suite was counting a test that ran nothing. That's now a real `Skip` carrying its original explanation.

**Net: `CIPulsar` goes from 158 executing tests to 213, plus 11 named skips.**

## Two things worth knowing that came out of this

- **`CIPulsar` runs Pulsar in Testcontainers, not docker-compose** (#3467). A local run hangs silently at `224 batched` if Docker is short on memory — nine stale containers were holding 4.7 of 7.7 GiB here and no Pulsar container could start. Stopping them fixed it; nothing in the output said so.
- **The supervisor's summary counts SKIPPED tests inside its "passed" number.** Run 2 below reports "224 passed" for 213 executed + 11 skipped. The per-assembly runner reports them correctly (`18 succeeded / 4 skipped` for one fixture). Worth a look given #3787's honest-reporting goal — not changed here.

## Verification

| | Result |
|---|---|
| CIPulsar, run 1 | 223 passed, 1 retry, **exit 0** |
| CIPulsar, run 2 | **224 passed, 0 retries**, exit 0 |

Repo flaky tags **16 → 13**. `wolverine.slnx` builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116vfBcKwcjWn8msM4ZjkuA