### PR TITLE
Fix the Polecat sample, run it in CI, and document why the solution excludes what it excludes (GH-3839, GH-3841)

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1155,6 +1155,21 @@ partial class Build
     /// </summary>
     Target CIPolecat => _ => _
         .ProceedAfterFailure()
-        .Executes(() => runPolecatShard(
-            excludeNamespaces([..PolecatWorkflowNamespaces, ..PolecatSagaNamespaces])));
+        .Executes(() =>
+        {
+            runPolecatShard(excludeNamespaces([..PolecatWorkflowNamespaces, ..PolecatSagaNamespaces]));
+
+            // GH-3839. This ran in no CI target at all, which is half of why it sat un-compilable
+            // for four months. Re-enabling it in wolverine.slnx makes the solution build catch a
+            // *compile* break; only running it catches a behavioural one, and the sample is the
+            // worked example a reader follows.
+            //
+            // Lives on this shard because it is the catch-all and because runPolecatShard has
+            // already started the SQL Server the sample connects to. ~9s against a 338s job.
+            BuildTestProjectsWithFramework("net10.0", PolecatIncidentServiceTests);
+            RunTestProject(PolecatIncidentServiceTests, frameworkOverride: "net10.0");
+        });
+
+    AbsolutePath PolecatIncidentServiceTests => RootDirectory / "src" / "Persistence" / "Polecat" /
+                                                "PolecatIncidentService.Tests" / "PolecatIncidentService.Tests.csproj";
 }

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/when_categorising_an_incident.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/when_categorising_an_incident.cs
@@ -25,7 +25,7 @@ public class when_categorising_an_incident : IntegrationContext
             x.StatusCodeShouldBe(201);
         });
 
-        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+        var incidentId = (await initial.ReadAsJsonAsync<CreationResponse<Guid>>()).Value;
 
         // Now categorise it
         var categorise = new CategoriseIncident(IncidentCategory.Network, Guid.NewGuid(), 1);
@@ -38,7 +38,7 @@ public class when_categorising_an_incident : IntegrationContext
 
         // Verify the category was applied
         await using var session = Store.LightweightSession();
-        var incident = await session.Events.FetchLatest<Incident>(incidentId);
+        var incident = await session.Events.FetchLatest<Incident>(incidentId, TestContext.Current.CancellationToken);
         incident.ShouldNotBeNull();
         incident!.Category.ShouldBe(IncidentCategory.Network);
     }
@@ -56,7 +56,7 @@ public class when_categorising_an_incident : IntegrationContext
             x.StatusCodeShouldBe(201);
         });
 
-        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+        var incidentId = (await initial.ReadAsJsonAsync<CreationResponse<Guid>>()).Value;
 
         // Close it
         var close = new CloseIncident(Guid.NewGuid(), 1);

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/when_categorising_via_asparameters.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/when_categorising_via_asparameters.cs
@@ -27,7 +27,7 @@ public class when_categorising_via_asparameters : IntegrationContext
             x.StatusCodeShouldBe(201);
         });
 
-        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+        var incidentId = (await initial.ReadAsJsonAsync<CreationResponse<Guid>>()).Value;
 
         var payload = new CategoriseIncidentPayload(IncidentCategory.Network, Guid.NewGuid());
 
@@ -37,12 +37,12 @@ public class when_categorising_via_asparameters : IntegrationContext
             x.StatusCodeShouldBe(200);
         });
 
-        var response = result.ReadAsJson<IncidentCategorisedResponse>();
+        var response = await result.ReadAsJsonAsync<IncidentCategorisedResponse>();
         response.IncidentId.ShouldBe(incidentId);
         response.Category.ShouldBe(IncidentCategory.Network);
 
         await using var session = Store.LightweightSession();
-        var incident = await session.Events.FetchLatest<Incident>(incidentId);
+        var incident = await session.Events.FetchLatest<Incident>(incidentId, TestContext.Current.CancellationToken);
         incident.ShouldNotBeNull();
         incident!.Category.ShouldBe(IncidentCategory.Network);
     }

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/when_closing_an_incident.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/when_closing_an_incident.cs
@@ -24,7 +24,7 @@ public class when_closing_an_incident : IntegrationContext
             x.StatusCodeShouldBe(201);
         });
 
-        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+        var incidentId = (await initial.ReadAsJsonAsync<CreationResponse<Guid>>()).Value;
 
         var close = new CloseIncident(Guid.NewGuid(), 1);
         var (tracked, result) = await TrackedHttpCall(x =>
@@ -33,7 +33,7 @@ public class when_closing_an_incident : IntegrationContext
             x.StatusCodeShouldBe(200);
         });
 
