### PR TITLE
Batching pipelines: back-pressure sees their depth, faulted receivers rebuild, OOM can't fault the block (CritterWatch#942)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Batching/BatchingPendingCountsTests.cs
+++ b/src/Testing/CoreTests/Runtime/Batching/BatchingPendingCountsTests.cs
@@ -1,0 +1,133 @@
+using Wolverine.Runtime;
+using Wolverine.Runtime.Batching;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Runtime.Batching;
+
+/// <summary>
+/// CritterWatch#942 — the per-listener pending count that folds message-batching pipeline depth
+/// into ListeningAgent.QueueCount so back-pressure can see past the (deliberately unbounded,
+/// GH-3287) batch execution queue.
+/// </summary>
+public class BatchingPendingCountsTests
+{
+    private static readonly Uri Address = new("stub://one");
+    private static readonly Uri OtherAddress = new("stub://two");
+
+    [Fact]
+    public void counts_per_listener_address()
+    {
+        var counts = new BatchingPendingCounts();
+
+        counts.Increment(Address);
+        counts.Increment(Address);
+        counts.Increment(OtherAddress);
+
+        counts.PendingFor(Address).ShouldBe(2);
+        counts.PendingFor(OtherAddress).ShouldBe(1);
+    }
+
+    [Fact]
+    public void null_address_is_ignored_local_publishers_are_never_counted()
+    {
+        var counts = new BatchingPendingCounts();
+
+        counts.Increment(null);
+        counts.Decrement(null);
+
+        counts.PendingFor(Address).ShouldBe(0);
+    }
+
+    [Fact]
+    public void decrement_clamps_at_zero()
+    {
+        var counts = new BatchingPendingCounts();
+
+        counts.Decrement(Address);
+        counts.PendingFor(Address).ShouldBe(0);
+
+        counts.Increment(Address);
+        counts.Decrement(Address);
+        counts.Decrement(Address);
+        counts.PendingFor(Address).ShouldBe(0);
+    }
+
+    [Fact]
+    public void settle_batch_decrements_each_member_against_its_own_listener()
+    {
+        var counts = new BatchingPendingCounts();
+
+        var one = envelopeFrom(Address);
+        var two = envelopeFrom(Address);
+        var three = envelopeFrom(OtherAddress);
+        var local = new Envelope(new object()); // no listener — a local send, never counted
+
+        counts.Increment(one.Listener!.Address);
+        counts.Increment(two.Listener!.Address);
+        counts.Increment(three.Listener!.Address);
+
+        var batch = new Envelope { Batch = [one, two, three, local] };
+        counts.SettleBatch(batch);
+
+        counts.PendingFor(Address).ShouldBe(0);
+        counts.PendingFor(OtherAddress).ShouldBe(0);
+    }
+
+    [Fact]
+    public void settle_batch_is_idempotent_per_batch_envelope()
+    {
+        var counts = new BatchingPendingCounts();
+
+        var one = envelopeFrom(Address);
+        var two = envelopeFrom(Address);
+        counts.Increment(Address);
+        counts.Increment(Address);
+        counts.Increment(Address); // a third member still in a DIFFERENT, unfinished batch
+
+        var batch = new Envelope { Batch = [one, two] };
+
+        // A double CompleteAsync (success continuation + dead-letter path racing, or a retried
+        // completion block) must not drive the count below the genuinely-pending third member.
+        counts.SettleBatch(batch);
+        counts.SettleBatch(batch);
+
+        counts.PendingFor(Address).ShouldBe(1);
+    }
+
+    [Fact]
+    public void settle_batch_ignores_a_non_batch_envelope()
+    {
+        var counts = new BatchingPendingCounts();
+        counts.Increment(Address);
+
+        counts.SettleBatch(envelopeFrom(Address));
+
+        counts.PendingFor(Address).ShouldBe(1);
+    }
+
+    private static Envelope envelopeFrom(Uri address)
+    {
+        return new Envelope(new object()) { Listener = new StubListener(address) };
+    }
+
+    private class StubListener : IListener
+    {
+        public StubListener(Uri address)
+        {
+            Address = address;
+        }
+
+        public Uri Address { get; }
+
+        public IHandlerPipeline? Pipeline => null;
+
+        public ValueTask CompleteAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+        public ValueTask StopAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Testing/CoreTests/Transports/BackPressureAgentTests.cs
+++ b/src/Testing/CoreTests/Transports/BackPressureAgentTests.cs
@@ -165,4 +165,50 @@ public class BackPressureAgentTests
         await theListeningAgent.Received().StartAsync();
         theLogger.Entries.Count.ShouldBe(2);
     }
+
+    [Fact]
+    public async Task forces_a_full_rebuild_when_the_receiver_has_terminally_faulted()
+    {
+        // CritterWatch#942 — a faulted receiver's QueueCount is frozen, so neither the latch nor the
+        // resume branch can ever act on it. The periodic check must notice the fault itself and force
+        // the teardown/rebuild, regardless of the listener's reported status.
+        theListeningAgent.Status.Returns(ListeningStatus.TooBusy);
+        theListeningAgent.QueueCount.Returns(theEndpoint.BufferingLimits.Restart + 100);
+        theListeningAgent.ReceiverHasFaulted.Returns(true);
+
+        await theBackPressureAgent.CheckNowAsync();
+
+        await theListeningAgent.Received(1).RestartAsync(true);
+
+        var critical = theLogger.Entries.ShouldHaveSingleItem();
+        critical.Level.ShouldBe(LogLevel.Critical);
+        critical.Message.ShouldContain("terminally faulted");
+    }
+
+    [Fact]
+    public async Task faulted_receiver_recovery_fires_even_while_accepting()
+    {
+        // The Accepting-status zombie: receive loop still polling, every post failing. Nothing about
+        // QueueCount thresholds applies — the fault check must run before the latch decision.
+        theListeningAgent.Status.Returns(ListeningStatus.Accepting);
+        theListeningAgent.QueueCount.Returns(0);
+        theListeningAgent.ReceiverHasFaulted.Returns(true);
+
+        await theBackPressureAgent.CheckNowAsync();
+
+        await theListeningAgent.Received(1).RestartAsync(true);
+        await theListeningAgent.DidNotReceive().MarkAsTooBusyAndStopReceivingAsync();
+    }
+
+    [Fact]
+    public async Task no_rebuild_when_the_receiver_is_healthy()
+    {
+        theListeningAgent.Status.Returns(ListeningStatus.Accepting);
+        theListeningAgent.QueueCount.Returns(0);
+        theListeningAgent.ReceiverHasFaulted.Returns(false);
+
+        await theBackPressureAgent.CheckNowAsync();
+
+        await theListeningAgent.DidNotReceive().RestartAsync(Arg.Any<bool>());
+    }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -243,6 +243,14 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         var attributes = message.MessageAttributes ?? new Dictionary<string, MessageAttributeValue>();
         _mapper.ReadEnvelopeData(envelope, message.Body, attributes);
 
+        // CritterWatch#942 — the Body string (base64, UTF-16, ~2.7× the wire payload size) is fully
+        // mapped into the envelope now, and every later use of SqsMessage — single delete, batched
+        // delete, requeue-then-delete — reads only ReceiptHandle. The envelope pins SqsMessage for
+        // its whole time in flight (which, for buffered endpoints feeding a batching pipeline, can
+        // be a long, deep queue), so release the one big thing on it. The mapping-failure path above
+        // (raw forward to the dead-letter queue) still has Body because it never reaches here.
+        message.Body = null;
+
         return envelope;
     }
 

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -133,6 +133,13 @@ public partial class Envelope
     
     [JsonIgnore]
     internal Envelope[]? Batch { get; set; }
