### PR TITLE
Report whether durability/projection affinity engaged (GH-3785)

### DIFF
--- a/src/Persistence/MartenTests/MultiTenancy/durability_projection_affinity_real_stores.cs
+++ b/src/Persistence/MartenTests/MultiTenancy/durability_projection_affinity_real_stores.cs
@@ -122,8 +122,16 @@ public class durability_projection_affinity_real_stores : IAsyncLifetime
         // The two passes in the order NodeAgentController guarantees, both over real URIs.
         grid.DistributeByGroupAffinity(EventSubscriptionAgentFamily.SchemeName,
             EventSubscriptionAgentFamily.DatabaseKeyOf);
-        grid.DistributeEvenlyWithAffinity(PersistenceConstants.AgentScheme,
-            DurabilityProjectionAffinity.BuildPreference(grid));
+        var preference = DurabilityProjectionAffinity.BuildPreference(grid);
+        grid.DistributeEvenlyWithAffinity(PersistenceConstants.AgentScheme, preference.NodeFor);
+
+        // GH-3785: the join is fail-silent at runtime, so the integration test that proves the two URI
+        // pipelines actually agree is exactly the place to pin the diagnostic that reports it. Every one
+        // of these real databases must have matched -- a miss here is the spelling divergence this whole
+        // test exists to catch, and it would otherwise look identical to success.
+        preference.KnownDatabases.ShouldBe(_databases.Length);
+        preference.Considered.ShouldBe(_messageStores.Count);
+        preference.Matched.ShouldBe(_messageStores.Count);
 
         grid.AllAgents.ShouldAllBe(a => a.AssignedNode != null);
 

--- a/src/Testing/CoreTests/Runtime/Agents/durability_follows_projection_affinity.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/durability_follows_projection_affinity.cs
@@ -1,7 +1,9 @@
 using JasperFx.Descriptors;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Wolverine.ComplianceTests;
+using Wolverine.Persistence;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
 using Xunit;
@@ -136,6 +138,177 @@ public class durability_follows_projection_affinity
             .ShouldAllBe(count => count == 3, "with no affinity available the spread stays even");
     }
 
