### PR TITLE
MySQL: resolve queue tables per tenant database (GH-3859)

### DIFF
--- a/src/Persistence/MySql/MySqlTests/MultiTenancy/queue_tables_are_per_tenant_database.cs
+++ b/src/Persistence/MySql/MySqlTests/MultiTenancy/queue_tables_are_per_tenant_database.cs
@@ -1,0 +1,189 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.MySql;
+using Wolverine.MySql.Transport;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MySqlTests.MultiTenancy;
+
+/// <summary>
+/// GH-3859. A MySQL schema IS a database, so qualifying the queue tables with the single transport-wide
+/// <c>TransportSchemaName</c> resolved every tenant's data source to the *same* physical table: no tenant
+/// isolation, and a <c>CountAsync()</c> that multiplied the true row count by the number of tenants.
+/// On a multi-tenanted host each data source now resolves its queue tables inside its own database.
+/// </summary>
+[Collection("mysql")]
+public class queue_tables_are_per_tenant_database : MySqlMultiTenancyContext
+{
+    private const string SchemaName = "queue_per_tenant";
+    private const string QueueName = "pertenant";
+
+    protected override void configureWolverine(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithMySql(Servers.MySqlConnectionString, SchemaName)
+            .EnableMessageTransport()
+            .RegisterStaticTenants(tenants =>
+            {
+                tenants.Register("red", tenant1ConnectionString);
+                tenants.Register("blue", tenant2ConnectionString);
+                tenants.Register("green", tenant3ConnectionString);
+            });
+
+        // Subscriber only -- no listener, so nothing drains the queue out from under the assertions.
+        opts.PublishAllMessages().ToMySqlQueue(QueueName);
+
+        opts.Services.AddResourceSetupOnStartup();
+    }
+
+    protected override async Task onStartup()
+    {
+        foreach (var connectionString in allConnectionStrings())
+        {
+            await using var conn = new MySqlConnection(connectionString);
+            await conn.OpenAsync();
+            try
+            {
+                foreach (var table in new[] { QueueTableName, ScheduledTableName })
+                {
+                    await using var cmd = conn.CreateCommand();
+                    cmd.CommandText = $"delete from {table}";
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                    catch (MySqlException)
+                    {
+                        // Nothing provisioned in this database yet, nothing to clean
+                    }
+                }
+            }
+            finally
+            {
+                await conn.CloseAsync();
+            }
+        }
+    }
+
+    private const string QueueTableName = $"wolverine_queue_{QueueName}";
+    private const string ScheduledTableName = $"wolverine_queue_{QueueName}_scheduled";
+
+    private string[] allConnectionStrings() =>
+    [
+        Servers.MySqlConnectionString, tenant1ConnectionString, tenant2ConnectionString, tenant3ConnectionString
+    ];
+
+    private MySqlQueue theQueue =>
+        theHost.GetRuntime().Options.Transports.GetOrCreate<MySqlTransport>().Queues[QueueName];
+
+    /// <summary>
+    /// The structural half: every tenant database must physically own its queue tables. Before the fix
+    /// they existed only in the single "wolverine_queues" database.
+    /// </summary>
+    [Fact]
+    public async Task every_tenant_database_owns_its_own_queue_tables()
+    {
+        ((MultiTenantedMessageStore)theHost.GetRuntime().Storage).ActiveDatabases().Count.ShouldBe(4);
+
+        foreach (var connectionString in allConnectionStrings())
+        {
+            var database = new MySqlConnectionStringBuilder(connectionString).Database;
+
+            (await tableExistsAsync(connectionString, database, QueueTableName))
+                .ShouldBeTrue($"Expected {database}.{QueueTableName} to exist");
+            (await tableExistsAsync(connectionString, database, ScheduledTableName))
+                .ShouldBeTrue($"Expected {database}.{ScheduledTableName} to exist");
+        }
+    }
+
+    /// <summary>
+    /// The behavioural half: a tenant's message lands in that tenant's database and nowhere else.
+    /// </summary>
+    [Fact]
+    public async Task a_tenants_message_lands_only_in_that_tenants_database()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.TenantId = "red";
+        envelope.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(envelope);
+
+        (await rowCountAsync(tenant1ConnectionString)).ShouldBe(1);
+
+        foreach (var other in new[] { Servers.MySqlConnectionString, tenant2ConnectionString, tenant3ConnectionString })
+        {
+            (await rowCountAsync(other)).ShouldBe(0);
+        }
+    }
+
+    /// <summary>
+    /// And with one row per database the sum is the true total, not a multiple of it. This is what
+    /// GetAttributesAsync() reports as queue depth.
+    /// </summary>
+    [Fact]
+    public async Task counts_sum_across_databases_instead_of_multiplying()
+    {
+        var untenanted = ObjectMother.Envelope();
+        untenanted.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(untenanted);
+
+        foreach (var tenantId in new[] { "red", "blue", "green" })
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.TenantId = tenantId;
+            envelope.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+            await theQueue.SendAsync(envelope);
+        }
+
+        foreach (var connectionString in allConnectionStrings())
+        {
+            (await rowCountAsync(connectionString)).ShouldBe(1);
+        }
+
+        (await theQueue.CountAsync()).ShouldBe(4);
+        (await theQueue.GetAttributesAsync())["Count"].ShouldBe("4");
+    }
+
+    private static async Task<bool> tableExistsAsync(string connectionString, string database, string tableName)
+    {
+        await using var conn = new MySqlConnection(connectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "select count(*) from information_schema.tables where table_schema = @schema and table_name = @table";
+            cmd.Parameters.AddWithValue("schema", database);
+            cmd.Parameters.AddWithValue("table", tableName);
+
+            return Convert.ToInt64(await cmd.ExecuteScalarAsync()) > 0;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
+    private static async Task<long> rowCountAsync(string connectionString)
+    {
+        await using var conn = new MySqlConnection(connectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"select count(*) from {QueueTableName}";
+            return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
@@ -23,6 +23,10 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
     private bool _hasInitialized;
     private IMySqlQueueSender? _sender;
     private ImHashMap<string, bool> _checkedDatabases = ImHashMap<string, bool>.Empty;
+    private ImHashMap<string, QueueTable> _queueTables = ImHashMap<string, QueueTable>.Empty;
+    private ImHashMap<string, ScheduledMessageTable> _scheduledTables = ImHashMap<string, ScheduledMessageTable>.Empty;
+    private readonly string _queueTableName;
+    private readonly string _scheduledTableName;
     private readonly Lazy<QueueTable> _queueTable;
     private readonly Lazy<ScheduledMessageTable> _scheduledMessageTable;
 
@@ -31,17 +35,17 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         base(ToUri(name, databaseName), role)
     {
         Parent = parent;
-        var queueTableName = $"wolverine_queue_{name}";
-        var scheduledTableName = $"wolverine_queue_{name}_scheduled";
+        _queueTableName = $"wolverine_queue_{name}";
+        _scheduledTableName = $"wolverine_queue_{name}_scheduled";
 
         Mode = EndpointMode.Durable;
         Name = name;
         EndpointName = name;
         BrokerRole = "queue";
 
-        _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, queueTableName));
+        _queueTable = new Lazy<QueueTable>(() => new QueueTable(Parent, _queueTableName));
         _scheduledMessageTable =
-            new Lazy<ScheduledMessageTable>(() => new ScheduledMessageTable(Parent, scheduledTableName));
+            new Lazy<ScheduledMessageTable>(() => new ScheduledMessageTable(Parent, _scheduledTableName));
     }
 
     public string Name { get; }
@@ -51,6 +55,44 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
     internal Table QueueTable => _queueTable.Value;
 
     internal Table ScheduledTable => _scheduledMessageTable.Value;
+
+    /// <summary>
+    /// GH-3859. MySQL has no schema-inside-database nesting — a schema IS a database — so the single
+    /// <see cref="MySqlTransport.TransportSchemaName"/> that works for the other providers resolves to one
+    /// physical database for every tenant, and all tenants end up sharing one queue table. On a
+    /// multi-tenanted host each data source therefore has to resolve its queue tables inside its *own*
+    /// database. Single database hosts are unaffected and keep using TransportSchemaName.
+    /// </summary>
+    internal string SchemaFor(MySqlDataSource source)
+    {
+        if (Parent.Databases == null) return Parent.TransportSchemaName;
+
+        var database = new MySqlConnectionStringBuilder(source.ConnectionString).Database;
+
+        return database.IsEmpty() ? Parent.TransportSchemaName : database;
+    }
+
+    internal QueueTable QueueTableFor(MySqlDataSource source)
+    {
+        var schema = SchemaFor(source);
+        if (_queueTables.TryFind(schema, out var table)) return table;
+
+        table = new QueueTable(schema, _queueTableName);
+        _queueTables = _queueTables.AddOrUpdate(schema, table);
+
+        return table;
+    }
+
+    internal ScheduledMessageTable ScheduledTableFor(MySqlDataSource source)
+    {
+        var schema = SchemaFor(source);
+        if (_scheduledTables.TryFind(schema, out var table)) return table;
+
+        table = new ScheduledMessageTable(schema, _scheduledTableName);
+        _scheduledTables = _scheduledTables.AddOrUpdate(schema, table);
+
+        return table;
+    }
 
     protected override bool supportsMode(EndpointMode mode)
     {
@@ -168,11 +210,11 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
             try
             {
                 await using var cmd1 = conn.CreateCommand();
-                cmd1.CommandText = $"DELETE FROM {QueueTable.Identifier.QualifiedName}";
+                cmd1.CommandText = $"DELETE FROM {QueueTableFor(source).Identifier.QualifiedName}";
                 await cmd1.ExecuteNonQueryAsync();
 
                 await using var cmd2 = conn.CreateCommand();
-                cmd2.CommandText = $"DELETE FROM {ScheduledTable.Identifier.QualifiedName}";
+                cmd2.CommandText = $"DELETE FROM {ScheduledTableFor(source).Identifier.QualifiedName}";
                 await cmd2.ExecuteNonQueryAsync();
             }
             finally
@@ -199,14 +241,14 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
             await using var conn = await source.OpenConnectionAsync();
             try
             {
-                var queueDelta = await QueueTable.FindDeltaAsync(conn);
+                var queueDelta = await QueueTableFor(source).FindDeltaAsync(conn);
                 if (queueDelta.HasChanges())
                 {
                     returnValue = false;
                     return;
                 }
 
-                var scheduledDelta = await ScheduledTable.FindDeltaAsync(conn);
+                var scheduledDelta = await ScheduledTableFor(source).FindDeltaAsync(conn);
 
                 returnValue = returnValue && !scheduledDelta.HasChanges();
             }
@@ -225,8 +267,8 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         {
             await using var conn = await source.OpenConnectionAsync();
 
-            await QueueTable.DropAsync(conn);
-            await ScheduledTable.DropAsync(conn);
+            await QueueTableFor(source).DropAsync(conn);
+            await ScheduledTableFor(source).DropAsync(conn);
 
             await conn.CloseAsync();
         });
@@ -252,8 +294,8 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
     {
         await using (var conn = await source.OpenConnectionAsync())
         {
-            await QueueTable.ApplyChangesAsync(conn);
-            await ScheduledTable.ApplyChangesAsync(conn);
+            await QueueTableFor(source).ApplyChangesAsync(conn);
+            await ScheduledTableFor(source).ApplyChangesAsync(conn);
 
             await conn.CloseAsync();
         }
@@ -271,7 +313,7 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
             try
             {
                 await using var cmd = conn.CreateCommand();
-                cmd.CommandText = $"SELECT COUNT(*) FROM {QueueTable.Identifier.QualifiedName}";
+                cmd.CommandText = $"SELECT COUNT(*) FROM {QueueTableFor(source).Identifier.QualifiedName}";
                 count += Convert.ToInt64(await cmd.ExecuteScalarAsync());
             }
             finally
@@ -292,7 +334,7 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
             try
             {
                 await using var cmd = conn.CreateCommand();
-                cmd.CommandText = $"SELECT COUNT(*) FROM {ScheduledTable.Identifier.QualifiedName}";
+                cmd.CommandText = $"SELECT COUNT(*) FROM {ScheduledTableFor(source).Identifier.QualifiedName}";
                 count += Convert.ToInt64(await cmd.ExecuteScalarAsync());
             }
             finally

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueue.cs
@@ -137,19 +137,26 @@ public class MySqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         return _sender!.SendAsync(envelope);
     }
 
+    /// <summary>
+    /// GH-3815. These two sources overlap: <c>MultiTenantedMessageStore.ActiveDatabases()</c> yields
+    /// <c>Main</c> first, and <see cref="MySqlTransport.Databases"/> is only ever assigned alongside
+    /// <c>Store = mt.Main</c>. Visiting both therefore hit the main database twice — doubling
+    /// <see cref="CountAsync"/>/<see cref="ScheduledCountAsync"/>, which <see cref="GetAttributesAsync"/>
+    /// reports as user visible queue depth, and running every schema check against it twice. The
+    /// SqlServer and Sqlite queues already branch this way.
+    /// </summary>
     private async ValueTask forEveryDatabase(Func<MySqlDataSource, string, Task> action)
     {
-        if (Parent?.Store?.MySqlDataSource != null)
-        {
-            await action(Parent.Store.MySqlDataSource, Parent.Store.Identifier);
-        }
-
         if (Parent?.Databases != null)
         {
             foreach (var database in Parent.Databases.ActiveDatabases().OfType<MySqlMessageStore>())
             {
                 await action(database.MySqlDataSource, database.Identifier);
             }
+        }
+        else if (Parent?.Store?.MySqlDataSource != null)
+        {
+            await action(Parent.Store.MySqlDataSource, Parent.Store.Identifier);
         }
     }
 

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueueListener.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueueListener.cs
@@ -43,8 +43,10 @@ internal class MySqlQueueListener : IListener
 
         _sender = new MySqlQueueSender(queue, _dataSource, databaseName);
 
-        _queueTableName = _queue.QueueTable.Identifier.QualifiedName;
-        _scheduledTableName = _queue.ScheduledTable.Identifier.QualifiedName;
+        // GH-3859: resolved against this listener's own data source -- on a multi-tenanted host each
+        // tenant's queue tables live in that tenant's database.
+        _queueTableName = _queue.QueueTableFor(dataSource).Identifier.QualifiedName;
+        _scheduledTableName = _queue.ScheduledTableFor(dataSource).Identifier.QualifiedName;
         _schemaName = _queue.Parent.MessageStorageSchemaName;
 
         // MySQL doesn't have CTID, so we use a different approach:
@@ -424,7 +426,7 @@ AND {DatabaseConstants.KeepUntil} <= UTC_TIMESTAMP(6)")
                 .ExecuteNonQueryAsync(cancellationToken);
 
             await conn.CreateCommand($@"
-DELETE FROM {_queue.ScheduledTable.Identifier}
+DELETE FROM {_scheduledTableName}
 WHERE {DatabaseConstants.KeepUntil} IS NOT NULL
 AND {DatabaseConstants.KeepUntil} <= UTC_TIMESTAMP(6)")
                 .ExecuteNonQueryAsync(cancellationToken);

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueueSender.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueueSender.cs
@@ -31,9 +31,15 @@ internal class MySqlQueueSender : IMySqlQueueSender
 
         Destination = MySqlQueue.ToUri(queue.Name, databaseName);
 
-        _schemaName = queue.Parent.TransportSchemaName;
+        // GH-3859: on a multi-tenanted host the queue tables live in each tenant's OWN database, so
+        // every one of the statements below has to be built against THIS sender's data source rather
+        // than the transport-wide schema name.
+        var queueTable = queue.QueueTableFor(dataSource).Identifier;
+        var scheduledTable = queue.ScheduledTableFor(dataSource).Identifier;
+
+        _schemaName = queue.SchemaFor(dataSource);
         _moveFromOutgoingToQueueSql = $@"
-INSERT INTO {queue.QueueTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil})
+INSERT INTO {queueTable} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil})
 SELECT {DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.DeliverBy}
 FROM {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.OutgoingTable}
 WHERE {DatabaseConstants.Id} = @id;
