### PR TITLE
Burn down the remaining Category=Flaky exclusions (GH-3763)

### DIFF
--- a/src/Persistence/LeaderElection/OracleTests.LeaderElection/leader_election.cs
+++ b/src/Persistence/LeaderElection/OracleTests.LeaderElection/leader_election.cs
@@ -11,11 +11,12 @@ namespace OracleTests.LeaderElection;
 // the OracleControlTransport / NodeControlEndpoint when running in Balanced
 // durability mode, otherwise leadership election cannot start.
 //
-// Marked Flaky so CI does not run them by default. The compliance suite spins up
-// 3-4 hosts per test and depends on TM/DML lock release between runs against a
-// single Oracle instance — fine to run locally one-at-a-time, but unstable
-// against the shared CI Oracle container. See #2618 (CI stabilization).
-[Trait("Category", "Flaky")]
+// Previously excluded from CI as Flaky because the compliance suite spins up 3-4 hosts per test
+// and depends on TM/DML lock release between runs against a single Oracle instance (#2618). The
+// beforeBuildingHost() teardown below has since grown the DDL_LOCK_TIMEOUT + per-table ORA-00054
+// retry that the exclusion was standing in for. Re-measured 2026-08-04: 15/15 green on four
+// consecutive runs, 1m44s each. Watch CIOracle -- the shared-container contention this was
+// hedging against cannot be reproduced on a dev box.
 public class leader_election : LeadershipElectionCompliance
 {
     public const string SchemaName = "WOLVERINE";

--- a/src/Persistence/MartenTests/MultiTenancy/using_tenant_specific_queues_and_subscriptions.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/using_tenant_specific_queues_and_subscriptions.cs
@@ -21,7 +21,6 @@ using Wolverine.Tracking;
 
 namespace MartenTests.MultiTenancy;
 
-[Trait("Category", "Flaky")]
 public class using_tenant_specific_queues_and_subscriptions : PostgresqlContext, IAsyncLifetime
 {
     private readonly List<IHost> _receivers = new();

--- a/src/Persistence/PolecatTests/Subscriptions/subscriptions_end_to_end.cs
+++ b/src/Persistence/PolecatTests/Subscriptions/subscriptions_end_to_end.cs
@@ -17,7 +17,6 @@ using Wolverine.Tracking;
 
 namespace PolecatTests.Subscriptions;
 
-[Trait("Category", "Flaky")]
 public class subscriptions_end_to_end
 {
     /// <summary>
@@ -233,7 +232,7 @@ public class subscriptions_end_to_end
         PcTotalsHandler.Handled.ShouldBe(['a', 'b', 'a', 'a', 'a', 'a', 'b', 'b']);
     }
 
-    [Fact(Skip = "Known TrackActivity race condition with publishing subscriptions - same failure in MartenSubscriptionTests")]
+    [Fact]
     public async Task use_unfiltered_publishing_subscription()
     {
         const string schema = "pc_subscriptions_pub";
@@ -276,8 +275,16 @@ public class subscriptions_end_to_end
             await daemon.WaitForNonStaleData(30.Seconds());
         };
 
+        // The daemon flushes the subscription's staged outbox AFTER it commits the page and its
+        // progress, so WaitForNonStaleData() returning does NOT mean the messages have been
+        // published. Without explicit waiters the session ends on the activity lull and the
+        // stragglers are never recorded. Same fix as the MartenSubscriptionTests twin.
         var tracked = await host
             .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForExecutionOf<IEvent<PcAEvent>>(6)
+            .WaitForExecutionOf<PcBEvent>(7)
+            .WaitForExecutionOf<IEvent<PcDEvent>>(6)
             .ExecuteAndWaitAsync(writeEvents);
 
         tracked.Executed.MessagesOf<IEvent<PcAEvent>>().Count().ShouldBe(6);
@@ -285,7 +292,7 @@ public class subscriptions_end_to_end
         tracked.Executed.MessagesOf<IEvent<PcDEvent>>().Count().ShouldBe(6);
     }
 
-    [Fact(Skip = "Known TrackActivity race condition with publishing subscriptions - same failure in MartenSubscriptionTests")]
+    [Fact]
     public async Task use_filtered_publishing_subscription()
     {
         const string schema = "pc_subscriptions_pub_filt";
@@ -332,8 +339,12 @@ public class subscriptions_end_to_end
             await daemon.WaitForNonStaleData(30.Seconds());
         };
 
+        // See use_unfiltered_publishing_subscription for why the explicit waiters are needed
         var tracked = await host
             .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForExecutionOf<IEvent<PcAEvent>>(6)
+            .WaitForExecutionOf<IEvent<PcDEvent>>(6)
             .ExecuteAndWaitAsync(writeEvents);
 
         tracked.Executed.MessagesOf<IEvent<PcAEvent>>().Count().ShouldBe(6);
@@ -391,8 +402,12 @@ public class subscriptions_end_to_end
             await daemon.WaitForNonStaleData(60.Seconds());
         };
 
