### PR TITLE
Fix two test-side races behind the CISqlServer retries (GH-3821)

### DIFF
--- a/src/Persistence/MartenTests/Persistence/marten_durability_end_to_end.cs
+++ b/src/Persistence/MartenTests/Persistence/marten_durability_end_to_end.cs
@@ -190,18 +190,30 @@ public class marten_durability_end_to_end : IAsyncLifetime
     protected async Task WaitForMessagesToBeProcessed(int count)
     {
         await using var session = _receiverStore.QuerySession();
+
+        var actual = 0L;
+        long envelopeCount = 0;
+        long outgoingCount = 0;
+
         for (var i = 0; i < 480; i++)
         {
-            var actual = await session.Query<TraceDoc>().CountAsync();
-            var envelopeCount = await PersistedIncomingCount();
+            actual = await session.Query<TraceDoc>().CountAsync();
+            envelopeCount = await PersistedIncomingCount();
 
-            if (actual == count && envelopeCount == 0)
+            // The sender deletes its outgoing rows through a RetryBlock that is POSTED to
+            // rather than awaited (DurableSendingAgent.MarkSuccessfulAsync), so the sender's
+            // outbox can still be draining after the receiver has processed everything. Wait
+            // for it here rather than letting the callers' assertions race the drain. GH-3821.
+            outgoingCount = await PersistedOutgoingCount();
+
+            if (actual == count && envelopeCount == 0 && outgoingCount == 0)
                 return;
 
             await Task.Delay(250);
         }
 
-        throw new Exception("All messages were not received");
+        throw new Exception(
+            $"All messages were not received. Expected {count} trace docs with 0 incoming and 0 outgoing envelopes, but last saw {actual} trace docs, {envelopeCount} incoming and {outgoingCount} outgoing.");
     }
 
     protected async Task<long> PersistedIncomingCount()

--- a/src/Persistence/SqlServerTests/Persistence/SqlServerMessageStoreTests.cs
+++ b/src/Persistence/SqlServerTests/Persistence/SqlServerMessageStoreTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Shouldly;
 using Weasel.Core;
 using Wolverine;
@@ -13,6 +14,7 @@ using Wolverine.Persistence.Durability;
 using Wolverine.RDBMS;
 using Wolverine.RDBMS.Durability;
 using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.WorkerQueues;
 using Wolverine.SqlServer;
@@ -172,7 +174,12 @@ public class SqlServerMessageStoreTests : MessageStoreCompliance
 
         var durabilitySettings = theHost.Services.GetRequiredService<DurabilitySettings>();
 
-        var runtime = theHost.GetRuntime();
+        // Use a substituted runtime rather than the live one. PollForScheduledMessagesAsync
+        // reassigns ownership AND hands the envelope straight to the execution pipeline via
+        // IWolverineRuntime.EnqueueDirectlyAsync. With the real runtime the envelope is picked
+        // up off local://replies and marked Handled within ~250ms, so asserting on the row's
+        // status is a race the test only usually wins -- it lost twice on CI. See GH-3821.
+        var runtime = Substitute.For<IWolverineRuntime>();
 
         await thePersistence.As<IMessageDatabase>().PollForScheduledMessagesAsync(runtime, NullLogger.Instance, durabilitySettings, TestContext.Current.CancellationToken);
 
@@ -180,6 +187,9 @@ public class SqlServerMessageStoreTests : MessageStoreCompliance
 
         stored.OwnerId.ShouldBe(durabilitySettings.AssignedNodeNumber);
         stored.Status.ShouldBe(EnvelopeStatus.Incoming);
+
+        // and the poll really did hand the envelope off to be executed
+        await runtime.Received().EnqueueDirectlyAsync(Arg.Is<IReadOnlyList<Envelope>>(x => x.Count == 1));
     }
     
         [Fact]

--- a/src/Persistence/SqlServerTests/Persistence/SqlServerMessageStore_with_IdAndDestination_Identity.cs
+++ b/src/Persistence/SqlServerTests/Persistence/SqlServerMessageStore_with_IdAndDestination_Identity.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Shouldly;
 using Weasel.Core;
 using Weasel.SqlServer;
