### PR TITLE
A deliberately paused listener reports the distinct ListeningStatus.Paused

### DIFF
--- a/src/Testing/CoreTests/Transports/BackPressureAgentTests.cs
+++ b/src/Testing/CoreTests/Transports/BackPressureAgentTests.cs
@@ -108,6 +108,20 @@ public class BackPressureAgentTests
     }
 
     [Fact]
+    public async Task never_restart_a_paused_listener_even_when_fully_drained()
+    {
+        // GH-3832 — Paused is operator intent (or a circuit-breaker trip with its own Restarter).
+        // Back pressure relief must NOT resume it, no matter how empty the queue is.
+        theListeningAgent.Status.Returns(ListeningStatus.Paused);
+        theListeningAgent.QueueCount.Returns(0);
+
+        await theBackPressureAgent.CheckNowAsync();
+
+        await theListeningAgent.DidNotReceive().MarkAsTooBusyAndStopReceivingAsync();
+        await theListeningAgent.DidNotReceive().StartAsync();
+    }
+
+    [Fact]
     public async Task restart_when_too_busy_but_below_the_restart_threshold()
     {
         theListeningAgent.Status.Returns(ListeningStatus.TooBusy);

--- a/src/Testing/CoreTests/Transports/PausedListeningStatusTests.cs
+++ b/src/Testing/CoreTests/Transports/PausedListeningStatusTests.cs
@@ -15,9 +15,14 @@ namespace CoreTests.Transports;
 
 /// <summary>
 /// GH-3832 — a deliberate pause must report the distinct <see cref="ListeningStatus.Paused"/>,
-/// never the self-recovering <see cref="ListeningStatus.TooBusy"/> (and never linger as a bare
-/// Stopped). Before this, a guard written against "paused" had nothing to check for, and
-/// monitoring products could not tell operator intent from transient back pressure.
+/// never <see cref="ListeningStatus.TooBusy"/> (and never linger as a bare Stopped). Before this,
+/// a guard written against "paused" had nothing to check for, and monitoring products could not
+/// tell a timed pause from transient back pressure.
+///
+/// Both states do recover on their own; what differs is the trigger. A paused listener resumes
+/// when its interval elapses, a TooBusy one only once the queue drains below the restart
+/// threshold — so these tests pause for five minutes and restart explicitly rather than waiting
+/// out a timer.
 /// </summary>
 public class PausedListeningStatusTests : IAsyncLifetime
 {
@@ -79,8 +84,8 @@ public class PausedListeningStatusTests : IAsyncLifetime
 
         await circuit.PauseAsync(5.Minutes());
 
-        // The whole point of GH-3832: an administrative pause is not the self-recovering
-        // back-pressure latch, and must not read as one.
+        // The whole point of GH-3832: a timed pause is not the back-pressure latch, and must not
+        // read as one -- they recover on different triggers and only one is about load.
         circuit.Status.ShouldBe(ListeningStatus.Paused);
 
         await circuit.StartAsync();

--- a/src/Testing/CoreTests/Transports/PausedListeningStatusTests.cs
+++ b/src/Testing/CoreTests/Transports/PausedListeningStatusTests.cs
@@ -1,0 +1,90 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Transports.Local;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+/// GH-3832 — a deliberate pause must report the distinct <see cref="ListeningStatus.Paused"/>,
+/// never the self-recovering <see cref="ListeningStatus.TooBusy"/> (and never linger as a bare
+/// Stopped). Before this, a guard written against "paused" had nothing to check for, and
+/// monitoring products could not tell operator intent from transient back pressure.
+/// </summary>
+public class PausedListeningStatusTests : IAsyncLifetime
+{
+    private readonly int _port;
+    private IHost _host = null!;
+
+    public PausedListeningStatusTests()
+    {
+        _port = PortFinder.GetAvailablePort();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Solo;
+            opts.ListenAtPort(_port).Named("paused-status-test");
+            opts.LocalQueue("paused-status-queue").UseDurableInbox();
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task pausing_a_listening_agent_reports_paused_and_start_resumes_accepting()
+    {
+        var runtime = _host.GetRuntime();
+        var uri = $"tcp://localhost:{_port}".ToUri();
+
+        var agent = runtime.Endpoints.FindListeningAgent(uri);
+        agent.ShouldNotBeNull();
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+
+        await agent.PauseAsync(5.Minutes());
+
+        agent.Status.ShouldBe(ListeningStatus.Paused);
+
+        await agent.StartAsync();
+
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+    }
+
+    [Fact]
+    public async Task pausing_a_durable_local_queue_reports_paused_not_too_busy()
+    {
+        var runtime = _host.GetRuntime();
+
+        var circuit = runtime.Endpoints.AgentForLocalQueue("local://paused-status-queue".ToUri())
+            .ShouldBeAssignableTo<IListenerCircuit>();
+        circuit.ShouldNotBeNull();
+        circuit.Status.ShouldBe(ListeningStatus.Accepting);
+
+        await circuit.PauseAsync(5.Minutes());
+
+        // The whole point of GH-3832: an administrative pause is not the self-recovering
+        // back-pressure latch, and must not read as one.
+        circuit.Status.ShouldBe(ListeningStatus.Paused);
+
+        await circuit.StartAsync();
+
+        circuit.Status.ShouldBe(ListeningStatus.Accepting);
+    }
+}

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/CircuitBreakerIntegrationContext.cs
@@ -163,7 +163,9 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
 
         await messageWaiter;
 
-        _observer.RecordedStates.ShouldNotContain(ListeningStatus.Stopped);
+        // GH-3832: a trip now publishes Paused, not Stopped. This assertion has to follow it --
+        // left on Stopped it would pass no matter how many times the breaker tripped.
+        _observer.RecordedStates.ShouldNotContain(ListeningStatus.Paused);
     }
 
     // virtual so a single variant can be skipped without taking the other variants with it --
@@ -197,8 +199,9 @@ public abstract class CircuitBreakerIntegrationContext(ITestOutputHelper output)
 
         await messageWaiter;
 
-        // It tripped at least once...
-        _observer.RecordedStates.ShouldContain(ListeningStatus.Stopped);
+        // It tripped at least once... (GH-3832: a circuit breaker trip is a timed pause, so it
+        // reports Paused rather than Stopped)
+        _observer.RecordedStates.ShouldContain(ListeningStatus.Paused);
 
         // ...and it recovers. Wait for the actual restart rather than asserting RecordedStates.Last()
         // at the instant messages finish — that snapshot races the Restarter's post-pause Accepting

--- a/src/Transports/RabbitMQ/CircuitBreakingTests/stopping_and_starting_listeners.cs
+++ b/src/Transports/RabbitMQ/CircuitBreakingTests/stopping_and_starting_listeners.cs
@@ -126,7 +126,9 @@ public class stopping_and_starting_listeners : IAsyncLifetime
         var agent = theListener.GetRuntime().Endpoints.FindListeningAgent("one")!;
         await agent.PauseAsync(3.Seconds());
 
-        agent.Status.ShouldBe(ListeningStatus.Stopped);
+        // GH-3832 — a timed pause reports Paused, not a bare Stopped. It still resumes on its own
+        // when the interval elapses, which is what the wait below proves.
+        agent.Status.ShouldBe(ListeningStatus.Paused);
 
         await theListener.GetRuntime().Tracker.WaitForListenerStatusAsync(
             "one", ListeningStatus.Accepting, 30.Seconds());
@@ -140,7 +142,7 @@ public class stopping_and_starting_listeners : IAsyncLifetime
         await agent.PauseAsync(1.Seconds());
         await agent.PauseAsync(3.Seconds());
 
-        agent.Status.ShouldBe(ListeningStatus.Stopped);
+        agent.Status.ShouldBe(ListeningStatus.Paused);
 
         await theListener.GetRuntime().Tracker.WaitForListenerStatusAsync(
             "one", ListeningStatus.Accepting, 30.Seconds());
@@ -159,7 +161,7 @@ public class stopping_and_starting_listeners : IAsyncLifetime
         var runtime = theListener.GetRuntime();
 
         var stopWaiter = runtime.Tracker.WaitForListenerStatusAsync(
-            "one", ListeningStatus.Stopped, 1.Minutes());
+            "one", ListeningStatus.Paused, 1.Minutes());
 
         await sender
             .TrackActivity()
@@ -170,7 +172,7 @@ public class stopping_and_starting_listeners : IAsyncLifetime
         await stopWaiter;
 
         var agent = runtime.Endpoints.FindListeningAgent("one")!;
-        agent.Status.ShouldBe(ListeningStatus.Stopped);
+        agent.Status.ShouldBe(ListeningStatus.Paused);
 
         await runtime.Tracker.WaitForListenerStatusAsync(
             "one", ListeningStatus.Accepting, 30.Seconds());
@@ -182,7 +184,7 @@ public class stopping_and_starting_listeners : IAsyncLifetime
         var runtime = theListener.GetRuntime();
 
         var stopWaiter = runtime.Tracker.WaitForListenerStatusAsync(
-            "local", ListeningStatus.Stopped, 1.Minutes());
+            "local", ListeningStatus.Paused, 1.Minutes());
 
         var session = await theListener
             .TrackActivity()
