### PR TITLE
Database queue Uris sanitize the queue name like the fluent API does

### DIFF
--- a/src/Persistence/MySql/MySqlTests/Transport/queue_uri_identity.cs
+++ b/src/Persistence/MySql/MySqlTests/Transport/queue_uri_identity.cs
@@ -1,0 +1,30 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.MySql.Transport;
+using Xunit;
+
+namespace MySqlTests.Transport;
+
+// A queue reached only by Uri bypasses the fluent API's MaybeCorrectName, and the raw
+// dashed name reached the wolverine_queue_* table DDL as an invalid identifier. Same
+// correction as the SQL Server / Postgresql / Oracle (GH-3820) transports.
+public class queue_uri_identity
+{
+    [Fact]
+    public void queue_name_from_uri_is_sanitized()
+    {
+        var transport = new MySqlTransport();
+        var queue = transport.GetOrCreateEndpoint("mysql://my-service-control".ToUri());
+        queue.ShouldBeOfType<MySqlQueue>().Name.ShouldBe("my_service_control");
+    }
+
+    [Fact]
+    public void dashed_uri_and_fluent_name_resolve_to_the_same_endpoint()
+    {
+        var transport = new MySqlTransport();
+        var queue = transport.Queues[transport.MaybeCorrectName("my-service-control")];
+        transport.GetOrCreateEndpoint("mysql://my-service-control".ToUri()).ShouldBeSameAs(queue);
+        transport.GetOrCreateEndpoint(queue.Uri).ShouldBeSameAs(queue);
+        transport.Queues.Count().ShouldBe(1);
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlTransport.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlTransport.cs
@@ -46,7 +46,11 @@ public class MySqlTransport : BrokerTransport<MySqlQueue>
 
     protected override MySqlQueue findEndpointByUri(Uri uri)
     {
-        var queueName = uri.Host;
+        // Same correction as the SQL Server / Postgresql / Oracle (GH-3820) transports: a queue
+        // reached only by Uri bypasses the fluent API's MaybeCorrectName, and a dash in the raw
+        // name reaches the wolverine_queue_* table DDL. SanitizeIdentifier (idempotent), not
+        // MaybeCorrectName (would double-apply an IdentifierPrefix).
+        var queueName = SanitizeIdentifier(uri.Host);
         return Queues[queueName];
     }
 

--- a/src/Persistence/PostgresqlTests/Transport/PostgreSQLTransportTests.cs
+++ b/src/Persistence/PostgresqlTests/Transport/PostgreSQLTransportTests.cs
@@ -14,4 +14,23 @@ public class PostgresqlTransportTests
         var queue = theTransport.GetOrCreateEndpoint("Postgresql://one".ToUri());
         queue.ShouldBeOfType<PostgresqlQueue>().Name.ShouldBe("one");
     }
+
+    // A queue reached only by Uri (ListenForMessagesFrom("postgresql://my-service-control"))
+    // bypasses the fluent API's MaybeCorrectName, and the raw dashed name reached the
+    // wolverine_queue_* table DDL as an invalid, unquoted identifier.
+    [Fact]
+    public void queue_name_from_uri_is_sanitized()
+    {
+        var queue = theTransport.GetOrCreateEndpoint("postgresql://my-service-control".ToUri());
+        queue.ShouldBeOfType<PostgresqlQueue>().Name.ShouldBe("my_service_control");
+    }
+
+    [Fact]
+    public void dashed_uri_and_fluent_name_resolve_to_the_same_endpoint()
+    {
+        var queue = theTransport.Queues[theTransport.MaybeCorrectName("my-service-control")];
+        theTransport.GetOrCreateEndpoint("postgresql://my-service-control".ToUri()).ShouldBeSameAs(queue);
+        theTransport.GetOrCreateEndpoint(queue.Uri).ShouldBeSameAs(queue);
+        theTransport.Queues.Count().ShouldBe(1);
+    }
 }