+
+    /// <summary>
+    /// CritterWatch#942 — set once when <see cref="Runtime.Batching.BatchingPendingCounts"/> settles
+    /// this grouped batch envelope's members at its terminal, so a repeated CompleteAsync can't
+    /// drive the pending count negative.
+    /// </summary>
+    internal bool BatchPendingSettled { get; set; }
     
     [JsonIgnore]
     internal bool HasBeenAcked { get; set; }

--- a/src/Wolverine/Runtime/Batching/BatchingOptions.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingOptions.cs
@@ -134,7 +134,7 @@ public class BatchingOptions : IAsyncDisposable
             var localQueue = (ILocalQueue)runtime.Endpoints.AgentForLocalQueue(options.LocalExecutionQueueName!);
 
             return new BatchingProcessor<T>(parentChain, batcher, options, localQueue,
-                runtime.DurabilitySettings);
+                runtime.DurabilitySettings, runtime.BatchingPendingCounts);
         }
     }
 

--- a/src/Wolverine/Runtime/Batching/BatchingPendingCounts.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingPendingCounts.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+
+namespace Wolverine.Runtime.Batching;
+
+/// <summary>
+/// CritterWatch#942 — tracks, per originating listener address, how many member envelopes are
+/// somewhere inside a message-batching pipeline: posted into a <see cref="BatchingProcessor{T}"/>'s
+/// batching channel, waiting in a grouped batch on the (deliberately unbounded, GH-3287) local
+/// execution queue, or executing in a batch handler that hasn't reached its terminal yet.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this, <c>BatchMessagesOf</c> severs the back-pressure chain: the transport listener's
+/// bounded receive block — the only stage <see cref="Transports.BackPressureAgent"/> watches —
+/// always drains instantly into the batching channel and onward to the unbounded local queue, so
+/// <c>QueueCount</c> reads near zero while the real backlog (with every member's payload and
+/// deserialized message graph pinned via <see cref="Envelope.Batch"/>) grows without bound. That is
+/// the mechanism behind the CritterWatch#942 field OOM: 2.7 → 6 GiB in two minutes, queue "empty".
+/// </para>
+/// <para>
+/// <see cref="Transports.ListeningAgent.QueueCount"/> adds <see cref="PendingFor"/> to the receive
+/// block's own depth, so the existing back-pressure latch pauses the external listener when the
+/// batching pipeline is deep — restoring the bounded-memory behavior per-message handling had,
+/// without bounding any local queue (which would deadlock self-cascading handlers, GH-3287) and
+/// without ever blocking a local publisher: envelopes with no <see cref="Envelope.Listener"/>
+/// (local sends and cascades) are not counted.
+/// </para>
+/// <para>
+/// Increment happens per member in <see cref="BatchingProcessor{T}.HandleAsync"/>; settlement
+/// happens once per grouped batch envelope at its terminal — the <c>CompleteAsync</c> batch
+/// branches in <c>BufferedReceiver</c>/<c>DurableReceiver</c> — guarded by
+/// <c>Envelope.BatchPendingSettled</c> so a double-complete can't drive the count negative.
+/// </para>
+/// </remarks>
+public class BatchingPendingCounts
+{
+    private readonly ConcurrentDictionary<Uri, long> _pending = new();
+
+    public void Increment(Uri? listenerAddress)
+    {
+        if (listenerAddress == null) return;
+        _pending.AddOrUpdate(listenerAddress, 1, static (_, current) => current + 1);
+    }
+
+    public void Decrement(Uri? listenerAddress)
+    {
+        if (listenerAddress == null) return;
+        // Clamp at zero: a decrement for an address we never counted (or after a reset) must not
+        // wedge the listener's QueueCount below reality.
+        _pending.AddOrUpdate(listenerAddress, 0, static (_, current) => current > 0 ? current - 1 : 0);
+    }
+
+    /// <summary>
+    /// Settle every member of a grouped batch envelope exactly once. Safe to call from any terminal
+    /// (success, dead-letter, discard) — the envelope-level flag makes repeats a no-op.
+    /// </summary>
+    public void SettleBatch(Envelope batchEnvelope)
+    {
+        if (batchEnvelope.Batch == null || batchEnvelope.BatchPendingSettled) return;
+        batchEnvelope.BatchPendingSettled = true;
+
+        foreach (var member in batchEnvelope.Batch)
+        {
+            Decrement(member.Listener?.Address);
+        }
+    }
+
+    /// <summary>How many member envelopes received at this listener address are still pending inside a batching pipeline.</summary>
+    public int PendingFor(Uri listenerAddress)
+    {
+        if (!_pending.TryGetValue(listenerAddress, out var count)) return 0;
+        return count > int.MaxValue ? int.MaxValue : (int)count;
+    }
+}