@@ -41,7 +47,7 @@ DELETE FROM {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.OutgoingT
 ";
 
         _moveFromOutgoingToScheduledSql = $@"
-INSERT INTO {queue.ScheduledTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.ExecutionTime}, {DatabaseConstants.KeepUntil})
+INSERT INTO {scheduledTable} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.ExecutionTime}, {DatabaseConstants.KeepUntil})
 SELECT {DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, @time, {DatabaseConstants.DeliverBy}
 FROM {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.OutgoingTable}
 WHERE {DatabaseConstants.Id} = @id;
@@ -49,10 +55,10 @@ DELETE FROM {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.OutgoingT
 ";
 
         _writeDirectlyToQueueTableSql =
-            $@"INSERT INTO {queue.QueueTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}) VALUES (@id, @body, @type, @expires)";
+            $@"INSERT INTO {queueTable} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}) VALUES (@id, @body, @type, @expires)";
 
         _writeDirectlyToTheScheduledTable = $@"
-INSERT INTO {queue.ScheduledTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}, {DatabaseConstants.ExecutionTime})
+INSERT INTO {scheduledTable} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}, {DatabaseConstants.ExecutionTime})
 VALUES (@id, @body, @type, @expires, @time)
 ON DUPLICATE KEY UPDATE {DatabaseConstants.Body} = @body, {DatabaseConstants.MessageType} = @type, {DatabaseConstants.KeepUntil} = @expires, {DatabaseConstants.ExecutionTime} = @time
 ".Trim();

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlTransport.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlTransport.cs
@@ -75,8 +75,15 @@ public class MySqlTransport : BrokerTransport<MySqlQueue>
 
         foreach (var queue in Queues)
         {
-            Store.AddTable(queue.QueueTable);
-            Store.AddTable(queue.ScheduledTable);
+            // GH-3859: on a multi-tenanted host the queue tables live in each database rather than in
+            // one transport-wide schema, and SetupAsync()/EnsureSchemaExists() provision them per data
+            // source. Registering a single set with the main store here would only ever provision one
+            // that nothing uses.
+            if (Databases == null)
+            {
+                Store.AddTable(queue.QueueTableFor(Store.MySqlDataSource));
+                Store.AddTable(queue.ScheduledTableFor(Store.MySqlDataSource));
+            }
         }
 
         MessageStorageSchemaName = Store.SchemaName;

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/QueueTable.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/QueueTable.cs
@@ -6,8 +6,13 @@ namespace Wolverine.MySql.Transport;
 
 internal class QueueTable : Table
 {
-    public QueueTable(MySqlTransport parent, string tableName) : base(
-        new DbObjectName(parent.TransportSchemaName, tableName))
+    public QueueTable(MySqlTransport parent, string tableName) : this(parent.TransportSchemaName, tableName)
+    {
+    }
+
+    // GH-3859: the schema is resolved per data source on a multi-tenanted host, because a MySQL schema
+    // IS a database and one fixed name would leave every tenant sharing a single physical queue table.
+    public QueueTable(string schemaName, string tableName) : base(new DbObjectName(schemaName, tableName))
     {
         AddColumn<Guid>(DatabaseConstants.Id).AsPrimaryKey();
         AddColumn(DatabaseConstants.Body, "LONGBLOB").NotNull();

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/ScheduledMessageTable.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/ScheduledMessageTable.cs
@@ -6,8 +6,13 @@ namespace Wolverine.MySql.Transport;
 
 internal class ScheduledMessageTable : Table
 {
-    public ScheduledMessageTable(MySqlTransport settings, string tableName) : base(
-        new DbObjectName(settings.TransportSchemaName, tableName))
+    public ScheduledMessageTable(MySqlTransport settings, string tableName)
+        : this(settings.TransportSchemaName, tableName)
+    {
+    }
+
+    // GH-3859: see the matching comment on QueueTable.
+    public ScheduledMessageTable(string schemaName, string tableName) : base(new DbObjectName(schemaName, tableName))
     {
         AddColumn<Guid>(DatabaseConstants.Id).AsPrimaryKey();
         AddColumn(DatabaseConstants.Body, "LONGBLOB").NotNull();

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueue.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueue.cs
@@ -137,19 +137,26 @@ public class OracleQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         return _sender!.SendAsync(envelope);
     }
 
+    /// <summary>
+    /// GH-3815. These two sources overlap: <c>MultiTenantedMessageStore.ActiveDatabases()</c> yields
+    /// <c>Main</c> first, and <see cref="OracleTransport.Databases"/> is only ever assigned alongside
+    /// <c>Store = mt.Main</c>. Visiting both therefore hit the main database twice — doubling
+    /// <see cref="CountAsync"/>/<see cref="ScheduledCountAsync"/>, which <see cref="GetAttributesAsync"/>
+    /// reports as user visible queue depth, and running every schema check against it twice. The
+    /// SqlServer and Sqlite queues already branch this way.
+    /// </summary>
     private async ValueTask forEveryDatabase(Func<OracleDataSource, string, Task> action)
     {
-        if (Parent?.Store?.OracleDataSource != null)
-        {
-            await action(Parent.Store.OracleDataSource, Parent.Store.Name);
-        }
-
         if (Parent?.Databases != null)
         {
             foreach (var database in Parent.Databases.ActiveDatabases().OfType<OracleMessageStore>())
             {
                 await action(database.OracleDataSource, database.Name);
             }
+        }
+        else if (Parent?.Store?.OracleDataSource != null)
+        {
+            await action(Parent.Store.OracleDataSource, Parent.Store.Name);
         }
     }
 

--- a/src/Persistence/PostgresqlTests/MultiTenancy/queue_counts_across_tenant_databases.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/queue_counts_across_tenant_databases.cs
@@ -1,0 +1,173 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Postgresql.Transport;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PostgresqlTests.MultiTenancy;
+
+/// <summary>
+/// GH-3815. <c>forEveryDatabase</c> walked <c>Parent.Store</c> and then every entry of
+/// <c>Parent.Databases.ActiveDatabases()</c> — but <c>MultiTenantedMessageStore.ActiveDatabases()</c>
+/// yields <c>Main</c> first, and <c>Databases</c> is only ever assigned alongside <c>Store = mt.Main</c>.
+/// The main database was therefore visited twice, so <c>CountAsync()</c> and <c>ScheduledCountAsync()</c>
+/// double counted every row living in it. Those two feed <c>GetAttributesAsync()</c>, so this was
+/// user visible queue depth, not just a test concern.
+///
+/// The existing multi-tenant coverage misses it because it only ever asserts a count of <c>0</c>, and
+/// zero doubled is still zero.
+/// </summary>
+public class queue_counts_across_tenant_databases : MultiTenancyContext
+{
+    private const string SchemaName = "queue_counts_tenanted";
+    private const string QueueName = "countone";
+
+    protected override void configureWolverine(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName)
+            .EnableMessageTransport(transport => transport.TransportSchemaName(SchemaName))
+            .RegisterStaticTenants(tenants =>
+            {
+                tenants.Register("red", tenant1ConnectionString);
+                tenants.Register("blue", tenant2ConnectionString);
+                tenants.Register("green", tenant3ConnectionString);
+            });
+
+        // Subscriber only -- no listener, so nothing drains the queue out from under the assertions.
+        opts.PublishAllMessages().ToPostgresqlQueue(QueueName);
+
+        opts.Services.AddResourceSetupOnStartup();
+    }
+
+    protected override async Task onStartup()
+    {
+        foreach (var connectionString in allConnectionStrings())
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+            try
+            {
+                foreach (var table in new[] { $"wolverine_queue_{QueueName}", $"wolverine_queue_{QueueName}_scheduled" })
+                {
+                    await using var cmd = conn.CreateCommand();
+                    cmd.CommandText = $"delete from {SchemaName}.{table}";
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                    catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UndefinedTable ||
+                                                      e.SqlState == PostgresErrorCodes.InvalidSchemaName)
+                    {
+                        // Nothing provisioned in this database yet, nothing to clean
+                    }
+                }
+            }
+            finally
+            {
+                await conn.CloseAsync();
+            }
+        }
+    }
+
+    private string[] allConnectionStrings() =>
+    [
+        Servers.PostgresConnectionString, tenant1ConnectionString, tenant2ConnectionString, tenant3ConnectionString
+    ];
+
+    private PostgresqlQueue theQueue =>
+        theHost.GetRuntime().Options.Transports.GetOrCreate<PostgresqlTransport>().Queues[QueueName];
+
+    /// <summary>
+    /// A row in the *main* database is the one that gets double counted — an untenanted send lands there.
+    /// </summary>
+    [Fact]
+    public async Task does_not_double_count_rows_in_the_main_database()
+    {
+        var runtime = theHost.GetRuntime();
+        ((MultiTenantedMessageStore)runtime.Storage).ActiveDatabases().Count.ShouldBe(4);
+
+        var immediate = ObjectMother.Envelope();
+        immediate.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(immediate);
+
+        var scheduled = ObjectMother.Envelope();
+        scheduled.ScheduleDelay = 1.Hours();
+        scheduled.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(scheduled);
+
+        // Precondition: exactly one row physically exists, in the main database only
+        (await rowCountAsync(Servers.PostgresConnectionString, $"wolverine_queue_{QueueName}")).ShouldBe(1);
+        (await rowCountAsync(Servers.PostgresConnectionString, $"wolverine_queue_{QueueName}_scheduled")).ShouldBe(1);
+
+        (await theQueue.CountAsync()).ShouldBe(1);
+        (await theQueue.ScheduledCountAsync()).ShouldBe(1);
+    }
+
+    /// <summary>
+    /// And the sum still reaches every tenant database -- the fix must not trade the double count for a
+    /// missed database.
+    /// </summary>
+    [Fact]
+    public async Task still_sums_across_main_and_every_tenant_database()
+    {
+        var untenanted = ObjectMother.Envelope();
+        untenanted.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(untenanted);
+
+        foreach (var tenantId in new[] { "red", "blue", "green" })
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.TenantId = tenantId;
+            envelope.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+            await theQueue.SendAsync(envelope);
+        }
+
+        foreach (var connectionString in allConnectionStrings())
+        {
+            (await rowCountAsync(connectionString, $"wolverine_queue_{QueueName}")).ShouldBe(1);
+        }
+
+        // One row in each of the four databases, counted once apiece
+        (await theQueue.CountAsync()).ShouldBe(4);
+    }
+
+    /// <summary>
+    /// GetAttributesAsync() is the user visible surface -- it reports whatever CountAsync() returns.
+    /// </summary>
+    [Fact]
+    public async Task reported_attributes_match_the_physical_row_count()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.DeliverBy = DateTimeOffset.UtcNow.AddHours(1);
+        await theQueue.SendAsync(envelope);
+
+        var attributes = await theQueue.GetAttributesAsync();
+
+        attributes["Count"].ShouldBe("1");
+    }
+
+    private static async Task<long> rowCountAsync(string connectionString, string tableName)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"select count(*) from {SchemaName}.{tableName}";
+            return (long)(await cmd.ExecuteScalarAsync())!;
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueue.cs
@@ -144,19 +144,26 @@ public class PostgresqlQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint
         return _sender!.SendAsync(envelope);
     }
 