-        var incident = result.ReadAsJson<Incident>();
+        var incident = await result.ReadAsJsonAsync<Incident>();
         incident.ShouldNotBeNull();
         incident!.Status.ShouldBe(IncidentStatus.Closed);
 
@@ -54,7 +54,7 @@ public class when_closing_an_incident : IntegrationContext
             x.StatusCodeShouldBe(201);
         });
 
-        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+        var incidentId = (await initial.ReadAsJsonAsync<CreationResponse<Guid>>()).Value;
 
         // Close once
         var close = new CloseIncident(Guid.NewGuid(), 1);

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/when_getting_an_incident.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/when_getting_an_incident.cs
@@ -23,7 +23,7 @@ public class when_getting_an_incident : IntegrationContext
             x.StatusCodeShouldBe(201);
         });
 
-        var incidentId = initial.ReadAsJson<CreationResponse<Guid>>().Value;
+        var incidentId = (await initial.ReadAsJsonAsync<CreationResponse<Guid>>()).Value;
 
         var result = await Scenario(x =>
         {
@@ -31,7 +31,7 @@ public class when_getting_an_incident : IntegrationContext
             x.StatusCodeShouldBe(200);
         });
 
-        var incident = result.ReadAsJson<Incident>();
+        var incident = await result.ReadAsJsonAsync<Incident>();
         incident.ShouldNotBeNull();
         incident!.Status.ShouldBe(IncidentStatus.Pending);
     }

--- a/src/Persistence/Polecat/PolecatIncidentService.Tests/when_logging_an_incident.cs
+++ b/src/Persistence/Polecat/PolecatIncidentService.Tests/when_logging_an_incident.cs
@@ -42,11 +42,11 @@ public class when_logging_an_incident : IntegrationContext
         });
 
         // Read the response body by deserialization
-        var response = initial.ReadAsJson<CreationResponse<Guid>>();
+        var response = await initial.ReadAsJsonAsync<CreationResponse<Guid>>();
 
         // Reaching into Polecat to build the current state of the new Incident
         await using var session = Store.LightweightSession();
-        var incident = await session.Events.FetchLatest<Incident>(response.Value);
+        var incident = await session.Events.FetchLatest<Incident>(response.Value, TestContext.Current.CancellationToken);
 
         incident!.Status.ShouldBe(IncidentStatus.Pending);
     }

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -44,8 +44,16 @@
     <Project Path="src/Http/OpenApiDemonstrator/OpenApiDemonstrator.csproj" />
     <Project Path="src/Http/StaticCodeGenDemonstrator/StaticCodeGenDemonstrator.csproj" />
     <Project Path="src/Http/Wolverine.AdminApi/Wolverine.AdminApi.csproj" />
-    <Project Path="src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj" />
-    <Project Path="src/Http/Wolverine.Http.AspVersioning/Wolverine.Http.AspVersioning.csproj" />
+    <!-- net10.0-only, and the Compile target builds wolverine.slnx pinned to net9.0
+         (.nuke/parameters.json), so including these makes the solution build fail NETSDK1005.
+         Gated by the CIHttpAspVersioning target instead, which builds and tests them at net10.0.
+         GH-3841: the reason, which no flag here previously carried. -->
+    <Project Path="src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj">
+      <Build Project="false" />
+    </Project>
+    <Project Path="src/Http/Wolverine.Http.AspVersioning/Wolverine.Http.AspVersioning.csproj">
+      <Build Project="false" />
+    </Project>
     <Project Path="src/Http/Wolverine.Http.FluentValidation/Wolverine.Http.FluentValidation.csproj" />
     <Project Path="src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj" />
     <Project Path="src/Http/Wolverine.Http.Tests.DifferentAssembly/Wolverine.Http.Tests.DifferentAssembly.csproj" />
@@ -113,8 +121,16 @@
   </Folder>
   <Folder Name="/Persistence/Polecat/">
     <Project Path="src/Http/Wolverine.Http.Polecat/Wolverine.Http.Polecat.csproj" />
