### PR TITLE
Say to build the solution the way CI does, pinned to net9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,16 @@ npm install && npm run docs
 > is clean across Wolverine. **Build `wolverine.slnx` before pushing**:
 >
 > ```bash
-> dotnet build wolverine.slnx -c Release
+> dotnet build wolverine.slnx -c Release -f net9.0
 > ```
+>
+> ⚠️ **Pass `-f net9.0`.** `.nuke/parameters.json` pins `"Framework": "net9.0"`, so the `Compile`
+> target builds the solution *pinned to a single framework*. A bare
+> `dotnet build wolverine.slnx` builds each project for its own `TargetFrameworks` instead, which
+> is a **weaker** check — a net10.0-only project passes locally and then fails CI with
+> `NETSDK1005: Assets file ... doesn't have a target for 'net9.0'`. That is not hypothetical; it
+> is what made GH-3839's first push red after a clean local build. Build the unpinned form too if
+> you like, but the pinned one is the gate.
 
 ## Key Entry Points
 


### PR DESCRIPTION
`CLAUDE.md` told contributors to run this before pushing:

```bash
dotnet build wolverine.slnx -c Release
```

That is a **weaker** check than the gate it stands in for. `.nuke/parameters.json` pins `"Framework": "net9.0"`, so the `Compile` target builds the solution pinned to one framework. The bare command builds each project for its own `TargetFrameworks` instead — so a net10.0-only project compiles happily locally and then fails CI with:

```
error NETSDK1005: Assets file '...' doesn't have a target for 'net9.0'.
```

Not hypothetical. #3848's first push re-enabled four net10.0-only projects in `wolverine.slnx`, passed the documented command locally, and went red on CI for every one of them. The instruction was followed exactly and still did not catch it — which makes it a bad instruction rather than a bad reader.

Changes the documented command to `-f net9.0` and explains why, so the pre-push check matches what CI actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m