### PR TITLE
Restore send ordering in BatchedSender, and order tracked records honestly (GH-3825)

### DIFF
--- a/src/Testing/CoreTests/Transports/Sending/BatchedSenderTests.cs
+++ b/src/Testing/CoreTests/Transports/Sending/BatchedSenderTests.cs
@@ -3,6 +3,7 @@ using JasperFx.Core;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
+using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 using Wolverine.Transports.Tcp;
@@ -118,4 +119,97 @@ public class BatchedSenderTests
     {
         new TcpEndpoint(2257).MessageBatchTimeout.ShouldBe(250.Milliseconds());
     }
+
+    // GH-3825: the serializing stage upstream of the batching block ran at
+    // Environment.ProcessorCount, so envelopes reached the outgoing batch in
+    // serialization-completion order instead of enqueue order. That silently broke the FIFO
+    // guarantee behind Azure Service Bus sessions, SQS FIFO message groups, and global
+    // partitioning. The uneven serializer below is what makes a parallel stage reorder every time.
+    [Fact]
+    public async Task preserves_enqueue_order_through_to_the_outgoing_batch()
+    {
+        var endpoint = new TcpEndpoint(2258)
+        {
+            MessageBatchSize = 100,
+            MessageBatchTimeout = 250.Milliseconds()
+        };
+
+        var batches = new List<OutgoingMessageBatch>();
+        var protocol = Substitute.For<ISenderProtocol>();
+        protocol.SendBatchAsync(Arg.Any<ISenderCallback>(), Arg.Any<OutgoingMessageBatch>())
+            .Returns(call =>
+            {
+                lock (batches)
+                {
+                    batches.Add(call.Arg<OutgoingMessageBatch>());
+                }
+
+                return Task.CompletedTask;
+            });
+
+        using var sender = new BatchedSender(endpoint, protocol, CancellationToken.None, NullLogger.Instance);
+        sender.RegisterCallback(Substitute.For<ISenderCallback>());
+
+        // Descending delays: under any parallelism the last envelope serializes first
+        var count = 8;
+        var expected = new List<string>();
+        for (var i = 0; i < count; i++)
+        {
+            var name = $"message-{i}";
+            expected.Add(name);
+
+            var envelope = new Envelope
+            {
+                Id = Guid.NewGuid(),
+                Destination = sender.Destination,
+                Message = name,
+                GroupId = name,
+                ContentType = "application/staggered",
+                Serializer = new StaggeredSerializer((count - i) * 20)
+            };
+
+            await sender.SendAsync(envelope);
+        }
+
+        var deadline = DateTimeOffset.UtcNow.Add(10.Seconds());
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            lock (batches)
+            {
+                if (batches.SelectMany(x => x.Messages).Count() >= count) break;
+            }
+
+            await Task.Delay(50.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+
+        List<string> actual;
+        lock (batches)
+        {
+            actual = batches.SelectMany(x => x.Messages).Select(x => x.GroupId!).ToList();
+        }
+
+        actual.ShouldBe(expected);
+    }
+}
+
+internal class StaggeredSerializer : IMessageSerializer
+{
+    private readonly int _delayInMilliseconds;
+
+    public StaggeredSerializer(int delayInMilliseconds)
+    {
+        _delayInMilliseconds = delayInMilliseconds;
+    }
+
+    public string ContentType => "application/staggered";
+
+    public byte[] Write(Envelope envelope)
+    {
+        Thread.Sleep(_delayInMilliseconds);
+        return [1, 2, 3];
+    }
+
+    public object ReadFromData(Type messageType, Envelope envelope) => throw new NotSupportedException();
+    public object ReadFromData(byte[] data) => throw new NotSupportedException();
+    public byte[] WriteMessage(object message) => throw new NotSupportedException();
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/end_to_end.cs
@@ -8,14 +8,6 @@ using Xunit;
 
 namespace Wolverine.AzureServiceBus.Tests;
 
-// NOT flaky, and NOT GH-3786: re-measured 2026-08-02 after the entity-name sanitizing fix, on a
-// freshly recreated emulator (2.0.1). Still 2 of 6, still deterministic, but 2.1m for the class and
-// no broker-initialization timeout anywhere in it -- the two failures are
-// send_and_receive_multiple_messages_to_queue_with_session_identifier and
-// split_messages_with_different_sessionids_into_separate_batches, i.e. SESSION handling, which
-// conventional routing never touched. The other 4 pass. Tracked as GH-3825; do not fold it back
-// into GH-3786.
-[Trait("Category", "Flaky")]
 public class end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;

--- a/src/Wolverine/Tracking/EnvelopeRecord.cs
+++ b/src/Wolverine/Tracking/EnvelopeRecord.cs
@@ -6,8 +6,11 @@ namespace Wolverine.Tracking;
 
 public class EnvelopeRecord
 {
+    private static long _sequence;
+
     public EnvelopeRecord(MessageEventType eventType, Envelope? envelope, long sessionTime, Exception? exception)
     {
+        Sequence = Interlocked.Increment(ref _sequence);
         Envelope = envelope;
         SessionTime = sessionTime;
         Exception = exception;
@@ -43,6 +46,15 @@ public class EnvelopeRecord
     ///     A timestamp of the milliseconds since the tracked session was started before this event
     /// </summary>
     public long SessionTime { get; }
+
+    /// <summary>
+    ///     Globally monotonic ordinal assigned when this record was created. GH-3825: SessionTime is
+    ///     only millisecond resolution, so every record from one receive batch lands on the same value
+    ///     and sorting by it degenerates to the (unordered) enumeration of the envelope cache. This is
+    ///     the tiebreaker that makes AllRecordsInOrder() actually report activity in the order it
+    ///     happened.
+    /// </summary>
+    public long Sequence { get; }
 
     public Exception? Exception { get; }
     public MessageEventType MessageEventType { get; private set; }

--- a/src/Wolverine/Tracking/TrackedSession.cs
+++ b/src/Wolverine/Tracking/TrackedSession.cs
@@ -191,9 +191,14 @@ internal partial class TrackedSession : ITrackedSession
             .ToArray();
     }
 
+    // GH-3825: order by EnvelopeRecord.Sequence, not SessionTime. SessionTime is whole
+    // milliseconds, so an entire receive batch shares one value and OrderBy falls back to the
+    // enumeration order of _envelopes -- a Guid-keyed cache with no relationship to the order the
+    // activity actually happened in. Every ordering assertion written against Received/Sent was
+    // silently at the mercy of that.
     public EnvelopeRecord[] AllRecordsInOrder()
     {
-        return _envelopes.SelectMany(x => x.Records).Concat(statusesSnapshot()).OrderBy(x => x.SessionTime).ToArray();
+        return _envelopes.SelectMany(x => x.Records).Concat(statusesSnapshot()).OrderBy(x => x.Sequence).ToArray();
     }
 
     public EnvelopeRecord[] AllRecordsInOrder(MessageEventType eventType)
@@ -202,7 +207,7 @@ internal partial class TrackedSession : ITrackedSession
             .SelectMany(x => x.Records)
             .Concat(statusesSnapshot())
             .Where(x => x.MessageEventType == eventType)
-            .OrderBy(x => x.SessionTime)
+            .OrderBy(x => x.Sequence)
             .ToArray();
     }
 

--- a/src/Wolverine/Transports/Sending/BatchedSender.cs
+++ b/src/Wolverine/Transports/Sending/BatchedSender.cs
@@ -28,7 +28,16 @@ public class BatchedSender : ISender, ISenderRequiresCallback, IConditionalNativ
             sender.PushUpstream<Envelope[]>(envelopes => new OutgoingMessageBatch(Destination, envelopes));
 
         var batching = transforming.BatchUpstream(destination.MessageBatchTimeout, batchSize:destination.MessageBatchSize);
-        _serializing = batching.PushUpstream<Envelope>(Environment.ProcessorCount, e =>
+
+        // GH-3825: this stage MUST stay single threaded. It is the only thing between
+        // SendAsync() and the outgoing batch, so any parallelism here hands envelopes to the
+        // batching block in serialization-completion order rather than enqueue order -- which
+        // silently destroys the FIFO guarantee that Azure Service Bus sessions, SQS FIFO groups,
+        // and global partitioning all rest on. This was an ordered ActionBlock (MaxDegreeOfParallelism
+        // defaults to 1) before the switch from TPL Dataflow to Channels; the rewrite raised it to
+        // Environment.ProcessorCount and lost the guarantee along the way. Everything downstream is
+        // already serial by default (Endpoint.MessageBatchMaxDegreeOfParallelism is 1).
+        _serializing = batching.PushUpstream<Envelope>(1, e =>
         {
             try
             {


### PR DESCRIPTION
Closes #3825.

The issue said "session handling, 2 of 6 fail deterministically." The symptom half was right; the cause was not. **Nothing was ever lost — every message arrived, in the wrong order.** And it was wrong for two independent reasons.

Recording the handler's own execution order next to `session.Received` split them apart:

```
run 0 BUFFERED tracked : B1, B6, B5, B3, B4, B2
run 0 BUFFERED handled: B1, B2, B3, B4, B5, B6   <-- actual processing was fine
```

## 1. `BatchedSender` lost enqueue order

The serializing stage ran at `Environment.ProcessorCount`, so envelopes reached the batching block in *serialization-completion* order rather than enqueue order.

`git log -L` on the constructor shows this was not a design decision. Before the Channels rewrite (`8576ce526`, "First cut at switching over to Channels in place of TPL DataFlow") it was an `ActionBlock`:

```csharp
_serializing = new ActionBlock<Envelope>(async e => { ... },
    new ExecutionDataflowBlockOptions { CancellationToken = _cancellation, ... });
```

TPL Dataflow's `MaxDegreeOfParallelism` **defaults to 1**, so that block was strictly ordered. The port raised it to `Environment.ProcessorCount` and the guarantee went with it — silently breaking the FIFO contract behind **Azure Service Bus sessions, SQS FIFO message groups, and global partitioning**, for every transport that sends through `BatchedSender`.

Demonstrated with a buffered publisher and an inline one side by side, same group id:

| | run 0 | run 1 | run 2 |
|---|---|---|---|
| buffered | `B1, B6, B5, B4, B2, B3` | `B1, B4, B3, B2, B5, B6` | `B5, B3, B4, B6, B2, B1` |
| inline | `I1..I6` | `I1..I6` | `I1..I6` |

Pinned back to 1. Everything downstream was already serial by default (`Endpoint.MessageBatchMaxDegreeOfParallelism` is 1).

## 2. `TrackedSession` mis-reported the order of its own records

```csharp
.OrderBy(x => x.SessionTime)   // whole milliseconds
```

`SessionTime` is `_stopwatch.ElapsedMilliseconds`. An entire receive batch shares one value, and the stable sort then falls back to enumerating `_envelopes` — a Guid-keyed cache with no relationship to when anything happened. **Every ordering assertion written against `Received`/`Sent` anywhere in the suite was riding on that.**

`EnvelopeRecord` now carries a monotonic `Sequence` assigned in the constructor (so every construction site is covered), and both `AllRecordsInOrder` overloads sort on it.

## Verification

- New `BatchedSenderTests.preserves_enqueue_order_through_to_the_outgoing_batch` uses a serializer with descending per-envelope delays, so any parallelism in that stage reorders **every** run rather than occasionally. Confirmed red before the change, green after.
- `end_to_end` **6/6**, untagged from `Category=Flaky`.
- CoreTests **2247/0** · ASB **315/0** · MartenTests **548/0** · `wolverine.slnx -c Release` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m