@@ -14,6 +15,7 @@ using Wolverine.Persistence.Durability;
 using Wolverine.RDBMS;
 using Wolverine.RDBMS.Durability;
 using Wolverine.RDBMS.Polling;
+using Wolverine.Runtime;
 using Wolverine.Runtime.WorkerQueues;
 using Wolverine.SqlServer;
 using Wolverine.SqlServer.Schema;
@@ -168,14 +170,20 @@ public class SqlServerMessageStore_with_IdAndDestination_Identity : MessageStore
 
         var durabilitySettings = theHost.Services.GetRequiredService<DurabilitySettings>();
 
-        var runtime = theHost.GetRuntime();
-        
+        // See the note on the twin of this test in SqlServerMessageStoreTests -- the live
+        // runtime would enqueue this envelope for execution and it would be marked Handled
+        // out from under the assertion below. GH-3821.
+        var runtime = Substitute.For<IWolverineRuntime>();
+
         await thePersistence.As<IMessageDatabase>().PollForScheduledMessagesAsync(runtime, NullLogger.Instance, durabilitySettings, TestContext.Current.CancellationToken);
 
         var stored = (await thePersistence.Admin.AllIncomingAsync()).Single();
 
         stored.OwnerId.ShouldBe(durabilitySettings.AssignedNodeNumber);
         stored.Status.ShouldBe(EnvelopeStatus.Incoming);
+
+        // and the poll really did hand the envelope off to be executed
+        await runtime.Received().EnqueueDirectlyAsync(Arg.Is<IReadOnlyList<Envelope>>(x => x.Count == 1));
     }
     
     [Fact]

--- a/src/Persistence/SqlServerTests/sqlserver_durability_end_to_end.cs
+++ b/src/Persistence/SqlServerTests/sqlserver_durability_end_to_end.cs
@@ -170,16 +170,29 @@ create table receiver.trace_doc
         await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
         await conn.OpenAsync();
 
+        var actual = 0;
+        long envelopeCount = 0;
+        long outgoingCount = 0;
+
         for (var i = 0; i < 200; i++)
         {
             await using var cmd = conn.CreateCommand("select count(*) from receiver.trace_doc");
             var countResult = await cmd.ExecuteScalarAsync();
-            var actual = Convert.ToInt32(countResult);
-            var envelopeCount = PersistedIncomingCount();
+            actual = Convert.ToInt32(countResult);
+            envelopeCount = PersistedIncomingCount();
 
-            Trace.WriteLine($"waitForMessages: {actual} actual & {envelopeCount} incoming envelopes");
+            // The sender deletes its outgoing rows through a RetryBlock that is POSTED to
+            // rather than awaited (DurableSendingAgent.MarkSuccessfulAsync), so the sender's
+            // outbox can still be draining after the receiver has processed everything. This
+            // condition used to be left to the assertions in the tests below, which meant they
+            // raced the drain -- on CI that surfaced as "PersistedOutgoingCount() should be 0
+            // but was 10". Wait for the drain here instead. GH-3821.
+            outgoingCount = PersistedOutgoingCount();
 
-            if (actual == count && envelopeCount == 0)
+            Trace.WriteLine(
+                $"waitForMessages: {actual} actual & {envelopeCount} incoming envelopes & {outgoingCount} outgoing envelopes");
+
+            if (actual == count && envelopeCount == 0 && outgoingCount == 0)
             {
                 await conn.CloseAsync();
                 return;
@@ -188,7 +201,8 @@ create table receiver.trace_doc
             await Task.Delay(250);
         }
 
-        throw new Exception("All messages were not received");
+        throw new Exception(
+            $"All messages were not received. Expected {count} trace docs with 0 incoming and 0 outgoing envelopes, but last saw {actual} trace docs, {envelopeCount} incoming and {outgoingCount} outgoing.");
     }
 
     protected long PersistedIncomingCount()
@@ -227,7 +241,7 @@ create table receiver.trace_doc
         _senders.Remove(name);
     }
 