-    <Project Path="src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj" />
-    <Project Path="src/Persistence/Polecat/PolecatIncidentService/PolecatIncidentService.csproj" />
+    <!-- net10.0-only; same net9.0-pinned Compile constraint as the AspVersioning pair above.
+         Gated by the CIPolecat target, which builds and runs PolecatIncidentService.Tests at
+         net10.0 (GH-3839 — before that it ran nowhere at all, which is how it sat un-compilable
+         for four months). -->
+    <Project Path="src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj">
+      <Build Project="false" />
+    </Project>
+    <Project Path="src/Persistence/Polecat/PolecatIncidentService/PolecatIncidentService.csproj">
+      <Build Project="false" />
+    </Project>
     <Project Path="src/Persistence/PolecatTests/PolecatTests.csproj" />
     <Project Path="src/Persistence/Wolverine.Polecat/Wolverine.Polecat.csproj" />
   </Folder>
@@ -317,18 +333,14 @@
     <Project Path="src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj" />
     <Project Path="src/Transports/SignalR/Wolverine.SignalR/Wolverine.SignalR.csproj" />
   </Folder>
-  <!-- The only project that should carry Build=false. The Nuke build project is the thing that
-       *drives* the build; it is not part of the product, and it is compiled by build.sh on its own.
+  <!-- The Nuke build project drives the build rather than being part of the product, and build.sh
+       compiles it on its own.
 
-       GH-3839/GH-3841: every other exclusion has been removed. A Build=false project is invisible to
-       the solution build, which is the gate CI's Compile target runs and the one CLAUDE.md tells
-       contributors to run before pushing — so nothing checks it at all. That is not theoretical:
-       PolecatIncidentService.Tests did not compile for four months and no gate noticed, and
-       Wolverine.Http.AspVersioning is a published package (WolverineFx.Http.AspVersioning) that
-       compiled only during Pack, where a break would first surface as a failed release.
-
-       If a project genuinely has to be excluded, say why right here. An unexplained Build=false is
-       indistinguishable from an accident. -->
+       GH-3841: every Build=false in this file now states its reason. An unexplained one is
+       indistinguishable from an accident — which is exactly how PolecatIncidentService.Tests sat
+       un-compilable for four months (GH-3839) behind a flag nobody could evaluate. The reason
+       matters more than the flag: a project excluded here is invisible to the solution build, so
+       it needs a gate somewhere else, and the comment is where you say which one. -->
   <Project Path="build/build.csproj">
     <Build Project="false" />
   </Project>

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -44,12 +44,8 @@
     <Project Path="src/Http/OpenApiDemonstrator/OpenApiDemonstrator.csproj" />
     <Project Path="src/Http/StaticCodeGenDemonstrator/StaticCodeGenDemonstrator.csproj" />
     <Project Path="src/Http/Wolverine.AdminApi/Wolverine.AdminApi.csproj" />
-    <Project Path="src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj">
-      <Build Project="false" />
-    </Project>
-    <Project Path="src/Http/Wolverine.Http.AspVersioning/Wolverine.Http.AspVersioning.csproj">
-      <Build Project="false" />
-    </Project>
+    <Project Path="src/Http/Wolverine.Http.AspVersioning.Tests/Wolverine.Http.AspVersioning.Tests.csproj" />
+    <Project Path="src/Http/Wolverine.Http.AspVersioning/Wolverine.Http.AspVersioning.csproj" />
     <Project Path="src/Http/Wolverine.Http.FluentValidation/Wolverine.Http.FluentValidation.csproj" />
     <Project Path="src/Http/Wolverine.Http.Marten/Wolverine.Http.Marten.csproj" />
     <Project Path="src/Http/Wolverine.Http.Tests.DifferentAssembly/Wolverine.Http.Tests.DifferentAssembly.csproj" />
@@ -117,12 +113,8 @@
   </Folder>
   <Folder Name="/Persistence/Polecat/">
     <Project Path="src/Http/Wolverine.Http.Polecat/Wolverine.Http.Polecat.csproj" />
-    <Project Path="src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj">
-      <Build Project="false" />
-    </Project>
-    <Project Path="src/Persistence/Polecat/PolecatIncidentService/PolecatIncidentService.csproj">
-      <Build Project="false" />
-    </Project>
+    <Project Path="src/Persistence/Polecat/PolecatIncidentService.Tests/PolecatIncidentService.Tests.csproj" />
+    <Project Path="src/Persistence/Polecat/PolecatIncidentService/PolecatIncidentService.csproj" />
     <Project Path="src/Persistence/PolecatTests/PolecatTests.csproj" />
     <Project Path="src/Persistence/Wolverine.Polecat/Wolverine.Polecat.csproj" />
   </Folder>
