### PR TITLE
Make every readiness gate fatal, and pin the images that still rolled (GH-3763)

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -133,154 +133,162 @@ partial class Build
             WaitForPubsubEmulatorToBeReady();
     }
 
-    void WaitForPubsubEmulatorToBeReady()
+    /// <summary>
+    /// Polls until a service reports itself ready, and <b>throws</b> when the budget runs out.
+    ///
+    /// <para>Every gate in this file used to log a warning and carry on. That is how
+    /// <c>CIAzureServiceBus</c> spent 22 of its 25-retry budget on four consecutive <i>green</i> main
+    /// runs: the gate declared the emulator ready in under a second, provisioning ran against an api
+    /// still answering 503, a class fixture threw, and 22 tests failed together — as flaky tests, not
+    /// as infrastructure that never came up. It was found by accident. GH-3783 made that one gate
+    /// fatal; this makes the rest of them fatal through a single shared path, so a gate added later
+    /// cannot quietly reintroduce the warn-and-continue shape.</para>
+    ///
+    /// <para>A container that never starts should fail its job in seconds with a message naming the
+    /// service, not hand the whole suite to a broker that cannot serve it.</para>
+    /// </summary>
+    /// <param name="probe">
+    /// Returns null when the service is ready, or a short reason why it is not. Exceptions are
+    /// treated as "not ready" and their message becomes the reason, so the final error carries the
+    /// last real failure rather than a generic timeout.
+    /// </param>
+    void awaitService(string name, TimeSpan budget, Func<string> probe)
     {
-        var attempt = 0;
-        while (attempt < 30)
+        var deadline = DateTime.UtcNow.Add(budget);
+        var lastReason = "no attempt completed";
+        var attempts = 0;
+
+        while (true)
         {
+            attempts++;
+
             try
             {
-                using var tcpClient = new System.Net.Sockets.TcpClient();
-                tcpClient.Connect("localhost", 8085);
-                Log.Information("GCP Pub/Sub emulator is up and ready!");
-                return;
+                var reason = probe();
+                if (reason is null)
+                {
+                    Log.Information("{Service} is up and ready (attempt {Attempts})", name, attempts);
+                    return;
+                }
+
+                lastReason = reason;
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                // ignore connection errors
+                lastReason = e.Message;
             }
+
+            if (DateTime.UtcNow >= deadline) break;
 
             Thread.Sleep(2000);
-            attempt++;
         }
 
-        Log.Warning("GCP Pub/Sub emulator did not become ready after 60 seconds");
+        throw new InvalidOperationException(
+            $"{name} was not ready after {budget.TotalSeconds:n0}s ({attempts} attempts). " +
+            $"Last attempt: {lastReason}");
+    }
+
+    /// <summary>
+    /// Opens a TCP connection, returning null when it succeeds. The weakest probe shape available —
+    /// a listening socket is not the same claim as a broker that will serve a request — so prefer a
+    /// real protocol call wherever the client library is already referenced here.
+    /// </summary>
+    static string tcpProbe(string host, int port)
+    {
+        using var tcpClient = new System.Net.Sockets.TcpClient();
+        tcpClient.Connect(host, port);
+        return null;
+    }
+
+    void WaitForPubsubEmulatorToBeReady()
+    {
+        // The emulator answers HTTP on its main port, so this asks it a question rather than only
+        // checking that something is listening — the distinction the ASB gate was built on.
+        using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        awaitService("GCP Pub/Sub emulator", TimeSpan.FromSeconds(60), () =>
+        {
+            var response = http.GetAsync("http://localhost:8085/").GetAwaiter().GetResult();
+
+            // Any HTTP answer means the emulator is serving. Deliberately not asserting 200: the
+            // lesson from GH-3783 is that pinning a gate to one status code is how it hangs when the
+            // service legitimately answers a different one.
+            return response is null ? "no response" : null;
+        });
     }
 
     void WaitForKafkaToBeReady()
     {
-        var attempt = 0;
-        while (attempt < 30)
-        {
-            try
-            {
-                using var tcpClient = new System.Net.Sockets.TcpClient();
-                tcpClient.Connect("localhost", 9092);
-                Log.Information("Kafka is up and ready!");
-                return;
-            }
-            catch (Exception)
-            {
-                // ignore connection errors
-            }
-
-            Thread.Sleep(2000);
-            attempt++;
-        }
-
-        Log.Warning("Kafka did not become ready after 60 seconds");
+        // Still TCP-only, and knowingly the weakest gate here: a Kafka broker accepts connections
+        // before it will serve metadata or allow topic creation, so this can pass while the broker
+        // is not yet usable. Fixing it properly means a metadata request through an AdminClient, and
+        // Confluent.Kafka is not referenced by this build project (nor centrally versioned), so that
+        // is a change with its own risk rather than a line here. Tracked separately; making the gate
+        // fatal is the part that matters today.
+        awaitService("Kafka", TimeSpan.FromSeconds(60), () => tcpProbe("localhost", 9092));
     }
 
     void WaitForSqlServerToBeReady()
     {
-        var attempt = 0;
-        while (attempt < 30)
+        // Budget is now wall-clock rather than an attempt count. The old "60 seconds" in the warning
+        // was never true: each failed attempt could burn the connection's own 5s timeout before the
+        // 2s sleep, so 30 attempts was anywhere from 60s to 210s depending on how the failure came
+        // back. A deadline says what it means.
+        awaitService("SQL Server", TimeSpan.FromMinutes(2), () =>
         {
-            try
-            {
-                using var conn = new Microsoft.Data.SqlClient.SqlConnection("Server=localhost,1434;User Id=sa;Password=P@55w0rd;Timeout=5;Encrypt=False");
-                conn.Open();
-                var cmd = conn.CreateCommand();
-                cmd.CommandText = "SELECT 1";
-                cmd.ExecuteNonQuery();
-                Log.Information("SQL Server is up and ready!");
-                return;
-            }
-            catch (Exception)
-            {
-                Thread.Sleep(2000);
-                attempt++;
-            }
-        }
-
-        Log.Warning("SQL Server did not become ready after 60 seconds");
+            using var conn = new Microsoft.Data.SqlClient.SqlConnection(
+                "Server=localhost,1434;User Id=sa;Password=P@55w0rd;Timeout=5;Encrypt=False");
+            conn.Open();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+            return null;
+        });
     }
 
     void WaitForMySqlToBeReady()
     {
-        var attempt = 0;
-        while (attempt < 30)
+        awaitService("MySQL", TimeSpan.FromMinutes(2), () =>
         {
-            try
-            {
-                using var conn = new MySqlConnector.MySqlConnection("Server=localhost;Port=3306;Database=wolverine;User=root;Password=P@55w0rd;");
-                conn.Open();
-                var cmd = conn.CreateCommand();
-                cmd.CommandText = "SELECT 1";
-                cmd.ExecuteNonQuery();
-                Log.Information("MySQL is up and ready!");
-                return;
-            }
-            catch (Exception)
-            {
-                Thread.Sleep(2000);
-                attempt++;
-            }
-        }
-
-        Log.Warning("MySQL did not become ready after 60 seconds");
+            using var conn = new MySqlConnector.MySqlConnection(
+                "Server=localhost;Port=3306;Database=wolverine;User=root;Password=P@55w0rd;");
+            conn.Open();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            cmd.ExecuteNonQuery();
+            return null;
+        });
     }
 
     void WaitForOracleToBeReady()
     {
-        var attempt = 0;
-        while (attempt < 60)
+        // Oracle is the slowest image in the compose file to reach a usable state, hence the roomiest
+        // budget. Connecting as the application user against FREEPDB1 (rather than pinging the
+        // listener) is deliberate: the listener answers well before the pluggable database will
+        // accept an application login.
+        awaitService("Oracle", TimeSpan.FromMinutes(3), () =>
         {
-            try
-            {
-                using var conn = new Oracle.ManagedDataAccess.Client.OracleConnection("User Id=wolverine;Password=wolverine;Data Source=localhost:1521/FREEPDB1");
-                conn.Open();
-                var cmd = conn.CreateCommand();
-                cmd.CommandText = "SELECT 1 FROM DUAL";
-                cmd.ExecuteNonQuery();
-                Log.Information("Oracle is up and ready!");
-                return;
-            }
-            catch (Exception)
-            {
-                Thread.Sleep(2000);
-                attempt++;
-            }
-        }
-
-        Log.Warning("Oracle did not become ready after 120 seconds");
+            using var conn = new Oracle.ManagedDataAccess.Client.OracleConnection(
+                "User Id=wolverine;Password=wolverine;Data Source=localhost:1521/FREEPDB1");
+            conn.Open();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1 FROM DUAL";
+            cmd.ExecuteNonQuery();
+            return null;
+        });
     }
 
     void WaitForLocalStackToBeReady()
     {
-        var attempt = 0;
         using var httpClient = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
-        while (attempt < 30)
+
+        awaitService("LocalStack", TimeSpan.FromMinutes(2), () =>
         {
-            try
-            {
-                var response = httpClient.GetAsync("http://localhost:4566/_localstack/health").GetAwaiter().GetResult();
-                if (response.IsSuccessStatusCode)
-                {
-                    Log.Information("LocalStack is up and ready!");
-                    return;
-                }
-            }
-            catch (Exception)
-            {
-                // ignore connection errors
-            }
+            var response = httpClient.GetAsync("http://localhost:4566/_localstack/health")
+                .GetAwaiter().GetResult();
 
-            Thread.Sleep(2000);
-            attempt++;
-        }
-
-        Log.Warning("LocalStack did not become ready after 60 seconds");
+            return response.IsSuccessStatusCode ? null : $"health endpoint answered {(int)response.StatusCode}";
+        });
     }
 
     /// <summary>
