### PR TITLE
Oracle clear_all: clean the schema the queue tables are actually in (GH-3763)

### DIFF
--- a/src/Persistence/Oracle/OracleTests/Transport/clear_all_wolverine_storage.cs
+++ b/src/Persistence/Oracle/OracleTests/Transport/clear_all_wolverine_storage.cs
@@ -14,6 +14,19 @@ public class clear_all_wolverine_storage : ClearAllWolverineStorageCompliance
 {
     private const string SchemaName = "WOLVERINE";
 
+    /// <summary>
+    /// The queue tables do <b>not</b> live in <see cref="SchemaName"/>. Unlike every other provider in
+    /// this compliance suite, the Oracle transport keeps them in a schema of its own —
+    /// <c>OracleTransport.TransportSchemaName</c>, which defaults to <c>WOLVERINE_QUEUES</c> — while
+    /// <see cref="SchemaName"/> holds only envelope storage.
+    ///
+    /// <para>Pinned here and passed to <c>EnableMessageTransport</c> below so that the schema the host
+    /// creates the tables in and the schema <see cref="beforeHostAsync"/> cleans are the same string by
+    /// construction. They were previously two independent guesses, and the cleanup was quietly aimed at
+    /// the wrong one — see the note on <see cref="dropTableWithRetryAsync"/>.</para>
+    /// </summary>
+    private const string TransportSchemaName = "WOLVERINE_QUEUES";
+
     protected override async Task beforeHostAsync()
     {
         // Oracle has no cheap "drop schema" — clear whatever a prior run left behind by name.
@@ -21,21 +34,21 @@ public class clear_all_wolverine_storage : ClearAllWolverineStorageCompliance
         await using var conn = await dataSource.OpenConnectionAsync();
         try
         {
+            // DDL_LOCK_TIMEOUT makes DROP TABLE block rather than fail outright with ORA-00054 while
+            // the previous test's listener still holds the TM lock. Same pairing as the Oracle
+            // leader-election teardown: session-level timeout first, explicit retry underneath.
+            await using (var sessionCmd = conn.CreateCommand("ALTER SESSION SET DDL_LOCK_TIMEOUT = 30"))
+            {
+                await sessionCmd.ExecuteNonQueryAsync();
+            }
+
             foreach (var table in new[]
                      {
                          $"WOLVERINE_QUEUE_{QueueName.ToUpperInvariant()}",
                          $"WOLVERINE_QUEUE_{QueueName.ToUpperInvariant()}_SCHEDULED"
                      })
             {
-                try
-                {
-                    await using var cmd = conn.CreateCommand($"DROP TABLE {SchemaName}.{table} CASCADE CONSTRAINTS");
-                    await cmd.ExecuteNonQueryAsync();
-                }
-                catch (OracleException)
-                {
-                    // Table doesn't exist, nothing to do
-                }
+                await dropTableWithRetryAsync(conn, table);
             }
         }
         finally
@@ -44,10 +57,67 @@ public class clear_all_wolverine_storage : ClearAllWolverineStorageCompliance
         }
     }
 