+        // See use_unfiltered_publishing_subscription for why the explicit waiters are needed
         var tracked = await host
             .TrackActivity()
+            .Timeout(60.Seconds())
+            .WaitForExecutionOf<IEvent<PcAEvent>>(6)
+            .WaitForExecutionOf<PcTransformedMessage>(6)
             .ExecuteAndWaitAsync(writeEvents);
 
         tracked.Executed.MessagesOf<IEvent<PcAEvent>>().Count().ShouldBe(6);

--- a/src/Persistence/SqliteTests/Transport/multi_tenancy_with_multiple_files.cs
+++ b/src/Persistence/SqliteTests/Transport/multi_tenancy_with_multiple_files.cs
@@ -9,11 +9,10 @@ using Wolverine.Sqlite;
 
 namespace SqliteTests.Transport;
 
-// CI marker: scheduled_messages_are_processed_in_tenant_files reliably hangs the
-// 10-minute sqlite job, and the 2-attempt retry policy multiplies that into a
-// guaranteed timeout. Until the test is rewritten with a hard wait-bound, run it
-// only locally via the Flaky filter. See #2618 (CI stabilization).
-[Trait("Category", "Flaky")]
+// The hang that got this class excluded (scheduled_messages_are_processed_in_tenant_files
+// eating the 10-minute sqlite job, see #2618) was cured when the test was rewritten around the
+// bounded Poll() helper below -- it no longer waits on an unbounded condition. Re-measured
+// 2026-08-04: 2 tests in 3s, five consecutive runs, and 1m15s for the whole SqliteTests project.
 [Collection("sqlite")]
 public class multi_tenancy_with_multiple_files : SqliteContext, IAsyncLifetime
 {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2588_durable_outbox_with_handler_and_conventional_routing.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Bugs/Bug_2588_durable_outbox_with_handler_and_conventional_routing.cs
@@ -18,7 +18,6 @@ namespace Wolverine.AzureServiceBus.Tests.Bugs;
 /// short-circuit on <c>endpoint.Subscriptions.Any() == false</c> and never upgrade
 /// the endpoint mode to Durable.
 /// </summary>
-[Trait("Category", "Flaky")]
 public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IAsyncLifetime
 {
     private IHost _host = null!;
@@ -74,7 +73,6 @@ public class Bug_2588_durable_outbox_with_handler_and_conventional_routing : IAs
 /// queue-based one. Both inherit from <c>MessageRoutingConvention&lt;,,,&gt;</c>
 /// and share the same fix path.
 /// </summary>
-[Trait("Category", "Flaky")]
 public class Bug_2588_durable_outbox_with_handler_and_topic_broadcasting_routing : IAsyncLifetime
 {
     private IHost _host = null!;

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/dead_letter_queue_recovery.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/dead_letter_queue_recovery.cs
@@ -20,7 +20,6 @@ namespace Wolverine.AzureServiceBus.Tests;
 /// set). The background recovery listener drains the sub-queue and the dead letter ends up queryable
 /// in Wolverine's durable storage.
 /// </summary>
-[Trait("Category", "Flaky")]
 public class dead_letter_queue_recovery : IAsyncLifetime
 {
     private readonly string _queueName = $"dlqrecovery{Guid.NewGuid():N}";

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/session_id_pinning.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/session_id_pinning.cs
@@ -11,7 +11,6 @@ namespace Wolverine.AzureServiceBus.Tests;
 // GH-3533: pinning a session-enabled listener to specific session identifiers turns the session id
 // into a broker-enforced routing key on a shared queue, so a listener pinned to "A" never sees the
 // messages meant for "B".
-[Trait("Category", "Flaky")]
 public class session_id_pinning : IAsyncLifetime
 {
     private IHost _host = null!;


### PR DESCRIPTION
Toward #3763. With #3833 (GH-3826) and #3834 (GH-3825) covering the other two classes, this takes the `Category=Flaky` exclusion list from **12 to 0**.

Seven classes here. **One real bug among them.**

## The real one: Polecat `subscriptions_end_to_end`

Failed **1 of 3** class runs but **6 of 6** in isolation — an in-class interaction, not a flake.

It is the daemon-outbox race: `WolverineSubscriptionRunner.ProcessEventsAsync` enlists the bus in a Marten outbox, so `bus.PublishAsync` only *stages* envelopes. The real flush is `AfterCommitAsync` → `FlushOutgoingMessagesAsync`, which the daemon calls **after** committing the page and its progress. So `daemon.WaitForNonStaleData()` returning does not mean the messages were published — the session completes on the activity lull and the stragglers are never recorded.

The `MartenSubscriptionTests` twin of this exact file already carries the fix — explicit `WaitForExecutionOf<T>(count)` waiters plus `.Timeout(60.Seconds())`. **The Polecat copy never inherited it.** Copied test files don't inherit each other's later repairs.

Two tests in the same class also carried:

```csharp
[Fact(Skip = "Known TrackActivity race condition with publishing subscriptions - same failure in MartenSubscriptionTests")]
```

for that same cause. Both are now unskipped and covered by the same waiters — **7 passing + 2 skipped becomes 9 passing**.

## The other six needed no code change

| class | why it was tagged | reality |
|---|---|---|
| ASB `session_id_pinning` | tagged in the GH-3533 commit that *added* the feature | green |
| ASB `dead_letter_queue_recovery` | tagged in the #3103 commit that *added* the feature | green |
| ASB `Bug_2588` ×2 | tagged in the #2596 commit that *fixed* the bug | green |
| Sqlite `multi_tenancy_with_multiple_files` | "reliably hangs the 10-minute sqlite job" | stale — test since rewritten around the bounded `Poll()` helper it now uses |
| Marten `using_tenant_specific_queues_and_subscriptions` | no note | green 5/5 |

Four of these were tagged **in the very commit that introduced the feature they test**. That isn't flakiness — it's a feature that shipped without its test ever passing. `git log -S` on the tag is a fast way to tell the two apart.

## One provisional untag — please weigh in

`OracleTests.LeaderElection.leader_election` is the only tag whose rationale was substantive: TM/DML lock contention against the **shared CI Oracle container**. The `DDL_LOCK_TIMEOUT` + per-table ORA-00054 retry it was standing in for has since been added to `beforeBuildingHost()`, and it is 15/15 on four consecutive runs locally at 1m44s each.

But that contention genuinely cannot be reproduced on a dev box. The code comment says so explicitly and points at `CIOracle`. If you'd rather not spend a CI cycle finding out, this one line is cheap to revert.

## Measurements

Polecat **245/0** (8/8 runs on the class) · Sqlite **162/0** · MartenTests **548/0** · Oracle **15/0 ×4** · ASB **315/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m