### PR TITLE
Complete a tracked session only when ALL conditions are satisfied (GH-3824)

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_1933_multi_tenant_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_1933_multi_tenant_conventional_routing.cs
@@ -20,7 +20,7 @@ public static class Bug1933MessageHandler
 // 2, and 5.5m for the class. The broker starts fine now; the survivor is
 // should_receive_message_when_published_without_tenant_id, which fails as a TrackedSession timeout
 // after 4m28s -- the message is Sent and never Received. That is real multi-tenant routing
-// behaviour, not provisioning. Needs its own issue.
+// behaviour, not provisioning. Tracked as GH-3826.
 [Trait("Category", "Flaky")]
 public class Bug_1933_multi_tenant_conventional_routing : IAsyncLifetime
 {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2307_batching_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2307_batching_with_conventional_routing.cs
@@ -19,7 +19,7 @@ namespace Wolverine.AzureServiceBus.Tests.Bugs;
 //
 // The listener IS created for the batch element type (that much of GH-2307 works) -- its
 // EndpointName is just the raw type name rather than the sanitized queue name. A naming bug in the
-// GH-2307 fix, not a routing or provisioning failure. Needs its own issue.
+// GH-2307 fix, not a routing or provisioning failure. Tracked as GH-3827.
 [Trait("Category", "Flaky")]
 public class Bug_2307_batching_with_conventional_routing : IAsyncLifetime
 {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
@@ -13,7 +13,7 @@ namespace Wolverine.AzureServiceBus.Tests;
 // no broker-initialization timeout anywhere in it -- the two failures are
 // send_and_receive_multiple_messages_to_queue_with_session_identifier and
 // split_messages_with_different_sessionids_into_separate_batches, i.e. SESSION handling, which
-// conventional routing never touched. The other 4 pass. Needs its own issue; do not fold it back
+// conventional routing never touched. The other 4 pass. Tracked as GH-3825; do not fold it back
 // into GH-3786.
 [Trait("Category", "Flaky")]
 public class end_to_end : IAsyncLifetime

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/end_to_end.cs
@@ -61,23 +61,25 @@ public static class RabbitTesting
     }
 }
 
-// GH-3763: stays tagged, but the earlier triage on this class was wrong in two ways and is replaced.
+// GH-3824: UNTAGGED. The last remaining failures in this class were a Wolverine bug, not flakiness.
 //
-// It cited "the exchange/binding-declaration race described in #2618" -- #2618 is a closed CI-stabilisation
-// tracer PR that describes nothing of the sort -- and it recorded
-// send_message_to_and_receive_through_rabbitmq_with_routing_key as failing 3 of 3. That test passes now.
+// The previous triage got as far as "use_fan_out_exchange and use_direct_exchange_with_binding_key each
+// pass ALONE and fail inside the class, in ~500ms on a null ColorHistory" -- all correct -- and then
+// inferred the cause: that WaitForMessageToBeReceivedAt is satisfied by MessageFailed as well as
+// MessageSucceeded, so a message that arrived and then failed ended the session early. That inference was
+// wrong. Dumping the session instead of inferring from the assertion (which is exactly what that triage
+// said to do next) showed status=Completed, ZERO exceptions, and the message marked successful -- but at
+// only ONE of the three receivers.
 //
-// What is actually true, measured 2026-08-03: use_fan_out_exchange and use_direct_exchange_with_binding_key
-// each pass ALONE (3 consecutive runs) and fail inside the class. They fail in ~500ms, nowhere near their
-// 30s tracked-session timeout, on a null ColorHistory -- which is possible because
-// WaitForMessageToBeReceivedAt is satisfied by MessageFailed as well as MessageSucceeded, so a message that
-// arrives and then fails completes the session and the test falls through to the assertion.
+// The real cause was in TrackedSession.IsCompleted(): it short-circuited on the first satisfied condition
+// (Any) rather than requiring all of them, which made the All(...) check on its own last line unreachable.
+// Both of these tests chain three WaitForMessageToBeReceivedAt calls for a fan-out, so the session returned
+// as soon as the FIRST receiver handled the message and the assertions raced the other two handlers. Alone
+// on an idle machine all three finish inside the same millisecond, which is why it only failed in-class.
 //