@@ -311,42 +319,26 @@ partial class Build
         // depend on getting the ATOM api-version right here.
         const string managementProbe = "http://localhost:5300/$Resources/topics";
 
-        var deadline = DateTime.UtcNow.AddMinutes(3);
-        var lastReason = "no attempt completed";
-
-        while (DateTime.UtcNow < deadline)
+        // Deliberately fatal, via the same shared path as every other gate. This used to log a warning
+        // and carry on, so an emulator that never came up at all still fed the entire suite into a
+        // broker that could not serve it — and the resulting failures read as flaky tests rather than
+        // as infrastructure that never started.
+        awaitService("Azure Service Bus emulator", TimeSpan.FromMinutes(3), () =>
         {
-            try
+            using (var tcpClient = new System.Net.Sockets.TcpClient())
             {
-                using (var tcpClient = new System.Net.Sockets.TcpClient())
-                {
-                    tcpClient.Connect("localhost", 5673);
-                }
-
-                var response = http.GetAsync(managementProbe).GetAwaiter().GetResult();
-                if (response.StatusCode != System.Net.HttpStatusCode.ServiceUnavailable)
-                {
-                    Log.Information(
-                        "Azure Service Bus emulator is up and ready for provisioning (management api answered {StatusCode})",
-                        (int)response.StatusCode);
-                    return;
-                }
-
-                lastReason = "the management api on 5300 is still warming up (503)";
-            }
-            catch (Exception e)
-            {
-                lastReason = e.Message;
+                tcpClient.Connect("localhost", 5673);
             }
 
-            Thread.Sleep(2000);
-        }
+            var response = http.GetAsync(managementProbe).GetAwaiter().GetResult();
 
-        // Deliberately fatal. This used to log a warning and carry on, so an emulator that never came up at
-        // all still fed the entire suite into a broker that could not serve it — and the resulting failures
-        // read as flaky tests rather than as infrastructure that never started.
-        throw new InvalidOperationException(
-            $"The Azure Service Bus emulator was not ready for provisioning after 3 minutes. Last attempt: {lastReason}");
+            // Keyed on "not 503", NOT on "== 200". CI answers 400 here and a developer machine
+            // answers 200; asserting 200 would hang for the whole budget and then fail the job. This
+            // distinction cost a day to find — do not tighten it.
+            return response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable
+                ? "the management api on 5300 is still warming up (503)"
+                : null;
+        });
     }
 
     /// <summary>

