### PR TITLE
Make EventSubscriptionAgentFamily.DatabaseKeyOf and TenantNeutralKeyOf public (GH-3819)

### DIFF
--- a/src/Persistence/MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs
@@ -217,12 +217,11 @@ public class blue_green_version_bump_assignment : IAsyncLifetime
         agents.Where(uri => uri.Segments.Any(segment =>
             segment.Trim('/').Equals(projectionName, StringComparison.OrdinalIgnoreCase))).ToList();
 
-    // The (type, name, databaseId) prefix of an agent URI, mirroring the internal
-    // EventSubscriptionAgentFamily.DatabaseKeyOf that group affinity keys on.
-    private static string DatabaseKeyOf(Uri uri) =>
-        uri.Segments.Length >= 3
-            ? $"{uri.Host}/{uri.Segments[1].Trim('/')}/{uri.Segments[2].Trim('/')}"
-            : uri.AbsoluteUri;
+    // Calls the real EventSubscriptionAgentFamily.DatabaseKeyOf rather than a local copy of it (GH-3819).
+    // This used to reimplement the URI grammar verbatim, which is exactly the drift risk that made the
+    // method public: a copy asserting co-location can quietly stop matching the key the distribution
+    // really groups on, and the test would keep passing while proving nothing.
+    private static string DatabaseKeyOf(Uri uri) => EventSubscriptionAgentFamily.DatabaseKeyOf(uri);
 }
 
 public record TripStarted(Guid Id, string Description);

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -321,10 +321,17 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
         return DatabaseId.TryParse(uri.Segments[2].Trim('/'), out var id) ? id : null;
     }
 
-    // Agent URIs are event-subscriptions://{type}/{name}/{databaseId}/{shard...} (see UriFor); the
-    // (type, name, databaseId) prefix identifies the shard database an agent belongs to, so grouping on it
-    // co-locates every tenant/projection agent for one database on the same node.
-    internal static string DatabaseKeyOf(Uri uri)
+    /// <summary>
+    /// The (type, name, databaseId) prefix of an event-subscription agent URI — the key group affinity
+    /// distributes on, so every tenant/projection agent belonging to one shard database is co-located on
+    /// the same node. Agent URIs are <c>event-subscriptions://{type}/{name}/{databaseId}/{shard...}</c>
+    /// (see <see cref="UriFor"/>).
+    ///
+    /// <para>Public so that callers reasoning about agent placement per database — an admin view, a
+    /// readiness probe, a test asserting co-location — can use the same key the distribution actually
+    /// uses instead of re-implementing the URI grammar and silently drifting from it. See GH-3819.</para>
+    /// </summary>
+    public static string DatabaseKeyOf(Uri uri)
         => uri.Segments.Length >= 3
             ? $"{uri.Host}/{uri.Segments[1].Trim('/')}/{uri.Segments[2].Trim('/')}"
             : uri.AbsoluteUri;
@@ -348,7 +355,7 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
     /// else is a tenant. Returns null for a URI that doesn't parse as this scheme's grammar — such an
     /// agent is never treated as superseded.
     /// </summary>
-    internal static string? TenantNeutralKeyOf(Uri uri)
+    public static string? TenantNeutralKeyOf(Uri uri)
     {
         // Segments: "/", {storeName}, {databaseId}, {projectionName}, {shardKey}, [v{n} | tenant], [tenant]
         var segments = uri.Segments.Skip(1).Select(x => x.Trim('/')).Where(x => x.Length > 0).ToArray();


### PR DESCRIPTION
Closes #3819.

`EventSubscriptionAgentFamily.DatabaseKeyOf` is the key group affinity distributes event-subscription agents on. It was `internal`, so anything outside Wolverine that wants to reason about agent placement per database — an admin view, a readiness probe, a test asserting co-location — had to re-implement the agent URI grammar.

### The drift risk is already real inside this repo

`MartenTests/MultiTenancy/blue_green_version_bump_assignment.cs` carried a verbatim copy:

```csharp
// The (type, name, databaseId) prefix of an agent URI, mirroring the internal
// EventSubscriptionAgentFamily.DatabaseKeyOf that group affinity keys on.
private static string DatabaseKeyOf(Uri uri) =>
    uri.Segments.Length >= 3
        ? $"{uri.Host}/{uri.Segments[1].Trim('/')}/{uri.Segments[2].Trim('/')}"
        : uri.AbsoluteUri;
```

…while its siblings (`sharded_two_databases_affine_colocation.cs`, `durability_projection_affinity_real_stores.cs`) call the real thing. That is the failure mode worth naming: a *copy* asserting co-location can silently stop matching the key the distribution actually groups on, and the test would keep passing while proving nothing. The copy is deleted here and delegates to the real method.

### Changes

- `DatabaseKeyOf` → `public`, with XML docs replacing the `//` comment (matching `DatabaseIdOf` right above it).
- `TenantNeutralKeyOf` → `public`, as the issue suggests in the same pass: it is the supersession relation's key, it **already** carried full XML documentation written as if it were public, and `CoreTests` reaches for it too.
- The duplicated private helper in `blue_green_version_bump_assignment.cs` now calls the public method.

Consistent with the existing position that consumers should not hand-build event-subscription agent URIs but call the public helpers — this is the read side of the same rule.

### Verification

- `CoreTests` `event_subscription_family*`: **24 passed**
- `MartenTests` `blue_green_version_bump_assignment`: **2 passed** — and since the deleted copy was byte-identical to the real implementation, that confirms no behaviour change
- Full `wolverine.slnx` Release build clean, 0 warnings

Raised from [marten#5170](https://github.com/JasperFx/marten/issues/5170), whose reporter runs a 512-shard-database deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m