--- a/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
@@ -10,9 +10,12 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
     private readonly BatchingOptions _options;
     private readonly Block<Envelope[]> _processingBlock;
 
+    private readonly BatchingPendingCounts? _pendingCounts;
+
     public BatchingProcessor(HandlerChain chain, IMessageBatcher batcher, BatchingOptions options, ILocalQueue queue,
-        DurabilitySettings settings)
+        DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null)
     {
+        _pendingCounts = pendingCounts;
         Chain = chain ?? throw new ArgumentOutOfRangeException(nameof(chain));
 
         _options = options;
@@ -33,10 +36,27 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
         await _batchingBlock.DisposeAsync();
     }
 
-    public override Task HandleAsync(MessageContext context, CancellationToken cancellation)
+    public override async Task HandleAsync(MessageContext context, CancellationToken cancellation)
     {
-        context.Envelope!.InBatch = true;
-        return _batchingBlock.PostAsync(context.Envelope).AsTask();
+        var envelope = context.Envelope!;
+        envelope.InBatch = true;
+
+        // CritterWatch#942 — count this member as pending against its originating listener so the
+        // listener's QueueCount (and therefore back-pressure) sees the batching pipeline's depth.
+        // Envelopes with no listener are local sends/cascades and are deliberately not counted —
+        // back-pressure can only ever pause an external listener. Settlement happens once per
+        // grouped batch envelope at its terminal (BatchingPendingCounts.SettleBatch).
+        _pendingCounts?.Increment(envelope.Listener?.Address);
+
+        try
+        {
+            await _batchingBlock.PostAsync(envelope).ConfigureAwait(false);
+        }
+        catch
+        {
+            _pendingCounts?.Decrement(envelope.Listener?.Address);
+            throw;
+        }
     }
 
     private async Task processEnvelopes(Envelope[] envelopes, CancellationToken _)

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -37,6 +37,13 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
     private bool _hasStopped;
 
     private readonly Lazy<MessageStoreCollection> _stores;