--- a/build/build.cs
+++ b/build/build.cs
@@ -405,30 +405,29 @@ partial class Build : NukeBuild
         return output.Any(line => line.Contains(toolName, StringComparison.OrdinalIgnoreCase));
     }
 
+    /// <summary>
+    /// Postgres readiness. This was the thinnest gate in the build by a wide margin: ten attempts
+    /// separated by 250ms is a <b>2.5 second</b> budget for a container start, after which it logged
+    /// an error and let the suite run anyway.
+    ///
+    /// <para>It was already running out of room in production. In CIMQTT5 on main run 30847233633 it
+    /// spent four of its ten attempts before Postgres answered — roughly 1.1s of a 2.5s allowance —
+    /// so a slower runner would have sailed past the end and started the tests against a database
+    /// that was not up. Every failure after that would have looked like a test problem.</para>
+    /// </summary>
     private void WaitForDatabaseToBeReady()
     {
-        var attempt = 0;
-        while (attempt < 10)
-            try
-            {
-                using var conn = new Npgsql.NpgsqlConnection(PostgresConnectionString + ";Pooling=false");
-                conn.Open();
+        awaitService("PostgreSQL", TimeSpan.FromMinutes(2), () =>
+        {
+            using var conn = new Npgsql.NpgsqlConnection(PostgresConnectionString + ";Pooling=false");
+            conn.Open();
 
-                var cmd = conn.CreateCommand();
-                cmd.CommandText = "select 1";
-                cmd.ExecuteNonQuery();
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "select 1";
+            cmd.ExecuteNonQuery();
 
-                Log.Information("Postgresql is up and ready!");
-                return;
-            }
-            catch (Exception ex)
-            {
-                Log.Information("Database is not ready ({Error})", ex.Message);
-                Thread.Sleep(250);
-                attempt++;
-            }
-
-        Log.Error("Database is not ready after all attempts.");
+            return null;
+        });
     }
 
     private Dictionary<string, string[]> ReferencedProjects = new()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,9 @@ services:
   # GCS emulator used by the WolverineFx.ClaimCheck.GoogleCloudStorage backend tests.
   # Serves plain HTTP on 4443; tests point the client at it via STORAGE_EMULATOR_HOST.
   fake-gcs-server:
-    image: "fsouza/fake-gcs-server:latest"
+    # Pinned: :latest resolved to exactly this tag when it was pinned, so this is byte-for-byte what
+    # CI had been running. See the note on asb-emulator below for why a rolling tag is a trap here.
+    image: "fsouza/fake-gcs-server:1.55.1"
     ports:
       - "4443:4443"
     command: ["-scheme", "http", "-host", "0.0.0.0", "-port", "4443", "-public-host", "localhost:4443"]
@@ -73,7 +75,11 @@ services:
   # If you're working locally on ARM and don't need Polecat tests, you can override this service 
   # using `docker-compose -f docker-compose.yml -f docker-compose.azure-sql-edge.yml up -d`
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2025-latest
+    # 2025-latest is a rolling tag: it moves on every cumulative update, CI pulls it fresh every run,
+    # and a developer machine keeps whatever it pulled months ago. Pinned by digest rather than tag
+    # because no concrete 2025-CU* tag matches the 2025-latest manifest -- the same reason
+    # azure-sql-edge below is pinned by digest. This is byte-for-byte what CI was already running.
+    image: mcr.microsoft.com/mssql/server@sha256:aff82a722378e1e30125d566dae40d4678e66ec3f7814fbe26cb1746b150b910
     ports:
       - "1434:1433"
     environment:
@@ -83,7 +89,9 @@ services:
       - "MSSQL_PID=Developer"
 
   pulsar:
-    image: "apachepulsar/pulsar:4.0.3"
+    # Kept in step with PulsarContainerFixture, which is what CI actually runs against (Testcontainers).
+    # This said 4.0.3 while the fixture said :latest -- two different Pulsars for the same test suite.
+    image: "apachepulsar/pulsar:4.2.4"
     ports:
       - "6650:6650"
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,13 @@ services:
     # and a developer machine keeps whatever it pulled months ago. Pinned by digest rather than tag
     # because no concrete 2025-CU* tag matches the 2025-latest manifest -- the same reason
     # azure-sql-edge below is pinned by digest. This is byte-for-byte what CI was already running.
-    image: mcr.microsoft.com/mssql/server@sha256:aff82a722378e1e30125d566dae40d4678e66ec3f7814fbe26cb1746b150b910
+    #
+    # Resolve this digest with `docker buildx imagetools inspect <image>:<tag>`, never with a curl of
+    # the registry's manifest endpoint. A HEAD with an Accept for a manifest LIST returns MCR a
+    # digest for a representation that does not exist as a pullable manifest here -- this tag is a
+    # single-platform manifest -- and the resulting pin fails every job that needs SQL Server with
+    # "manifest unknown". Ask the tool that will do the pulling.
+    image: mcr.microsoft.com/mssql/server@sha256:86cc6144ef39bb0fbed2329e1ad79b13ee82e7b2e4739213a0db0800e668a74a
     ports:
       - "1434:1433"
     environment:
@@ -129,7 +135,9 @@ services:
       - "6379:6379"
 
   nats:
-    image: "nats:2"
+    # Kept in step with NatsContainerFixture.NatsImage, which is what the NATS tests actually run
+    # against (Testcontainers). "nats:2" is a floating minor; it happens to equal 2.14.4 today.
+    image: "nats:2.14.4"
     ports:
       - "4222:4222"
       - "8222:8222"