+    // GH-3785 diagnostics. The join falls back silently whenever it cannot match, which is the correct
+    // runtime behavior and an unusable diagnostic story: a join that never fires because the two families
+    // spell the same database differently looks exactly like the feature working. These pin the counters
+    // that tell an operator which one they got.
+
+    [Fact]
+    public void the_affinity_report_counts_what_actually_joined()
+    {
+        var databases = new[] { "tenant1", "tenant2", "tenant3" };
+        var projections = databases.Select(db => Projection("localhost", db, "t1")).ToArray();
+        var durability = databases.Select(db => Durability("localhost", db)).ToArray();
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(projections.Concat(durability).ToArray());
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+        var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+        grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+        preference.KnownDatabases.ShouldBe(3);
+        preference.Considered.ShouldBe(3);
+        preference.Matched.ShouldBe(3);
+    }
+
+    [Fact]
+    public void a_spelling_divergence_between_the_two_pipelines_reports_zero_matches()
+    {
+        // THE failure this diagnostic exists for. Both families describe the same three physical databases,
+        // but through descriptor pipelines that disagree about the name — so nothing joins, every durability
+        // agent silently falls back to the even spread, and the cluster keeps paying the two-pools-per-shard
+        // cost with no outward sign. Known and Considered are both non-zero while Matched is zero, which is
+        // the shape that has to be distinguishable from "this app simply has no projections".
+        var projections = new[] { "tenant1", "tenant2", "tenant3" }
+            .Select(db => Projection("localhost", db, "t1")).ToArray();
+        var durability = new[] { "tenant_1", "tenant_2", "tenant_3" }
+            .Select(db => Durability("localhost", db)).ToArray();
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(projections.Concat(durability).ToArray());
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+        var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+        grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+        preference.KnownDatabases.ShouldBe(3);
+        preference.Considered.ShouldBe(3);
+        preference.Matched.ShouldBe(0);
+
+        // ...and the fallback still placed everything. A miss is never wrong, only not-better.
+        grid.AllAgents.ShouldAllBe(a => a.AssignedNode != null);
+    }
+
+    [Fact]
+    public void a_durability_uri_that_names_no_database_is_not_counted_as_a_miss()
+    {
+        // The null store and the multi-tenanted composite marker are not databases. Counting them as
+        // considered-but-unmatched would show a permanent shortfall on a healthy cluster and train an
+        // operator to ignore the number.
+        var projections = new[] { Projection("localhost", "tenant1", "t1") };
+        var durability = new[] { Durability("localhost", "tenant1"), new Uri("wolverinedb://nullstore") };
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(projections.Concat(durability).ToArray());
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+        var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+        grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+        preference.Considered.ShouldBe(1, "only the URI that actually names a database is eligible");
+        preference.Matched.ShouldBe(1);
+        grid.AllAgents.ShouldAllBe(a => a.AssignedNode != null);
+    }
+
+    [Fact]
+    public void an_application_with_no_projections_reports_nothing_to_follow()
+    {
+        // Distinguishable from the divergence case above by KnownDatabases == 0: there was never anything
+        // to co-locate with, so there is nothing to warn about.
+        var durability = Enumerable.Range(1, 4).Select(i => Durability("localhost", $"plain{i}")).ToArray();
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(durability);
+
+        var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+        grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+        preference.KnownDatabases.ShouldBe(0);
+        preference.Matched.ShouldBe(0);
+    }
+
+    [Fact]
+    public void the_report_is_written_once_and_then_stays_quiet_until_it_changes()
+    {
+        // Assignment is re-evaluated on every health check. A settled cluster reports the same numbers
+        // forever, and an unconditional log line at that cadence is noise an operator learns to filter —
+        // which defeats the point of having it at all.
+        var databases = new[] { "tenant1", "tenant2" };
+        var projections = databases.Select(db => Projection("localhost", db, "t1")).ToArray();
+        var durability = databases.Select(db => Durability("localhost", db)).ToArray();
+
+        var logger = new RecordingLogger();
+        (int Known, int Considered, int Matched) last = default;
+
+        for (var i = 0; i < 5; i++)
+        {
+            var grid = new AssignmentGrid();
+            grid.WithNode(1, Guid.NewGuid());
+            grid.WithNode(2, Guid.NewGuid());
+            grid.WithAgents(projections.Concat(durability).ToArray());
+
+            grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+            var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+            grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+            preference.ReportTo(logger, ref last);
+        }
+
+        logger.Messages.Count.ShouldBe(1, "five identical evaluations are one event, not five");
+        logger.Messages.Single().Level.ShouldBe(LogLevel.Information);
+    }
+
+    [Fact]
+    public void the_fail_silent_case_is_logged_as_a_warning()
+    {
+        var projections = new[] { Projection("localhost", "tenant1", "t1") };
+        var durability = new[] { Durability("localhost", "tenant_1") };
+
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(projections.Concat(durability).ToArray());
+
+        grid.DistributeByGroupAffinity("event-subscriptions", DatabaseKey);
+        var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+        grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+        var logger = new RecordingLogger();
+        (int Known, int Considered, int Matched) last = default;
+        preference.ReportTo(logger, ref last);
+
+        var message = logger.Messages.ShouldHaveSingleItem();
+        message.Level.ShouldBe(LogLevel.Warning);
+        message.Text.ShouldContain("GH-3785");
+    }
+
+    [Fact]
+    public void an_application_with_no_projections_logs_nothing_at_all()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(Durability("localhost", "plain1"), Durability("localhost", "plain2"));
+
+        var preference = DurabilityProjectionAffinityAccess.BuildPreferenceReport(grid);
+        grid.DistributeEvenlyWithAffinity("wolverinedb", preference.NodeFor);
+
+        var logger = new RecordingLogger();
+        (int Known, int Considered, int Matched) last = default;
+        preference.ReportTo(logger, ref last);
+
+        logger.Messages.ShouldBeEmpty("nothing to co-locate with is not a finding");
+    }
+
     [Fact]
     public void the_same_database_name_on_two_servers_is_disambiguated_by_server()
     {
@@ -267,6 +440,20 @@ public class durability_follows_projection_affinity
             "the durability family must evaluate after every other family so cross-family affinity can see their assignments");
         calls.Count.ShouldBe(3);
     }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Text)> Messages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add((logLevel, formatter(state, exception)));
