### PR TITLE
Stop visiting the main database twice in forEveryDatabase (GH-3815)

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
@@ -137,19 +137,26 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         return _sender!.SendAsync(envelope);
     }
 
+    /// <summary>
+    /// GH-3815. These two sources overlap: <c>MultiTenantedMessageStore.ActiveDatabases()</c> yields
+    /// <c>Main</c> first, and <see cref="MySqlTransport.Databases"/> is only ever assigned alongside
+    /// <c>Store = mt.Main</c>. Visiting both therefore hit the main database twice — doubling
+    /// <see cref="CountAsync"/>/<see cref="ScheduledCountAsync"/>, which <see cref="GetAttributesAsync"/>
+    /// reports as user visible queue depth, and running every schema check against it twice. The
+    /// SqlServer and Sqlite queues already branch this way.
+    /// </summary>
     private async ValueTask forEveryDatabase(Func<MySqlDataSource, string, Task> action)
     {
-        if (Parent?.Store?.MySqlDataSource != null)
-        {
-            await action(Parent.Store.MySqlDataSource, Parent.Store.Identifier);
-        }
-
         if (Parent?.Databases != null)
         {
             foreach (var database in Parent.Databases.ActiveDatabases().OfType<MySqlMessageStore>())
             {
                 await action(database.MySqlDataSource, database.Identifier);
             }
+        }
+        else if (Parent?.Store?.MySqlDataSource != null)
+        {
+            await action(Parent.Store.MySqlDataSource, Parent.Store.Identifier);
         }
     }
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueue.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueue.cs
@@ -137,19 +137,26 @@ public class OracleQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         return _sender!.SendAsync(envelope);
     }
 
+    /// <summary>
+    /// GH-3815. These two sources overlap: <c>MultiTenantedMessageStore.ActiveDatabases()</c> yields
+    /// <c>Main</c> first, and <see cref="OracleTransport.Databases"/> is only ever assigned alongside
+    /// <c>Store = mt.Main</c>. Visiting both therefore hit the main database twice — doubling
+    /// <see cref="CountAsync"/>/<see cref="ScheduledCountAsync"/>, which <see cref="GetAttributesAsync"/>
+    /// reports as user visible queue depth, and running every schema check against it twice. The
+    /// SqlServer and Sqlite queues already branch this way.
+    /// </summary>
     private async ValueTask forEveryDatabase(Func<OracleDataSource, string, Task> action)
     {
-        if (Parent?.Store?.OracleDataSource != null)
-        {
-            await action(Parent.Store.OracleDataSource, Parent.Store.Name);
-        }
-
         if (Parent?.Databases != null)
         {
             foreach (var database in Parent.Databases.ActiveDatabases().OfType<OracleMessageStore>())
             {
                 await action(database.OracleDataSource, database.Name);
             }
+        }
+        else if (Parent?.Store?.OracleDataSource != null)
+        {
+            await action(Parent.Store.OracleDataSource, Parent.Store.Name);
         }
     }
 

