### PR TITLE
#3867 a batched handler participates in partitioned sequential processing

### DIFF
--- a/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
+++ b/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
@@ -1,0 +1,168 @@
+# Handoff — GH-3867: `BatchMessagesOf()` cannot compose with partitioned sequential processing
+
+**Written 2026-08-07.** Issue: [wolverine#3867](https://github.com/JasperFx/wolverine/issues/3867).
+Driver: [CritterWatch#949](https://github.com/JasperFx/CritterWatch/issues/949).
+
+**Branch: `cw949-group-id-batching`** (off `main` @ `1131eac79`, the 6.24.10 tag commit).
+One commit: `8bc8ded8a` — **part 1 only**. Part 2 is unstarted and is the real gap.
+
+---
+
+## TL;DR
+
+A batched handler cannot participate in `PartitionProcessingByGroupId` sequential ordering. Two
+independent causes:
+
+1. **The batch envelope carries no group id** — and a null group id means *a random slot*, not "no
+   partitioning". **Fixed on this branch.**
+2. **The batch envelope is never routed** — `BatchingProcessor` hardcodes its destination, so the
+   batch always executes on one dedicated local queue no matter what partitioning is configured.
+   **Not fixed. This is the work.**
+
+Consequence worth stating plainly, because it surprised two separate reviewers:
+**`GlobalPartitioned` does not give you a single writer per group id if any participating message
+type is batched.**
+
+---
+
+## Part 1 — done, on the branch
+
+`BatchingOptions.GroupByGroupId()` (`src/Wolverine/Runtime/Batching/BatchingOptions.cs:81`) opts into
+`GroupIdMessageBatcher<T>` (`src/Wolverine/Runtime/Batching/GroupIdMessageBatcher.cs`), which groups
+by `(TenantId, GroupId)` and stamps the group id onto each produced batch envelope.
+
+Why it is needed, precisely — `PartitionedMessagingExtensions.SlotForProcessing:51`:
+
+```csharp
+var groupId = rules.DetermineGroupId(envelope);
+if (groupId == null) return Random.Shared.Next(1, numberOfSlots) - 1;   // <-- random, not "unpartitioned"
+```
+
+`DefaultMessageBatcher<T>` groups only by `TenantId`, so a batch spans group ids and has none of its
+own; `DetermineGroupId` then falls through to the rules, which cannot find an identity on a `T[]`.
+So today a batched handler on a sharded endpoint silently draws a different slot every trigger. No
+configuration error, nothing in the logs.
+
+Design points that were deliberate, please preserve them:
+
+- **Key is `(tenant, group)`, never group alone.** Members settle against the batch envelope
+  (`Envelope(object message, IEnumerable<Envelope> batch)` sets `InBatch` on each), so merging
+  tenants would lose the tenant each member arrived under. This narrows `DefaultMessageBatcher`'s
+  behaviour rather than replacing it.
+- **Ungroupable envelopes batch together and stay ungrouped.** The batcher does not invent an
+  identity. That leaves them exactly where they are today rather than making them worse.
+- **Rules are injected, not resolved.** `MessagePartitioningRules` is not available when
+  `BatchingOptions` is configured, so `ProcessorBuilder.Build` sets it through the internal
+  `IRequirePartitioningRules` (`BatchingOptions.cs:158`). `DetermineGroupId` prefers an already-set
+  `Envelope.GroupId` and writes the resolved value back, so on a listener already using
+  `PartitionProcessingByGroupId` the id is present before the batching processor ever sees it.
+
+Tests: `src/Testing/CoreTests/Acceptance/group_id_message_batcher.cs`, 5 tests, green on net9.0 and
+net10.0.
+
+```bash
+dotnet test src/Testing/CoreTests/CoreTests.csproj --filter "FullyQualifiedName~GroupIdMessageBatcherTests"
+```
+
+**Not yet done for part 1:** no docs page update (`docs/guide/messaging/partitioning.md` and the
+batching guide both describe the composition as if it works), and no sample. Worth adding once part
+2 settles, since the two together are what a user needs.
+
+---
+
+## Part 2 — the actual gap
+
+`BatchingProcessor.processEnvelopes` (`src/Wolverine/Runtime/Batching/BatchingProcessor.cs:62`):
+
+```csharp
+foreach (var grouped in Batcher.Group(envelopes))
+{
+    grouped.Destination = Queue.Uri;      // <-- the single LocalExecutionQueueName
+    grouped.MessageType = Chain!.TypeName;
+    grouped.SentAt = DateTimeOffset.UtcNow;
+    await Queue.EnqueueAsync(grouped);
+}
+```
+
+`Queue` comes from `BatchingOptions.LocalExecutionQueueName`, resolved once in
+`ProcessorBuilder.Build`. The batch never goes through routing, so nothing downstream can act on the
+group id part 1 now stamps.
+
+Meanwhile the **unbatched** handlers for the same entity execute somewhere else entirely:
+
+- On a plain external listener: on the listener's receiver. When `PartitionProcessingByGroupId` is
+  applied, `BufferedReceiver.cs:63-69` / `DurableReceiver.cs:126-132` build a
+  `ShardedExecutionBlock`, whose slots are `new Block<Envelope>(1, …)`
+  (`ShardedExecutionBlock.cs:26`) — strictly ordered per slot.
+- Under `GlobalPartitioned`: on a companion local queue, via `GlobalPartitionedReceiverBridge`
+  installed at `ListeningAgent.cs:404-411` when `Endpoint.GlobalPartitionLocalQueueUri` is set.
+
+Either way that is a **different execution block from the batching queue**. Batched and unbatched
+handlers for the same group id run concurrently.
+
+Useful thing already verified so you do not have to: **`LocalQueueConfiguration` extends
+`ListenerConfiguration<…>`** (`src/Wolverine/Transports/Local/LocalQueueConfiguration.cs:6`), so
+`PartitionProcessingByGroupId` *is* available on a local queue, and `BufferedLocalQueue` /
+`DurableLocalQueue` both go through the receivers that honour `GroupShardingSlotNumber`. So
+group-sharding the batching queue itself works today — it just does not help on its own, because the
+other writers are on a different queue.
+
+### Three shapes, no strong preference from me
+
+1. **Honour a `Destination` the batcher set** instead of unconditionally overwriting it. Smallest
+   change; pushes slot selection into batcher implementations, which then need topology knowledge.
+2. **Route the grouped envelope** through the normal routing path so it flows into a partitioned
+   local topology like any other message. Most consistent, but `MessageType`/`Destination`/`SentAt`
+   are currently set by hand here for a reason — check what routing would and would not reproduce
+   (notably `BatchingPendingCounts.SettleBatch`, and the CritterWatch#942 back-pressure accounting
+   at `BatchingProcessor.cs:48`, which counts members against the originating listener).
+3. **Let `BatchingOptions` take a partitioned local topology** rather than a single
+   `LocalExecutionQueueName`, and pick the slot from the batch's group id. Most explicit; largest
+   API surface.
+
+The only hard constraint: a batch that has a group id must be able to land on that group's slot.
+
+### Things to check before choosing
+
+- `ProcessorBuilder.Build` resolves exactly one `ILocalQueue` up front
+  (`BatchingOptions.cs:163`). Shapes 2 and 3 need N, or need resolution deferred per batch.
+- Retry/dead-letter: `ProbeIndividuallyAfter` re-runs members as size-1 batches. Confirm a re-probed
+  batch keeps its group id, or a poison probe will scatter across slots.
+- `BatchingPendingCounts` settles once per grouped batch envelope. Confirm per-slot fan-out does not
+  double-count or lose a settle.
+
+---
+
+## Reproduction and verification
+
+The downstream effect reproduces reliably in CritterWatch's soak harness (`src/IngestSoakTests` in
+`~/code/CritterWatch`, target `./build.sh IngestSoak`), where a batched `ServiceUpdates` handler and
+~10 unbatched handlers all append to one Marten event stream:
+
+| run | conflicts |
+|---|---|
+| 4 hosts / 1 service / 60 min, unbatched writers active | **4,275** `EventStreamUnexpectedMaxEventIdException` (71/min), across 7 handler types, batched one = 59% |
+| same batched volume, unbatched writers off | **0** |
+
+`CW_SOAK_DISCOVERY_CHURN=0` is the negative control. That harness is the acceptance test for part 2:
+with the fix in, the churn-on run should go to zero conflicts while keeping cross-service
+parallelism (compare the `many_services_many_nodes` topology before and after).
+
+A pure-Wolverine equivalent would be better for this repo — a batched handler and an unbatched
+handler for the same group id, both writing to a shared in-memory structure through a partitioned
+endpoint, asserting no interleaving. That test does not exist yet and would be worth writing first,
+since it fails today and is the tightest statement of the bug.
+
+---
+
+## Hazards
+
+- `MessagePartitioningRules.DetermineGroupId` is `internal` and **mutates the envelope** (writes the
+  resolved id back). Fine inside the assembly; do not expose it casually.
+- `GlobalPartitionLocalQueueUri` is `internal` — an outside assembly cannot bridge a listener to a
+  chosen local queue. Anything that expects users to wire this themselves is a non-starter.
+- The `else if` at `ListeningAgent.cs:412` intercepts matching messages on *non-paired* endpoints
+  when global topologies exist. I did not trace that path; if part 2 touches routing, read it.
+- CritterWatch currently carries its own `ServiceUpdatesBatcher` (uncommitted, in
+  `src/CritterWatch.Services/`) that duplicates part 1. It should be deleted in favour of
+  `GroupByGroupId()` once this ships — do not treat it as a second implementation to keep in sync.

--- a/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
+++ b/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
@@ -107,20 +107,38 @@ Useful thing already verified so you do not have to: **`LocalQueueConfiguration`
 group-sharding the batching queue itself works today — it just does not help on its own, because the
 other writers are on a different queue.
 
-### Three shapes, no strong preference from me
+### Three shapes — updated, shape 3 preferred
 
 1. **Honour a `Destination` the batcher set** instead of unconditionally overwriting it. Smallest
-   change; pushes slot selection into batcher implementations, which then need topology knowledge.
+   change, but it pushes slot selection into batcher implementations, which then have to know slot
+   counts and queue naming. That is the framework's job, not a batcher's.
 2. **Route the grouped envelope** through the normal routing path so it flows into a partitioned
-   local topology like any other message. Most consistent, but `MessageType`/`Destination`/`SentAt`
-   are currently set by hand here for a reason — check what routing would and would not reproduce
-   (notably `BatchingPendingCounts.SettleBatch`, and the CritterWatch#942 back-pressure accounting
-   at `BatchingProcessor.cs:48`, which counts members against the originating listener).
+   local topology like any other message. Attractive, but it has to reproduce what
+   `processEnvelopes` does by hand: `MessageType`, `SentAt`, `BatchingPendingCounts.SettleBatch`,
+   and in particular the CritterWatch#942 back-pressure accounting at `BatchingProcessor.cs:48`
+   that counts members against the originating listener. That accounting exists because of a real
+   production incident; do not let routing re-derive it by accident.
 3. **Let `BatchingOptions` take a partitioned local topology** rather than a single
-   `LocalExecutionQueueName`, and pick the slot from the batch's group id. Most explicit; largest
-   API surface.
+   `LocalExecutionQueueName`, and pick the slot from the batch's group id. **Preferred.** It is the
+   only shape that makes a batched handler a first-class participant in global partitioning rather
+   than an exception to it: the batch lands on the same companion local queue as its group's other
+   messages, giving a genuine single writer per group id, cluster-wide. Largest API surface, but the
+   concrete change is small — `ProcessorBuilder.Build` currently resolves exactly one `ILocalQueue`
+   (`BatchingOptions.cs:163`); that becomes N, or a deferred per-batch resolve.
 
 The only hard constraint: a batch that has a group id must be able to land on that group's slot.
+
+### The field data point that decided the preference
+
+I originally recorded that the affected CritterWatch console had clustering off (single replica).
+**That was wrong.** The shipped console wires `GlobalPartitioned` *unconditionally* — one
+`AddCritterWatchServices` call supplying `configureClusterShardedTopology` with 5 sharded slots
+across RabbitMQ, SQS and Azure Service Bus.
+
+So the failing deployment already has the strongest partitioning Wolverine offers and still sees
+~20 stream-concurrency exceptions/min. Global partitioning correctly sequences every participating
+message type **except the batched one**, and the batched one accounts for 59% of the failures. That
+is the clearest available statement of what part 2 is for.
 
 ### Things to check before choosing
 

--- a/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
+++ b/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
@@ -1,35 +1,36 @@
-# Handoff — GH-3867: `BatchMessagesOf()` cannot compose with partitioned sequential processing
+# GH-3867: `BatchMessagesOf()` composing with partitioned sequential processing
 
 **Written 2026-08-07.** Issue: [wolverine#3867](https://github.com/JasperFx/wolverine/issues/3867).
 Driver: [CritterWatch#949](https://github.com/JasperFx/CritterWatch/issues/949).
 
 **Branch: `cw949-group-id-batching`** (off `main` @ `1131eac79`, the 6.24.10 tag commit).
-One commit: `8bc8ded8a` — **part 1 only**. Part 2 is unstarted and is the real gap.
+**Both parts are now implemented.** This note records why, what was deliberate, and what is still
+not covered.
 
 ---
 
 ## TL;DR
 
-A batched handler cannot participate in `PartitionProcessingByGroupId` sequential ordering. Two
+A batched handler could not participate in `PartitionProcessingByGroupId` sequential ordering. Two
 independent causes:
 
-1. **The batch envelope carries no group id** — and a null group id means *a random slot*, not "no
-   partitioning". **Fixed on this branch.**
-2. **The batch envelope is never routed** — `BatchingProcessor` hardcodes its destination, so the
-   batch always executes on one dedicated local queue no matter what partitioning is configured.
-   **Not fixed. This is the work.**
+1. **The batch envelope carried no group id** — and a null group id means *a random slot*, not "no
+   partitioning". **Fixed** (`GroupByGroupId()`).
+2. **The batch envelope was never routed** — `BatchingProcessor` hardcoded its destination, so the
+   batch always executed on one dedicated local queue no matter what partitioning was configured.
+   **Fixed** (shape 3, below).
 
-Consequence worth stating plainly, because it surprised two separate reviewers:
-**`GlobalPartitioned` does not give you a single writer per group id if any participating message
-type is batched.**
+Consequence worth stating plainly, because it surprised two separate reviewers and was true until
+part 2: **`GlobalPartitioned` did not give you a single writer per group id if any participating
+message type was batched.**
 
 ---
 
-## Part 1 — done, on the branch
+## Part 1 — `BatchingOptions.GroupByGroupId()`
 
-`BatchingOptions.GroupByGroupId()` (`src/Wolverine/Runtime/Batching/BatchingOptions.cs:81`) opts into
-`GroupIdMessageBatcher<T>` (`src/Wolverine/Runtime/Batching/GroupIdMessageBatcher.cs`), which groups
-by `(TenantId, GroupId)` and stamps the group id onto each produced batch envelope.
+`BatchingOptions.GroupByGroupId()` opts into `GroupIdMessageBatcher<T>`
+(`src/Wolverine/Runtime/Batching/GroupIdMessageBatcher.cs`), which groups by `(TenantId, GroupId)`
+and stamps the group id onto each produced batch envelope.
 
 Why it is needed, precisely — `PartitionedMessagingExtensions.SlotForProcessing:51`:
 
@@ -40,7 +41,7 @@ if (groupId == null) return Random.Shared.Next(1, numberOfSlots) - 1;   // <-- r
 
 `DefaultMessageBatcher<T>` groups only by `TenantId`, so a batch spans group ids and has none of its
 own; `DetermineGroupId` then falls through to the rules, which cannot find an identity on a `T[]`.
-So today a batched handler on a sharded endpoint silently draws a different slot every trigger. No
+So a batched handler on a sharded endpoint silently drew a different slot every trigger. No
 configuration error, nothing in the logs.
 
 Design points that were deliberate, please preserve them:
@@ -50,135 +51,149 @@ Design points that were deliberate, please preserve them:
   tenants would lose the tenant each member arrived under. This narrows `DefaultMessageBatcher`'s
   behaviour rather than replacing it.
 - **Ungroupable envelopes batch together and stay ungrouped.** The batcher does not invent an
-  identity. That leaves them exactly where they are today rather than making them worse.
+  identity.
 - **Rules are injected, not resolved.** `MessagePartitioningRules` is not available when
   `BatchingOptions` is configured, so `ProcessorBuilder.Build` sets it through the internal
-  `IRequirePartitioningRules` (`BatchingOptions.cs:158`). `DetermineGroupId` prefers an already-set
-  `Envelope.GroupId` and writes the resolved value back, so on a listener already using
-  `PartitionProcessingByGroupId` the id is present before the batching processor ever sees it.
+  `IRequirePartitioningRules`. `DetermineGroupId` prefers an already-set `Envelope.GroupId` and
+  writes the resolved value back, so on a listener already using `PartitionProcessingByGroupId` the
+  id is present before the batching processor ever sees it.
 
-Tests: `src/Testing/CoreTests/Acceptance/group_id_message_batcher.cs`, 5 tests, green on net9.0 and
-net10.0.
-
-```bash
-dotnet test src/Testing/CoreTests/CoreTests.csproj --filter "FullyQualifiedName~GroupIdMessageBatcherTests"
-```
-
-**Not yet done for part 1:** no docs page update (`docs/guide/messaging/partitioning.md` and the
-batching guide both describe the composition as if it works), and no sample. Worth adding once part
-2 settles, since the two together are what a user needs.
+Tests: `src/Testing/CoreTests/Acceptance/group_id_message_batcher.cs`, 5 tests.
 
 ---
 
-## Part 2 — the actual gap
+## Part 2 — shape 3, as preferred
 
-`BatchingProcessor.processEnvelopes` (`src/Wolverine/Runtime/Batching/BatchingProcessor.cs:62`):
-
-```csharp
-foreach (var grouped in Batcher.Group(envelopes))
-{
-    grouped.Destination = Queue.Uri;      // <-- the single LocalExecutionQueueName
-    grouped.MessageType = Chain!.TypeName;
-    grouped.SentAt = DateTimeOffset.UtcNow;
-    await Queue.EnqueueAsync(grouped);
-}
-```
-
-`Queue` comes from `BatchingOptions.LocalExecutionQueueName`, resolved once in
-`ProcessorBuilder.Build`. The batch never goes through routing, so nothing downstream can act on the
-group id part 1 now stamps.
-
-Meanwhile the **unbatched** handlers for the same entity execute somewhere else entirely:
-
-- On a plain external listener: on the listener's receiver. When `PartitionProcessingByGroupId` is
-  applied, `BufferedReceiver.cs:63-69` / `DurableReceiver.cs:126-132` build a
-  `ShardedExecutionBlock`, whose slots are `new Block<Envelope>(1, …)`
-  (`ShardedExecutionBlock.cs:26`) — strictly ordered per slot.
-- Under `GlobalPartitioned`: on a companion local queue, via `GlobalPartitionedReceiverBridge`
-  installed at `ListeningAgent.cs:404-411` when `Endpoint.GlobalPartitionLocalQueueUri` is set.
-
-Either way that is a **different execution block from the batching queue**. Batched and unbatched
-handlers for the same group id run concurrently.
-
-Useful thing already verified so you do not have to: **`LocalQueueConfiguration` extends
-`ListenerConfiguration<…>`** (`src/Wolverine/Transports/Local/LocalQueueConfiguration.cs:6`), so
-`PartitionProcessingByGroupId` *is* available on a local queue, and `BufferedLocalQueue` /
-`DurableLocalQueue` both go through the receivers that honour `GroupShardingSlotNumber`. So
-group-sharding the batching queue itself works today — it just does not help on its own, because the
-other writers are on a different queue.
-
-### The requirement, stated plainly (Jeremy, 2026-08-07)
-
-> **A batched message must execute on the same local, partitioned queue that an unbatched message
-> of the same group id would execute on.**
+> **The requirement:** a batched message must execute on the same local, partitioned queue that an
+> unbatched message of the same group id would execute on.
 
 For a message type participating in a partitioned topology, the batch envelope for group `G` goes to
 slot `hash(G) % N` — `global-{base}{slot}` under global partitioning, `{base}{slot}` under
-`PublishToPartitionedLocalMessaging`. No partitioned topology covering the type → today's
-single-queue behaviour, unchanged. The property being bought is **one writer per group id**,
-batched and unbatched alike, cluster-wide.
+`PublishToPartitionedLocalMessaging`. No partitioned topology covering the type → the previous
+single-queue behaviour, unchanged.
 
-**Two implementation notes, both verified against the source:**
+### How it is wired
 
-- **No self-deadlock.** The obvious worry — enqueueing the batch back onto the same
-  single-parallelism slot whose handler produced it — does not apply. `HandleAsync` runs on the slot
-  block but only posts into `_batchingBlock`; `processEnvelopes` runs on a separate
-  `_processingBlock` (`BatchingProcessor.cs:24-25`), so the enqueue happens off the slot block.
-- **Head-of-line blocking is the real hazard.** `_processingBlock` is shared across all groups, so a
-  blocking `EnqueueAsync` into one saturated slot would stall batch dispatch for *every* group.
-  Either post non-blocking with a fallback, or document the coupling. Test this first.
+- **`WolverineRuntime.resolveBatchExecutionTopologies()`** runs at bootstrap, right after
+  `applyBatchProbePolicies()` and well before the transports start. For each `BatchDefinition` whose
+  element type matches a `GlobalPartitioned` (companion local queues) or
+  `PublishToPartitionedLocalMessaging` topology, it records the slot endpoints on
+  `BatchingOptions.ExecutionSlots`.
+- **`IBatchExecutionQueues`** (`src/Wolverine/Runtime/Batching/BatchExecutionQueues.cs`) selects the
+  queue per assembled batch, so `ProcessorBuilder.Build`'s single `ILocalQueue` resolve becomes N.
+  `PartitionedBatchExecutionQueues` uses **`SlotForSending`** — the same hash
+  `GlobalPartitionedRoute` and `PartitionedMessageTopology.SelectSlot` use, so the batch agrees with
+  where the unbatched messages for that group went. (`SlotForSending` and `SlotForProcessing`
+  deliberately use *different* hashes; the topology layer is the former. Getting this wrong would
+  silently reintroduce the race, so there is a test pinning it.)
+- **The batcher is auto-swapped** to `GroupIdMessageBatcher<T>` when it is still the built-in
+  default, since slotting requires a batch to belong to exactly one group. An application-supplied
+  batcher is left alone, and any batch it emits without a group id falls back to the dedicated queue
+  rather than drawing a random slot.
+- **Opting out:** `ExecuteOnDedicatedLocalQueue()`, or setting `LocalExecutionQueueName` — naming a
+  queue is read as meaning it. Wolverine's own default assignment goes through the internal
+  `SetDefaultLocalExecutionQueueName` so it does not read as a user choice.
 
-Also confirm the batch chain resolves on the companion queues (the processor only sets
-`MessageType` + `Destination`), and that `BatchingPendingCounts.SettleBatch` still fires once per
-batch when the batch lands somewhere other than the configured execution queue.
+Automatic rather than opt-in because `GlobalPartitionLocalQueueUri` is `internal`: users cannot wire
+this themselves, and an application that declared `GlobalPartitioned` for a message type has already
+stated the intent that the batch was silently exempting itself from.
 
-### Three shapes — updated, shape 3 preferred
+### On the deadlock question
 
-1. **Honour a `Destination` the batcher set** instead of unconditionally overwriting it. Smallest
-   change, but it pushes slot selection into batcher implementations, which then have to know slot
-   counts and queue naming. That is the framework's job, not a batcher's.
-2. **Route the grouped envelope** through the normal routing path so it flows into a partitioned
-   local topology like any other message. Attractive, but it has to reproduce what
-   `processEnvelopes` does by hand: `MessageType`, `SentAt`, `BatchingPendingCounts.SettleBatch`,
-   and in particular the CritterWatch#942 back-pressure accounting at `BatchingProcessor.cs:48`
-   that counts members against the originating listener. That accounting exists because of a real
-   production incident; do not let routing re-derive it by accident.
-3. **Let `BatchingOptions` take a partitioned local topology** rather than a single
-   `LocalExecutionQueueName`, and pick the slot from the batch's group id. **Preferred.** It is the
-   only shape that makes a batched handler a first-class participant in global partitioning rather
-   than an exception to it: the batch lands on the same companion local queue as its group's other
-   messages, giving a genuine single writer per group id, cluster-wide. Largest API surface, but the
-   concrete change is small — `ProcessorBuilder.Build` currently resolves exactly one `ILocalQueue`
-   (`BatchingOptions.cs:163`); that becomes N, or a deferred per-batch resolve.
+The earlier note here was right that there is **no direct self-deadlock**: `HandleAsync` runs on the
+slot block but only posts into `_batchingBlock`, while `processEnvelopes` runs on a separate
+`_processingBlock`, so the enqueue happens off the slot block.
 
-The only hard constraint: a batch that has a group id must be able to land on that group's slot.
+The head-of-line hazard flagged alongside it is real, though, and it is worse than a stall — it
+closes a cycle across three bounded buffers:
 
-### The field data point that decided the preference
+```
+slot block (bounded, DOP 1) → BatchingProcessor.HandleAsync
+  → BatchingChannel._inner (bounded) → addItem → _processingBlock (bounded)
+  → processEnvelopes → queue.EnqueueAsync → back into the same slot block
+```
 
-I originally recorded that the affected CritterWatch console had clustering off (single replica).
-**That was wrong.** The shipped console wires `GlobalPartitioned` *unconditionally* — one
-`AddCritterWatchServices` call supplying `configureClusterShardedTopology` with 5 sharded slots
-across RabbitMQ, SQS and Azure Service Bus.
+Saturate all three and every worker in the ring is blocked on the next. This did not exist before,
+because the batch's dedicated local queue is unbounded (GH-3287).
 
-So the failing deployment already has the strongest partitioning Wolverine offers and still sees
-~20 stream-concurrency exceptions/min. Global partitioning correctly sequences every participating
-message type **except the batched one**, and the batched one accounts for 59% of the failures. That
-is the clearest available statement of what part 2 is for.
+The fix is `Endpoint.HostsBatchExecution`, set on every slot endpoint a batch targets;
+`DurableReceiver` gives those an unbounded execution block. `EnqueueAsync` into an unbounded slot
+never blocks, so `_processingBlock` never stalls and the cycle cannot close — which also removes the
+cross-group head-of-line coupling, without the drop risk of a non-blocking `Post`. Back-pressure is
+not lost: `BatchingPendingCounts` counts members against the originating external listener, which is
+what `ListeningAgent.QueueCount` watches. `BufferedReceiver` already passes unbounded for local
+queues, so only the durable path needed the change.
 
-### Things to check before choosing
+### The two other checks that were asked for, and their answers
 
-- `ProcessorBuilder.Build` resolves exactly one `ILocalQueue` up front
-  (`BatchingOptions.cs:163`). Shapes 2 and 3 need N, or need resolution deferred per batch.
-- Retry/dead-letter: `ProbeIndividuallyAfter` re-runs members as size-1 batches. Confirm a re-probed
-  batch keeps its group id, or a poison probe will scatter across slots.
-- `BatchingPendingCounts` settles once per grouped batch envelope. Confirm per-slot fan-out does not
-  double-count or lose a settle.
+- **Does the batch chain resolve on the companion queues?** Yes. `ExecutorFor(T[], slot)` falls
+  through to the default chain; and for the Separated-mode case with sticky `Handle(T[])` handlers,
+  `HandlerGraph.HandlerFor` already special-cases a local queue with `UsedInShardedTopology` and
+  builds a fanout. Covered end to end by the acceptance test below.
+- **Does `BatchingPendingCounts.SettleBatch` still fire once per batch?** Yes, by construction. Both
+  `DurableReceiver.CompleteAsync` and `BufferedReceiver`'s channel callback settle on
+  `envelope.Batch != null`, keyed off the batch envelope itself and independent of which queue it
+  landed on. Each grouped envelope still goes to exactly **one** queue — this is slot selection, not
+  fan-out — so there is no double-count and no lost settle.
+
+### Also fixed
+
+`BatchReplay.EnqueueReducedBatchAsync` copied `Destination`, `MessageType` and `TenantId` but **not
+`GroupId`**, so a `ProbeIndividuallyAfter` or `ApplyItemException` probe lost the batch's identity
+and scattered the survivors across slots. That was already wrong with part 1 alone.
+
+---
+
+## What is still NOT covered
+
+Shape 3 only reaches configurations where the unbatched handlers execute on an *addressable local
+queue*:
+
+| Configuration | Unbatched handlers run on | Covered? |
+|---|---|---|
+| `GlobalPartitioned` | companion local queue `global-{base}{slot}` | **yes** |
+| `PublishToPartitionedLocalMessaging` | local queue `{base}{slot}` | **yes** |
+| Plain listener + `PartitionProcessingByGroupId` | the listener receiver's own `ShardedExecutionBlock` | **no** |
+
+The third row is not a queue and cannot be enqueued to. The most a batched handler gets there is
+part 1 plus group-sharding the batching queue, which sequences the batches against each other but
+not against the unbatched handlers. The answer today is to move to one of the two topologies;
+closing it properly would mean making a listener's sharded block addressable, which is a much larger
+change.
+
+One more edge, noted rather than solved: under `MultipleHandlerBehavior.Separated` with **multiple**
+sticky `Handle(T[])` handlers, the batch fans out from the slot queue to each sticky handler's own
+queue, so those handlers execute off-slot and the sequencing guarantee does not extend to them.
 
 ---
 
 ## Reproduction and verification
 
-The downstream effect reproduces reliably in CritterWatch's soak harness (`src/IngestSoakTests` in
+**The pure-Wolverine acceptance test now exists and needs no broker:**
+`src/Testing/CoreTests/Acceptance/batching_with_partitioned_processing.cs`. `ExplicitRouting` already
+sends a batched element type to its topology slots, so a `PublishToPartitionedLocalMessaging`
+topology reproduces the whole thing in memory. One batched and one unbatched message type share a
+group id; the test asserts no intra-group overlap while still observing cross-group parallelism (so
+a fix that merely serialized everything would not pass).
+
+**It fails on `main`** — 12 violations of exactly the shape described above.
+
+```bash
+dotnet test src/Testing/CoreTests/CoreTests.csproj -f net9.0 \
+  --filter "FullyQualifiedName~batching_with_partitioned_processing"
+```
+
+Also `batch_execution_topology_resolution.cs` (bootstrap resolution and the opt-outs),
+`BatchExecutionQueuesTests` (slot selection, including agreement with `SlotForSending`), and
+`BatchReplayTests` (group id survives a probe).
+
+Full CoreTests on net9.0: 2,315 passed / 0 failed. `dotnet build wolverine.slnx -c Release -f net9.0`
+clean.
+
+**Not yet run:** the broker-backed `global_partitioned_sharded_processing` suites (RabbitMQ, Kafka,
+SQS, Postgres, SqlServer), which need `docker compose up -d`.
+
+The downstream effect also reproduces in CritterWatch's soak harness (`src/IngestSoakTests` in
 `~/code/CritterWatch`, target `./build.sh IngestSoak`), where a batched `ServiceUpdates` handler and
 ~10 unbatched handlers all append to one Marten event stream:
 
@@ -187,25 +202,27 @@ The downstream effect reproduces reliably in CritterWatch's soak harness (`src/I
 | 4 hosts / 1 service / 60 min, unbatched writers active | **4,275** `EventStreamUnexpectedMaxEventIdException` (71/min), across 7 handler types, batched one = 59% |
 | same batched volume, unbatched writers off | **0** |
 
-`CW_SOAK_DISCOVERY_CHURN=0` is the negative control. That harness is the acceptance test for part 2:
-with the fix in, the churn-on run should go to zero conflicts while keeping cross-service
-parallelism (compare the `many_services_many_nodes` topology before and after).
+`CW_SOAK_DISCOVERY_CHURN=0` is the negative control. That harness is the field acceptance test: with
+this in, the churn-on run should go to zero conflicts while keeping cross-service parallelism
+(compare the `many_services_many_nodes` topology before and after). **It has not been re-run.**
 
-A pure-Wolverine equivalent would be better for this repo — a batched handler and an unbatched
-handler for the same group id, both writing to a shared in-memory structure through a partitioned
-endpoint, asserting no interleaving. That test does not exist yet and would be worth writing first,
-since it fails today and is the tightest statement of the bug.
+The field data point that decided the shape: the affected CritterWatch console wires
+`GlobalPartitioned` *unconditionally* — one `AddCritterWatchServices` call supplying
+`configureClusterShardedTopology` with 5 sharded slots across RabbitMQ, SQS and Azure Service Bus.
+So the failing deployment already had the strongest partitioning Wolverine offers and still saw ~20
+stream-concurrency exceptions/min, because global partitioning sequenced every participating message
+type *except* the batched one.
 
 ---
 
-## Hazards
+## Hazards for whoever touches this next
 
 - `MessagePartitioningRules.DetermineGroupId` is `internal` and **mutates the envelope** (writes the
   resolved id back). Fine inside the assembly; do not expose it casually.
 - `GlobalPartitionLocalQueueUri` is `internal` — an outside assembly cannot bridge a listener to a
-  chosen local queue. Anything that expects users to wire this themselves is a non-starter.
+  chosen local queue.
 - The `else if` at `ListeningAgent.cs:412` intercepts matching messages on *non-paired* endpoints
-  when global topologies exist. I did not trace that path; if part 2 touches routing, read it.
-- CritterWatch currently carries its own `ServiceUpdatesBatcher` (uncommitted, in
-  `src/CritterWatch.Services/`) that duplicates part 1. It should be deleted in favour of
-  `GroupByGroupId()` once this ships — do not treat it as a second implementation to keep in sync.
+  when global topologies exist. Still untraced.
+- CritterWatch carries its own `ServiceUpdatesBatcher` (uncommitted, in `src/CritterWatch.Services/`)
+  that duplicates part 1. It should be deleted — with this branch, `ServiceUpdates` needs no batcher
+  configuration at all, since the topology match does both the grouping and the slotting.

--- a/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
+++ b/GH-3867-BATCHING-PARTITIONING-HANDOFF.md
@@ -107,6 +107,31 @@ Useful thing already verified so you do not have to: **`LocalQueueConfiguration`
 group-sharding the batching queue itself works today — it just does not help on its own, because the
 other writers are on a different queue.
 
+### The requirement, stated plainly (Jeremy, 2026-08-07)
+
+> **A batched message must execute on the same local, partitioned queue that an unbatched message
+> of the same group id would execute on.**
+
+For a message type participating in a partitioned topology, the batch envelope for group `G` goes to
+slot `hash(G) % N` — `global-{base}{slot}` under global partitioning, `{base}{slot}` under
+`PublishToPartitionedLocalMessaging`. No partitioned topology covering the type → today's
+single-queue behaviour, unchanged. The property being bought is **one writer per group id**,
+batched and unbatched alike, cluster-wide.
+
+**Two implementation notes, both verified against the source:**
+
+- **No self-deadlock.** The obvious worry — enqueueing the batch back onto the same
+  single-parallelism slot whose handler produced it — does not apply. `HandleAsync` runs on the slot
+  block but only posts into `_batchingBlock`; `processEnvelopes` runs on a separate
+  `_processingBlock` (`BatchingProcessor.cs:24-25`), so the enqueue happens off the slot block.
+- **Head-of-line blocking is the real hazard.** `_processingBlock` is shared across all groups, so a
+  blocking `EnqueueAsync` into one saturated slot would stall batch dispatch for *every* group.
+  Either post non-blocking with a fallback, or document the coupling. Test this first.
+
+Also confirm the batch chain resolves on the companion queues (the processor only sets
+`MessageType` + `Destination`), and that `BatchingPendingCounts.SettleBatch` still fires once per
+batch when the batch lands somewhere other than the configured execution queue.
+
 ### Three shapes — updated, shape 3 preferred
 
 1. **Honour a `Destination` the batcher set** instead of unconditionally overwriting it. Smallest

--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -337,12 +337,61 @@ stamped it upstream), falling back to your `MessagePartitioning` rules. A few de
 - Like `CoalesceBy`, this only changes how the batch is *assembled and slotted* -- every original member message
   still rides on the batch, so inbox/outbox tracking and dead-lettering are unaffected.
 
+## Batching inside a partitioned topology <Badge type="tip" text="6.25" />
+
+The section above stamps a group id onto the batch. The other half of the problem is *where the batch runs*.
+
+If the batched element type already belongs to a [`GlobalPartitioned`](/guide/messaging/partitioning#global-partitioning)
+or [`PublishToPartitionedLocalMessaging`](/guide/messaging/partitioning#partitioned-publishing-locally) topology, then
+the **unbatched** handlers for a given group id are being sequenced onto one slot of that topology, while the assembled
+batch used to be enqueued to the batch's own dedicated local queue -- a different execution block. The batched handler
+therefore raced the very handlers the topology had just sequenced.
+
+Wolverine now picks the batch's queue from the batch's own group id, so it lands on the same slot as everything else in
+that group. **This is automatic**; there is nothing to configure:
+
+```csharp
+opts.MessagePartitioning
+    .ByMessage<IOrderCommand>(x => x.OrderId)
+    .GlobalPartitioned(topology =>
+    {
+        topology.MessagesImplementing<IOrderCommand>();
+        // ... external transport slots ...
+    });
+
+// OrderPlaced is part of that topology, so its batches execute on the topology slot
+// for each batch's group id -- sequenced against the unbatched IOrderCommand handlers
+// for the same OrderId, cluster-wide.
+opts.BatchMessagesOf<OrderPlaced>(batching =>
+{
+    batching.TriggerTime = 1.Seconds();
+});
+```
+
+Two consequences of this being automatic:
+
+- **The batcher is swapped for you.** Slotting a batch only makes sense if the batch belongs to exactly one group, so
+  when a partitioned topology is in play and you have not supplied your own `IMessageBatcher`, Wolverine installs the
+  `GroupByGroupId()` batcher. A batcher you registered yourself is left alone; any batch it produces without a group id
+  falls back to the dedicated queue rather than drawing a random slot.
+- **Naming a queue opts out.** Setting `LocalExecutionQueueName` is read as a deliberate choice of where batches run,
+  and so is `ExecuteOnDedicatedLocalQueue()`:
+
+  ```csharp
+  opts.BatchMessagesOf<OrderPlaced>(batching =>
+  {
+      // Run the batches on their own queue, concurrently with the unbatched
+      // handlers for the same group id
+      batching.ExecuteOnDedicatedLocalQueue();
+  });
+  ```
+
 ::: warning
-This gives you sequential processing **among the batches** for a group id. It does *not* yet serialize a batched
-handler against the **unbatched** handlers for that same group id: the assembled batch is enqueued directly to the
-batching local queue rather than routed, so it executes on a different block than a partitioned external listener
-or a `GlobalPartitioned` topology uses. If several message types write to one event stream and only some of them
-are batched, you can still see concurrent writers. Tracked as
+This covers the configurations where the unbatched handlers run on a **local queue** -- `GlobalPartitioned` and
+`PublishToPartitionedLocalMessaging`. It does not cover a plain external listener that only has
+`PartitionProcessingByGroupId` applied to it: there the unbatched handlers execute inside the listener's own execution
+block, which is not a queue and cannot be enqueued to. For that case, use one of the two topologies above if you need
+the batched and unbatched handlers for a group id to be sequenced against each other. See
 [GH-3867](https://github.com/JasperFx/wolverine/issues/3867).
 :::
 

--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -286,6 +286,66 @@ member message still rides on the batch, so the transactional inbox/outbox track
 exactly as they do for a normal (non-coalesced) batch. If you drop from 1,000 messages to 40 distinct keys,
 the handler runs once over 40 items, but all 1,000 member messages are settled with that batch.
 
+## Batching by group id with `GroupByGroupId` <Badge type="tip" text="6.25" />
+
+The default batcher groups only by tenant id, so one batch envelope can span many
+[message group ids](/guide/messaging/partitioning) -- and therefore carries none of its own. That is fine until
+batching has to coexist with [partitioned sequential processing](/guide/messaging/partitioning), because an
+envelope with no group id is **not** treated as "unpartitioned". It is assigned a *randomly chosen* slot:
+
+```csharp
+// PartitionedMessagingExtensions.SlotForProcessing
+var groupId = rules.DetermineGroupId(envelope);
+
+// Pick one at random, and has to be zero based
+if (groupId == null) return Random.Shared.Next(1, numberOfSlots) - 1;
+```
+
+So a batched handler on a partitioned endpoint silently draws a different slot on every trigger, and successive
+batches for the *same* entity can run concurrently. There is no configuration error and nothing in the logs.
+
+`GroupByGroupId()` opts into a batcher that groups by `(tenant id, group id)` and stamps that group id onto every
+batch envelope it produces, so the batch itself is a member of exactly one group:
+
+```csharp
+opts.MessagePartitioning
+    .ByMessage<ScoreEvent>(x => x.AggregateId);
+
+opts.BatchMessagesOf<ScoreEvent>(batching =>
+{
+    batching.BatchSize = 500;
+    batching.TriggerTime = 1.Seconds();
+
+    // Group the batches by the message group id, and stamp that group id
+    // onto the batch envelope
+    batching.GroupByGroupId();
+})
+    // BatchMessagesOf() returns the local queue configuration for the batched
+    // messages, and that queue is a listening endpoint like any other -- so the
+    // stamped group id can be used to shard its execution
+    .PartitionProcessingByGroupId(PartitionSlots.Five);
+```
+
+The group id is resolved from the envelope first (a listener already using `PartitionProcessingByGroupId` has
+stamped it upstream), falling back to your `MessagePartitioning` rules. A few deliberate behaviors:
+
+- **The key is `(tenant, group)`, never the group id alone.** Wolverine settles a batch's members against the batch
+  envelope, so merging tenants into one batch would lose the tenant each member arrived under. Two tenants sharing
+  a group id still produce two batches.
+- **Envelopes with no determinable group id are batched together and left ungrouped.** The batcher does not invent
+  an identity for them, so they behave exactly as they do under the default batcher.
+- Like `CoalesceBy`, this only changes how the batch is *assembled and slotted* -- every original member message
+  still rides on the batch, so inbox/outbox tracking and dead-lettering are unaffected.
+
+::: warning
+This gives you sequential processing **among the batches** for a group id. It does *not* yet serialize a batched
+handler against the **unbatched** handlers for that same group id: the assembled batch is enqueued directly to the
+batching local queue rather than routed, so it executes on a different block than a partitioned external listener
+or a `GlobalPartitioned` topology uses. If several message types write to one event stream and only some of them
+are batched, you can still see concurrent writers. Tracked as
+[GH-3867](https://github.com/JasperFx/wolverine/issues/3867).
+:::
+
 ## Batch identity with `IBatchContext`
 
 A batched handler can inject `IBatchContext` to get read-only information about the batch it is processing —

--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -366,6 +366,41 @@ builder.UseWolverine(opts =>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L14-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_partitioned_processing_on_any_listener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Partitioned Processing with Batched Handlers <Badge type="tip" text="6.25" />
+
+::: warning
+A [batched handler](/guide/handlers/batching) does **not** participate in partitioned sequential processing by
+default, and the failure is silent. The default batcher groups only by tenant id, so the assembled batch envelope
+carries no group id -- and as `SlotForProcessing` above shows, a missing group id means *a randomly chosen slot*,
+not "leave this unpartitioned". Successive batches for the same entity land on different slots and run
+concurrently.
+:::
+
+Opt the batcher into group id grouping so the batch envelope is stamped with a group id and can be sharded like
+any other message:
+
+```csharp
+opts.MessagePartitioning
+    .ByMessage<IOrderCommand>(x => x.OrderId);
+
+opts.BatchMessagesOf<OrderPlaced>(batching =>
+{
+    batching.TriggerTime = 1.Seconds();
+
+    // Group by the message group id, and stamp it onto the batch envelope
+    batching.GroupByGroupId();
+})
+    // The local queue that runs the batched handler is a listening endpoint
+    // like any other
+    .PartitionProcessingByGroupId(PartitionSlots.Five);
+```
+
+Note that this serializes the batches for a group id against *each other*. It does not yet serialize the batched
+handler against **unbatched** handlers for the same group id, because the assembled batch is enqueued straight to
+the batching local queue instead of being routed into the partitioned topology. See
+[Batching by group id](/guide/handlers/batching#batching-by-group-id-with-groupbygroupid) and
+[GH-3867](https://github.com/JasperFx/wolverine/issues/3867) for the details.
+
 ## Partitioned Publishing to External Transports
 
 ::: info

--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -369,24 +369,44 @@ builder.UseWolverine(opts =>
 ## Partitioned Processing with Batched Handlers <Badge type="tip" text="6.25" />
 
 ::: warning
-A [batched handler](/guide/handlers/batching) does **not** participate in partitioned sequential processing by
-default, and the failure is silent. The default batcher groups only by tenant id, so the assembled batch envelope
+A [batched handler](/guide/handlers/batching) needs help to participate in partitioned sequential processing, and
+without it the failure is silent. The default batcher groups only by tenant id, so the assembled batch envelope
 carries no group id -- and as `SlotForProcessing` above shows, a missing group id means *a randomly chosen slot*,
 not "leave this unpartitioned". Successive batches for the same entity land on different slots and run
 concurrently.
 :::
 
-Opt the batcher into group id grouping so the batch envelope is stamped with a group id and can be sharded like
-any other message:
+**When the batched message type belongs to a partitioned topology, this is handled for you.** If the element type
+matches a `PublishToPartitionedLocalMessaging` or [`GlobalPartitioned`](#global-partitioning) topology, Wolverine
+groups the batches by group id and runs each batch on that group's topology slot -- the same slot the unbatched
+messages for that group are being sequenced onto, so the batched handler is one more writer in the same queue rather
+than a concurrent one beside it:
 
 ```csharp
 opts.MessagePartitioning
-    .ByMessage<IOrderCommand>(x => x.OrderId);
+    .ByMessage<IOrderCommand>(x => x.OrderId)
+    .PublishToPartitionedLocalMessaging("orders", 4, topology =>
+    {
+        topology.MessagesImplementing<IOrderCommand>();
+    });
 
+// OrderPlaced is an IOrderCommand, so its batches land on the "orders{n}" slot for
+// each batch's OrderId -- sequenced against the unbatched IOrderCommand handlers
+// for that same OrderId.
+opts.BatchMessagesOf<OrderPlaced>(batching => batching.TriggerTime = 1.Seconds());
+```
+
+Setting `LocalExecutionQueueName`, or calling `ExecuteOnDedicatedLocalQueue()`, opts back out and runs the batches
+on their own queue.
+
+Outside a topology -- a plain listener with only `PartitionProcessingByGroupId` applied -- there is no queue to
+place the batch on, because the unbatched handlers execute inside the listener's own execution block. The most you
+can get there is sequencing the batches for a group id against *each other*, by stamping the group id and sharding
+the batching queue:
+
+```csharp
 opts.BatchMessagesOf<OrderPlaced>(batching =>
 {
-    batching.TriggerTime = 1.Seconds();
-
     // Group by the message group id, and stamp it onto the batch envelope
     batching.GroupByGroupId();
 })
@@ -395,10 +415,7 @@ opts.BatchMessagesOf<OrderPlaced>(batching =>
     .PartitionProcessingByGroupId(PartitionSlots.Five);
 ```
 
-Note that this serializes the batches for a group id against *each other*. It does not yet serialize the batched
-handler against **unbatched** handlers for the same group id, because the assembled batch is enqueued straight to
-the batching local queue instead of being routed into the partitioned topology. See
-[Batching by group id](/guide/handlers/batching#batching-by-group-id-with-groupbygroupid) and
+See [Batching inside a partitioned topology](/guide/handlers/batching#batching-inside-a-partitioned-topology) and
 [GH-3867](https://github.com/JasperFx/wolverine/issues/3867) for the details.
 
 ## Partitioned Publishing to External Transports

--- a/src/Testing/CoreTests/Acceptance/batch_execution_topology_resolution.cs
+++ b/src/Testing/CoreTests/Acceptance/batch_execution_topology_resolution.cs
@@ -1,0 +1,145 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.Runtime.Batching;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+/// GH-3867. Startup decides whether a batch executes on one dedicated local queue or is distributed
+/// across the partitioned topology its element type already belongs to.
+/// </summary>
+public class batch_execution_topology_resolution
+{
+    private static async Task<IHost> hostWith(Action<WolverineOptions> configure, bool withTopology = true)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.MessagePartitioning.ByMessage<IPartitionedOrderMessage>(x => x.OrderId);
+
+                if (withTopology)
+                {
+                    opts.MessagePartitioning.PublishToPartitionedLocalMessaging("gh3867resolve", 4,
+                        topology => { topology.MessagesImplementing<IPartitionedOrderMessage>(); });
+                }
+
+                configure(opts);
+            }).StartAsync();
+    }
+
+    private static BatchingOptions batchingFor(IHost host)
+    {
+        return host.GetRuntime().Options.BatchDefinitions.Single(x => x.ElementType == typeof(OrderTouched));
+    }
+
+    [Fact]
+    public async Task targets_the_topology_slots_when_the_element_type_belongs_to_one()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>());
+
+        var batching = batchingFor(host);
+
+        batching.ExecutionSlots.ShouldNotBeNull();
+        batching.ExecutionSlots!.Count.ShouldBe(4);
+        batching.ExecutionSlots.Select(x => x.Uri.ToString()).ShouldBe([
+            "local://gh3867resolve1/", "local://gh3867resolve2/", "local://gh3867resolve3/", "local://gh3867resolve4/"
+        ]);
+    }
+
+    [Fact]
+    public async Task flags_the_slot_endpoints_so_they_get_an_unbounded_execution_block()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>());
+
+        // Those queues are now their own cascade target, which would deadlock a bounded block.
+        batchingFor(host).ExecutionSlots!.ShouldAllBe(x => x.HostsBatchExecution);
+    }
+
+    [Fact]
+    public async Task swaps_the_default_batcher_for_the_group_id_batcher()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>());
+
+        // Slotting is only coherent if a batch belongs to exactly one group.
+        batchingFor(host).Batcher.ShouldBeOfType<GroupIdMessageBatcher<OrderTouched>>();
+    }
+
+    [Fact]
+    public async Task leaves_an_application_supplied_batcher_alone()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>(b =>
+        {
+            b.Batcher = new PassthroughOrderBatcher();
+        }));
+
+        var batching = batchingFor(host);
+
+        batching.Batcher.ShouldBeOfType<PassthroughOrderBatcher>();
+
+        // It still gets the slots — a custom batcher may well stamp its own group ids, and any batch
+        // that arrives without one falls back to the dedicated queue.
+        batching.ExecutionSlots.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task naming_the_execution_queue_opts_out()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>(b =>
+        {
+            b.LocalExecutionQueueName = "gh3867-explicit";
+        }));
+
+        var batching = batchingFor(host);
+
+        batching.IsLocalQueueExplicit.ShouldBeTrue();
+        batching.ExecutionSlots.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task execute_on_dedicated_local_queue_opts_out()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>(b =>
+        {
+            b.ExecuteOnDedicatedLocalQueue();
+        }));
+
+        batchingFor(host).ExecutionSlots.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task no_topology_means_the_original_single_queue_behavior()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>(), withTopology: false);
+
+        var batching = batchingFor(host);
+
+        batching.ExecutionSlots.ShouldBeNull();
+
+        // And the batcher is untouched, so nothing changes for the overwhelming majority of users.
+        batching.Batcher.ShouldBeOfType<DefaultMessageBatcher<OrderTouched>>();
+    }
+
+    [Fact]
+    public async Task wolverines_own_default_queue_name_is_not_treated_as_an_explicit_choice()
+    {
+        using var host = await hostWith(opts => opts.BatchMessagesOf<OrderTouched>());
+
+        var batching = batchingFor(host);
+
+        batching.LocalExecutionQueueName.ShouldNotBeNull();
+        batching.IsLocalQueueExplicit.ShouldBeFalse();
+    }
+}
+
+internal class PassthroughOrderBatcher : IMessageBatcher
+{
+    public IEnumerable<Envelope> Group(IReadOnlyList<Envelope> envelopes)
+    {
+        yield return new Envelope(envelopes.Select(x => x.Message).OfType<OrderTouched>().ToArray(), envelopes);
+    }
+
+    public Type BatchMessageType => typeof(OrderTouched[]);
+}