+
+    /// <summary>
+    /// CritterWatch#942 — per-listener-address count of member envelopes pending inside message
+    /// batching pipelines, folded into ListeningAgent.QueueCount so back-pressure sees the depth
+    /// of the (unbounded, GH-3287) batch execution queues.
+    /// </summary>
+    public Batching.BatchingPendingCounts BatchingPendingCounts { get; } = new();
     private readonly Lazy<MetricsAccumulator> _accumulator;
     private readonly Lazy<ISagaStoreDiagnostics> _sagaStorage;
 

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -12,7 +12,8 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.Runtime.WorkerQueues;
 
-internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeScheduling, ISupportDeadLetterQueue
+internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeScheduling, ISupportDeadLetterQueue,
+    IFaultTrackingReceiver
 {
     private readonly RetryBlock<Envelope> _completeBlock;
 
@@ -88,19 +89,42 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         }
     }
 
+    /// <summary>CritterWatch#942 — set when the receiving block faults terminally (jasperfx#506).</summary>
+    public bool HasFaulted { get; private set; }
+
     private void onBlockError(Envelope? envelope, Exception ex)
     {
-        // A terminal block fault (jasperfx#506) reports with a null item
+        // A terminal block fault (jasperfx#506) reports with a null item. Record the fault FIRST —
+        // the flag is what lets ListeningAgent/BackPressureAgent rebuild this receiver — and only
+        // then attempt to log: under the memory pressure that typically causes the fault
+        // (CritterWatch#942), the logging call itself can throw.
         if (envelope == null)
         {
-            _logger.LogCritical(ex,
-                "The local worker queue for {Uri} has faulted and stopped processing. Messages buffered locally will not be executed",
-                Uri);
+            HasFaulted = true;
+            try
+            {
+                _logger.LogCritical(ex,
+                    "The local worker queue for {Uri} has faulted and stopped processing. Messages buffered locally will not be executed",
+                    Uri);
+            }
+            catch
+            {
+                // Logging failed (e.g. OOM at the GC ceiling). The flag is already set; recovery
+                // does not depend on this line landing.
+            }
         }
         else
         {
-            _logger.LogError(ex, "Error processing envelope {EnvelopeId} ({MessageType}) in the local worker queue for {Uri}",
-                envelope.Id, envelope.MessageType, Uri);
+            try
+            {
+                _logger.LogError(ex, "Error processing envelope {EnvelopeId} ({MessageType}) in the local worker queue for {Uri}",
+                    envelope.Id, envelope.MessageType, Uri);
+            }
+            catch
+            {
+                // Swallow: an exception escaping this handler would fault the block terminally
+                // (Block's onError rung), converting one failed message into a dead listener.
+            }
         }
     }
 