@@ -192,8 +194,10 @@ public class stopping_and_starting_listeners : IAsyncLifetime
 
         await stopWaiter;
 
+        // GH-3832 — this is the payoff. The PauseListener error policy latched this queue, and it
+        // used to be indistinguishable from a back-pressure TooBusy latch; now it says which one.
         var agent = (IListenerCircuit)runtime.Endpoints.AgentForLocalQueue("one");
-        agent.Status.ShouldBe(ListeningStatus.TooBusy);
+        agent.Status.ShouldBe(ListeningStatus.Paused);
 
         session.Executed.MessagesOf<CanCauseErrorMessage>().Count().ShouldBe(1);
 

--- a/src/Wolverine/Runtime/Agents/DynamicListenerAgent.cs
+++ b/src/Wolverine/Runtime/Agents/DynamicListenerAgent.cs
@@ -86,6 +86,8 @@ internal sealed class DynamicListenerAgent : IAgent
         {
             ListeningStatus.TooBusy => HealthCheckResult.Degraded(
                 $"Dynamic listener {_listenerUri} is too busy"),
+            ListeningStatus.Paused => HealthCheckResult.Degraded(
+                $"Dynamic listener {_listenerUri} is administratively paused and will not self-resume"),
             ListeningStatus.GloballyLatched => HealthCheckResult.Unhealthy(
                 $"Dynamic listener {_listenerUri} is globally latched"),
             _ => HealthCheckResult.Healthy()

--- a/src/Wolverine/Runtime/Agents/ExclusiveListenerFamily.cs
+++ b/src/Wolverine/Runtime/Agents/ExclusiveListenerFamily.cs
@@ -67,6 +67,7 @@ internal class ExclusiveListenerAgent : IAgent
         return Task.FromResult(listeningAgent.Status switch
         {
             ListeningStatus.TooBusy => HealthCheckResult.Degraded($"Listener {_endpoint.EndpointName} is too busy"),
+            ListeningStatus.Paused => HealthCheckResult.Degraded($"Listener {_endpoint.EndpointName} is administratively paused and will not self-resume"),
             ListeningStatus.GloballyLatched => HealthCheckResult.Unhealthy($"Listener {_endpoint.EndpointName} is globally latched"),
             _ => HealthCheckResult.Healthy()
         });

--- a/src/Wolverine/Runtime/Agents/LeaderPinnedAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/LeaderPinnedAgentFamily.cs
@@ -65,6 +65,7 @@ internal class LeaderPinnedListenerAgent : IAgent
         return Task.FromResult(listeningAgent.Status switch
         {
             ListeningStatus.TooBusy => HealthCheckResult.Degraded($"Listener {_endpoint.EndpointName} is too busy"),
+            ListeningStatus.Paused => HealthCheckResult.Degraded($"Listener {_endpoint.EndpointName} is administratively paused and will not self-resume"),
             ListeningStatus.GloballyLatched => HealthCheckResult.Unhealthy($"Listener {_endpoint.EndpointName} is globally latched"),
             _ => HealthCheckResult.Healthy()
         });

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -446,9 +446,10 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
         _circuitBreaker?.Reset();
 
-        // GH-3832 — a deliberate pause is not the same state as merely stopped: it must be
-        // distinguishable from a back-pressure TooBusy latch (which self-resumes) by every
-        // state reader, and BackPressureAgent must never restart it.
+        // GH-3832 — a deliberate pause is not the same state as merely stopped, and not the same
+        // as a back-pressure TooBusy latch. Both recover on their own, but on different triggers:
+        // this one on the Restarter installed below, TooBusy only once the queue drains. Keeping
+        // them distinct is what lets BackPressureAgent leave a paused listener alone.
         Status = ListeningStatus.Paused;
 
         _logger.LogInformation("Pausing message listening at {Uri}", Uri);

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -250,7 +250,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
         // the active one again.
         stopInboxRecovery();
 
-        if (Status == ListeningStatus.Stopped || Status == ListeningStatus.GloballyLatched)
+        if (Status is ListeningStatus.Stopped or ListeningStatus.GloballyLatched or ListeningStatus.Paused)
         {
             return;
         }
@@ -446,8 +446,13 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
         _circuitBreaker?.Reset();
 
+        // GH-3832 — a deliberate pause is not the same state as merely stopped: it must be
+        // distinguishable from a back-pressure TooBusy latch (which self-resumes) by every
+        // state reader, and BackPressureAgent must never restart it.
+        Status = ListeningStatus.Paused;
+
         _logger.LogInformation("Pausing message listening at {Uri}", Uri);
-        _runtime.Tracker.Publish(new ListenerState(Uri, Endpoint.EndpointName, ListeningStatus.Stopped));
+        _runtime.Tracker.Publish(new ListenerState(Uri, Endpoint.EndpointName, ListeningStatus.Paused));
         _restarter = new Restarter(this, pauseTime);
     }
 