--- a/src/Testing/CoreTests/Acceptance/batching_with_partitioned_processing.cs
+++ b/src/Testing/CoreTests/Acceptance/batching_with_partitioned_processing.cs
@@ -1,0 +1,191 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.Configuration;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+/// GH-3867 part 2. A batched handler and an unbatched handler for the SAME group id must not run
+/// concurrently when both message types belong to a partitioned topology. Before the fix the
+/// assembled batch was enqueued to its own dedicated local queue instead of the topology slot for
+/// its group, so the batch raced the very handlers the topology had just sequenced.
+/// </summary>
+public class batching_with_partitioned_processing : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost theHost = null!;
+
+    public batching_with_partitioned_processing(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        GroupExecutionLog.Reset();
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.MessagePartitioning
+                    .ByMessage<IPartitionedOrderMessage>(x => x.OrderId)
+                    .PublishToPartitionedLocalMessaging("gh3867orders", 4,
+                        topology => { topology.MessagesImplementing<IPartitionedOrderMessage>(); });
+
+                opts.BatchMessagesOf<OrderTouched>(batching =>
+                {
+                    batching.BatchSize = 5;
+                    batching.TriggerTime = 100.Milliseconds();
+                });
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task batched_and_unbatched_handlers_for_a_group_id_never_overlap()
+    {
+        // Three group ids so we can also prove that different groups still run in parallel -- a fix
+        // that just serialized everything would pass the primary assertion but be useless.
+        string[] groups = ["one", "two", "three"];
+
+        var bus = theHost.MessageBus();
+        for (var i = 0; i < 12; i++)
+        {
+            foreach (var group in groups)
+            {
+                await bus.PublishAsync(new OrderTouched(group, i));
+                await bus.PublishAsync(new OrderAudited(group, i));
+            }
+        }
+
+        // 12 audits per group are handled individually; the batched touches arrive as a handful of
+        // batches, so wait on the audits and give the trailing batches their trigger window.
+        await GroupExecutionLog.WaitForAuditsAsync(groups.Length * 12, 30.Seconds());
+        await Task.Delay(500.Milliseconds(), TestContext.Current.CancellationToken);
+
+        foreach (var violation in GroupExecutionLog.Violations)
+        {
+            _output.WriteLine(violation);
+        }
+
+        GroupExecutionLog.Violations.ShouldBeEmpty();
+
+        // Sanity: the batched handler actually ran, so an empty violation list means something.
+        GroupExecutionLog.BatchedItemCount.ShouldBe(groups.Length * 12);
+
+        // And the partitioning is still buying us cross-group parallelism.
+        GroupExecutionLog.SawDistinctGroupsRunConcurrently.ShouldBeTrue();
+    }
+}
+
+public interface IPartitionedOrderMessage
+{
+    string OrderId { get; }
+}
+
+public record OrderTouched(string OrderId, int Sequence) : IPartitionedOrderMessage;
+
+public record OrderAudited(string OrderId, int Sequence) : IPartitionedOrderMessage;
+
+/// <summary>
+/// Records which group ids are executing at any instant. Two handlers inside the same group id at
+/// the same time is the bug; two different group ids at the same time is the feature.
+/// </summary>
+public static class GroupExecutionLog
+{
+    private static readonly ConcurrentDictionary<string, int> _active = new();
+    private static int _auditsHandled;
+    private static int _batchedItems;
+    private static int _sawConcurrentGroups;
+
+    public static ConcurrentBag<string> Violations { get; private set; } = new();
+    public static int BatchedItemCount => _batchedItems;
+    public static bool SawDistinctGroupsRunConcurrently => _sawConcurrentGroups > 0;
+
+    public static void Reset()
+    {
+        _active.Clear();
+        Violations = new ConcurrentBag<string>();
+        _auditsHandled = 0;
+        _batchedItems = 0;
+        _sawConcurrentGroups = 0;
+    }
+
+    public static async Task ExecuteAsync(string groupId, string who)
+    {
+        var depth = _active.AddOrUpdate(groupId, 1, static (_, current) => current + 1);
+        if (depth > 1)
+        {
+            Violations.Add($"group '{groupId}': {who} ran concurrently with another handler for the same group");
+        }
+
+        if (_active.Count(pair => pair.Value > 0) > 1)
+        {
+            Interlocked.Exchange(ref _sawConcurrentGroups, 1);
+        }
+
+        try
+        {
+            // Wide enough that a genuine overlap is observed rather than missed by timing luck.
+            await Task.Delay(25.Milliseconds());
+        }
+        finally
+        {
+            _active.AddOrUpdate(groupId, 0, static (_, current) => current - 1);
+        }
+    }
+
+    public static void CountAudit() => Interlocked.Increment(ref _auditsHandled);
+
+    public static void CountBatchedItems(int count) => Interlocked.Add(ref _batchedItems, count);
+
+    public static async Task WaitForAuditsAsync(int expected, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (Volatile.Read(ref _auditsHandled) >= expected) return;
+            await Task.Delay(50.Milliseconds());
+        }
+
+        throw new TimeoutException(
+            $"Only {Volatile.Read(ref _auditsHandled)} of {expected} OrderAudited messages were handled within {timeout}");
+    }
+}
+
+public static class PartitionedOrderHandler
+{
+    // The BATCHED handler. Note there is deliberately no Handle(OrderTouched) -- the batch owns the
+    // element type.
+    public static async Task Handle(OrderTouched[] touches)
+    {
+        GroupExecutionLog.CountBatchedItems(touches.Length);
+
+        // Targeting a partitioned topology is only coherent if each batch belongs to exactly one
+        // group, so the runtime swaps in the group-id batcher. Assert that rather than assume it --
+        // otherwise the overlap check below would silently under-report on a mixed batch.
+        var groupIds = touches.Select(x => x.OrderId).Distinct().ToArray();
+        if (groupIds.Length > 1)
+        {
+            GroupExecutionLog.Violations.Add(
+                $"a single batch spanned {groupIds.Length} group ids ({groupIds.Join(", ")}) and cannot be slotted");
+        }
+
+        await GroupExecutionLog.ExecuteAsync(groupIds[0], $"batch of {touches.Length} OrderTouched");
+    }
+
+    // The UNBATCHED handler for a sibling message type in the same group.
+    public static async Task Handle(OrderAudited audited)
+    {
+        await GroupExecutionLog.ExecuteAsync(audited.OrderId, "OrderAudited");
+        GroupExecutionLog.CountAudit();
+    }
+}