+    /// <summary>
+    /// Drops one queue table, tolerating only the two outcomes that are actually fine.
+    ///
+    /// <para>GH-3763. This cleanup never once deleted a row. It dropped
+    /// <c>WOLVERINE.WOLVERINE_QUEUE_RESETONE</c>, but the transport creates its tables in
+    /// <see cref="TransportSchemaName"/> (<c>WOLVERINE_QUEUES</c>) — so every DROP raised ORA-00942
+    /// against a table that was never there, and the old <c>catch (OracleException)</c> swallowed it
+    /// as "table doesn't exist, nothing to do". It was right that nothing existed, and wrong about
+    /// which schema it had looked in.</para>
+    ///
+    /// <para>What that leaks: this class runs serially, and
+    /// <c>clear_all_async_alone_leaves_the_queue_tables_alone</c> deliberately ends with one queued
+    /// and one scheduled row still present — it is the negative control for GH-3592. Every other
+    /// test calls <c>ClearAllWolverineStorageAsync</c>, which on Oracle drops the queue tables
+    /// outright, so the residue only survives when that one test runs immediately before another,
+    /// and only then does <c>seedQueueAsync</c> see `Queued should be 1 but was 2`. Order-dependent,
+    /// hence intermittent, hence read as flakiness: it reddened CIOracle on 2026-08-03 (run
+    /// 30835978599) and burned this class's two retries in the run after it. Left alone the count
+    /// climbs monotonically — a local repro reached 3.</para>
+    ///
+    /// <para>Now that the DROP resolves a table that actually exists, ORA-00054 becomes reachable
+    /// for the first time: this class is the only provider in the suite that attaches a listener,
+    /// and a polling listener holds a TM lock on the queue table (see the matching retry in
+    /// <c>OracleQueue.TeardownAsync</c>). Hence 942 = done, 54 = wait and retry, anything else
+    /// throws. Exhausting the retries throws too, rather than returning quietly: "could not drop the
+    /// queue table" is a far better failure than a count assertion two calls later that names
+    /// neither the lock nor the leftover rows.</para>
+    /// </summary>
+    private static async Task dropTableWithRetryAsync(OracleConnection conn, string table)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await using var cmd =
+                    conn.CreateCommand($"DROP TABLE {TransportSchemaName}.{table} CASCADE CONSTRAINTS");
+                await cmd.ExecuteNonQueryAsync();
+                return;
+            }
+            catch (OracleException e) when (e.Number == 942)
+            {
+                // ORA-00942: table or view does not exist — nothing to drop, which is the goal.
+                return;
+            }
+            catch (OracleException e) when (e.Number == 54 && attempt < maxAttempts)
+            {
+                // ORA-00054: resource busy. The prior host's connections are still tearing down.
+                await Task.Delay(TimeSpan.FromSeconds(2 * attempt));
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not drop {TransportSchemaName}.{table} after {maxAttempts} attempts — it is still locked by " +
+            "another session. The test would otherwise start against a table holding a previous test's rows.");
+    }
+
     protected override void ConfigureStorage(WolverineOptions options)
     {
         options.PersistMessagesWithOracle(Servers.OracleConnectionString, SchemaName)
-            .EnableMessageTransport();
+            .EnableMessageTransport(t => t.TransportSchemaName(TransportSchemaName));
 
         // Registered through the listener rather than as a subscriber, unlike the other
         // providers: Oracle uppercases queue identifiers, but Uri.Host lowercases, so the


### PR DESCRIPTION
CIOracle went red on main run [30835978599](https://github.com/JasperFx/wolverine/actions/runs/30835978599) with `counts.Queued should be 1L but was 2L`, and this class spent two of the repository's five retries in the run beside it. It read as a timing flake. It is a leak — and the cleanup meant to prevent it **has never once deleted a row**.

## Root cause

The Oracle transport does not keep its queue tables in the message-storage schema. `OracleTransport.TransportSchemaName` defaults to **`WOLVERINE_QUEUES`**, while this test's `SchemaName` is `WOLVERINE` and was being used for both. So every

```sql
DROP TABLE WOLVERINE.WOLVERINE_QUEUE_RESETONE CASCADE CONSTRAINTS
```

raised ORA-00942 against a table that was never there, and `catch (OracleException)` swallowed it as *"table doesn't exist, nothing to do"* — correct that nothing existed, wrong about which schema it had looked in.

Confirmed directly against the running database:

```
$ select owner || '.' || table_name from all_tables where table_name like '%RESETONE%';
WOLVERINE_QUEUES.WOLVERINE_QUEUE_RESETONE
WOLVERINE_QUEUES.WOLVERINE_QUEUE_RESETONE_SCHEDULED
```

## Why that leaks intermittently

The class runs serially, and `clear_all_async_alone_leaves_the_queue_tables_alone` deliberately ends with one queued and one scheduled row still present — it is the negative control for GH-3592. Every *other* test calls `ClearAllWolverineStorageAsync`, which on Oracle drops the queue tables outright. So the residue only survives when that one test runs immediately before another, and only then does `seedQueueAsync` see two rows where it seeded one.

Order-dependent, hence intermittent, hence read as flakiness. Left alone the count climbs monotonically — a local reproduction reached 3.

## The change

`TransportSchemaName` is now a const passed to `EnableMessageTransport` *and* used by the cleanup, so the schema the host creates tables in and the schema the cleanup empties are the same string by construction rather than two independent guesses.

Now that the DROP resolves a table that exists, **ORA-00054 becomes reachable for the first time**: this is the only provider in the compliance suite that attaches a listener, and a polling listener holds a TM lock on the queue table (see the matching retry in `OracleQueue.TeardownAsync`). Hence `DDL_LOCK_TIMEOUT` plus an explicit retry — 942 = done, 54 = wait and retry, anything else throws. Exhausting the retries throws too, rather than returning quietly: *"could not drop the queue table"* is a better failure than a count assertion two calls later that names neither the lock nor the leftover rows.

## Verification

A true before/after against a real reproduction, not a green run:

| | |
|---|---|
| residue standing at `QUEUED=3, SCHEDULED=3`, old code | `is_idempotent` **fails**, `should be 1L but was 3L` |
| same residue, this change | **passes** |
| 5 consecutive runs of the class | 5/5 green, residue `0` after every one |
| full `OracleTests` suite | **113/113** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m