--- a/src/Persistence/SqlServerTests/Transport/SqlServerTransportTests.cs
+++ b/src/Persistence/SqlServerTests/Transport/SqlServerTransportTests.cs
@@ -22,6 +22,25 @@ public class SqlServerTransportTests
         queue.ShouldBeOfType<SqlServerQueue>().Name.ShouldBe("one");
     }
 
+    // A queue reached only by Uri (ListenForMessagesFrom("sqlserver://my-service-control"))
+    // bypasses the fluent API's MaybeCorrectName, and the raw dashed name reached the
+    // wolverine_queue_* table DDL as an invalid, unbracketed identifier.
+    [Fact]
+    public void queue_name_from_uri_is_sanitized()
+    {
+        var queue = theTransport.GetOrCreateEndpoint("sqlserver://my-service-control".ToUri());
+        queue.ShouldBeOfType<SqlServerQueue>().Name.ShouldBe("my_service_control");
+    }
+
+    [Fact]
+    public void dashed_uri_and_fluent_name_resolve_to_the_same_endpoint()
+    {
+        var queue = theTransport.Queues[theTransport.MaybeCorrectName("my-service-control")];
+        theTransport.GetOrCreateEndpoint("sqlserver://my-service-control".ToUri()).ShouldBeSameAs(queue);
+        theTransport.GetOrCreateEndpoint(queue.Uri).ShouldBeSameAs(queue);
+        theTransport.Queues.Count().ShouldBe(1);
+    }
+
     // Regression test for https://github.com/JasperFx/wolverine/issues/2472
     // Turkish culture maps 'I'.ToLower() to dotless 'ı' instead of 'i',
     // which corrupts SQL identifiers when SanitizeIdentifier uses ToLower().