--- a/src/Testing/CoreTests/Acceptance/group_id_message_batcher.cs
+++ b/src/Testing/CoreTests/Acceptance/group_id_message_batcher.cs
@@ -1,0 +1,105 @@
+using Wolverine;
+using Wolverine.Runtime.Batching;
+using Wolverine.Runtime.Partitioning;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+public class GroupIdMessageBatcherTests
+{
+    private static GroupIdMessageBatcher<ScoreEvent> batcher(MessagePartitioningRules? rules = null)
+    {
+        var batcher = new GroupIdMessageBatcher<ScoreEvent>();
+        if (rules != null) batcher.Rules = rules;
+        return batcher;
+    }
+
+    private static Envelope envelopeFor(ScoreEvent message, string? groupId = null, string? tenantId = null)
+    {
+        return new Envelope(message) { GroupId = groupId, TenantId = tenantId };
+    }
+
+    [Fact]
+    public void one_batch_per_group_id_and_the_batch_carries_that_group_id()
+    {
+        var envelopes = new[]
+        {
+            envelopeFor(new ScoreEvent("A", 1), "one"),
+            envelopeFor(new ScoreEvent("A", 2), "two"),
+            envelopeFor(new ScoreEvent("A", 3), "one")
+        };
+
+        var batches = batcher().Group(envelopes).ToArray();
+
+        batches.Length.ShouldBe(2);
+
+        // The stamp is the point: without it the batch has no group id, and an envelope with no
+        // group id draws a RANDOM partition slot rather than being left unpartitioned.
+        var one = batches.Single(x => x.GroupId == "one");
+        one.Message.ShouldBeOfType<ScoreEvent[]>().Length.ShouldBe(2);
+        one.Batch!.Length.ShouldBe(2);
+
+        batches.Single(x => x.GroupId == "two").Message.ShouldBeOfType<ScoreEvent[]>().Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void never_mixes_tenants_into_one_batch()
+    {
+        var envelopes = new[]
+        {
+            envelopeFor(new ScoreEvent("A", 1), "one", "tenant1"),
+            envelopeFor(new ScoreEvent("A", 2), "one", "tenant2"),
+            envelopeFor(new ScoreEvent("A", 3), "one", "tenant1")
+        };
+
+        var batches = batcher().Group(envelopes).ToArray();
+
+        // Same group id, two tenants -> two batches. Members settle against the batch envelope, so
+        // merging them would lose the tenant each member arrived under.
+        batches.Length.ShouldBe(2);
+        batches.ShouldAllBe(x => x.GroupId == "one");
+        batches.Single(x => x.TenantId == "tenant1").Batch!.Length.ShouldBe(2);
+        batches.Single(x => x.TenantId == "tenant2").Batch!.Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void resolves_the_group_id_from_the_partitioning_rules_when_the_envelope_has_none()
+    {
+        var rules = new MessagePartitioningRules(new WolverineOptions());
+        rules.ByMessage<ScoreEvent>(x => x.AggregateId);
+
+        var envelopes = new[]
+        {
+            envelopeFor(new ScoreEvent("A", 1)),
+            envelopeFor(new ScoreEvent("B", 1)),
+            envelopeFor(new ScoreEvent("A", 2))
+        };
+
+        var batches = batcher(rules).Group(envelopes).ToArray();
+
+        batches.Length.ShouldBe(2);
+        batches.Single(x => x.GroupId == "A").Batch!.Length.ShouldBe(2);
+        batches.Single(x => x.GroupId == "B").Batch!.Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ungroupable_envelopes_batch_together_and_stay_ungrouped()
+    {
+        // No rules and no GroupId — this batcher does not invent one, it just does not make things
+        // worse than the default batcher does.
+        var batches = batcher().Group([
+            envelopeFor(new ScoreEvent("A", 1)),
+            envelopeFor(new ScoreEvent("B", 1))
+        ]).ToArray();
+
+        var single = batches.ShouldHaveSingleItem();
+        single.GroupId.ShouldBeNull();
+        single.Batch!.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void batch_message_type_is_the_array_of_the_element_type()
+    {
+        batcher().BatchMessageType.ShouldBe(typeof(ScoreEvent[]));
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Batching/BatchExecutionQueuesTests.cs
+++ b/src/Testing/CoreTests/Runtime/Batching/BatchExecutionQueuesTests.cs
@@ -1,0 +1,91 @@
+using NSubstitute;
+using Wolverine;
+using Wolverine.Runtime.Batching;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Runtime.WorkerQueues;
+using Xunit;
+
+namespace CoreTests.Runtime.Batching;
+
+public class BatchExecutionQueuesTests
+{
+    private readonly MessagePartitioningRules theRules = new(new WolverineOptions());
+    private readonly ILocalQueue theFallback = queueFor("local://fallback");
+    private readonly ILocalQueue[] theSlots =
+    [
+        queueFor("local://slot1"),
+        queueFor("local://slot2"),
+        queueFor("local://slot3"),
+        queueFor("local://slot4")
+    ];
+
+    private static ILocalQueue queueFor(string uri)
+    {
+        var queue = Substitute.For<ILocalQueue>();
+        queue.Uri.Returns(new Uri(uri));
+        return queue;
+    }
+
+    private PartitionedBatchExecutionQueues theQueues => new(theSlots, theRules, theFallback);
+
+    private static Envelope batchFor(string? groupId) => new(new object()) { GroupId = groupId };
+
+    [Fact]
+    public void a_group_id_always_picks_the_same_slot()
+    {
+        var first = theQueues.SelectQueue(batchFor("aaa"));
+
+        for (var i = 0; i < 25; i++)
+        {
+            theQueues.SelectQueue(batchFor("aaa")).ShouldBeSameAs(first);
+        }
+    }
+
+    [Fact]
+    public void picks_the_same_slot_the_unbatched_messages_for_that_group_would_land_on()
+    {
+        // This is the whole point of the fix: the batch has to agree with SlotForSending, which is
+        // what GlobalPartitionedRoute and PartitionedMessageTopology.SelectSlot use to place the
+        // unbatched messages for the same group id. A different hash here silently reintroduces
+        // the race.
+        foreach (var groupId in new[] { "one", "two", "three", "orders-4815162342" })
+        {
+            var expected = theSlots[batchFor(groupId).SlotForSending(theSlots.Length, theRules)];
+            theQueues.SelectQueue(batchFor(groupId)).ShouldBeSameAs(expected);
+        }
+    }
+
+    [Fact]
+    public void spreads_distinct_group_ids_over_more_than_one_slot()
+    {
+        var chosen = Enumerable.Range(0, 50)
+            .Select(i => theQueues.SelectQueue(batchFor($"group-{i}")))
+            .Distinct()
+            .ToArray();
+
+        chosen.Length.ShouldBeGreaterThan(1);
+    }
+
+    [Fact]
+    public void an_ungrouped_batch_falls_back_rather_than_drawing_a_random_slot()
+    {
+        theQueues.SelectQueue(batchFor(null)).ShouldBeSameAs(theFallback);
+        theQueues.SelectQueue(batchFor(string.Empty)).ShouldBeSameAs(theFallback);
+    }
+
+    [Fact]
+    public void the_single_queue_variant_ignores_the_group_id()
+    {
+        var queues = new SingleBatchExecutionQueue(theFallback);
+
+        queues.SelectQueue(batchFor("aaa")).ShouldBeSameAs(theFallback);
+        queues.SelectQueue(batchFor(null)).ShouldBeSameAs(theFallback);
+    }
+
+    [Fact]
+    public void must_have_at_least_one_slot()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new PartitionedBatchExecutionQueues([], theRules, theFallback));
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Batching/BatchReplayTests.cs
+++ b/src/Testing/CoreTests/Runtime/Batching/BatchReplayTests.cs
@@ -1,0 +1,83 @@
+using CoreTests.Acceptance;
+using NSubstitute;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Batching;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Runtime.Batching;
+
+public class BatchReplayTests
+{
+    private readonly Uri theDestination = new("local://items");
+
+    // AgentForLocalQueue is declared as returning ISendingAgent, and BatchReplay casts it to
+    // ILocalQueue, so the substitute has to be both.
+    private readonly ISendingAgent theAgent = Substitute.For<ISendingAgent, ILocalQueue>();
+
+    private readonly IWolverineRuntime theRuntime = Substitute.For<IWolverineRuntime>();
+
+    private ILocalQueue theQueue => (ILocalQueue)theAgent;
+
+    public BatchReplayTests()
+    {
+        var endpoints = Substitute.For<IEndpointCollection>();
+        endpoints.AgentForLocalQueue(theDestination).Returns(theAgent);
+        theRuntime.Endpoints.Returns(endpoints);
+    }
+
+    private async Task<Envelope> replay(Envelope batch, params object[] items)
+    {
+        await BatchReplay.EnqueueReducedBatchAsync(theRuntime, batch, items);
+
+        var enqueued = theQueue.ReceivedCalls()
+            .Where(x => x.GetMethodInfo().Name == nameof(ILocalQueue.EnqueueAsync))
+            .Select(x => (Envelope)x.GetArguments()[0]!)
+            .ToArray();
+
+        return enqueued.ShouldHaveSingleItem();
+    }
+
+    private Envelope batchEnvelope(string? groupId, string? tenantId = null)
+    {
+        return new Envelope(new[] { new Item("one"), new Item("two") })
+        {
+            Destination = theDestination,
+            MessageType = "item-array",
+            GroupId = groupId,
+            TenantId = tenantId
+        };
+    }
+
+    [Fact]
+    public async Task the_reduced_batch_keeps_the_group_id()
+    {
+        // GH-3867 — without this the probed batch has no group id, and an envelope with no group id
+        // draws a RANDOM partition slot, so isolating a poison item scatters the survivors.
+        var reduced = await replay(batchEnvelope("aaa"), new Item("one"));
+
+        reduced.GroupId.ShouldBe("aaa");
+    }
+
+    [Fact]
+    public async Task carries_the_rest_of_the_batch_identity_across()
+    {
+        var reduced = await replay(batchEnvelope("aaa", "tenant1"), new Item("one"));
+
+        reduced.Destination.ShouldBe(theDestination);
+        reduced.MessageType.ShouldBe("item-array");
+        reduced.TenantId.ShouldBe("tenant1");
+        reduced.Message.ShouldBeOfType<Item[]>().Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task an_ungrouped_batch_stays_ungrouped()
+    {
+        var reduced = await replay(batchEnvelope(null), new Item("one"));
+
+        reduced.GroupId.ShouldBeNull();
+    }
+}

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -594,6 +594,17 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// </summary>
     internal Uri? GlobalPartitionLocalQueueUri { get; set; }
 
+    /// <summary>
+    /// GH-3867. Set when a <c>BatchMessagesOf</c> definition executes its assembled batches on this
+    /// endpoint. Such a queue is its own cascade target: the messages it executes are absorbed into
+    /// a batching channel and the resulting batch is enqueued right back onto it. With a bounded
+    /// execution block that closes a cycle through the batching channel's own bounded buffers and
+    /// can wedge, so these endpoints get an unbounded one — the same trade GH-3287 made for local
+    /// queues. Back-pressure is preserved by <see cref="Runtime.Batching.BatchingPendingCounts" />,
+    /// which counts pending members against the originating external listener.
+    /// </summary>
+    internal bool HostsBatchExecution { get; set; }
+
     public virtual bool AutoStartSendingAgent()
     {
         return UsedInShardedTopology || Subscriptions.Any();

--- a/src/Wolverine/Runtime/Batching/ApplyItemContinuation.cs
+++ b/src/Wolverine/Runtime/Batching/ApplyItemContinuation.cs
@@ -190,7 +190,11 @@ internal static class BatchReplay
         {
             Destination = destination,
             MessageType = batchEnvelope.MessageType,
-            TenantId = batchEnvelope.TenantId
+            TenantId = batchEnvelope.TenantId,
+
+            // GH-3867 — carry the group id, or the reduced batch draws a RANDOM partition slot on the
+            // way back in and a poison probe scatters the original batch's items across slots.
+            GroupId = batchEnvelope.GroupId
         };
 
         await queue.EnqueueAsync(reduced).ConfigureAwait(false);

--- a/src/Wolverine/Runtime/Batching/BatchExecutionQueues.cs
+++ b/src/Wolverine/Runtime/Batching/BatchExecutionQueues.cs
@@ -1,0 +1,74 @@
+using JasperFx.Core;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Runtime.WorkerQueues;
+
+namespace Wolverine.Runtime.Batching;
+
+/// <summary>
+/// Chooses the local queue that an assembled batch executes on. GH-3867.
+/// </summary>
+internal interface IBatchExecutionQueues
+{
+    ILocalQueue SelectQueue(Envelope grouped);
+}
+
+/// <summary>
+/// Every batch runs on one dedicated local queue — the original behavior, and still what you get
+/// when the batched element type is not part of a partitioned topology.
+/// </summary>
+internal class SingleBatchExecutionQueue : IBatchExecutionQueues
+{
+    private readonly ILocalQueue _queue;
+
+    public SingleBatchExecutionQueue(ILocalQueue queue)
+    {
+        _queue = queue;
+    }
+
+    public ILocalQueue SelectQueue(Envelope grouped) => _queue;
+}
+
+/// <summary>
+/// Distributes assembled batches across the local queues of the partitioned topology that the
+/// batched element type belongs to, choosing the slot from the batch's own group id. This is what
+/// puts a batched handler on the same execution block as the unbatched handlers for that group,
+/// rather than on a queue of its own where it races them. GH-3867.
+/// </summary>
+internal class PartitionedBatchExecutionQueues : IBatchExecutionQueues
+{
+    private readonly ILocalQueue[] _slots;
+    private readonly MessagePartitioningRules _rules;
+    private readonly ILocalQueue _fallback;
+
+    /// <param name="fallback">
+    /// Where a batch with no determinable group id goes. It cannot be slotted — and an envelope with
+    /// no group id draws a <em>random</em> slot rather than being left unpartitioned — so it stays on
+    /// the dedicated queue instead of scattering. Only reachable with a custom
+    /// <see cref="IMessageBatcher" />, since Wolverine swaps the built-in batcher for the group-id
+    /// one whenever this type is in play.
+    /// </param>
+    public PartitionedBatchExecutionQueues(ILocalQueue[] slots, MessagePartitioningRules rules, ILocalQueue fallback)
+    {
+        if (slots.Length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(slots), "At least one execution slot is required");
+        }
+
+        _slots = slots;
+        _rules = rules;
+        _fallback = fallback;
+    }
+
+    public ILocalQueue SelectQueue(Envelope grouped)
+    {
+        if (grouped.GroupId.IsEmpty())
+        {
+            return _fallback;
+        }
+
+        // SlotForSending, not SlotForProcessing: this is the same layer — and must be the same hash —
+        // that GlobalPartitionedRoute and PartitionedMessageTopology.SelectSlot use to place the
+        // unbatched messages for this group id.
+        return _slots[grouped.SlotForSending(_slots.Length, _rules)];
+    }
+}

--- a/src/Wolverine/Runtime/Batching/BatchingOptions.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingOptions.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Runtime.WorkerQueues;
 
@@ -120,7 +121,55 @@ public class BatchingOptions : IAsyncDisposable
     /// The name of the local queue where the batch messages will be executed. Note
     /// that the default is the local queue for the batch element message type
     /// </summary>
-    public string? LocalExecutionQueueName { get; set; }
+    /// <remarks>
+    /// Setting this explicitly also opts the batch out of the partitioned execution described on
+    /// <see cref="ExecuteOnDedicatedLocalQueue" /> — naming a queue is taken as meaning it.
+    /// </remarks>
+    public string? LocalExecutionQueueName
+    {
+        get => _localExecutionQueueName;
+        set
+        {
+            _localExecutionQueueName = value;
+            IsLocalQueueExplicit = true;
+        }
+    }
+
+    private string? _localExecutionQueueName;
+
+    /// <summary>
+    /// Wolverine's own default assignment of the execution queue, which must not read as a user
+    /// choice. Used by <c>WolverineOptions.BatchMessagesOf</c> and by the Separated-mode queue
+    /// reassignment at startup.
+    /// </summary>
+    internal void SetDefaultLocalExecutionQueueName(string queueName)
+    {
+        _localExecutionQueueName = queueName;
+    }
+
+    /// <summary>True when the application named the execution queue rather than Wolverine defaulting it.</summary>
+    internal bool IsLocalQueueExplicit { get; private set; }
+
+    internal bool ForcesDedicatedQueue { get; private set; }
+
+    /// <summary>
+    /// Always run the assembled batches on this batch's own dedicated local queue, even when the
+    /// element type belongs to a partitioned message topology. By default a batched element type
+    /// that participates in <c>GlobalPartitioned</c> or <c>PublishToPartitionedLocalMessaging</c>
+    /// executes its batches on the topology slot for the batch's group id, so that the batched
+    /// handler is sequenced against the unbatched handlers for that same group. Call this to opt
+    /// out and accept that the batch runs concurrently with them. See GH-3867.
+    /// </summary>
+    public void ExecuteOnDedicatedLocalQueue()
+    {
+        ForcesDedicatedQueue = true;
+    }
+
+    /// <summary>
+    /// The partitioned topology slots that assembled batches are distributed across by group id,
+    /// resolved at startup. Null when this batch executes on a single dedicated local queue.
+    /// </summary>
+    internal IReadOnlyList<Endpoint>? ExecutionSlots { get; set; }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026",
         Justification = "ProcessorBuilder<> closed over runtime ElementType; AOT consumers register batchers explicitly. See AOT guide.")]
@@ -162,8 +211,39 @@ public class BatchingOptions : IAsyncDisposable
 
             var localQueue = (ILocalQueue)runtime.Endpoints.AgentForLocalQueue(options.LocalExecutionQueueName!);
 
-            return new BatchingProcessor<T>(parentChain, batcher, options, localQueue,
+            var queues = buildExecutionQueues(runtime, options, localQueue);
+
+            return new BatchingProcessor<T>(parentChain, batcher, options, localQueue, queues,
                 runtime.DurabilitySettings, runtime.BatchingPendingCounts);
+        }
+
+        /// <summary>
+        /// GH-3867. When startup found a partitioned topology for the element type, assembled batches
+        /// are distributed across that topology's local queues by group id instead of all landing on
+        /// the one dedicated queue.
+        /// </summary>
+        private static IBatchExecutionQueues buildExecutionQueues(WolverineRuntime runtime,
+            BatchingOptions options, ILocalQueue dedicatedQueue)
+        {
+            if (options.ExecutionSlots is not { Count: > 0 } slots)
+            {
+                return new SingleBatchExecutionQueue(dedicatedQueue);
+            }
+
+            var slotQueues = new ILocalQueue[slots.Count];
+            for (var i = 0; i < slots.Count; i++)
+            {
+                if (runtime.Endpoints.AgentForLocalQueue(slots[i].Uri) is not ILocalQueue queue)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to resolve local queue '{slots[i].Uri}' as an execution slot for batches of {options.ElementType.FullNameInCode()}");
+                }
+
+                slotQueues[i] = queue;
+            }
+
+            return new PartitionedBatchExecutionQueues(slotQueues, runtime.Options.MessagePartitioning,
+                dedicatedQueue);
         }
     }
 

--- a/src/Wolverine/Runtime/Batching/BatchingOptions.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingOptions.cs
@@ -62,6 +62,27 @@ public class BatchingOptions : IAsyncDisposable
         Batcher = new CoalescingMessageBatcher<T, TKey>(keySelector);
     }
 
+    /// <summary>
+    /// Batch the messages by their <see cref="Envelope.GroupId"/> (and tenant) rather than by tenant
+    /// alone, and stamp that group id onto each batch envelope. Use this when the batched handler has
+    /// to participate in the same partitioned sequential ordering as the unbatched handlers for the
+    /// same entity — for example when several message types all write to one event stream and the
+    /// batched one must not race the others.
+    /// </summary>
+    /// <remarks>
+    /// Without this, a batch envelope carries no group id, and an envelope with no group id is
+    /// assigned a <b>random</b> partition slot rather than being left unpartitioned — so a batched
+    /// handler silently opts out of the sequential guarantee its unbatched siblings have.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "GroupIdMessageBatcher<> closed over runtime ElementType; AOT consumers register batchers explicitly. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "GroupIdMessageBatcher<> closed over runtime ElementType; AOT consumers register batchers explicitly. See AOT guide.")]
+    public void GroupByGroupId()
+    {
+        Batcher = typeof(GroupIdMessageBatcher<>).CloseAndBuildAs<IMessageBatcher>(ElementType);
+    }
+
     internal int? ProbeIndividuallyAfterAttempts { get; private set; }
 
     /// <summary>
@@ -129,6 +150,14 @@ public class BatchingOptions : IAsyncDisposable
             {
                 throw new InvalidOperationException(
                     $"This Wolverine application has a configuration for batching messages of type {typeof(T).FullNameInCode()}, but there is no known handler for {typeof(T).FullNameInCode()}[]");
+            }
+
+            // A batcher that groups by group id needs the application's partitioning rules to
+            // resolve a group id for any envelope that does not already carry one. The runtime is
+            // not available when BatchingOptions is configured, so it is supplied here.
+            if (batcher is IRequirePartitioningRules needsRules)
+            {
+                needsRules.Rules = runtime.Options.MessagePartitioning;
             }
 
             var localQueue = (ILocalQueue)runtime.Endpoints.AgentForLocalQueue(options.LocalExecutionQueueName!);

--- a/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
@@ -12,8 +12,16 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
 
     private readonly BatchingPendingCounts? _pendingCounts;
 
+    private readonly IBatchExecutionQueues _queues;
+
     public BatchingProcessor(HandlerChain chain, IMessageBatcher batcher, BatchingOptions options, ILocalQueue queue,
         DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null)
+        : this(chain, batcher, options, queue, new SingleBatchExecutionQueue(queue), settings, pendingCounts)
+    {
+    }
+
+    internal BatchingProcessor(HandlerChain chain, IMessageBatcher batcher, BatchingOptions options, ILocalQueue queue,
+        IBatchExecutionQueues queues, DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null)
     {
         _pendingCounts = pendingCounts;
         Chain = chain ?? throw new ArgumentOutOfRangeException(nameof(chain));
@@ -21,6 +29,7 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
         _options = options;
         Batcher = batcher ?? throw new ArgumentNullException(nameof(batcher));
         Queue = queue;
+        _queues = queues ?? throw new ArgumentNullException(nameof(queues));
 
         _processingBlock = new Block<Envelope[]>(processEnvelopes);
         _batchingBlock = new BatchingChannel<Envelope>(_options.TriggerTime, _processingBlock, _options.BatchSize);
@@ -28,6 +37,12 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
 
 
     public IMessageBatcher Batcher { get; }
+
+    /// <summary>
+    /// The batch's dedicated local queue. Note that an individual batch does not necessarily execute
+    /// here — when the element type belongs to a partitioned topology, each batch runs on the slot
+    /// for its own group id. See GH-3867.
+    /// </summary>
     public ILocalQueue Queue { get; }
 
     public async ValueTask DisposeAsync()
@@ -63,11 +78,16 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
     {
         foreach (var grouped in Batcher.Group(envelopes))
         {
-            grouped.Destination = Queue.Uri;
+            // GH-3867 — the destination is per batch, not per processor: a batch that carries a group
+            // id lands on that group's partition slot, so it is sequenced against the unbatched
+            // handlers for the same group rather than racing them from a queue of its own.
+            var queue = _queues.SelectQueue(grouped);
+
+            grouped.Destination = queue.Uri;
             grouped.MessageType = Chain!.TypeName;
             grouped.SentAt = DateTimeOffset.UtcNow;
 
-            await Queue.EnqueueAsync(grouped);
+            await queue.EnqueueAsync(grouped);
         }
     }
 }

--- a/src/Wolverine/Runtime/Batching/GroupIdMessageBatcher.cs
+++ b/src/Wolverine/Runtime/Batching/GroupIdMessageBatcher.cs
@@ -1,0 +1,90 @@
+using Wolverine.Runtime.Partitioning;
+
+namespace Wolverine.Runtime.Batching;
+
+/// <summary>
+/// Implemented by an <see cref="IMessageBatcher"/> that needs the application's message
+/// partitioning rules in order to group. Supplied by the batching processor builder, which is the
+/// first point at which the <see cref="WolverineRuntime"/> is available.
+/// </summary>
+internal interface IRequirePartitioningRules
+{
+    MessagePartitioningRules Rules { set; }
+}
+
+/// <summary>
+/// Batches messages by their <see cref="Envelope.GroupId"/> (and tenant), and stamps that group id
+/// onto each batch envelope it produces. Opt in with <see cref="BatchingOptions.GroupByGroupId"/>.
+/// </summary>
+/// <remarks>
+/// <para>The default batcher groups only by tenant, so a single batch envelope can span many group
+/// ids and therefore carries none of its own. That matters as soon as batching is combined with
+/// partitioned sequential processing: <see cref="PartitionedMessagingExtensions.SlotForProcessing"/>
+/// falls back to <b>a randomly chosen slot</b> when it cannot determine a group id, so an unstamped
+/// batch lands on a different slot on every trigger and is serialized against nothing. Grouping the
+/// batch by group id makes the batch itself a member of exactly one group, which is what lets a
+/// batched handler participate in the same sequential ordering as the unbatched handlers for the
+/// same entity.</para>
+///
+/// <para>Tenancy is still honoured — the grouping key is (tenant, group id), never group id alone.
+/// Wolverine settles a batch's members against the batch envelope, so mixing tenants into one
+/// envelope would lose the tenant each member arrived under.</para>
+///
+/// <para>Envelopes whose group id cannot be determined are batched together and the resulting
+/// envelope is left ungrouped, which is the same treatment they get today. This batcher does not
+/// invent a group id for them.</para>
+/// </remarks>
+internal class GroupIdMessageBatcher<T> : IMessageBatcher, IRequirePartitioningRules
+{
+    private MessagePartitioningRules? _rules;
+
+    public MessagePartitioningRules Rules
+    {
+        set => _rules = value;
+    }
+
+    public Type BatchMessageType => typeof(T[]);
+
+    public IEnumerable<Envelope> Group(IReadOnlyList<Envelope> envelopes)
+    {
+        // Dictionary<string,...> disallows null keys, so both slots use "" as the null sentinel and
+        // are mapped back on the way out.
+        var groups = new Dictionary<(string Tenant, string Group), List<Envelope>>();
+
+        foreach (var envelope in envelopes)
+        {
+            // Prefer whatever is already on the envelope; DetermineGroupId does that first anyway,
+            // and also writes the resolved value back so later stages do not re-resolve it. On a
+            // listener using PartitionProcessingByGroupId this has already happened upstream.
+            var group = _rules?.DetermineGroupId(envelope) ?? envelope.GroupId;
+
+            var key = (envelope.TenantId ?? string.Empty, group ?? string.Empty);
+            if (!groups.TryGetValue(key, out var list))
+            {
+                list = new List<Envelope>();
+                groups[key] = list;
+            }
+
+            list.Add(envelope);
+        }
+
+        foreach (var pair in groups)
+        {
+            var members = pair.Value;
+            var messages = new List<T>(members.Count);
+            foreach (var envelope in members)
+            {
+                if (envelope.Message is T typed)
+                {
+                    messages.Add(typed);
+                }
+            }
+
+            yield return new Envelope(messages.ToArray(), members)
+            {
+                TenantId = pair.Key.Tenant.Length == 0 ? null : pair.Key.Tenant,
+                GroupId = pair.Key.Group.Length == 0 ? null : pair.Key.Group
+            };
+        }
+    }
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -10,6 +10,7 @@ using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Batching;
 using Wolverine.Runtime.Scheduled;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Runtime.WorkerQueues;
@@ -124,6 +125,13 @@ public partial class WolverineRuntime
             // Apply BatchMessagesOf<T>(b => b.ProbeIndividuallyAfter(N)) as a failure rule on the batch
             // handler chain. GH-3289.
             applyBatchProbePolicies();
+
+            // Point each batch at the partitioned topology its element type already belongs to, so
+            // the assembled batch is sequenced against the unbatched handlers for its group id
+            // rather than racing them on a separate queue. GH-3867. Must run before the transports
+            // start so the chosen slot endpoints can still be flagged for an unbounded execution
+            // block.
+            resolveBatchExecutionTopologies();
 
             // Pre-populate the message-type-name cache so the per-message ToMessageTypeName()
             // hot path inside Envelope construction never pays the first-occurrence reflection
@@ -619,7 +627,9 @@ public partial class WolverineRuntime
             var batchQueueName = directQueue.EndpointName + BatchQueueSuffix;
             var batchQueue = local.QueueFor(batchQueueName);
             batchQueue.Mode = directQueue.Mode;
-            batch.LocalExecutionQueueName = batchQueue.EndpointName;
+
+            // Wolverine's own reassignment, not a user choice — see SetDefaultLocalExecutionQueueName.
+            batch.SetDefaultLocalExecutionQueueName(batchQueue.EndpointName);
         }
     }
 
@@ -665,6 +675,81 @@ public partial class WolverineRuntime
 
             Logger.LogWarning(message);
         }