+    /// <summary>
+    /// GH-3815. These two sources overlap: <c>MultiTenantedMessageStore.ActiveDatabases()</c> yields
+    /// <c>Main</c> first, and <see cref="PostgresqlTransport.Databases"/> is only ever assigned alongside
+    /// <c>Store = mt.Main</c>. Visiting both therefore hit the main database twice — doubling
+    /// <see cref="CountAsync"/>/<see cref="ScheduledCountAsync"/>, which <see cref="GetAttributesAsync"/>
+    /// reports as user visible queue depth, and running every schema check against it twice. The
+    /// SqlServer and Sqlite queues already branch this way.
+    /// </summary>
     private async ValueTask forEveryDatabase(Func<NpgsqlDataSource, string, Task> action)
     {
-        if (Parent?.Store?.NpgsqlDataSource != null)
-        {
-            await action(Parent.Store.NpgsqlDataSource, Parent.Store.Identifier);
-        }
-
         if (Parent?.Databases != null)
         {
             foreach (var database in Parent.Databases.ActiveDatabases().OfType<PostgresqlMessageStore>())
             {
                 await action(database.NpgsqlDataSource, database.Identifier);
             }
+        }
+        else if (Parent?.Store?.NpgsqlDataSource != null)
+        {
+            await action(Parent.Store.NpgsqlDataSource, Parent.Store.Identifier);
         }
     }
 