--- a/src/Persistence/PostgresqlTests/MultiTenancy/queue_counts_across_tenant_databases.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/queue_counts_across_tenant_databases.cs
@@ -1,0 +1,173 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Postgresql.Transport;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PostgresqlTests.MultiTenancy;
+
+/// <summary>
+/// GH-3815. <c>forEveryDatabase</c> walked <c>Parent.Store</c> and then every entry of
+/// <c>Parent.Databases.ActiveDatabases()</c> — but <c>MultiTenantedMessageStore.ActiveDatabases()</c>
+/// yields <c>Main</c> first, and <c>Databases</c> is only ever assigned alongside <c>Store = mt.Main</c>.
+/// The main database was therefore visited twice, so <c>CountAsync()</c> and <c>ScheduledCountAsync()</c>
+/// double counted every row living in it. Those two feed <c>GetAttributesAsync()</c>, so this was
+/// user visible queue depth, not just a test concern.
+///
+/// The existing multi-tenant coverage misses it because it only ever asserts a count of <c>0</c>, and
+/// zero doubled is still zero.
+/// </summary>
+public class queue_counts_across_tenant_databases : MultiTenancyContext
+{
+    private const string SchemaName = "queue_counts_tenanted";
+    private const string QueueName = "countone";
+
+    protected override void configureWolverine(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName)
+            .EnableMessageTransport(transport => transport.TransportSchemaName(SchemaName))
+            .RegisterStaticTenants(tenants =>
+            {
+                tenants.Register("red", tenant1ConnectionString);
+                tenants.Register("blue", tenant2ConnectionString);
+                tenants.Register("green", tenant3ConnectionString);
+            });
+
+        // Subscriber only -- no listener, so nothing drains the queue out from under the assertions.
+        opts.PublishAllMessages().ToPostgresqlQueue(QueueName);
+
+        opts.Services.AddResourceSetupOnStartup();
+    }
+
+    protected override async Task onStartup()
+    {
+        foreach (var connectionString in allConnectionStrings())
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+            try
+            {
+                foreach (var table in new[] { $"wolverine_queue_{QueueName}", $"wolverine_queue_{QueueName}_scheduled" })
+                {
+                    await using var cmd = conn.CreateCommand();
+                    cmd.CommandText = $"delete from {SchemaName}.{table}";
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                    catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UndefinedTable ||
+                                                      e.SqlState == PostgresErrorCodes.InvalidSchemaName)
+                    {
+                        // Nothing provisioned in this database yet, nothing to clean
+                    }
+                }
+            }
+            finally
+            {
+                await conn.CloseAsync();
+            }
+        }
+    }
+
+    private string[] allConnectionStrings() =>
+    [
+        Servers.PostgresConnectionString, tenant1ConnectionString, tenant2ConnectionString, tenant3ConnectionString
+    ];
+
+    private PostgresqlQueue theQueue =>
+        theHost.GetRuntime().Options.Transports.GetOrCreate<PostgresqlTransport>().Queues[QueueName];
+
+    /// <summary>
+    /// A row in the *main* database is the one that gets double counted — an untenanted send lands there.
+    /// </summary>
+    [Fact]
+    public async Task does_not_double_count_rows_in_the_main_database()
+    {
+        var runtime = theHost.GetRuntime();
+        ((MultiTenantedMessageStore)runtime.Storage).ActiveDatabases().Count.ShouldBe(4);
+
+        var immediate = ObjectMother.Envelope();
+        immediate.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(immediate);
+
+        var scheduled = ObjectMother.Envelope();
+        scheduled.ScheduleDelay = 1.Hours();
+        scheduled.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(scheduled);
+
+        // Precondition: exactly one row physically exists, in the main database only
+        (await rowCountAsync(Servers.PostgresConnectionString, $"wolverine_queue_{QueueName}")).ShouldBe(1);
+        (await rowCountAsync(Servers.PostgresConnectionString, $"wolverine_queue_{QueueName}_scheduled")).ShouldBe(1);
+
+        (await theQueue.CountAsync()).ShouldBe(1);
+        (await theQueue.ScheduledCountAsync()).ShouldBe(1);
+    }
+
+    /// <summary>
+    /// And the sum still reaches every tenant database -- the fix must not trade the double count for a
+    /// missed database.
+    /// </summary>
+    [Fact]
+    public async Task still_sums_across_main_and_every_tenant_database()
+    {
+        var untenanted = ObjectMother.Envelope();
+        untenanted.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(untenanted);
+
+        foreach (var tenantId in new[] { "red", "blue", "green" })
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.TenantId = tenantId;
+            envelope.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+            await theQueue.SendAsync(envelope);
+        }
+
+        foreach (var connectionString in allConnectionStrings())
+        {
+            (await rowCountAsync(connectionString, $"wolverine_queue_{QueueName}")).ShouldBe(1);
+        }
+
+        // One row in each of the four databases, counted once apiece
+        (await theQueue.CountAsync()).ShouldBe(4);
+    }
+
+    /// <summary>
+    /// GetAttributesAsync() is the user visible surface -- it reports whatever CountAsync() returns.
+    /// </summary>
+    [Fact]
+    public async Task reported_attributes_match_the_physical_row_count()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(envelope);
+
+        var attributes = await theQueue.GetAttributesAsync();
+
+        attributes["Count"].ShouldBe("1");
+    }
+
+    private static async Task<long> rowCountAsync(string connectionString, string tableName)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"select count(*) from {SchemaName}.{tableName}";
+            return (long)(await cmd.ExecuteScalarAsync())!;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
@@ -144,19 +144,26 @@ public class PostgresqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         return _sender!.SendAsync(envelope);
     }
 
