### PR TITLE
Carry an exception type name, not an Exception, through the compliance harness (GH-3800)

### DIFF
--- a/src/Testing/CoreTests/ErrorHandling/ErrorHandlingContext.cs
+++ b/src/Testing/CoreTests/ErrorHandling/ErrorHandlingContext.cs
@@ -33,7 +33,7 @@ public class ErrorHandlingContext : IDisposable
 
     protected void throwOnAttempt<T>(int attempt) where T : Exception, new()
     {
-        theMessage.Errors.Add(attempt, new T());
+        theMessage.ThrowOnAttempt<T>(attempt);
     }
 
     protected async Task<EnvelopeRecord> afterProcessingIsComplete()

--- a/src/Testing/CoreTests/ErrorHandling/error_injection_survives_serialization_3800.cs
+++ b/src/Testing/CoreTests/ErrorHandling/error_injection_survives_serialization_3800.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests.ErrorHandling;
+using Xunit;
+
+namespace CoreTests.ErrorHandling;
+
+/// <summary>
+/// GH-3800. The compliance battery injects errors through <see cref="ErrorCausingMessage"/>, and it
+/// used to do so by carrying live <c>Exception</c> instances. <c>System.Text.Json</c> cannot
+/// round-trip those, so any transport wired <c>.InteropWithCloudEvents()</c> and run through
+/// TransportCompliance silently lost dead-lettering-by-exception-type coverage — the handler threw
+/// the wrong type and an exception-match rule could never fire.
+///
+/// <para>These pin the harness itself rather than a transport. Pulsar is currently the only
+/// CloudEvents fixture in the battery, and its DLQ tests are skipped for an unrelated reason
+/// (GH-3797), so without these the fix would have no coverage anywhere.</para>
+/// </summary>
+public class error_injection_survives_serialization_3800
+{
+    private static ErrorCausingMessage roundTrip(ErrorCausingMessage message)
+    {
+        // The same serializer CloudEvents uses internally, with no custom converters -- which is
+        // exactly the configuration that corrupted the old Dictionary<int, Exception>.
+        var json = JsonSerializer.Serialize(message);
+        return JsonSerializer.Deserialize<ErrorCausingMessage>(json)!;
+    }
+
+    private static void handle(ErrorCausingMessage message, int attempt)
+    {
+        new ErrorCausingMessageHandler()
+            .Handle(message, new Envelope { Attempts = attempt }, new AttemptTracker());
+    }
+
+    [Fact]
+    public void the_declared_exception_type_survives_a_json_round_trip()
+    {
+        var message = new ErrorCausingMessage();
+        message.ThrowOnAttempt<DivideByZeroException>(1);
+
+        var received = roundTrip(message);
+
+        // Before GH-3800 this threw *something*, but not this -- which is worse than throwing
+        // nothing, because an exception-match rule then quietly never fires.
+        Should.Throw<DivideByZeroException>(() => handle(received, 1));
+    }
+
+    [Fact]
+    public void distinct_attempts_keep_their_own_exception_types()
+    {
+        var message = new ErrorCausingMessage();
+        message.ThrowOnAttempt<DivideByZeroException>(1);
+        message.ThrowOnAttempt<BadImageFormatException>(2);
+
+        var received = roundTrip(message);
+
+        Should.Throw<DivideByZeroException>(() => handle(received, 1));
+        Should.Throw<BadImageFormatException>(() => handle(received, 2));
+    }
+
+    [Fact]
+    public void an_attempt_with_no_error_is_processed_normally()
+    {
+        var message = new ErrorCausingMessage();
+        message.ThrowOnAttempt<DivideByZeroException>(1);
+
+        var received = roundTrip(message);
+
+        handle(received, 2);
+
+        received.WasProcessed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_unresolvable_type_name_fails_loudly()
+    {
+        // A silently-wrong exception type is the failure this replaced, so a name that cannot be
+        // resolved in the receiving process must not quietly become "no error".
+        var message = new ErrorCausingMessage { Errors = { [1] = "Not.A.Real.Type, Nowhere" } };
+
+        var ex = Should.Throw<InvalidOperationException>(() => handle(roundTrip(message), 1));
+        ex.Message.ShouldContain("Not.A.Real.Type");
+    }
+}

--- a/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Compliance/TransportCompliance.cs
@@ -460,7 +460,9 @@ public abstract class TransportCompliance<T> : IAsyncLifetime where T : Transpor
 
     protected void throwOnAttempt<TException>(int attempt) where TException : Exception, new()
     {
-        theMessage.Errors.Add(attempt, new TException());
+        // GH-3800: records the type NAME, not an instance -- an Exception does not round-trip
+        // through System.Text.Json, and this battery runs under serializers that use it.
+        theMessage.ThrowOnAttempt<TException>(attempt);
     }
 
     protected async Task<EnvelopeRecord> afterProcessingIsComplete()

--- a/src/Testing/Wolverine.ComplianceTests/ErrorHandling/ErrorCausingMessage.cs
+++ b/src/Testing/Wolverine.ComplianceTests/ErrorHandling/ErrorCausingMessage.cs
@@ -10,7 +10,32 @@ public class ErrorCausingMessage
     /// </summary>
     public Guid Id { get; set; } = Guid.NewGuid();
 
-    public Dictionary<int, Exception> Errors { get; set; } = new();
+    /// <summary>
+    /// Which attempt should throw what, keyed by attempt number and carrying the exception's
+    /// assembly-qualified type NAME rather than a live Exception instance.
+    ///
+    /// <para>GH-3800. This used to be a <c>Dictionary&lt;int, Exception&gt;</c>, which only works
+    /// for serializers that can carry an arbitrary exception graph. <c>System.Text.Json</c> cannot:
+    /// under CloudEvents the dictionary arrived corrupted, the handler threw the wrong type, and an
+    /// exception-match rule could never fire — so <c>with_cloud_events</c> opted out of
+    /// <c>will_move_to_dead_letter_queue_with_exception_match</c> entirely. The hole was in this
+    /// shared harness, not in one transport: any transport wired <c>.InteropWithCloudEvents()</c>
+    /// and run through TransportCompliance inherited it.</para>
+    ///
+    /// <para>A type name is a string, so it survives every serializer we run the battery under. The
+    /// handler rehydrates it — see <see cref="ErrorCausingMessageHandler"/>.</para>
+    /// </summary>
+    public Dictionary<int, string> Errors { get; set; } = new();
+
     public bool WasProcessed { get; set; }
     public int LastAttempt { get; set; }
+
+    /// <summary>
+    /// Records that <paramref name="attempt"/> should throw <typeparamref name="TException"/>.
+    /// Kept here rather than at the call sites so the name/instance distinction lives in one place.
+    /// </summary>
+    public void ThrowOnAttempt<TException>(int attempt) where TException : Exception, new()
+    {
+        Errors[attempt] = typeof(TException).AssemblyQualifiedName!;
+    }
 }