--- a/src/Persistence/SqliteTests/Transport/queue_uri_identity.cs
+++ b/src/Persistence/SqliteTests/Transport/queue_uri_identity.cs
@@ -1,0 +1,30 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.Sqlite.Transport;
+using Xunit;
+
+namespace SqliteTests.Transport;
+
+// A queue reached only by Uri bypasses the fluent API's MaybeCorrectName, and the raw
+// dashed name reached the wolverine_queue_* table DDL as an invalid identifier. Same
+// correction as the SQL Server / Postgresql / Oracle (GH-3820) transports.
+public class queue_uri_identity
+{
+    [Fact]
+    public void queue_name_from_uri_is_sanitized()
+    {
+        var transport = new SqliteTransport();
+        var queue = transport.GetOrCreateEndpoint("sqlite://my-service-control".ToUri());
+        queue.ShouldBeOfType<SqliteQueue>().Name.ShouldBe("my_service_control");
+    }
+
+    [Fact]
+    public void dashed_uri_and_fluent_name_resolve_to_the_same_endpoint()
+    {
+        var transport = new SqliteTransport();
+        var queue = transport.Queues[transport.MaybeCorrectName("my-service-control")];
+        transport.GetOrCreateEndpoint("sqlite://my-service-control".ToUri()).ShouldBeSameAs(queue);
+        transport.GetOrCreateEndpoint(queue.Uri).ShouldBeSameAs(queue);
+        transport.Queues.Count().ShouldBe(1);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -102,7 +102,14 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
 
     protected override PostgresqlQueue findEndpointByUri(Uri uri)
     {
-        var queueName = uri.Host;
+        // A queue reached ONLY by Uri (e.g. ListenForMessagesFrom on "postgresql://my-queue-name")
+        // bypasses the fluent API's MaybeCorrectName, and the raw name is interpolated into the
+        // wolverine_queue_* table names — a dash produced invalid, unquoted DDL. Correct the name
+        // at lookup like the Oracle transport does (GH-3820): SanitizeIdentifier, NOT
+        // MaybeCorrectName, which would prepend an IdentifierPrefix a second time on a Uri built
+        // from an already-corrected name. SanitizeIdentifier is idempotent for fluent-registered
+        // queues.
+        var queueName = SanitizeIdentifier(uri.Host);
         return Queues[queueName];
     }
 

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -78,7 +78,16 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
 
     protected override SqlServerQueue findEndpointByUri(Uri uri)
     {
-        var queueName = uri.Host;
+        // The fluent API (ListenToSqlServerQueue / ToSqlServerQueue) runs queue names through
+        // MaybeCorrectName, but a queue reached ONLY by Uri (e.g. ListenForMessagesFrom on
+        // "sqlserver://my-service-control") used to land here raw — and the queue name is
+        // interpolated into the wolverine_queue_* table names, so a dash produced invalid,
+        // unbracketed DDL. Correct the name at lookup exactly like the Oracle transport does
+        // (GH-3820): SanitizeIdentifier rather than MaybeCorrectName, because a Uri built from
+        // an already-corrected name carries any IdentifierPrefix and MaybeCorrectName would
+        // prepend it a second time. SanitizeIdentifier is idempotent, so fluent-registered
+        // queues resolve to the same endpoint they always did.
+        var queueName = SanitizeIdentifier(uri.Host);
         return Queues[queueName];
     }
 

--- a/src/Persistence/Wolverine.Sqlite/Transport/SqliteTransport.cs
+++ b/src/Persistence/Wolverine.Sqlite/Transport/SqliteTransport.cs
@@ -77,7 +77,11 @@ public class SqliteTransport : BrokerTransport<SqliteQueue>, ITransportConfigure
 
     protected override SqliteQueue findEndpointByUri(Uri uri)
     {
-        var queueName = uri.Host;
+        // Same correction as the SQL Server / Postgresql / Oracle (GH-3820) transports: a queue
+        // reached only by Uri bypasses the fluent API's MaybeCorrectName, and a dash in the raw
+        // name reaches the wolverine_queue_* table DDL. SanitizeIdentifier (idempotent), not
+        // MaybeCorrectName (would double-apply an IdentifierPrefix).
+        var queueName = SanitizeIdentifier(uri.Host);
         return Queues[queueName];
     }
 


### PR DESCRIPTION
## The bug (field report via CritterWatch)

```csharp
wolverineOptions.AddCritterWatchMonitoring(
    critterWatchUri: new Uri("sqlserver://critterwatch"),
    systemControlUri: new Uri("sqlserver://my-service-control"));
```

fails at auto-provision time with invalid SQL — the dash reaches the queue table DDL unbracketed:

```sql
CREATE TABLE myapp_cw_control.wolverine_queue_my-service-control ( ... )
```

## Root cause

The fluent API (`ListenToSqlServerQueue` / `ToSqlServerQueue` and siblings) runs queue names through `MaybeCorrectName` → `SanitizeIdentifier` (dash → underscore, lowercase). But a queue reached **only by Uri** (`ListenForMessagesFrom(uri)`, publish-to-uri, etc.) resolves through `findEndpointByUri`, which did a raw `Queues[uri.Host]` — and the ctor of each database queue interpolates that raw name straight into the `wolverine_queue_*` table names. Same asymmetry in the SQL Server, PostgreSQL, SQLite, and MySQL transports.

## The fix

`findEndpointByUri` in all four transports now runs the host through `SanitizeIdentifier`, extending the Oracle transport's GH-3820 correction (which fixed the same lookup for casing) to its siblings. `SanitizeIdentifier` rather than `MaybeCorrectName`: a Uri built from an already-corrected name carries any `IdentifierPrefix`, which `MaybeCorrectName` would prepend a second time. `SanitizeIdentifier` is idempotent, so fluent-registered queues resolve to the same endpoint they always did — covered by the new resolve-to-same-endpoint tests in each transport's suite.

The NServiceBus/MassTransit interop transports keep their own verbatim `findEndpointByUri` overrides — foreign endpoint names are matched exactly by design, so they are deliberately untouched.

## Tests

New endpoint-resolution tests (no database needed) in SqlServerTests, PostgresqlTests, SqliteTests, and MySqlTests: a dashed Uri resolves to the sanitized queue name, and the dashed Uri, the fluent-corrected name, and the queue's own round-tripped Uri all resolve to the **same** endpoint (no second endpoint minted over the same tables). All pass on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)