### PR TITLE
Bug_2518: stop asserting exclusivity on the lock every migration takes (GH-3763)

### DIFF
--- a/src/Persistence/PostgresqlTests/Bugs/Bug_2518_concurrent_migration_advisory_lock.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_2518_concurrent_migration_advisory_lock.cs
@@ -46,12 +46,32 @@ public class Bug_2518_concurrent_migration_advisory_lock : PostgresqlContext
         }
     }
 
+    /// <summary>
+    /// A lock id belonging to this test alone, deliberately <b>not</b>
+    /// <see cref="DatabaseSettings.MigrationLockId"/>.
+    ///
+    /// <para>GH-3763. The advisory lock namespace is global to the Postgres server, and 4006 is the id
+    /// every Wolverine migration takes (<c>MessageDatabase.Admin</c>) — while Bobcat runs
+    /// PostgresqlTests across <b>three worker processes</b> against this one server. Any host
+    /// bootstrapping in a sibling process holds 4006 for the length of its DDL, so the assertions
+    /// below were racing every migration in a 470-test suite: the holder could fail to acquire, or
+    /// another session could take the lock in the window after the release. That is the entirety of
+    /// this test's flakiness — it cost CIPersistence its only retry of main run 30847233633.</para>
+    ///
+    /// <para>Nothing is lost by moving off 4006: what is under test is the mutual exclusion of the
+    /// primitive, not the numeric value of the constant, and the constant is never asserted on.
+    /// GH-2518's actual subject — that concurrent <c>MigrateAsync</c> calls serialize on the real
+    /// lock id — is covered by <see cref="concurrent_migrate_async_calls_do_not_race_on_create_schema"/>,
+    /// which still exercises the production path end to end.</para>
+    /// </summary>
+    private const int TestLockId = 25180001;
+
     [Fact]
-    public async Task migration_lock_id_is_actually_held_during_migration()
+    public async Task global_advisory_lock_is_exclusive_while_held()
     {
         // Verify the migration lock primitive itself works: while one connection holds
-        // the configured MigrationLockId, another cannot acquire it.
-        var lockId = new DatabaseSettings().MigrationLockId;
+        // a lock id, another cannot acquire it.
+        var lockId = TestLockId;
 
         await using var holder = new NpgsqlConnection(Servers.PostgresConnectionString);
         await holder.OpenAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
`migration_lock_id_is_actually_held_during_migration` cost CIPersistence its only retry of main run [30847233633](https://github.com/JasperFx/wolverine/actions/runs/30847233633).

## Root cause

The test asserted that while one session holds `DatabaseSettings.MigrationLockId`, no other session can acquire it.

That id is **4006** — the advisory lock *every* Wolverine migration takes in `MessageDatabase.Admin` — and the Postgres advisory lock namespace is global to the server. Meanwhile Bobcat runs this project across **three worker processes** against that one server:

```
=== PostgresqlTests: 469 passed, 1 passed on retry (1 retries, 3 worker processes) ===
```

Any host bootstrapping in a sibling process holds 4006 for the length of its DDL, so the assertions were racing every migration in a 470-test suite: the holder could fail to acquire it, or another session could take it in the window after the release.

## The change

A lock id belonging to this test alone.

Nothing is lost by moving off 4006. What is under test is the **mutual exclusion of the primitive**, not the numeric value of the constant — and the constant is never asserted on. GH-2518's actual subject, that concurrent `MigrateAsync` calls serialize on the real lock id, is covered by `concurrent_migrate_async_calls_do_not_race_on_create_schema`, which still exercises the production path end to end and is untouched.

Renamed to `global_advisory_lock_is_exclusive_while_held`, because the old name would now describe something the test deliberately no longer does.

## Verification

Both directions, by holding 4006 from a separate `psql` session — exactly what a sibling worker's migration does:

| lock id under test | 4006 held externally | result |
|---|---|---|
| `MigrationLockId` (4006) — old | yes | **fails** |
| dedicated id — this change | yes | **passes** |
| dedicated id | no | passes (2/2 in class) |

The interim state where the *other* test failed while 4006 was hostage is itself confirmation that it, and only it, genuinely needs the production lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m