+    }
+
+    /// <summary>
+    /// GH-3867. When a batched element type already belongs to a partitioned message topology, the
+    /// unbatched handlers for a given group id are being sequenced onto one topology slot while the
+    /// assembled batch goes to its own dedicated local queue — a different execution block, so the
+    /// batch races the very handlers the topology just sequenced. Point the batch at the same
+    /// topology so its slot is chosen from the batch's group id.
+    /// </summary>
+    private void resolveBatchExecutionTopologies()
+    {
+        if (Options.BatchDefinitions.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var batch in Options.BatchDefinitions)
+        {
+            // Naming a queue, or asking for a dedicated one outright, is an explicit choice to run
+            // the batches somewhere of your own choosing. Respect it.
+            if (batch.IsLocalQueueExplicit || batch.ForcesDedicatedQueue)
+            {
+                continue;
+            }
+
+            var slots = findPartitionedExecutionSlots(batch.ElementType);
+            if (slots == null)
+            {
+                continue;
+            }
+
+            batch.ExecutionSlots = slots;
+
+            foreach (var slot in slots)
+            {
+                // These queues now receive the batches produced by the very messages they execute,
+                // which closes a cycle through the batching channel's bounded buffers. Same
+                // reasoning as GH-3287's unbounded local queues; see Endpoint.HostsBatchExecution.
+                slot.HostsBatchExecution = true;
+            }
+
+            // Slotting a batch requires the batch to belong to exactly one group, which the default
+            // tenant-only batcher cannot promise. Swap it for the group-id batcher — but leave a
+            // batcher the application supplied alone, since it may stamp group ids itself.
+            var batcherType = batch.Batcher.GetType();
+            if (batcherType.IsGenericType && batcherType.GetGenericTypeDefinition() == typeof(DefaultMessageBatcher<>))
+            {
+                batch.GroupByGroupId();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The local queues an element type's partitioned topology executes on, or null when it does not
+    /// belong to one. A global topology's companion local queues win over a purely local sharded
+    /// topology because global partitioning is the stronger guarantee of the two.
+    /// </summary>
+    private IReadOnlyList<Endpoint>? findPartitionedExecutionSlots(Type elementType)
+    {
+        var partitioning = Options.MessagePartitioning;
+
+        if (partitioning.TryFindGlobalTopology(elementType, out var global) && global!.LocalTopology != null)
+        {
+            return global.LocalTopology.Slots;
+        }
+
+        if (partitioning.TryFindTopology(elementType, out var topology) &&
+            topology is Partitioning.LocalPartitionedMessageTopology local)
+        {
+            return local.Slots;
+        }
+
+        // A sharded topology over an EXTERNAL transport has no local queue to enqueue a batch onto —
+        // its unbatched handlers execute inside the listener's own sharded block. Nothing to target.
+        return null;
     }
 
     private void applyBatchProbePolicies()

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -123,14 +123,21 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             }
         };
         
+        // GH-3867: an endpoint that executes assembled message batches is its own cascade target,
+        // and a bounded block closes a deadlock cycle through the batching channel. See
+        // Endpoint.HostsBatchExecution.
+        var boundedCapacity = endpoint.HostsBatchExecution
+            ? Block<Envelope>.Unbounded
+            : Block<Envelope>.DefaultBoundedCapacity;
+
         if (endpoint.GroupShardingSlotNumber == null)
         {
-            _receiver = new Block<Envelope>(endpoint.MaxDegreeOfParallelism, execute);
+            _receiver = new Block<Envelope>(endpoint.MaxDegreeOfParallelism, boundedCapacity, execute);
         }
         else
         {
             var sharded = new ShardedExecutionBlock((int)endpoint.GroupShardingSlotNumber,
-                runtime.Options.MessagePartitioning, execute);
+                runtime.Options.MessagePartitioning, boundedCapacity, execute);
             sharded.OnError = onBlockError;
             _receiver = sharded.DeserializeFirst(pipeline, runtime, this);
         }