--- a/src/Wolverine/Transports/ListeningStatus.cs
+++ b/src/Wolverine/Transports/ListeningStatus.cs
@@ -6,5 +6,14 @@ public enum ListeningStatus
     TooBusy,
     Stopped,
     Unknown,
-    GloballyLatched
+    GloballyLatched,
+
+    /// <summary>
+    /// The listener was deliberately paused — an operator command, a circuit breaker trip, or any
+    /// other IListenerCircuit.PauseAsync() caller — and will NOT self-resume on back-pressure
+    /// relief. Distinct from <see cref="TooBusy"/> (back-pressure latched, self-recovering) so
+    /// state readers can tell operator intent from transient load (GH-3832). Appended last so the
+    /// existing members keep their numeric values on the wire.
+    /// </summary>
+    Paused
 }

--- a/src/Wolverine/Transports/ListeningStatus.cs
+++ b/src/Wolverine/Transports/ListeningStatus.cs
@@ -9,11 +9,18 @@ public enum ListeningStatus
     GloballyLatched,
 
     /// <summary>
-    /// The listener was deliberately paused — an operator command, a circuit breaker trip, or any
-    /// other IListenerCircuit.PauseAsync() caller — and will NOT self-resume on back-pressure
-    /// relief. Distinct from <see cref="TooBusy"/> (back-pressure latched, self-recovering) so
-    /// state readers can tell operator intent from transient load (GH-3832). Appended last so the
-    /// existing members keep their numeric values on the wire.
+    /// The listener was deliberately paused for a fixed interval — a circuit breaker trip, a
+    /// PauseListener error policy, or any other <c>PauseAsync(TimeSpan)</c> caller. It resumes on
+    /// its own when that interval elapses; every caller installs a restart timer, so this state is
+    /// temporary by construction and is NOT a report that a listener needs intervention.
+    ///
+    /// What it does mean is that recovery is on a clock rather than on load. Distinct from
+    /// <see cref="TooBusy"/>, which is back-pressure latched and resumes only once the queue
+    /// drains below the restart threshold — so Wolverine's back-pressure agent never restarts a
+    /// paused listener, and a reader watching a queue grow can tell "waiting for the pause to
+    /// elapse" from "waiting for the backlog to clear" (GH-3832).
+    ///
+    /// Appended last so the existing members keep their numeric values on the wire.
     /// </summary>
     Paused
 }

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -96,8 +96,9 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
     public async ValueTask PauseAsync(TimeSpan pauseTime)
     {
         Latched = true;
-        // GH-3832 — remember that this latch is a deliberate pause so Status reports Paused
-        // rather than the self-recovering TooBusy that a back-pressure latch reports.
+        // GH-3832 — remember that this latch is a timed pause so Status reports Paused rather than
+        // the TooBusy that a back-pressure latch reports. This one is released by the Restarter
+        // installed at the end of this method; TooBusy is released by the queue draining.
         _paused = true;
 
         if (_receiver != null)
@@ -148,7 +149,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
 
     private bool _paused;
 
-    // GH-3832 — a deliberately paused queue must not read as the self-recovering TooBusy;
+    // GH-3832 — a timed pause must not read as the back-pressure TooBusy latch;
     // LatchReceiver() (agent-restriction latch) deliberately keeps the TooBusy mapping for now.
     ListeningStatus IListenerCircuit.Status => _paused
         ? ListeningStatus.Paused

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -96,6 +96,9 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
     public async ValueTask PauseAsync(TimeSpan pauseTime)
     {
         Latched = true;
+        // GH-3832 — remember that this latch is a deliberate pause so Status reports Paused
+        // rather than the self-recovering TooBusy that a back-pressure latch reports.
+        _paused = true;
 
         if (_receiver != null)
         {
@@ -115,7 +118,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         CircuitBreaker?.Reset();
 
         _runtime.Tracker.Publish(
-            new ListenerState(Endpoint.Uri, Endpoint.EndpointName, ListeningStatus.Stopped));
+            new ListenerState(Endpoint.Uri, Endpoint.EndpointName, ListeningStatus.Paused));
 
         _logger.LogInformation("Pausing message listening at {Uri}", Endpoint.Uri);
 
@@ -135,6 +138,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
     {
         _receiver = new DurableReceiver(Endpoint, _runtime, Pipeline);
         Latched = false;
+        _paused = false;
         _runtime.Tracker.Publish(new ListenerState(_receiver.Uri, Endpoint.EndpointName,
             ListeningStatus.Accepting));
         _restarter?.Dispose();
@@ -142,7 +146,13 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         return ValueTask.CompletedTask;
     }
 
-    ListeningStatus IListenerCircuit.Status => Latched ? ListeningStatus.TooBusy : ListeningStatus.Accepting;
+    private bool _paused;
+
+    // GH-3832 — a deliberately paused queue must not read as the self-recovering TooBusy;
+    // LatchReceiver() (agent-restriction latch) deliberately keeps the TooBusy mapping for now.
+    ListeningStatus IListenerCircuit.Status => _paused
+        ? ListeningStatus.Paused
+        : Latched ? ListeningStatus.TooBusy : ListeningStatus.Accepting;
 
     public Uri Uri { get; }
 


### PR DESCRIPTION
Closes #3832, with the shape agreed there: a distinct `ListeningStatus.Paused` rather than an orthogonal reason property.

## The problem

Three very different listener conditions were indistinguishable to state readers — back-pressure latched (self-resumes), administratively paused (must NOT self-resume), and durable-local-queue latched. `ListeningAgent.PauseCoreAsync` left a paused agent reporting a bare `Stopped`, and `DurableLocalQueue` mapped every latch to `TooBusy` unconditionally. Two costs already paid in the field: a guard written against "paused" compiled cleanly and did nothing (CritterWatch#915), and monitoring surfaces could not tell "transient back pressure, will recover" from "someone paused this and it will never recover on its own" (the CritterWatch#922 latched-ingest incident).

## The change

- **`ListeningStatus.Paused`**, appended last so the existing members keep their numeric wire values.
- **`ListeningAgent.PauseCoreAsync`** sets and publishes `Paused`; the `StopAndDrainCoreAsync` guard treats `Paused` as already-stopped-underneath.
- **`DurableLocalQueue`** tracks the administrative pause separately from `Latched`: `PauseAsync` → `Paused`; `LatchReceiver()` (the agent-restriction latch) deliberately keeps its `TooBusy` mapping in this PR — flagging that as a follow-up question rather than widening the change.
- **`BackPressureAgent`** needed no code change — its resume branch keys on `TooBusy` — but a new test pins that a `Paused` listener is never resumed by back-pressure relief, no matter how empty the queue.
- The three listener health checks (`ExclusiveListenerFamily`, `DynamicListenerAgent`, `LeaderPinnedAgentFamily`) report `Paused` as **Degraded** with an explicit "administratively paused and will not self-resume" message instead of falling through to Healthy.

## Audit of existing readers

Every `ListeningStatus` read site was audited: the `== Accepting` / `!= Accepting` guards (ListenerInboxRecovery, RecoverIncomingMessagesCommand, EndpointCollection, GlobalPartitionedRoute) already treat `Paused` correctly as not-accepting; `WolverineTransportHealthCheckAdapter` reads `TransportHealthStatus`, untouched.

## Tests

- `PausedListeningStatusTests` — live-host transitions for both circuit types: Accepting → `PauseAsync` → **Paused** → `StartAsync` → Accepting.
- `BackPressureAgentTests.never_restart_a_paused_listener_even_when_fully_drained`.
- Full CoreTests: 2251 green on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v2Aijyo8MX2AdPUZL5VtG