--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsContainerFixture.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsContainerFixture.cs
@@ -5,6 +5,17 @@ namespace Wolverine.Nats.Tests;
 
 public class NatsContainerFixture : IAsyncLifetime
 {
+    /// <summary>
+    /// GH-3799. Pinned, and shared by every NATS container in this project so the version lives in
+    /// one place instead of three string literals that can drift apart.
+    ///
+    /// <para>2.14.4 is exactly what <c>nats:latest</c> resolved to when this was pinned, so nothing
+    /// about what CI runs changes — it just stops changing on its own. A rolling tag is pulled fresh
+    /// on every CI run and never on a developer machine, which is how a moving
+    /// <c>servicebus-emulator</c> spent four runs looking like a code regression (GH-3783).</para>
+    /// </summary>
+    public const string NatsImage = "nats:2.14.4";
+
     private static NatsContainer? _container;
     private static string? _connectionString;
     private static int _referenceCount;
@@ -21,7 +32,7 @@ public class NatsContainerFixture : IAsyncLifetime
             if (_container != null) return;
 
             _container = new NatsBuilder()
-                .WithImage("nats:latest")
+                .WithImage(NatsImage)
                 .Build();
 
             await _container.StartAsync();

--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsNamedBrokerTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsNamedBrokerTests.cs
@@ -102,7 +102,7 @@ public class NatsNamedBrokerTests : IAsyncLifetime
             return;
         }
 
-        _serverB = new NatsBuilder().WithImage("nats:latest").Build();
+        _serverB = new NatsBuilder().WithImage(NatsContainerFixture.NatsImage).Build();
         await _serverB.StartAsync();
         _serverBUrl = _serverB.GetConnectionString();
 

--- a/src/Transports/NATS/Wolverine.Nats.Tests/NatsPerTenantConnectionTests.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/NatsPerTenantConnectionTests.cs
@@ -54,7 +54,7 @@ public class NatsPerTenantConnectionTests : IAsyncLifetime
 
         // Server B is a second, independent broker so "used the tenant's own connection" is provable: the
         // message can only appear on B if the dedicated connection carried it there.