@@ -124,7 +148,17 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         catch (Exception? e)
         {
             // This *should* never happen, but of course it will
-            _logger.LogError(e, "Unexpected error in Pipeline invocation");
+            try
+            {
+                _logger.LogError(e, "Unexpected error in Pipeline invocation");
+            }
+            catch
+            {
+                // CritterWatch#942 — if the log call itself throws (an OOM at the GC hard limit is
+                // the observed case), letting it escape here faults the receiving block terminally
+                // via Block's error rung, and a faulted block never recovers. Swallowing is the
+                // lesser evil: the message fails, the listener survives.
+            }
         }
     }
 
@@ -138,6 +172,15 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         if (envelope.Listener is LocalQueueRecoveryListener recovery)
         {
             return recovery.CompleteAsync(envelope);
+        }
+
+        // CritterWatch#942 — a grouped batch envelope reaching its terminal on a buffered local
+        // queue settles its members' pending-count against their originating listeners, so the
+        // listeners' back-pressure accounting sees the batching pipeline drain. All terminals
+        // (success, dead-letter move, discard) funnel through this channel callback.
+        if (envelope.Batch != null && _runtime is WolverineRuntime runtime)
+        {
+            runtime.BatchingPendingCounts.SettleBatch(envelope);
         }
 
         return ValueTask.CompletedTask;

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -13,7 +13,7 @@ using Wolverine.Transports.Sending;
 namespace Wolverine.Runtime.WorkerQueues;
 
 public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeScheduling, ISupportDeadLetterQueue,