+    /// <summary>
+    /// GH-3815. These two sources overlap: <c>MultiTenantedMessageStore.ActiveDatabases()</c> yields
+    /// <c>Main</c> first, and <see cref="PostgresqlTransport.Databases"/> is only ever assigned alongside
+    /// <c>Store = mt.Main</c>. Visiting both therefore hit the main database twice — doubling
+    /// <see cref="CountAsync"/>/<see cref="ScheduledCountAsync"/>, which <see cref="GetAttributesAsync"/>
+    /// reports as user visible queue depth, and running every schema check against it twice. The
+    /// SqlServer and Sqlite queues already branch this way.
+    /// </summary>
     private async ValueTask forEveryDatabase(Func<NpgsqlDataSource, string, Task> action)
     {
-        if (Parent?.Store?.NpgsqlDataSource != null)
-        {
-            await action(Parent.Store.NpgsqlDataSource, Parent.Store.Identifier);
-        }
-
         if (Parent?.Databases != null)
         {
             foreach (var database in Parent.Databases.ActiveDatabases().OfType<PostgresqlMessageStore>())
             {
                 await action(database.NpgsqlDataSource, database.Identifier);
             }
+        }
+        else if (Parent?.Store?.NpgsqlDataSource != null)
+        {
+            await action(Parent.Store.NpgsqlDataSource, Parent.Store.Identifier);
         }
     }
 


### PR DESCRIPTION
Fixes #3815.

## The unverified fact resolves to "yes"

#3815 called out one thing that had to be checked before any change: does `MultiTenantedMessageStore.ActiveDatabases()` actually include `Main`? It does — `databases()` yields it first:

```csharp
private IEnumerable<IMessageStore> databases()
{
    yield return Main;                                        // <-- here
    foreach (var database in Source.AllActive()) yield return database;
}
```

And every affected transport assigns `Databases` **only** alongside `Store = mt.Main` (checked at both assignment sites — `Initialize` and `ConnectAsync` — in each). So walking `Parent.Store` and then all of `ActiveDatabases()` hits the main database twice.

Measured on a real multi-tenanted Postgres host: `GetAttributesAsync()["Count"]` returns **`"2"` for a single row**, and **5 for 4 rows**.

## Scope is wider than the title, but not universal

| Transport | Shape | Affected |
|---|---|---|
| Oracle, PostgreSQL, MySQL | `if` … `if` | **yes** |
| SqlServer, Sqlite | `if` … `else` | no — already correct |

The SqlServer and Sqlite queues already branch the right way, so this PR brings the other three in line with them rather than introducing a new dedupe concept.

What was doubled:

- `CountAsync()` / `ScheduledCountAsync()` — these feed `GetAttributesAsync()`, so this is **user visible queue depth**, not just a test concern
- `CheckAsync()` — ran its schema diff against the main database twice
- `SetupAsync()` / `PurgeAsync()` / `TeardownAsync()` — did their work twice

## Why no existing test caught it

The multi-tenant coverage in `clear_all_wolverine_storage_across_tenant_databases` asserts `CountAsync()` is `0` after a purge — and zero doubled is still zero. The new tests assert a *non-zero* count, with a row deliberately placed in the main database (an untenanted send lands there).

## Verification

| Evidence | Without fix | With fix |
|---|---|---|
| `does_not_double_count_rows_in_the_main_database` | fails — `2` vs `1` | passes |
| `still_sums_across_main_and_every_tenant_database` | fails — `5` vs `4` | passes |
| `reported_attributes_match_the_physical_row_count` | fails — `"2"` vs `"1"` | passes |
| `dotnet build wolverine.slnx -c Release -f net9.0` | — | clean, 0 warnings |
| PostgresqlTests.MultiTenancy (incl. the pre-existing suite) | — | 21 / 21 |
| OracleTests.Transport | — | 22 / 22 |

The second test guards the obvious way to get this wrong — trading the double count for a missed tenant database.

## A related finding, filed separately

While trying to add the same test for MySQL I found a **different and larger** problem, tracked in its own issue rather than fixed here: MySQL has no per-tenant queue tables at all. Because a schema *is* a database in MySQL, `TransportSchemaName` resolves to one fixed database on the server, so the multi-tenant fan-out queries a single physical table once per tenant:

```
TABLE_SCHEMA      TABLE_NAME                        rows
wolverine_queues  wolverine_queue_countone          10      <-- one table, total
```

…while `CountAsync()` reported 40. This PR takes the MySQL multiplier from N+1 down to N, which is strictly closer to correct, but does not resolve that. PostgreSQL is unaffected because its transport schema nests inside each tenant database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKfy5EzLX1i149gjUb3Tfg
