### PR TITLE
Bump version to 6.24.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.24.5</Version>
+        <Version>6.24.6</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Fix-version bump for the 6.24.6 release.

`6.24.5` is already published to nuget.org and the publish workflow pushes with `--skip-duplicate`, so without this bump the JasperFx 2.39.5 upgrade in #3837 would be packed, skipped as a duplicate, and never actually ship.

Shipping in 6.24.6:

- **GH-3825** — `BatchedSender` lost send ordering in the Channels rewrite, breaking FIFO under ASB sessions, SQS FIFO groups and global partitioning on every transport that uses it.
- **GH-3826** — a tenanted Azure Service Bus endpoint could not send anything at all.
- **#3831 + JasperFx 2.39.5 (jasperfx#632)** — back-pressure latched and resumed against a count that reported zero for backlog held downstream, and a latched listener never said so again after the first line.
- **GH-3820** — Oracle queue Uri identity round-trip.
- **GH-3824** — `TrackedSession` completes only when *all* conditions are satisfied. Public testing API; noted as a behavior change in the release notes.
- **GH-3819** — `DatabaseKeyOf` / `TenantNeutralKeyOf` made public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m