-    IAsyncDisposable
+    IAsyncDisposable, IFaultTrackingReceiver
 {
     private readonly RetryBlock<Envelope> _completeBlock;
 
@@ -55,18 +55,34 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         void onBlockError(Envelope? envelope, Exception ex)
         {
-            // A terminal block fault (jasperfx#506) reports with a null item
+            // A terminal block fault (jasperfx#506) reports with a null item. Record the fault
+            // FIRST, then log defensively — see BufferedReceiver.onBlockError (CritterWatch#942).
             if (envelope == null)
             {
-                _logger.LogCritical(ex,
-                    "The local worker queue for {Uri} has faulted and stopped processing. Messages buffered locally will not be executed",
-                    Uri);
+                HasFaulted = true;
+                try
+                {
+                    _logger.LogCritical(ex,
+                        "The local worker queue for {Uri} has faulted and stopped processing. Messages buffered locally will not be executed",
+                        Uri);
+                }
+                catch
+                {
+                    // Logging failed; the flag is already set and recovery does not depend on it.
+                }
             }
             else
             {
-                _logger.LogError(ex,
-                    "Error processing envelope {EnvelopeId} ({MessageType}) in the local worker queue for {Uri}",
-                    envelope.Id, envelope.MessageType, Uri);
+                try
+                {
+                    _logger.LogError(ex,
+                        "Error processing envelope {EnvelopeId} ({MessageType}) in the local worker queue for {Uri}",
+                        envelope.Id, envelope.MessageType, Uri);
+                }
+                catch
+                {
+                    // Swallow: an escape here would fault the block terminally.
+                }
             }
         }
 
@@ -85,13 +101,25 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             }
             catch (Exception? e)
             {
-                if (_receiver != null)
+                // CritterWatch#942 — everything in this recovery path must be exception-safe: an
+                // escape here faults the execution block terminally (jasperfx#506) and a faulted
+                // block never recovers. Both the requeue and the log call can throw under the same
+                // memory pressure that caused the original failure.
+                try
                 {
-                    await _receiver.PostAsync(envelope).ConfigureAwait(false);
-                }
+                    if (_receiver != null)
+                    {
+                        await _receiver.PostAsync(envelope).ConfigureAwait(false);
+                    }
 
-                // This *should* never happen, but of course it will
-                _logger.LogError(e, "Unexpected pipeline invocation error");
+                    // This *should* never happen, but of course it will
+                    _logger.LogError(e, "Unexpected pipeline invocation error");
+                }
+                catch
+                {
+                    // The message is lost to this attempt, but durable inbox recovery re-offers it;
+                    // the listener survives.
+                }
             }
         };
         
@@ -234,6 +262,13 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         if (envelope.Batch != null)
         {
+            // CritterWatch#942 — same settlement as BufferedReceiver: the members' pending-count
+            // against their originating listeners drains with the batch's terminal.
+            if (_runtime is WolverineRuntime runtime)
+            {
+                runtime.BatchingPendingCounts.SettleBatch(envelope);
+            }
+
             foreach (var child in envelope.Batch)
             {
                 child.InBatch = false;
@@ -272,6 +307,9 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     public IHandlerPipeline Pipeline { get; } = null!;
 
     public Uri Uri { get; set; }
+
+    /// <summary>CritterWatch#942 — set when the execution block faults terminally (jasperfx#506).</summary>
+    public bool HasFaulted { get; private set; }
 
     public int QueueCount => (int)_receiver.Count;
 

--- a/src/Wolverine/Runtime/WorkerQueues/IFaultTrackingReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/IFaultTrackingReceiver.cs
@@ -1,0 +1,13 @@
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+/// CritterWatch#942 — a receiver whose execution block can fault terminally (jasperfx#506) and say
+/// so. A faulted block has no un-fault: every subsequent post throws, its QueueCount freezes (which
+/// permanently latches a back-pressured listener), and the receive loop keeps polling into a dead
+/// sink. <see cref="Transports.ListeningAgent"/> and <see cref="Transports.BackPressureAgent"/>
+/// consult this to tear down and rebuild the receiver instead of reusing the corpse forever.
+/// </summary>
+internal interface IFaultTrackingReceiver
+{
+    bool HasFaulted { get; }
+}

--- a/src/Wolverine/Transports/BackPressureAgent.cs
+++ b/src/Wolverine/Transports/BackPressureAgent.cs
@@ -71,6 +71,21 @@ internal class BackPressureAgent : IDisposable
             la.UpdateQueueCountObservation();
         }
 
+        // CritterWatch#942 — a terminally faulted receiver (jasperfx#506) can never make progress:
+        // its QueueCount is frozen (so a latched listener never resumes) and every post from the
+        // receive loop throws (so an Accepting listener receives and drops messages forever). This
+        // periodic check is the one reliable place to notice and force the full teardown/rebuild
+        // that RestartAsync(force) already knows how to do.
+        if (_agent.ReceiverHasFaulted)
+        {
+            _logger.LogCritical(
+                "The receiver for the listener at {Uri} has terminally faulted; forcing a full listener rebuild",
+                _endpoint.Uri);
+            _latchedChecks = 0;
+            await _agent.RestartAsync(force: true);
+            return;
+        }
+
         if (_agent.Status is ListeningStatus.Accepting or ListeningStatus.Unknown)
         {
             _latchedChecks = 0;

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -55,6 +55,15 @@ public interface IListeningAgent : IListenerCircuit
     ValueTask MarkAsTooBusyAndStopReceivingAsync();
 
     ValueTask LatchPermanently();
+
+    /// <summary>
+    /// CritterWatch#942 — true when this listener's receiver execution block has faulted terminally
+    /// (jasperfx#506). A faulted receiver can never make progress: its QueueCount freezes and every
+    /// post from the receive loop throws, so the listener looks alive while dropping everything it
+    /// receives. BackPressureAgent forces a full rebuild when it sees this; health checks should
+    /// treat it as unhealthy. Default false for implementations that don't track it.
+    /// </summary>
+    bool ReceiverHasFaulted => false;
 }
 
 public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
@@ -144,7 +153,18 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
         _semaphore.Dispose();
     }
 