### PR DESCRIPTION
Fixes #3859.

> **Contains #3858.** The count assertion here depends on the `forEveryDatabase` fix from #3858, so that commit is carried on this branch rather than stacking — a PR based on a feature branch gets no CI in this repo. Merge #3858 first and this rebases to a single commit.

## The bug

A MySQL schema **is** a database. The transport qualifies its queue tables with one transport-wide name:

```csharp
internal class QueueTable : Table
{
    public QueueTable(MySqlTransport parent, string tableName) : base(
        new DbObjectName(parent.TransportSchemaName, tableName))   // "wolverine_queues"
```

So on a multi-tenanted host every tenant data source resolves `wolverine_queues.wolverine_queue_<name>` to the **same physical table**. Four registered databases, one queue table between them:

```
MySQL, before                          MySQL, after
--------------------------------       --------------------------------
wolverine_queues  wolverine_queue_x     wolverine   wolverine_queue_x
                                        tenant_db1  wolverine_queue_x
(tenant_db1/2/3 have none)              tenant_db2  wolverine_queue_x
                                        tenant_db3  wolverine_queue_x
```

Consequences:

- **No tenant isolation.** Every tenant's sends landed in one table.
- **`CountAsync()` multiplied rather than summed** — with 10 rows physically present it reported 40. That feeds `GetAttributesAsync()`, so it is user visible queue depth.
- `Purge` / `Setup` / `Teardown` / `Check` repeated their work against that one table.