-// Two real causes were found and fixed in this pass (see RabbitTesting above, and the GH-3521 pins on the
-// receiver hosts), and they are not enough on their own: both tests still fail in-class. What remains is
-// unidentified cross-test state, and the next step is to dump the tracked session on failure rather than
-// infer from the assertion.
-[Trait("Category", "Flaky")]
+// Two further real causes were found and fixed earlier and were prerequisites, not red herrings: the
+// process-unique naming in RabbitTesting above, and the GH-3521 ApplicationAssembly pins on the receiver
+// hosts.
 public class end_to_end
 {
     private readonly ITestOutputHelper _output;

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -594,17 +594,20 @@ internal partial class TrackedSession : ITrackedSession
     {
         if (!_executionComplete) return false;
 
-        if (_conditions.Any(x => x.IsCompleted()))
+        if (_conditions.Any())
         {
-            return true;
+            // ALL of the conditions, not ANY. This used to short-circuit on the first satisfied
+            // condition, which made the final All(...) check below unreachable and silently broke
+            // every session that registers more than one condition -- e.g. three chained
+            // WaitForMessageToBeReceivedAt calls for a fan-out exchange returned as soon as the
+            // FIRST receiver handled the message, so assertions against the other two receivers'
+            // state raced the handlers that were still running. With a single condition ANY and ALL
+            // are the same, which is why this survived: almost every session registers just one.
+            // GH-3824.
+            return _conditions.All(x => x.IsCompleted());
         }
 
-        if (!_envelopes.All(x => x.IsComplete()))
-        {
-            return false;
-        }
-
-        return !_conditions.Any() || _conditions.All(x => x.IsCompleted());
+        return _envelopes.All(x => x.IsComplete());
     }
 
     public void LogException(Exception exception, string? serviceName)


### PR DESCRIPTION
Closes #3824.

`TrackedSession.IsCompleted()` short-circuited on the **first** satisfied condition instead of requiring all of them:

```csharp
if (_conditions.Any(x => x.IsCompleted())) return true;     // ANY
...
return !_conditions.Any() || _conditions.All(x => x.IsCompleted());   // ALL — unreachable
```

With a single condition `Any` and `All` are identical, which is why this survived: nearly every session registers just one.

`Wolverine.Tracking` is public test-support API, so this is not only our problem — a user chaining two `WaitForMessageToBeReceivedAt` calls gets a session that returns when *either* host handles the message, then asserts against handlers still running. A test that passes locally and fails under load, pointing nowhere near its cause.

There was already a workaround implying someone hit this and routed around it rather than fixing it: `WaitForExecutionOf<T>` deliberately merges repeat calls into a single condition object, and its doc comment says so — *"Multiple calls combine into a single condition that requires every registered count to be reached."* That is only necessary because multiple *conditions* don't AND together.

### How it surfaced, and a refuted hypothesis

`Wolverine.RabbitMQ.Tests.end_to_end` carried `[Trait("Category", "Flaky")]`, excluding **20 tests** from CI. Its two persistent failures each chain three `WaitForMessageToBeReceivedAt` calls for a fan-out exchange.

The in-file triage had every symptom right — both pass alone, fail in-class, fail in ~500ms on a null `ColorHistory` nowhere near the 30s timeout — and then *inferred* the cause: that the wait is satisfied by `MessageFailed`, so a message that arrived and then failed ended the session early. It also recorded that the next step was to dump the session rather than infer.

Doing that dump refutes the inference outright:

```
PROBE status=Completed exceptions=0
Sent ColorChosen to rabbitmq://exchange/exchange-...
Received ColorChosen at .../messages-...-20e23   (node 5321b23d)
Received ColorChosen at .../messages-...-21e23   (node 7d6a0afc)
Received ColorChosen at .../messages-...-22e23   (node ee1d1ae4)
Started execution   (node ee1d1ae4)
Finished execution  (node ee1d1ae4)
marked as successful (node ee1d1ae4)
```

Nothing failed. The message *succeeded* — at exactly one of the three receivers, whose condition alone satisfied `Any`. Alone on an idle machine all three finish inside the same millisecond; in-class under load the other two lag and their `ColorHistory` is still null at assertion time.

### Verification — baselined, not assumed

Because this changes shared test infrastructure, the full RabbitMQ project was run on both sides:

| | `main` | this branch |
|---|---|---|
| `end_to_end.use_fan_out_exchange` | **FAIL** | pass |
| `end_to_end.use_direct_exchange_with_binding_key` | **FAIL** | pass |
| `ConventionalRouting…send_from_one_node_to_another…` | FAIL | FAIL |
| `multi_tenancy_through_virtual_hosts.send_message_to_a_specific_tenant` | FAIL | FAIL |
| **total** | **4 / 491** | **2 / 491** |

The fix removes exactly its two targets and adds nothing. The two survivors are the known tracked-debt pair, failing identically on both sides.

- `CoreTests`: **2246 passed, 0 failed**
- `end_to_end` class alone: **20/20 on three consecutive runs**
- 163 `WaitForMessageToBeReceivedAt` call sites repo-wide; **exactly one file** chains more than one
- One documentation sample mixes `WaitForMessageToBeReceivedAt` with `WaitForExecutionOf`; its comments describe wanting *both*, so the fix makes it match its own documentation
- Full `wolverine.slnx` Release build clean, 0 warnings

**Reviewers:** the failure mode to watch for on CI is a *timeout*, not an assertion — a session that now correctly waits for something that never arrives.

### Also in here

The `Category=Flaky` tag comes off `end_to_end` (20 tests back into `CIRabbitMQ`), and the three Azure Service Bus "Needs its own issue" notes now point at the issues finally filed for them — #3825, #3826, #3827. Those were diagnosed product defects sitting behind `Flaky` tags with nothing tracking them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m