-        _serverB = new NatsBuilder().WithImage("nats:latest").Build();
+        _serverB = new NatsBuilder().WithImage(NatsContainerFixture.NatsImage).Build();
         await _serverB.StartAsync();
         _serverBUrl = _serverB.GetConnectionString();
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarContainerFixture.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarContainerFixture.cs
@@ -6,6 +6,17 @@ namespace Wolverine.Pulsar.Tests;
 
 public static class PulsarContainerFixture
 {
+    /// <summary>
+    /// GH-3799. Pinned, and shared by every Pulsar container in this project.
+    ///
+    /// <para>4.2.4 is exactly what <c>apachepulsar/pulsar:latest</c> resolved to when this was
+    /// pinned — and <c>:latest</c> had moved to it that same day, so CI's Pulsar was changing under
+    /// the suite with nothing in the repository recording it. docker-compose.yml is set to the same
+    /// version; it previously said 4.0.3, which meant a developer and CI were running different
+    /// brokers for the same tests.</para>
+    /// </summary>
+    public const string PulsarImage = "apachepulsar/pulsar:4.2.4";
+
     private static PulsarContainer? _container;
 
     public static Uri ServiceUrl { get; private set; } = new("pulsar://localhost:6650");
@@ -35,7 +46,7 @@ public static class PulsarContainerFixture
         // Console.Out. The banner lands in the raw protocol channel and the whole assembly dies
         // with "Test process did not return valid JSON", running no tests at all.
         _container = new PulsarBuilder()
-            .WithImage("apachepulsar/pulsar:latest")
+            .WithImage(PulsarImage)
             .WithLogger(NullLogger.Instance)
             .Build();
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarPerTenantConnectionTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarPerTenantConnectionTests.cs
@@ -44,7 +44,7 @@ public class PulsarPerTenantConnectionTests : IAsyncLifetime
 
         try
         {
-            _clusterB = new PulsarBuilder().WithImage("apachepulsar/pulsar:latest").Build();
+            _clusterB = new PulsarBuilder().WithImage(PulsarContainerFixture.PulsarImage).Build();
             await _clusterB.StartAsync();
             _clusterBServiceUrl = new Uri(_clusterB.GetBrokerAddress());
 


### PR DESCRIPTION
Two failure modes that have each already cost this repo real time, both still live.

## 1. Readiness gates

**Seven of eight gates logged a warning and carried on.** That is precisely the shape that made `CIAzureServiceBus` spend 22 of its 25-retry budget on four consecutive **green** main runs — the gate declared the emulator ready in under a second, provisioning ran against a management API still answering 503, a class fixture threw, and 22 tests failed together, reported as flaky tests rather than infrastructure that never came up. It was found by accident. #3783 made that one gate fatal and left the rest.

| gate | before | after |
|---|---|---|
| ASB emulator | throws | throws (moved onto shared path) |
| Pub/Sub | TCP, warn+continue | **HTTP**, throws |
| Kafka | TCP, warn+continue | TCP, **throws** |
| SqlServer / MySql / Oracle | conn, warn+continue | conn, **throws** |
| LocalStack | HTTP, warn+continue | HTTP, **throws** |
| **Postgres** | conn, **2.5s budget**, warn+continue | conn, 2min, **throws** |

They now share one path, `awaitService`, which throws when its budget expires and names the service, budget, attempt count and last real error. The single path matters as much as the behaviour — a gate added later cannot quietly reintroduce warn-and-continue.

### The Postgres gate was already failing in production

Ten attempts separated by 250ms is a **2.5 second** budget for a container start, after which it logged an error and let the suite run anyway. In CIMQTT5 on main run [30847233633](https://github.com/JasperFx/wolverine/actions/runs/30847233633) it spent four of its ten attempts before Postgres answered — ~1.1s of its 2.5s allowance:

```
[INF] Database is not ready (Exception while reading from stream)   ×4
[INF] Postgresql is up and ready!
```

A slower runner sails past the end and starts tests against a database that is not up. Every failure after that looks like a test problem.

### Two probes changed shape, not just their ending
- **Pub/Sub**: TCP connect → HTTP request, so it asks the emulator a question rather than checking that something is listening.
- **Budgets**: attempt counts → wall-clock deadlines. The old SQL Server `"60 seconds"` was never true — each failed attempt could burn the connection's own 5s timeout before the 2s sleep, making 30 attempts anywhere from 60s to 210s.

**Kafka is knowingly still TCP-only** — a broker accepts connections before it will serve metadata — because a real probe needs `Confluent.Kafka`, which this build project does not reference. Filed separately; making it fatal is what matters today.

The **ASB gate keeps its semantics exactly**, including keying on *not 503* rather than *== 200*: CI answers 400 there and a dev machine answers 200, so asserting 200 would hang the full budget and fail the job.

## 2. Image pins

Every remaining rolling tag CI pulls is pinned to **exactly what it resolved to**, so nothing about what CI runs changes — it just stops changing on its own.

| image | was | now |
|---|---|---|
| `apachepulsar/pulsar` (×2) | `:latest` | `4.2.4` |
| `nats` (×3) | `:latest` | `2.14.4` (one shared constant) |
| `fsouza/fake-gcs-server` | `:latest` | `1.55.1` (same digest) |
| `mcr.microsoft.com/mssql/server` | `2025-latest` | **digest** |

**Pulsar was live.** `:latest` moved to 4.2.4 on 2026-08-03 — the same day — while `docker-compose.yml` said `4.0.3`. CI uses Testcontainers, so CI and a developer running `docker compose up` were on *different Pulsar versions*, and only one of them could move without warning. Both now say 4.2.4. That is the concrete half of #3799.

SQL Server is pinned by **digest** because no concrete `2025-CU*` tag matches the `2025-latest` manifest — the same reason `azure-sql-edge` is pinned by digest.

**Not changed:** `jaegertracing/all-in-one:latest` in `src/Testing/OpenTelemetry/docker-compose.yml`. That file is referenced by no build target and no workflow — a local tracing demo, not a CI exposure. Calling it out so "no rolling tags remain" is not overclaimed.

## Verification

```
PROBE throw-path OK: BogusService was not ready after 3s (3 attempts).
                     Last attempt: Connection refused [::ffff:127.0.0.1]:59999
GCP Pub/Sub emulator is up and ready (attempt 1)
PostgreSQL is up and ready (attempt 1)
```

Throw path, the reshaped Pub/Sub probe, and the Postgres gate (which lives in `build.cs` and proves the cross-file wiring) all verified against live containers. **The remaining gates are exercised by CI itself** — every job starts its services through them, so a wrong probe fails that specific job in this PR rather than hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m