### PR TITLE
Record the MQTT Broken pipe flake as accepted retry debt (GH-3763)

### DIFF
--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/broadcast_to_topic_by_user_logic.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/broadcast_to_topic_by_user_logic.cs
@@ -6,6 +6,11 @@ using Wolverine.Util;
 using Xunit;
 namespace Wolverine.MQTT.Tests;
 
+// GH-3763: route_by_derived_topics_2 costs one retry in CIMQTT5, accepted on purpose and deliberately
+// NOT tagged Category=Flaky. It fails with the same
+// `MqttCommunicationException : Broken pipe` as listen_with_topic_wildcards.broadcast, in the same
+// run -- see the note on that class for the three candidates already eliminated and where the next
+// evidence will come from. Two classes, one symptom: treat them as one investigation, not two.
 [Collection("acceptance")]
 public class broadcast_to_topic_by_user_logic: IAsyncLifetime
 {

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/listen_with_topic_wildcards.cs
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/listen_with_topic_wildcards.cs
@@ -7,6 +7,38 @@ using Wolverine.Util;
 using Xunit;
 namespace Wolverine.MQTT.Tests;
 
+// GH-3763: costs one retry in CIMQTT5, accepted on purpose. Deliberately NOT tagged Category=Flaky --
+// a tag would stop it running, and a test that runs and occasionally retries is worth more than a test
+// that runs nowhere. This note exists so the next person does not repeat the search below.
+//
+// Symptom, from the retry ledger (GH-3787, main run 30856898284):
+//
+//     MQTTnet.Exceptions.MqttCommunicationException : Broken pipe
+//       ---- System.Net.Sockets.SocketException : Broken pipe
+//
+// broadcast_to_topic_by_user_logic.route_by_derived_topics_2 failed with the identical error in the
+// same run, so whatever this is, it is not specific to either class.
+//
+// Three candidates were tested and eliminated. Do not re-run these:
+//
+//   - Teardown ordering. DisposeAsync below stops the Broker BEFORE the two hosts still connected to
+//     it, and 7 of the 12 broker-using classes in this project share that shape. It looks like the
+//     obvious culprit and it is not: a faithful reproduction -- sender and receiver hosts, a real
+//     tracked broadcast through the broker, then broker-first teardown -- throws nothing in 10 runs,
+//     in either ordering.
+//   - A port collision between Bobcat worker processes. PortFinder.GetAvailablePort() is a genuine
+//     TOCTOU: it binds port 0, reads the port, closes the socket, and the broker binds later. But a
+//     collision cannot produce this error -- MQTTnet throws SocketException "Address already in use",
+//     which fails the whole class at InitializeAsync rather than breaking a pipe mid-test.
+//   - Local reproduction under concurrency. Six concurrent full-suite runs (three processes, twice)
+//     produced no occurrence at all.
+//
+// What is left standing is a keep-alive drop under CI load, which needs a call site to confirm. The
+// ledger now records the failing attempt's stack (GH-3763, PR #3811), so the next occurrence writes it
+// into the test-ledger-CIMQTT5 artifact. Start there, not from scratch.
+//
+// Worth weighing before spending more on it: this is one retry, it has never turned main red, and two
+// rounds of investigation have already gone into it.
 [Collection("acceptance")]
 public class listen_with_topic_wildcards : IAsyncLifetime
 {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
@@ -160,10 +160,21 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
 //     SingleRecord throw.
 //
 // What remains: the class still passes 7/7 alone and still costs exactly one retry in-suite, every run.
-// The remaining interference is unidentified. Next step is to dump the tracked session on the FIRST
-// attempt rather than infer from the assertion -- the fixture's queues (Queue1, multi_response,
-// global_response, multi_incoming) are fixed names in the shared default vhost and are the first
-// suspects.
+// The remaining interference is unidentified.
+//
+// The next step this note used to ask for -- "dump the tracked session on the FIRST attempt rather than
+// infer from the assertion" -- has since been built and no longer needs doing by hand. GH-3787's retry
+// ledger records the first failing attempt's error and stack for every retried test, so the dump
+// arrives on its own. From main run 30856898284:
+//
+//     System.Exception : No messages of type Wolverine.RabbitMQ.Tests.MultiTenantResponse were received
+//     Activity detected: | Service (Node Id) | Message Id | Message Type | ...
+//
+// So the request never produced its response, rather than the response going somewhere unexpected.
+// That is consistent with the standing suspicion recorded above -- the fixture's Queue1,
+// multi_response, global_response and multi_incoming are fixed names in the shared default vhost -- but
+// it does not yet prove it. The full tracked-session table and the stack are in the per-run
+// test-ledger-CIRabbitMQ artifact; read one before theorising further.
 public class multi_tenancy_through_virtual_hosts : IClassFixture<MultiTenantedRabbitFixture>
 {
     private readonly MultiTenantedRabbitFixture _fixture;


### PR DESCRIPTION
Comments only; no behaviour change.

`listen_with_topic_wildcards.broadcast` and `broadcast_to_topic_by_user_logic.route_by_derived_topics_2` each cost one retry in CIMQTT5, failing with the same error in the same run:

```
MQTTnet.Exceptions.MqttCommunicationException : Broken pipe
  ---- System.Net.Sockets.SocketException : Broken pipe
```

**Neither is tagged `Category=Flaky`, deliberately.** A tag would stop them running, and the trade this repo has been making all along is that a test which runs and occasionally retries is worth more than a test that runs nowhere. This is visible debt in the retry ledger rather than hidden debt in an exclusion list — the same trade already recorded on `multi_tenancy_through_virtual_hosts`.

## What the note buys

The search that has already been done. Three candidates tested and eliminated — recorded so nobody repeats them:

| candidate | verdict |
|---|---|
| **Teardown ordering** — both classes stop the broker before the hosts still connected to it, and 7 of 12 broker-using classes share the shape | **Refuted.** A faithful reproduction (sender + receiver, real tracked broadcast, broker-first teardown) throws nothing in 10 runs, either ordering |
| **Port collision** between worker processes via `PortFinder`'s TOCTOU | **Refuted.** MQTTnet throws `SocketException: Address already in use`, which fails the class at `InitializeAsync` rather than breaking a pipe mid-test |
| **Local reproduction under concurrency** | **No occurrence** in six concurrent full-suite runs |

Left standing is a keep-alive drop under CI load, which needs a call site. #3811 makes the ledger record one, so the next occurrence writes its stack into the `test-ledger-CIMQTT5` artifact.

The note also says plainly what it costs — one retry, never a red `main`, two rounds of investigation already spent — so the next reader can weigh that before starting a third.

## Also here

The note on `multi_tenancy_through_virtual_hosts` asked for a next step — *"dump the tracked session on the FIRST attempt rather than infer from the assertion"* — that has since been built (#3810) and now happens on its own. Amended with its first captured failure:

```
System.Exception : No messages of type MultiTenantResponse were received
Activity detected: | Service (Node Id) | Message Id | Message Type | ...
```

The request never produced its response, which is consistent with the fixed queue names already under suspicion there — without yet proving them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m