+        }
+    }
 }
 
 // DurabilityProjectionAffinity is internal to Wolverine; CoreTests has InternalsVisibleTo, and this alias
@@ -274,5 +461,8 @@ public class durability_follows_projection_affinity
 internal static class DurabilityProjectionAffinityAccess
 {
     internal static Func<Uri, AssignmentGrid.Node?> BuildPreference(AssignmentGrid grid)
+        => Wolverine.Persistence.DurabilityProjectionAffinity.BuildPreference(grid).NodeFor;
+
+    internal static DurabilityAffinityPreference BuildPreferenceReport(AssignmentGrid grid)
         => Wolverine.Persistence.DurabilityProjectionAffinity.BuildPreference(grid);
 }

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageDatabase.Agents.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageDatabase.Agents.cs
@@ -48,9 +48,15 @@ public partial class MultiTenantedMessageStore : IAgentFamily
     public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments)
     {
         // GH-3785: same cross-family database affinity as MessageStoreCollection — see the note there.
-        assignments.DistributeEvenlyWithAffinity(Scheme, DurabilityProjectionAffinity.BuildPreference(assignments));
+        var preference = DurabilityProjectionAffinity.BuildPreference(assignments);
+        assignments.DistributeEvenlyWithAffinity(Scheme, preference.NodeFor);
+
+        preference.ReportTo(_logger, ref _lastAffinityReport);
+
         return ValueTask.CompletedTask;
     }