@@ -325,6 +317,18 @@
     <Project Path="src/Transports/SignalR/Wolverine.SignalR.Tests/Wolverine.SignalR.Tests.csproj" />
     <Project Path="src/Transports/SignalR/Wolverine.SignalR/Wolverine.SignalR.csproj" />
   </Folder>
+  <!-- The only project that should carry Build=false. The Nuke build project is the thing that
+       *drives* the build; it is not part of the product, and it is compiled by build.sh on its own.
+
+       GH-3839/GH-3841: every other exclusion has been removed. A Build=false project is invisible to
+       the solution build, which is the gate CI's Compile target runs and the one CLAUDE.md tells
+       contributors to run before pushing — so nothing checks it at all. That is not theoretical:
+       PolecatIncidentService.Tests did not compile for four months and no gate noticed, and
+       Wolverine.Http.AspVersioning is a published package (WolverineFx.Http.AspVersioning) that
+       compiled only during Pack, where a break would first surface as a failed release.
+
+       If a project genuinely has to be excluded, say why right here. An unexplained Build=false is
+       indistinguishable from an accident. -->
   <Project Path="build/build.csproj">
     <Build Project="false" />
   </Project>


### PR DESCRIPTION
Closes #3839. Closes #3841.

> **This PR changed shape after CI.** It originally removed every `Build=false` from `wolverine.slnx`. That was wrong — the flags were load-bearing — and the correction is described below. What survives is the sample repair, a CI gate for it, and the documentation #3841 actually asked for.

## What was actually broken

`PolecatIncidentService.Tests` had not compiled since the slnx migration (`1fb8e865b`, 2026-04-08). Four months, no gate noticed — because the project was excluded from the solution build *and* ran in no CI target.

13 errors: 10 × VSTHRD103 (`ReadAsJson` blocks synchronously) and 3 × xUnit1051 (pass `TestContext.Current.CancellationToken`) — xUnit v3 migration leftovers.

The fix is not invented. `src/Samples/IncidentService/IncidentService.Tests/when_logging_an_incident.cs` is the Marten twin of this sample and already carries both repairs:

```csharp
// Marten twin -- repaired
var response = await initial.ReadAsJsonAsync<CreationResponse<Guid>>();
var incident  = await session.Events.FetchLatest<Incident>(response.Value, TestContext.Current.CancellationToken);

// Polecat copy -- as found
var response = initial.ReadAsJson<CreationResponse<Guid>>();
var incident  = await session.Events.FetchLatest<Incident>(response.Value);
```

Copied test files do not inherit each other's later fixes.

## Running it, not only compiling it

The sample's tests now run on the `CIPolecat` catch-all shard, which has already started the SQL Server the sample connects to. ~9s against a 338s job. They are built and run **by path** at net10.0, independent of the solution — so this gate holds regardless of the exclusion discussion below.

That is the other half of "and nothing notices": a compile gate catches a compile break, and only running it catches a behavioural one.

## The correction: the exclusions were load-bearing

The first push removed all four `Build=false` flags. CI failed with `NETSDK1005`, and it was right to.

All four projects are **net10.0-only**, and `.nuke/parameters.json` pins `"Framework": "net9.0"` — so `Compile` builds `wolverine.slnx` at net9.0, and including them cannot work.

I had verified with `dotnet build wolverine.slnx -c Release`, which builds each project for its own TFMs. CI runs it **pinned**. `CLAUDE.md` says to build the full slnx before pushing and does not mention the framework pin, which is exactly how a green local build preceded a red CI one. `-f net9.0` reproduces the failure locally.

**So #3841's premise was wrong twice.** It named two shipping packages as excluded; only `Wolverine.Http.AspVersioning` is excluded at all (already corrected on the issue), and that one is built *and tested* at net10.0 by the `CIHttpAspVersioning` target. It was never ungated — it simply cannot be gated by a net9.0 solution build.

## What #3841 was right about

None of the flags said why. That is what let a project sit broken for four months behind something nobody could evaluate. Every `Build=false` in `wolverine.slnx` now states its reason **and names the gate that covers the project instead** — which is the useful half, since an excluded project needs coverage somewhere.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean. **This is the CI shape, and the check I should have run the first time.**
- `dotnet build wolverine.slnx -c Release` — clean.
- `./build.sh CIPolecat` — green, with `PolecatIncidentService.Tests: 9 passed` running inside it.
- `PolecatIncidentService.Tests` 9/9 and `Wolverine.Http.AspVersioning.Tests` 66/66 directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m