--- a/src/Wolverine/WolverineOptions.Batching.cs
+++ b/src/Wolverine/WolverineOptions.Batching.cs
@@ -56,7 +56,10 @@ public sealed partial class WolverineOptions
 
         var options = new BatchingOptions(elementType);
         var localQueue = Transports.GetOrCreate<LocalTransport>().FindQueueForMessageType(elementType);
-        options.LocalExecutionQueueName = localQueue.EndpointName;
+
+        // Deliberately NOT through the public setter: this is Wolverine's default, and the setter
+        // records an explicit user choice that opts the batch out of partitioned execution (GH-3867).
+        options.SetDefaultLocalExecutionQueueName(localQueue.EndpointName);
 
         configure?.Invoke(options);
 


### PR DESCRIPTION
Closes [#3867](https://github.com/JasperFx/wolverine/issues/3867). Driver: [CritterWatch#949](https://github.com/JasperFx/CritterWatch/issues/949).

A batched handler could not participate in `PartitionProcessingByGroupId` sequential ordering. Two independent causes, both fixed here.

Stated plainly, because it surprised two separate reviewers: **`GlobalPartitioned` did not give you a single writer per group id if any participating message type was batched.** The affected CritterWatch deployment already ran `GlobalPartitioned` with 5 slots and still saw ~20 stream-concurrency exceptions/min, the batched type accounting for 59% of them.

## Part 1 — the batch envelope carried no group id

And a null group id means *a random slot*, not "no partitioning":

```csharp
// PartitionedMessagingExtensions.SlotForProcessing
var groupId = rules.DetermineGroupId(envelope);
if (groupId == null) return Random.Shared.Next(1, numberOfSlots) - 1;   // <-- random, not "unpartitioned"
```

`DefaultMessageBatcher<T>` groups only by `TenantId`, so a batch spans group ids and has none of its own. `BatchingOptions.GroupByGroupId()` opts into a batcher that groups by `(TenantId, GroupId)` and stamps that id onto every batch envelope.

Deliberate behaviors:

- **The key is `(tenant, group)`, never group alone.** Members settle against the batch envelope, so merging tenants would lose the tenant each member arrived under.
- **Ungroupable envelopes batch together and stay ungrouped.** The batcher does not invent an identity.
- **Rules are injected, not resolved.** `MessagePartitioningRules` isn't available when `BatchingOptions` is configured, so `ProcessorBuilder.Build` supplies it via the internal `IRequirePartitioningRules`.

## Part 2 — the batch executed on the wrong queue

`BatchingProcessor.processEnvelopes` hardcoded `grouped.Destination = Queue.Uri`, so the assembled batch always ran on one dedicated local queue — while the unbatched handlers for the same group id ran on a topology slot. Different execution blocks, so the batch raced the very handlers the topology had just sequenced.

This implements **shape 3**: `BatchingOptions` targets the partitioned topology its element type already belongs to, and the slot comes from the batch's group id.

- `resolveBatchExecutionTopologies()` at bootstrap records the slot endpoints for any batched element type matching a `GlobalPartitioned` (companion local queues) or `PublishToPartitionedLocalMessaging` topology.
- `IBatchExecutionQueues` selects the queue per assembled batch, so `ProcessorBuilder.Build`'s single `ILocalQueue` resolve becomes N. `PartitionedBatchExecutionQueues` uses **`SlotForSending`** — the same hash `GlobalPartitionedRoute` and `PartitionedMessageTopology.SelectSlot` use, so the batch agrees with where its group's other messages went. (`SlotForSending` and `SlotForProcessing` deliberately use *different* hashes; getting this wrong would silently reintroduce the race, so there's a test pinning it.)
- **The built-in batcher is swapped** for `GroupIdMessageBatcher`, since slotting requires a batch to belong to exactly one group. An application-supplied batcher is left alone, and any batch it emits without a group id falls back to the dedicated queue rather than drawing a random slot.
- **Opt out** with `ExecuteOnDedicatedLocalQueue()`, or by naming `LocalExecutionQueueName`. Wolverine's own default assignment goes through an internal `SetDefaultLocalExecutionQueueName` so it doesn't read as a user choice.

Automatic rather than opt-in because `GlobalPartitionLocalQueueUri` is `internal` — users can't wire this themselves — and because an app that declared `GlobalPartitioned` for a message type already stated the intent the batch was silently exempting itself from.

### The deadlock this had to handle

The note on the issue was right that there's **no direct self-deadlock**: `HandleAsync` runs on the slot block but only posts into `_batchingBlock`, while `processEnvelopes` runs on a separate `_processingBlock`. The head-of-line hazard flagged alongside it is real though, and it's worse than a stall — it closes a cycle across three bounded buffers:

```
slot block (bounded, DOP 1) → BatchingProcessor.HandleAsync
  → BatchingChannel._inner (bounded) → addItem → _processingBlock (bounded)
  → processEnvelopes → queue.EnqueueAsync → back into the same slot block
```

Saturate all three and every worker in the ring is blocked on the next. This didn't exist before, because the batch's dedicated local queue is unbounded (GH-3287).

`Endpoint.HostsBatchExecution` is set on every slot endpoint a batch targets, and `DurableReceiver` gives those an unbounded execution block. `EnqueueAsync` into an unbounded slot never blocks, so `_processingBlock` never stalls and the cycle can't close — which also removes the cross-group head-of-line coupling, without the drop risk of a non-blocking `Post`. Back-pressure is preserved by `BatchingPendingCounts`, which counts members against the originating external listener. `BufferedReceiver` already passes unbounded for local queues, so only the durable path needed changing.

### The two other checks that were asked for

- **Does the batch chain resolve on the companion queues?** Yes. `ExecutorFor(T[], slot)` falls through to the default chain; and for Separated mode with sticky `Handle(T[])` handlers, `HandlerGraph.HandlerFor` already special-cases a local queue with `UsedInShardedTopology` and builds a fanout.
- **Does `BatchingPendingCounts.SettleBatch` still fire once per batch?** Yes, by construction. Both `DurableReceiver.CompleteAsync` and `BufferedReceiver`'s channel callback settle on `envelope.Batch != null`, keyed off the batch envelope and independent of which queue it landed on. Each grouped envelope still goes to exactly **one** queue — this is slot selection, not fan-out — so no double-count and no lost settle.

### Also fixed

`BatchReplay.EnqueueReducedBatchAsync` copied `Destination`, `MessageType` and `TenantId` but **not `GroupId`**, so a `ProbeIndividuallyAfter` or `ApplyItemException` probe lost the batch's identity and scattered the survivors across slots. Already wrong with part 1 alone.

## What this does NOT cover

| Configuration | Unbatched handlers run on | Covered? |
|---|---|---|
| `GlobalPartitioned` | companion local queue `global-{base}{slot}` | **yes** |
| `PublishToPartitionedLocalMessaging` | local queue `{base}{slot}` | **yes** |
| Plain listener + `PartitionProcessingByGroupId` | the listener receiver's own `ShardedExecutionBlock` | **no** |

The third row is not a queue and cannot be enqueued to. The docs say so rather than implying the composition is complete.

One more edge, noted rather than solved: under `MultipleHandlerBehavior.Separated` with **multiple** sticky `Handle(T[])` handlers, the batch fans out from the slot queue to each sticky handler's own queue, so those handlers execute off-slot.

## Tests

**`src/Testing/CoreTests/Acceptance/batching_with_partitioned_processing.cs`** is the pure-Wolverine acceptance test the issue asked for, and it needs **no broker** — `ExplicitRouting` already sends a batched element type to its topology slots, so `PublishToPartitionedLocalMessaging` reproduces the whole thing in memory. One batched and one unbatched message type share a group id; it asserts no intra-group overlap while still observing cross-group parallelism, so a fix that merely serialized everything would not pass.

**It fails on `main`** — 12 violations of exactly the described shape.

Also `batch_execution_topology_resolution.cs` (bootstrap resolution and both opt-outs), `BatchExecutionQueuesTests` (slot selection, including agreement with `SlotForSending`), `BatchReplayTests` (group id survives a probe), and the 5 existing `GroupIdMessageBatcherTests`.

```
Full CoreTests, net9.0:  2315 passed / 0 failed / 2 pre-existing skips
dotnet build wolverine.slnx -c Release -f net9.0:  clean, 0 warnings
```

Not yet run: the broker-backed `global_partitioned_sharded_processing` suites (RabbitMQ, Kafka, SQS, Postgres, SqlServer), which need `docker compose up -d`. The CritterWatch soak harness (`./build.sh IngestSoak`, `many_services_many_nodes`) remains the field acceptance test and has not been re-run.

## Docs

New sections in both guides, which previously didn't mention each other: "Batching by group id" and "Batching inside a partitioned topology" in `docs/guide/handlers/batching.md`, and "Partitioned Processing with Batched Handlers" in `docs/guide/messaging/partitioning.md`. Both spell out the random-slot behavior explicitly and state the uncovered case above.

`GH-3867-BATCHING-PARTITIONING-HANDOFF.md` is updated to a record of what was built and what is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKfy5EzLX1i149gjUb3Tfg