-    public int QueueCount => _receiver is ILocalQueue q ? q.QueueCount : 0;
+    // CritterWatch#942 — the receive block's own depth PLUS the members this listener has fed into
+    // message-batching pipelines that haven't reached a batch terminal yet. Without the second term,
+    // BatchMessagesOf drains the (bounded, watched) receive block into an unbounded local execution
+    // queue and back-pressure never fires while memory grows without bound.
+    /// <summary>
+    /// CritterWatch#942 — see <see cref="IListeningAgent.ReceiverHasFaulted"/>. True when the
+    /// current receiver's execution block has faulted terminally (jasperfx#506).
+    /// </summary>
+    public bool ReceiverHasFaulted => _receiver is IFaultTrackingReceiver { HasFaulted: true };
+
+    public int QueueCount => (_receiver is ILocalQueue q ? q.QueueCount : 0)
+                             + _runtime.BatchingPendingCounts.PendingFor(Endpoint.Uri);
 
     /// <summary>
     /// Approximate timestamp of the last time a message was received on this listener,
@@ -349,6 +369,33 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             _logger.LogInformation(
                 "Listener at {Uri} is not being started because of an existing agent restriction", Uri);
             return;
+        }
+
+        // CritterWatch#942 — never re-attach a listener to a terminally faulted receiver. A faulted
+        // block (jasperfx#506) rejects every post and its QueueCount freezes, so reusing it turns a
+        // restart into a zombie: the receive loop polls, fails to enqueue, and (for brokers that
+        // settle at receipt) drops messages, forever. Rebuild instead.
+        if (_receiver is IFaultTrackingReceiver { HasFaulted: true } faulted)
+        {
+            _logger.LogWarning(
+                "The receiver for {Uri} had terminally faulted and is being rebuilt before the listener restarts",
+                Uri);
+            _receiver = null;
+            try
+            {
+                if (faulted is IAsyncDisposable disposable)
+                {
+                    await disposable.DisposeAsync();
+                }
+                else
+                {
+                    ((IDisposable)faulted).Dispose();
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogInformation(e, "Error disposing the faulted receiver for {Uri}", Uri);
+            }
         }
 
         _receiver ??= Endpoint.MaybeWrapReceiver(await buildReceiverAsync());


### PR DESCRIPTION
## Context

CritterWatch RC.7 moved telemetry ingest to `BatchMessagesOf` and a production fleet (10.8k agents, 117 msg/s steady inflow) went from 2.7 GiB to its 6 GiB GC hard limit **in two minutes**, then split non-deterministically between a hard restart and a zombie: the SQS receive loop polling forever against a terminally faulted receive block, deleting nothing, 934 identical `This Block<Envelope> has faulted` errors while status reported green. Full mechanical analysis in JasperFx/CritterWatch#942.

Three composable defects, all fixed here. Verified first that neither 6.24.8 nor current JasperFx (jasperfx#506 closed via #509 — loud-only) addresses any of them.

## 1. `BatchMessagesOf` severs the back-pressure chain

The transport receive block (bounded, the only stage `BackPressureAgent` watches) drains instantly into the batching channel and onward to the batch handler's local queue — **deliberately unbounded** (GH-3287) and excluded from back-pressure. `QueueCount` reads ~0 while the real backlog (every member pinned via `Envelope.Batch` with payload + deserialized graph, ~20–30× wire size each) grows without bound.

**Fix — accounting, not bounding:** `BatchingPendingCounts` tracks members in flight per originating listener address; `ListeningAgent.QueueCount` adds it to the receive block's depth, so the existing latch oscillates exactly as it did under per-message handling. Increment in `BatchingProcessor.HandleAsync`; settle exactly once per grouped envelope at both receivers' `CompleteAsync` batch terminals (`Envelope.BatchPendingSettled` guard). Nothing blocks, and local publishers (null `Listener`) are never counted — the GH-3287 no-deadlock rule for self-cascading handlers is preserved.

## 2. Retention amplification

`SqsListener` now releases `Message.Body` (UTF-16 base64, ~2.7× wire size, previously pinned for the envelope's whole life) once mapping into the envelope succeeds; the mapping-failure DLQ path keeps it. Deliberately **not** done: nulling `Envelope.Data` post-deserialization — dead-letter persistence and durable retry re-upserts store `Data` and would be corrupted. (The complementary consumer-side fix — CritterWatch's brotli serializer no longer overwriting `Data` with the decompressed payload — ships in CritterWatch.)

## 3. An OOM in a recovery path faults the block terminally, forever

Every catch rung in `BufferedReceiver.executeAsync`, both `onBlockError`s, and `DurableReceiver`'s requeue-on-failure allocate (logging), so the same memory pressure that fails a message can throw again *inside recovery*, hit the block's error rung, and fault it — no un-fault exists, `QueueCount` freezes (a latched listener never resumes), every post throws (an Accepting listener receives and drops forever), and `StartAsync`'s `_receiver ??=` re-attached each new transport listener to the same corpse.

**Fix:** all recovery rungs are exception-safe; receivers record the jasperfx#506 terminal fault (null-item `OnError`) as `IFaultTrackingReceiver.HasFaulted`; `IListeningAgent.ReceiverHasFaulted` exposes it for health checks (default-interface `false`, non-breaking); `StartAsync` disposes and rebuilds a faulted receiver; and `BackPressureAgent`'s 2s check force-restarts on fault — covering both the frozen-latched and the Accepting-but-dropping zombie.

## Known gaps (on purpose)

- Durable-mode endpoints with back-pressure disabled have no automatic fault watchdog (`BackPressureAgent` hosts the timer); `RestartAsync(force: true)` remains the manual remediation.
- GH-3236 receive-loop health reporting doesn't yet read `ReceiverHasFaulted`.
- No JasperFx changes required; optional follow-ups there would be lifting `Failure` onto `IBlock` and an un-fault primitive.

## Tests

CoreTests 2292 passed / 0 failed (net9.0), including 6 new `BatchingPendingCountsTests` and 3 new `BackPressureAgent` watchdog tests (`forces_a_full_rebuild_when_the_receiver_has_terminally_faulted`, `faulted_receiver_recovery_fires_even_while_accepting`, `no_rebuild_when_the_receiver_is_healthy`). `Wolverine.AmazonSqs` builds; its LocalStack integration suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v2Aijyo8MX2AdPUZL5VtG