-    [Fact] // This test "blinks"
+    [Fact]
     public async Task sending_recovered_messages_when_sender_starts_up()
     {
         StartSender("Sender1");


### PR DESCRIPTION
Closes #3821.

Both retries on `CISqlServer` in the last green `main` run (30877953106) were races **in the tests**,
not product bugs. The handoff flagged these as "the most likely real product bug currently visible
anywhere in CI" — that turned out not to be the case, but they were worth chasing down, and they only
became attributable at all because of the retry-ledger work in #3810.

### 1. `should_reasign_incoming_envelope_to_owner_id` — reproduced

`PollForScheduledMessagesAsync` does two things in one call: it reassigns ownership and flips the row
to `Incoming`, then hands the envelope straight to the execution pipeline
(`SqlServerMessageStore.cs:459`). `ObjectMother.Envelope()` is addressed to
`TransportConstants.RepliesUri` (`local://replies`), so with the **live** runtime the envelope is
enqueued onto a live local queue, executed, and marked `Handled` — while the test is still on its way
to reading the row back. Sampling the row after the poll:

```
PROBE t=0ms    count=1 :: status=Incoming owner=1
PROBE t=250ms  count=1 :: status=Handled  owner=1   <- and stays Handled
```

This also explains the exact failure shape. `MarkIncomingEnvelopeAsHandledAsync` writes `status` and
`keep_until` and leaves `owner_id` alone, so the `OwnerId` assertion passes and the `Status`
assertion fails — which is precisely what CI reported.

**Fix:** pass a substituted `IWolverineRuntime`. The poll uses `runtime` for nothing but
`EnqueueDirectlyAsync`, so this isolates the database behaviour the test exists to cover. With the
substitute the row is stable across 2s of sampling. The substitute is then asserted against, so the
test now also covers the hand-off, which it never verified before.

Applies to both copies (`SqlServerMessageStoreTests` and
`SqlServerMessageStore_with_IdAndDestination_Identity`).

### 2. `sending_recovered_messages_when_sender_starts_up` — not reproduced locally

`WaitForMessagesToBeProcessed` only synchronises on the **receiver** (`trace_doc` count and the
receiver's incoming table). The assertion immediately after it is against the **sender's** outgoing
table, which nothing waited on. Deletion there is asynchronous by construction —
`DurableSendingAgent.MarkSuccessfulAsync` *posts* to a `RetryBlock` rather than awaiting it — so every
send can have succeeded (receiver has all 10 trace docs) while all 10 deletes are still queued. That
is exactly `should be 0 but was 10`.

**Fix:** wait for the drain in the loop, and report the last observed counts on timeout instead of a
bare "All messages were not received".

> **Caveat, stated up front:** I could not reproduce this one locally. Instrumenting the loop to
> record the outgoing count at the moment the *old* exit condition first became true gave
> `outgoingCount=0` on all 6 measured runs — the drain finishes in under 250ms on a quiet machine. The
> fix closes a synchronisation gap that exists by construction, but the timing evidence for it is the
> CI failure itself, not a local red/green. Reviewers should weigh it on that basis.

The stale `// This test "blinks"` comment is dropped.

### Scope

- `sqlserver_durability_end_to_end` — wait for the outbox drain
- `SqlServerMessageStoreTests`, `SqlServerMessageStore_with_IdAndDestination_Identity` — substituted runtime + hand-off assertion
- `marten_durability_end_to_end` — same wait-loop gap, fixed and verified
- **RavenDb twin — deliberately left alone.** It has the same gap (and already reads the outgoing
  count for its trace line at `ravendb_durability_end_to_end.cs:155` without using it in the exit
  condition, so someone hit this before and stopped at instrumentation). There is no `ravendb`
  service in `docker-compose.yml`, so I can't run it — and the most expensive lesson in the current
  handoff is shipping an unverified one-line change that reddened 9 jobs. Left as follow-up.

### Verification

- Full `SqlServerTests` suite: **388 passed, 0 failed, 2 skipped** (13m36s)
- `marten_durability_end_to_end`: 2 passed
- Full `wolverine.slnx` Release build clean before push (per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m