+
+    private (int Known, int Considered, int Matched) _lastAffinityReport;
 
     private class DummyAgent : IAgent
     {

--- a/src/Wolverine/Persistence/DurabilityAffinityPreference.cs
+++ b/src/Wolverine/Persistence/DurabilityAffinityPreference.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime.Agents;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+///     GH-3785: the preference function handed to <see cref="AssignmentGrid.DistributeEvenlyWithAffinity" />,
+///     plus a count of how much of it actually engaged.
+///
+///     <para>The affinity join is deliberately fail-silent — <see cref="DurabilityProjectionAffinity" /> falls
+///     back to the even spread whenever it cannot match a durability agent to a projection owner, because a
+///     miss is never <i>wrong</i>, only not-better. That is the right runtime behavior and the wrong
+///     diagnostic story: a join that never fires because the two families spell the same database differently
+///     looks exactly like the feature working, minus the benefit. Short of joining <c>pg_stat_activity</c>
+///     against the assignment table on a production cluster, there was no way to tell the two apart.</para>
+///
+///     <para>So count the two outcomes and let the caller report them. <see cref="Considered" /> counts only
+///     durability agents whose URI carries a (server, database) — the null store and the multi-tenanted
+///     composite marker are not databases and would otherwise show up as permanent misses.</para>
+/// </summary>
+internal sealed class DurabilityAffinityPreference
+{
+    private readonly Func<Uri, AssignmentGrid.Node?> _resolve;
+
+    internal DurabilityAffinityPreference(Func<Uri, AssignmentGrid.Node?> resolve, int knownDatabases)
+    {
+        _resolve = resolve;
+        KnownDatabases = knownDatabases;
+    }
+
+    /// <summary>
+    ///     How many distinct databases had event-subscription agents in the grid to follow. Zero is the
+    ///     ordinary case for an application with no Marten projections — nothing to co-locate with, and
+    ///     nothing worth reporting.
+    /// </summary>
+    public int KnownDatabases { get; }
+
+    /// <summary>
+    ///     Durability agents whose URI named a database, and so were eligible to follow a projection owner.
+    /// </summary>
+    public int Considered { get; private set; }
+
+    /// <summary>
+    ///     Of those, how many resolved to the node already owning that database's projections.
+    /// </summary>
+    public int Matched { get; private set; }
+
+    public AssignmentGrid.Node? NodeFor(Uri uri)
+    {
+        if (DurabilityProjectionAffinity.DatabaseOf(uri) == null)
+        {
+            return null;
+        }
+
+        Considered++;
+
+        var node = _resolve(uri);
+        if (node != null)
+        {
+            Matched++;
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    ///     Write the outcome to the log, but only when it has changed since the last evaluation. Assignment
+    ///     is re-evaluated on every health check, and a settled cluster reports the same numbers forever — an
+    ///     unconditional log line would be pure noise at exactly the cadence that makes it unreadable. A
+    ///     change means a deploy, a rebalance, or a database coming and going, which is when an operator
+    ///     wants to see it.
+    /// </summary>
+    public void ReportTo(ILogger logger, ref (int Known, int Considered, int Matched) last)
+    {
+        var current = (KnownDatabases, Considered, Matched);
+        if (current == last)
+        {
+            return;
+        }
+
+        last = current;
+
+        if (KnownDatabases == 0 || Considered == 0)
+        {
+            // Nothing to co-locate with. Not a failure, and not worth an operator's attention.
+            return;
+        }
+
+        if (Matched == 0)
+        {
+            // The fail-silent case, and the only one that needs a warning: there ARE projection agents and
+            // there ARE database-bearing durability agents, and not one of them joined. On a multi-database
+            // store that is a spelling divergence between the two descriptor pipelines, not a coincidence.
+            logger.LogWarning(
+                "Durability/projection database affinity (GH-3785) matched none of {Considered} durability agents against {KnownDatabases} databases holding event subscription agents. Durability agents fall back to an even spread, so each of those databases will attract two nodes' connection pools instead of one. This usually means the durability and event subscription URIs spell the same database differently.",
+                Considered, KnownDatabases);
+
+            return;
+        }
+
+        logger.LogInformation(
+            "Durability/projection database affinity (GH-3785) co-located {Matched} of {Considered} durability agents with their database's event subscription agents across {KnownDatabases} databases",
+            Matched, Considered, KnownDatabases);
+    }
+}

--- a/src/Wolverine/Persistence/DurabilityProjectionAffinity.cs
+++ b/src/Wolverine/Persistence/DurabilityProjectionAffinity.cs
@@ -41,7 +41,7 @@ internal static class DurabilityProjectionAffinity
     ///     one owner per version; the durability agent follows the larger side, tie-broken by node id for
     ///     determinism).
     /// </summary>
-    internal static Func<Uri, AssignmentGrid.Node?> BuildPreference(AssignmentGrid assignments)
+    internal static DurabilityAffinityPreference BuildPreference(AssignmentGrid assignments)
     {
         // (DatabaseId, node) -> how many of that database's event-subscription agents the node holds
         var owners = new Dictionary<DatabaseId, Dictionary<AssignmentGrid.Node, int>>();
@@ -69,7 +69,7 @@ internal static class DurabilityProjectionAffinity
 
         if (owners.Count == 0)
         {
-            return _ => null;
+            return new DurabilityAffinityPreference(_ => null, 0);
         }
 
         var ownerOf = owners.ToDictionary(
@@ -89,7 +89,7 @@ internal static class DurabilityProjectionAffinity
             .GroupBy(pair => pair.Key.Name, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
 
-        return uri =>
+        return new DurabilityAffinityPreference(uri =>
         {
             var database = DatabaseOf(uri);
             if (database == null)
@@ -113,7 +113,7 @@ internal static class DurabilityProjectionAffinity
                 .ToList();
 
             return matching.Count == 1 ? matching[0].Value : null;
-        };
+        }, owners.Count);
     }
 
     // The durability URI's server segment is descriptor.ServerName.Split(',')[0] while DatabaseId.Server

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -321,9 +321,19 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         // so the database attracts one node's connection pool instead of two. Depends on
         // NodeAgentController evaluating this family AFTER the event-subscription family. A database with
         // no projection agents in the grid falls back to the even spread.
-        assignments.DistributeEvenlyWithAffinity(Scheme, DurabilityProjectionAffinity.BuildPreference(assignments));
+        var preference = DurabilityProjectionAffinity.BuildPreference(assignments);
+        assignments.DistributeEvenlyWithAffinity(Scheme, preference.NodeFor);
+
+        // The fallback is silent by design, so say out loud how much of it engaged -- see
+        // DurabilityAffinityPreference. Logged only when the numbers move.
+        _affinityLogger ??= _runtime.LoggerFactory.CreateLogger<MessageStoreCollection>();
+        preference.ReportTo(_affinityLogger, ref _lastAffinityReport);
+
         return ValueTask.CompletedTask;
     }
+
+    private ILogger? _affinityLogger;
+    private (int Known, int Considered, int Matched) _lastAffinityReport;
 
     internal async Task<IAgent> StartScheduledJobProcessing(IWolverineRuntime runtime)
     {


### PR DESCRIPTION
The GH-3785 cross-family affinity join (#3805) is deliberately fail-silent — a durability agent that cannot be matched to its database's projection owner falls back to the even spread, because *a miss is never wrong, only not-better*. That is the right runtime behavior and an unusable diagnostic story: **a join that never fires because the two descriptor pipelines spell the same database differently looks exactly like the feature working, minus the benefit.**

Short of joining `pg_stat_activity` against the assignment table on a production cluster, there was no way to tell the two apart. That matters right now: #3785 is one confirming measurement away from closing, and the measurement it is waiting on is precisely "did the join engage against *this* cluster's 512 databases and its particular server naming."

## What this adds

`DurabilityAffinityPreference` wraps the preference function and counts both outcomes:

| | |
|---|---|
| `KnownDatabases` | databases with event-subscription agents in the grid — something to follow |
| `Considered` | durability agents whose URI actually names a database (the null store and the composite marker are not databases, and would otherwise read as permanent misses) |
| `Matched` | of those, how many resolved to their database's projection owner |

**Logged only when the numbers move.** Assignment is re-evaluated on every health check, and a settled cluster reports the same figures forever — an unconditional line would be noise at exactly the cadence that makes it unreadable. A change means a deploy, a rebalance, or a database arriving or leaving.

Three outcomes, three behaviors:

- `Matched > 0` → **Information**, once: `co-located {Matched} of {Considered} durability agents ... across {KnownDatabases} databases`
- `Matched == 0` with `KnownDatabases` and `Considered` both non-zero → **Warning**. There *are* projection agents, there *are* database-bearing durability agents, and not one joined. On a multi-database store that is a spelling divergence, not a coincidence — and it names the consequence (each of those databases attracts two nodes' connection pools instead of one).
- `KnownDatabases == 0` → silent. An application with no projections has nothing to co-locate with; that is not a finding.

## Testing

7 new CoreTests, **each mutation-tested against a matching defect** — counting non-database URIs as considered, dropping the change gate, not escalating the fail-silent case, warning when there was nothing to follow. All four mutants killed, one test each, no overlap.

The real-stores Marten test now also asserts every database matched. That test exists *because* the join spans two descriptor pipelines (Weasel vs Marten), so it is the right place to pin the counters — it is the only test where a spelling divergence could actually occur.

- `CoreTests.Runtime.Agents` — 293/293
- `durability_projection_affinity_real_stores` — passes against real Postgres tenant databases, 3 of 3 matched
- Full `wolverine.slnx` Release build clean

Behavior is unchanged: this is counting and logging only.

Related: #3785, #3805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHAuhdWS3XeAk16swV9G8m