### PR TITLE
Retry `docker compose up` so a registry timeout does not redden main

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -25,10 +25,41 @@ partial class Build
     }
 
     /// <summary>
+    /// How many times <see cref="ComposeUp"/> will try `docker compose up -d` before giving up.
+    /// </summary>
+    const int DockerComposeAttempts = 3;
+
+    /// <summary>
     /// Fires `docker compose up -d` for the services and returns as soon as the containers are
     /// launched — no readiness wait. Pair with <see cref="AwaitDockerServices"/>.
     /// </summary>
     void LaunchDockerServices(params string[] services)
+    {
+        var serviceList = string.Join(" ", services);
+        Log.Information("Starting docker services: {Services}", serviceList);
+
+        // Pass each service as a separate argument to avoid quoting issues
+        ComposeUp("compose up -d " + serviceList, serviceList);
+    }
+
+    /// <summary>
+    /// Runs a `docker compose up` invocation, retrying a failed attempt.
+    ///
+    /// <para>`docker compose up` contacts the registry for any image not already cached, and GitHub's
+    /// runners time out against Docker Hub often enough to redden main on their own. On 2026-08-03,
+    /// three of the four red main runs were exactly this and nothing else — CIOtel twice and CIMQTT5
+    /// once, each dying in under a minute on
+    /// `Get "https://registry-1.docker.io/v2/": context deadline exceeded` before a single test ran.
+    /// A pull timeout is transient and says nothing about the commit that triggered it, so it should
+    /// cost a retry rather than a red build.</para>
+    ///
+    /// <para>Every failure is retried, not just registry-shaped ones: matching on the message text
+    /// would be guessing at a moving target, and a genuinely broken compose file still fails — it
+    /// just takes <see cref="DockerComposeAttempts"/> tries to get there, and the exception it throws
+    /// carries the real reason either way. Each failed attempt logs the tool's own output, so the
+    /// job log always says which it was instead of leaving the reader to infer it.</para>
+    /// </summary>
+    void ComposeUp(string args, string serviceList)
     {
         bool IsToolAvailable(string toolName)
         {
@@ -42,15 +73,40 @@ partial class Build
         string toolName = new List<string> { "docker", "podman" }
                               .FirstOrDefault(IsToolAvailable) ?? "docker";
 
-        var serviceList = string.Join(" ", services);
-        Log.Information("Starting docker services: {Services}", serviceList);
+        for (var attempt = 1;; attempt++)
+        {
+            var process = ProcessTasks
+                .StartProcess(toolName, args, logOutput: false, logInvocation: false)
+                .AssertWaitForExit();
 
-        // Pass each service as a separate argument to avoid quoting issues
-        var args = "compose up -d " + serviceList;
-        ProcessTasks
-            .StartProcess(toolName, args, logOutput: false, logInvocation: false)
-            .AssertWaitForExit()
-            .AssertZeroExitCode();
+            if (process.ExitCode == 0)
+            {
+                if (attempt > 1)
+                {
+                    Log.Information("docker compose up succeeded for {Services} on attempt {Attempt}",
+                        serviceList, attempt);
+                }
+
+                return;
+            }
+
+            var output = string.Join(Environment.NewLine, process.Output.Select(x => x.Text));
+
+            // Out of attempts: let AssertZeroExitCode throw with the tool's own message.
+            if (attempt >= DockerComposeAttempts)
+            {
+                Log.Error("docker compose up failed for {Services} after {Attempts} attempts:{NewLine}{Output}",
+                    serviceList, DockerComposeAttempts, Environment.NewLine, output);
+                process.AssertZeroExitCode();
+                return;
+            }
+
+            var delay = TimeSpan.FromSeconds(5 * attempt);
+            Log.Warning(
+                "docker compose up failed for {Services} (attempt {Attempt} of {Attempts}), retrying in {Delay}s:{NewLine}{Output}",
+                serviceList, attempt, DockerComposeAttempts, delay.TotalSeconds, Environment.NewLine, output);
+            Thread.Sleep(delay);
+        }
     }
 
     /// <summary>

--- a/build/build.cs
+++ b/build/build.cs
@@ -345,21 +345,9 @@ partial class Build : NukeBuild
     Target DockerUp => _ => _
         .Executes(() =>
         {
-            bool IsToolAvailable(string toolName)
-            {
-                try
-                { ToolPathResolver.GetPathExecutable(toolName);
-                  return true; }
-                catch (ArgumentException)
-                { return false; }
-            }
-
-            string toolName = new List<string> { "docker", "podman" }
-                                  .FirstOrDefault(IsToolAvailable) ?? "docker";
-            ProcessTasks
-                .StartProcess(toolName, "compose up -d", logOutput: false)
-                .AssertWaitForExit()
-                .AssertZeroExitCode();
+            // Shares ComposeUp with the CI targets so this path gets the same registry-timeout
+            // retry — it pulls every image in the compose file, so it is the most exposed of all.
+            ComposeUp("compose up -d", "all services");
             WaitForDatabaseToBeReady();
         });
 


### PR DESCRIPTION
Three of the four red `main` runs on 2026-08-03 were not test failures. CIOtel (twice, runs [30835955313](https://github.com/JasperFx/wolverine/actions/runs/30835955313) and [30782661294](https://github.com/JasperFx/wolverine/actions/runs/30782661294)) and CIMQTT5 ([30843486384](https://github.com/JasperFx/wolverine/actions/runs/30843486384)) each died in under a minute, before a single test ran:

```
rabbitmq Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

`docker compose up` contacts the registry for any image that is not already cached, and GitHub's runners time out against Docker Hub often enough to do this on their own. `LaunchDockerServices` fired exactly one attempt and asserted a zero exit code, so a single blip failed the whole job.

## The change

`ComposeUp` makes three attempts with a 5s/10s backoff, logging the tool's own output on each failure, and throws the real message when they are exhausted.

**Every failure is retried, not just registry-shaped ones.** Matching on message text would be guessing at a moving target. A genuinely broken compose file still fails — it just takes three tries to get there, and the exception carries the real reason either way. Each failed attempt logs the output, so the job log states which case it was rather than leaving the reader to infer it.

`DockerUp` in `build.cs` was a byte-for-byte duplicate of the same single-shot logic and pulls *every* image in the compose file, making it the most exposed caller of all, so it now shares the helper.

## Verification

Run against a nonexistent service via a temporary target — two warnings, then the genuine error, and a total elapsed time of `0:15` confirming the 5s + 10s backoff actually happened:

```
[WRN] docker compose up failed for no-such-service (attempt 1 of 3), retrying in 5s:
      no such service: no-such-service
[WRN] docker compose up failed for no-such-service (attempt 2 of 3), retrying in 10s:
      no such service: no-such-service
[ERR] docker compose up failed for no-such-service after 3 attempts:
      no such service: no-such-service
ProcessException: Process 'docker' exited with code 1.
   Error output:
      no such service: no-such-service

ProbeRetry         Failed          0:15
```

The success path is unchanged apart from a log line when it took more than one attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m