### PR TITLE
Share one pinned Pulsar broker per job instead of one container per process (GH-3799)

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -132,6 +132,8 @@ partial class Build
             WaitForKafkaToBeReady();
         if (services.Contains("gcp-pubsub"))
             WaitForPubsubEmulatorToBeReady();
+        if (services.Contains("pulsar"))
+            WaitForPulsarToBeReady();
     }
 
     /// <summary>
@@ -215,6 +217,34 @@ partial class Build
             // lesson from GH-3783 is that pinning a gate to one status code is how it hangs when the
             // service legitimately answers a different one.
             return response is null ? "no response" : null;
+        });
+    }
+
+    /// <summary>
+    /// GH-3799. Pulsar standalone takes tens of seconds to come up and its broker port accepts long
+    /// before it will serve, so this asks the admin api a real question instead of checking the
+    /// socket — the same distinction that made the Kafka gate below worth rewriting.
+    ///
+    /// <para>The budget is deliberately generous. This gate is also the thing that turns a Docker
+    /// memory shortage into a named failure: previously the suite started its own container per
+    /// worker process, and when Docker could not satisfy that the run simply sat at "224 test(s):
+    /// 224 batched" forever with nothing pointing at Docker. Timing out here says which service
+    /// never came up, in the job that owns it.</para>
+    /// </summary>
+    void WaitForPulsarToBeReady()
+    {
+        using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        awaitService("Pulsar", TimeSpan.FromMinutes(3), () =>
+        {
+            // /admin/v2/brokers/health is the broker's own readiness answer, not merely "something
+            // is listening on 8080" — it stays unavailable while the standalone cluster boots.
+            var response = http.GetAsync("http://localhost:8080/admin/v2/brokers/health")
+                .GetAwaiter().GetResult();
+
+            return response.IsSuccessStatusCode
+                ? null
+                : $"admin api answered {(int)response.StatusCode} {response.StatusCode}";
         });
     }
 
@@ -730,9 +760,21 @@ partial class Build
             var tests = RootDirectory / "src" / "Transports" / "Pulsar" / "Wolverine.Pulsar.Tests" / "Wolverine.Pulsar.Tests.csproj";
 
             BuildTestProjects(tests);
+
             // The global partitioning topology forces durable mode on every slot, so that suite
-            // needs a real message store. Pulsar itself runs in Testcontainers. See #3467.
-            StartDockerServices("postgresql");
+            // needs a real message store. See #3467.
+            //
+            // GH-3799: Pulsar now comes from docker-compose rather than Testcontainers. The fixture's
+            // [ModuleInitializer] starts a container per *process*, and the supervisor partitions this
+            // project across worker processes (2-24 observed, plus a fresh process per retried test) —
+            // so one job could ask Docker for that many concurrent Pulsar standalone brokers, an image
+            // that is not small. One compose broker, started once and shared, is the whole fix.
+            StartDockerServices("pulsar", "postgresql");
+
+            // The fixture already honours these ("an already-running Pulsar wins") and they were set
+            // nowhere. With them set, no worker process starts a container at all.
+            Environment.SetEnvironmentVariable("WOLVERINE_PULSAR", "pulsar://localhost:6650");
+            Environment.SetEnvironmentVariable("WOLVERINE_PULSAR_HTTP", "http://localhost:8080");
 
             RunTestProject(tests);
         });


### PR DESCRIPTION
Closes #3799.

`PulsarContainerFixture` starts a Pulsar container from a `[ModuleInitializer]`, which runs **once per process**. The supervisor partitions this project across worker processes (2, 3, 6 and 24 observed depending on machine load) and the retry harness spawns another fresh process per retried test — so one `CIPulsar` run could ask Docker for that many concurrent Pulsar standalone brokers. That is not a small image.

`docker-compose.yml` already defines a pinned `pulsar` service that **nothing used**, and the fixture already has the escape hatch — `WOLVERINE_PULSAR` wins over starting a container, *"same shape as Servers.cs"*. That variable was set nowhere. So the fix is mostly wiring: start the compose broker once per job and point every worker process at it.

## The readiness gate is the half that matters most

With Docker starved, the old arrangement did not fail. It sat at

```
[INF]   Filter kept 224 of 224 discovered test(s)
[INF]   224 test(s): 224 batched, 0 isolated
```

forever — no Pulsar container running, no timeout, nothing in the output naming Docker. A silent hang is the worst failure shape we have, because it looks identical to slow. A gate that throws turns it into a named failure in the job that owns it.

The probe asks `/admin/v2/brokers/health` rather than opening a socket. Pulsar standalone accepts on 6650 well before it will serve, and #3814 measured exactly what a TCP-only gate is worth on Kafka: it passed at 0.0s every time while the broker was still ~3 seconds from ready. Budget is 3 minutes, since a cold Pulsar standalone genuinely takes tens of seconds.

## On the third item in the issue

The image pin is already done — both `PulsarContainerFixture.PulsarImage` and `docker-compose.yml` are on `apachepulsar/pulsar:4.2.4`, and the fixture carries the note about `:latest` having moved that same day. Nothing to do there.

## Verification

Ran the `CIPulsar` target locally:

```
pulsar containers BEFORE: 1
Starting docker services: pulsar postgresql
Pulsar is up and ready (attempt 1)
=== Wolverine.Pulsar.Tests: 224 passed (0 retries, 2 worker processes) ===
```

**224 passed, and exactly one Pulsar container for the whole run** — two worker processes that would previously have started two of their own. `docker ps -a --filter ancestor=apachepulsar/pulsar:4.2.4` shows only `wolverine-pulsar-1` from compose, so no Testcontainers broker was created at any point.

The probe itself was checked against a real container before wiring it in: `GET /admin/v2/brokers/health` → `200 ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m
