### PR TITLE
Assert on the queue name, not the endpoint name, and untag Bug_2307 (GH-3827)

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2307_batching_with_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2307_batching_with_conventional_routing.cs
@@ -10,17 +10,23 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests.Bugs;
 
-// NOT flaky. Re-measured 2026-08-02 after the entity-name sanitizing fix: 1 of 1 still fails, but in
-// 5 SECONDS on a plain assertion instead of the 2-minute broker timeout, so the real defect is now
-// readable:
+// GH-3827: UNTAGGED. This was never a product bug -- the assertion was reading the wrong property.
 //
-//   Expected a listener endpoint for queue 'wolverine.azureservicebus.tests.bugs.batcheditem'
-//   but found only: Wolverine.AzureServiceBus.Tests.Bugs.BatchedItem, AzureServiceBusResponses, ...
+// The 2026-08-02 triage was right that the listener IS created for the batch element type (so GH-2307
+// works) and right that the failure was readable rather than a broker timeout, but it concluded the
+// endpoint had been given "the raw type name rather than the sanitized queue name". Dumping the
+// endpoints shows both names are exactly what they should be:
 //
-// The listener IS created for the batch element type (that much of GH-2307 works) -- its
-// EndpointName is just the raw type name rather than the sanitized queue name. A naming bug in the
-// GH-2307 fix, not a routing or provisioning failure. Tracked as GH-3827.
-[Trait("Category", "Flaky")]
+//   EndpointName='Wolverine.AzureServiceBus.Tests.Bugs.BatchedItem'
+//   Uri='asb://queue/wolverine.azureservicebus.tests.bugs.batcheditem'   <- the real queue, sanitized
+//
+// EndpointName is a LOGICAL name and is deliberately not the entity name: MessageRoutingConvention
+// has `endpoint.EndpointName = queueName` commented out on both listener paths, and the transport's
+// own system endpoints do the same thing (AzureServiceBusResponses ->
+// asb://queue/wolverine.response.*). AzureServiceBusQueue.QueueName is the physical entity name and
+// is set once at construction; EndpointName is mutable and gets the friendly value afterwards.
+//
+// So the test asserts on QueueName now, which is the thing GH-2307 is actually about.
 public class Bug_2307_batching_with_conventional_routing : IAsyncLifetime
 {
     private IHost _host = null!;
@@ -60,14 +66,17 @@ public class Bug_2307_batching_with_conventional_routing : IAsyncLifetime
         // Without the fix, only the array type (BatchedItem[]) gets a listener, not the element type.
         var expectedQueueName = typeof(BatchedItem).ToMessageTypeName().ToLowerInvariant();
 
-        var endpoints = runtime.Options.Transports.AllEndpoints()
-            .Where(x => x is AzureServiceBusQueue)
+        // QueueName, not EndpointName: the former is the Azure Service Bus entity this convention is
+        // supposed to have created, the latter is a friendly label that deliberately keeps the
+        // unsanitized type name. See the note on this class.
+        var queues = runtime.Options.Transports.AllEndpoints()
+            .OfType<AzureServiceBusQueue>()
             .Where(x => x.IsListener)
             .ToArray();
 
-        endpoints.ShouldContain(
-            e => e.EndpointName == expectedQueueName,
-            $"Expected a listener endpoint for queue '{expectedQueueName}' but found only: {string.Join(", ", endpoints.Select(e => e.EndpointName))}");
+        queues.ShouldContain(
+            q => q.QueueName == expectedQueueName,
+            $"Expected a listener for Azure Service Bus queue '{expectedQueueName}' but found only: {string.Join(", ", queues.Select(q => q.QueueName))}");
     }
 }
 


### PR DESCRIPTION
Closes #3827.

**This was never a product bug**, contrary to how I filed the issue — I inherited the diagnosis from the in-file note instead of reproducing it first. Correction is on the issue too.

`Bug_2307_batching_with_conventional_routing` carried `[Trait("Category", "Flaky")]`, excluding it from `CIAzureServiceBus`. The note said the listener's *"EndpointName is just the raw type name rather than the sanitized queue name — a naming bug in the GH-2307 fix"*.

Dumping every Azure Service Bus endpoint the convention builds says otherwise:

```
EndpointName='Wolverine.AzureServiceBus.Tests.Bugs.BatchedItem'
Uri='asb://queue/wolverine.azureservicebus.tests.bugs.batcheditem'   <- correctly sanitized
IsListener=True
```

The listener exists and **its Azure Service Bus entity name is correct**. GH-2307 works end to end; nothing is misnamed on the broker.

`EndpointName` is a *logical* label that deliberately is not the entity name:

- `MessageRoutingConvention` has `endpoint.EndpointName = queueName` **commented out** on both listener-creation paths.
- The transport's own system endpoints behave identically — `AzureServiceBusResponses` → `asb://queue/wolverine.response.*`, `AzureServiceBusRetries` → `asb://queue/wolverine.retries.*`.
- `AzureServiceBusQueue.QueueName` is the physical entity name, assigned once at construction; `EndpointName` is mutable and picks up the friendly value afterwards.

So the test was asserting on the wrong property. It now asserts on `QueueName` — the thing GH-2307 is actually about — and the `Flaky` tag comes off.

### Verification

- **3/3 passes in ~5s** against the emulator
- Full `wolverine.slnx` Release build clean, 0 warnings

The class returns to `CIAzureServiceBus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m
