### PR TITLE
Retry ledger: record the failing attempt's stack, not just its message (GH-3763)

### DIFF
--- a/build/RetryLedger.cs
+++ b/build/RetryLedger.cs
@@ -115,8 +115,39 @@ partial class Build
             ErrorType = string.IsNullOrWhiteSpace(outcome?.ErrorType) ? null : outcome.ErrorType,
             // One line and bounded: this is a lead to open the log with, not a copy of it. A
             // multi-line reason would also break the ::warning workflow command downstream.
-            Reason = condense(outcome?.ErrorMessage)
+            Reason = condense(outcome?.ErrorMessage),
+            Stack = topFrames(outcome?.StackTrace)
         };
+    }
+
+    /// <summary>
+    /// The top frames of the failing attempt's stack, for the ledger JSON only.
+    ///
+    /// <para>The message says what went wrong; the stack is what says <i>where</i>, and for a whole
+    /// class of flake that is the only thing that distinguishes the candidates. The MQTT
+    /// <c>Broken pipe</c> flake is the worked example: the message alone is equally consistent with a
+    /// teardown ordering bug, a port collision between worker processes, and a keep-alive drop under
+    /// CI load. Three local experiments eliminated the first two and the third needs a call site, so
+    /// the investigation stalls on precisely this field.</para>
+    ///
+    /// <para>Deliberately kept out of the step summary, the annotation and the roll-up — all three are
+    /// glanceable surfaces and a stack would drown them. The JSON ledger is already a downloadable
+    /// artifact, which is the right place for something you go looking for on purpose.</para>
+    /// </summary>
+    static string[] topFrames(string stackTrace)
+    {
+        if (string.IsNullOrWhiteSpace(stackTrace)) return [];
+
+        // Enough to cross a teardown/dispatch boundary and name the caller, not so much that the
+        // ledger becomes a copy of the log.
+        const int maxFrames = 12;
+
+        return stackTrace
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => x.Length > 0)
+            .Take(maxFrames)
+            .ToArray();
     }
 
     /// <summary>
@@ -290,5 +321,11 @@ partial class Build
 
         /// <summary>The failing attempt's own error message, flattened to one bounded line.</summary>
         public string Reason { get; init; }
+
+        /// <summary>
+        /// Top frames of the failing attempt's stack. Ledger JSON only — see <see cref="topFrames"/>
+        /// for why it is not rendered on the summary surfaces.
+        /// </summary>
+        public string[] Stack { get; init; } = [];
     }
 }


### PR DESCRIPTION
Follow-up to #3810, prompted by trying to use it.

#3810 made the MQTT `Broken pipe` flake legible for the first time:

```
MQTTnet.Exceptions.MqttCommunicationException : Broken pipe
  ---- System.Net.Sockets.SocketException : Broken pipe
```

That is a real lead — and it is not enough. The message alone is equally consistent with three different bugs, and it took three local experiments to start telling them apart:

| candidate | outcome |
|---|---|
| **Teardown ordering** — both flaky classes stop the broker *before* the hosts still connected to it, and 7 of 12 classes share that shape | **Refuted.** 10 runs of a faithful reproduction, including one with real tracked traffic through the broker, throw nothing either way |
| **Port collision** between worker processes, via `PortFinder` handing the same port to two of them | **Refuted.** MQTTnet throws `SocketException: Address already in use`, which fails the class outright rather than producing a broken pipe |
| **Keep-alive drop under CI load** | Still standing — and needs a call site to confirm |

Six concurrent full-suite local runs did not reproduce it, so the next real occurrence will be on CI. The one thing that would separate the remaining candidates is the field the ledger throws away, and `WorkerOutcome` already carries it.

## The change

The failing attempt's stack, capped at 12 frames, into the **ledger JSON only**:

```json
"Stack": [
  "at SqliteTests.TempFlakyProbe.fails_once_then_passes() in .../TempFlakyProbe.cs:line 16",
  "at System.RuntimeMethodHandle.InvokeMethod(...)"
]
```

Deliberately **not** on the step summary, the annotation or the roll-up. Those three are glanceable surfaces and a stack would drown them. The JSON is already a downloadable artifact, which is the right place for something you go looking for on purpose.

## Verification

With a test rigged to fail its first attempt and pass on the retry: the ledger records frames down to file and line, the step summary renders exactly as before, and the roll-up jq ignores the new field. Aggregation re-checked against a mixed set including a pre-change ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m