PostgreSQL is unaffected: its `TransportSchemaName` is a schema *nested inside* each tenant database, so each tenant already had its own copy. Verified both ways.

## The fix

`MySqlQueue.SchemaFor(MySqlDataSource)` resolves the schema from the connecting data source's own database when the host is multi-tenanted, and the sender, listener, and every `forEveryDatabase` operation build their identifiers through it. **Single database hosts are untouched** and keep using `TransportSchemaName`.

## Verification

| Evidence | Without fix | With fix |
|---|---|---|
| `every_tenant_database_owns_its_own_queue_tables` | fails | passes |
| `a_tenants_message_lands_only_in_that_tenants_database` | fails | passes |
| `counts_sum_across_databases_instead_of_multiplying` | fails | passes |
| **Full MySqlTests suite** | — | **116 / 116** |
| PostgresqlTests.MultiTenancy | — | 21 / 21 |
| `dotnet build wolverine.slnx -c Release -f net9.0` | — | clean, 0 warnings |

The full MySQL suite passing matters most here: it covers the single-database transport paths that must not change.

## Known wart

Bootstrap still leaves an **empty, unused** pair of tables in the `wolverine_queues` database on a multi-tenanted host. A provisioning pass runs before the transport has resolved its tenancy, so it provisions against `TransportSchemaName`. I confirmed by elimination that this is not the `Store.AddTable` registration — disabling it entirely does not stop it. Nothing reads or writes those tables: every sender, listener and count goes through the per-tenant resolution. I left it rather than restructure transport bootstrap ordering inside a bug fix; happy to chase it separately if you'd rather not ship the clutter.

## Not addressed here

#3860 — the same root cause in the tenant *message stores* (`wolverine_incoming_envelopes` and friends also share one schema across tenants). That one is a design decision about how MySQL should map Wolverine's two-level `schema.table` model, not a bug fix, so it is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKfy5EzLX1i149gjUb3Tfg