--- a/src/Testing/Wolverine.ComplianceTests/ErrorHandling/ErrorCausingMessageHandler.cs
+++ b/src/Testing/Wolverine.ComplianceTests/ErrorHandling/ErrorCausingMessageHandler.cs
@@ -8,16 +8,38 @@ public class ErrorCausingMessageHandler
     {
         tracker.LastAttempt = envelope.Attempts;
 
-        if (!message.Errors.ContainsKey(envelope.Attempts))
+        if (!message.Errors.TryGetValue(envelope.Attempts, out var typeName))
         {
             message.WasProcessed = true;
 
             return;
         }
 
-        if (message.Errors.TryGetValue(envelope.Attempts, out var ex))
+        throw rehydrate(typeName);
+    }
+
+    /// <summary>
+    /// GH-3800. The message carries an exception TYPE NAME, not an instance, so that the error
+    /// injection survives any serializer the compliance battery runs under — <c>System.Text.Json</c>
+    /// (and therefore CloudEvents) cannot round-trip an Exception, and used to hand this handler a
+    /// corrupted dictionary that made it throw the wrong type.
+    ///
+    /// <para>A failure to resolve or construct the type is thrown loudly rather than swallowed: a
+    /// silently-wrong exception type is exactly the failure mode this replaced, and it presents as
+    /// an error-handling rule that mysteriously does not match.</para>
+    /// </summary>
+    private static Exception rehydrate(string typeName)
+    {
+        var type = Type.GetType(typeName)
+                   ?? throw new InvalidOperationException(
+                       $"ErrorCausingMessage asked for exception type '{typeName}', which could not be resolved in the receiving process.");
+
+        if (Activator.CreateInstance(type) is not Exception exception)
         {
-            throw ex;
+            throw new InvalidOperationException(
+                $"ErrorCausingMessage asked for exception type '{typeName}', which is not an Exception.");
         }
+
+        return exception;
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
@@ -50,15 +50,14 @@ public class PulsarWithCloudEventsFixture : TransportComplianceFixture, IAsyncLi
 [Collection("acceptance")]
 public class with_cloud_events : TransportCompliance<PulsarWithCloudEventsFixture>
 {
-    // This test uses ErrorCausingMessage which contains a Dictionary<int, Exception>.
-    // Exception objects don't serialize/deserialize properly with System.Text.Json,
-    // which CloudEvents uses internally. The test message's Errors dictionary gets
-    // corrupted during serialization, causing the wrong exception type to be thrown.
-    // This is a test infrastructure limitation, not a CloudEvents functionality issue.
+    // GH-3800 removed the CloudEvents-specific reason this test used to carry: ErrorCausingMessage
+    // now records an exception TYPE NAME rather than a live Exception, so it survives
+    // System.Text.Json and CloudEvents no longer corrupts it.
     //
-    // Skip rather than an empty body: an override that just returns Task.CompletedTask reports as a
-    // PASS, so the suite counted a test that never ran anything. GH-3763.
-    [Fact(Skip = "CloudEvents' System.Text.Json serialization corrupts ErrorCausingMessage's Dictionary<int, Exception>, so the wrong exception type is thrown -- a test-infrastructure limit, not a CloudEvents defect.")]
+    // It stays skipped, but for the same reason as its two sibling fixtures below rather than a
+    // serialization one -- Pulsar has not implemented dead-letter routing. When GH-3797 lands this
+    // skip goes with the others, not separately.
+    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
     public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
 
     // GH-3763. Deterministic failures shared with the other two Pulsar compliance fixtures -- the


### PR DESCRIPTION
Closes #3800.

## The defect, demonstrated

`TransportCompliance` injects errors via `ErrorCausingMessage`, which carried a `Dictionary<int, Exception>`. `System.Text.Json` cannot round-trip that. Run directly rather than inferred:

```
serialized:                {"1":{"TargetSite":null,"Message":"Attempted to divide by zero.",...}}
deserialized runtime type: System.Exception
is DivideByZeroException?  False
```

It writes the exception's *properties* and rebuilds it as a bare `System.Exception`. The type identity — the only thing an exception-match rule keys on — is gone. So the handler threw the wrong type, the rule could never fire, and `with_cloud_events` opted out of `will_move_to_dead_letter_queue_with_exception_match` entirely.

**The hole is in the shared harness, not in one transport.** Anything wired `.InteropWithCloudEvents()` and run through `TransportCompliance` inherits it, silently. Pulsar is simply the only CloudEvents fixture in the battery, so it is the only place it surfaced.

## The change

`Errors` becomes `Dictionary<int, string>` of assembly-qualified type names, with a `ThrowOnAttempt<T>()` helper on the message so the name/instance distinction lives in one place. `ErrorCausingMessageHandler` rehydrates it.

A type name is a string, so it survives every serializer the battery runs under. A name that cannot be resolved throws loudly rather than falling through to "no error" — a silently wrong exception type is precisely the failure this replaces, and it presents as an error-handling rule that mysteriously never matches.

## What this does not fix

`with_cloud_events.will_move_to_dead_letter_queue_with_exception_match` **stays skipped**, but for its siblings' reason rather than a serialization one: Pulsar has not implemented dead-letter routing (#3797). The skip message now matches the other three in that fixture, so when #3797 lands it goes with them instead of needing to be rediscovered.

That is also why the new tests exist. Pulsar being the only CloudEvents fixture means this fix would otherwise ship with **zero** coverage anywhere — the one test that would have exercised it is blocked on an unrelated issue.

## Verification

Four new tests in `CoreTests.ErrorHandling.error_injection_survives_serialization_3800` pin the harness directly: type survives a round trip, distinct attempts keep distinct types, a no-error attempt still processes, and an unresolvable name fails loudly. The first would have failed on the old shape — `Should.Throw<DivideByZeroException>` against a deserialized `System.Exception`.

- `CoreTests` `ErrorHandling` — **214/214** existing, plus the 4 new.
- `dotnet build wolverine.slnx -c Release` — clean, which matters here because `Wolverine.ComplianceTests` is referenced by every transport test project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m
