### PR TITLE
#3869: latch endpoint-originated causation reporting

### DIFF
--- a/src/Http/Wolverine.Http.Tests/endpoint_message_causation_tracking.cs
+++ b/src/Http/Wolverine.Http.Tests/endpoint_message_causation_tracking.cs
@@ -137,6 +137,10 @@ public class endpoint_message_causation_tracking
     [Fact]
     public async Task observer_is_notified_of_endpoint_originated_publish_at_runtime()
     {
+        // The latch is static for the life of the process, so an edge already reported by another
+        // test in this assembly would leave nothing to observe here.
+        CausationLatch.Clear();
+
         await using var host = await buildHostAsync(trackingEnabled: true);
 
         var observer = new CapturingObserver();
@@ -151,5 +155,32 @@ public class endpoint_message_causation_tracking
         var pair = observer.Pairs.SingleOrDefault(p => p.Outgoing.Contains(nameof(CausePing)));
         pair.ShouldNotBeNull();
         pair!.Incoming.ShouldBe("POST /cause/publish");
+    }
+
+    // GH-3869. The causation edge set is topology, not telemetry -- it only grows when a code path
+    // first executes. MessageHandler.RecordCauseAndEffect has always latched; the endpoint path did
+    // not, so a service that publishes one message per request re-reported the same edge on every
+    // request forever. Observers cannot assume MessageCausedBy is cheap: CritterWatch pays a
+    // FetchForWriting against a contended per-service event stream for each one.
+    [Fact]
+    public async Task endpoint_originated_causation_edge_is_only_reported_once()
+    {
+        CausationLatch.Clear();
+
+        await using var host = await buildHostAsync(trackingEnabled: true);
+
+        var observer = new CapturingObserver();
+        host.Services.GetRequiredService<IWolverineRuntime>().Observer = observer;
+
+        for (var i = 0; i < 3; i++)
+        {
+            await host.Scenario(x =>
+            {
+                x.Post.Url("/cause/publish");
+                x.StatusCodeShouldBe(204);
+            });
+        }
+
+        observer.Pairs.Count(p => p.Outgoing.Contains(nameof(CausePing))).ShouldBe(1);
     }
 }

--- a/src/Wolverine/Runtime/CausationLatch.cs
+++ b/src/Wolverine/Runtime/CausationLatch.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+
+namespace Wolverine.Runtime;
+
+/// <summary>
+/// Node-lifetime latch shared by every causation-reporting path so that each unique causation edge
+/// reaches <see cref="IWolverineObserver.MessageCausedBy"/> exactly once per process.
+///
+/// The causation edge set is topology, not telemetry: it only grows when a code path first executes,
+/// so re-reporting an edge that has already been observed tells an observer nothing new while costing
+/// it real work. <see cref="Wolverine.Runtime.Handlers.MessageHandler"/> has always latched; the
+/// endpoint-origin path (<see cref="EndpointCausation"/>, used by HTTP and gRPC endpoints) did not,
+/// so a service that published one message per request re-reported the same edge on every request
+/// forever. See GH-3869.
+///
+/// Both paths share one store deliberately -- an edge first seen through a message handler should not
+/// be re-reported when the endpoint path sees the same triple. The key intentionally omits the
+/// endpoint Uri: <c>MessageHandler</c> has never included it in its own key, and the endpoint path
+/// always passes null for it, so the identity is the (cause, effect, handler) triple in both cases.
+/// </summary>
+internal static class CausationLatch
+{
+    private static readonly ConcurrentDictionary<string, byte> _known = new();
+
+    /// <summary>
+    /// True the first time this exact causation edge is seen in this process, false every time after.
+    /// </summary>
+    /// <param name="cause">The incoming message type name, or the endpoint origin for endpoint-originated publishes</param>
+    /// <param name="effect">The outgoing message type name</param>
+    /// <param name="handlerType">The handler type name, or the endpoint origin when there is no handler type</param>
+    internal static bool ShouldReport(string cause, string effect, string handlerType)
+    {
+        return _known.TryAdd($"{cause}->{effect}@{handlerType}", 0);
+    }
+
+    /// <summary>
+    /// Testing hook only. The latch is static for the life of the process, so tests that assert on
+    /// report counts have to start from a known state.
+    /// </summary>
+    internal static void Clear()
+    {
+        _known.Clear();
+    }
+}

--- a/src/Wolverine/Runtime/EndpointCausation.cs
+++ b/src/Wolverine/Runtime/EndpointCausation.cs
@@ -32,7 +32,14 @@ public static class EndpointCausation
 
             // endpointOrigin (e.g. "POST /orders" or "Orders.Ship") stands in for the incoming
             // message type; the lifecycle assembler renders it on the trigger lane.
-            observer.MessageCausedBy(endpointOrigin, outgoingType!, handlerType ?? endpointOrigin, null);
+            var handler = handlerType ?? endpointOrigin;
+
+            // Latch on the shared store, exactly as MessageHandler.RecordCauseAndEffect does. Without
+            // this an endpoint that publishes on every request re-reports the same edge forever, and
+            // an observer cannot assume the call is cheap. See GH-3869.
+            if (!CausationLatch.ShouldReport(endpointOrigin, outgoingType!, handler)) continue;
+
+            observer.MessageCausedBy(endpointOrigin, outgoingType!, handler, null);
         }
     }
 }

--- a/src/Wolverine/Runtime/Handlers/MessageHandler.cs
+++ b/src/Wolverine/Runtime/Handlers/MessageHandler.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration.Capabilities;
@@ -35,10 +34,6 @@ public interface IMessageHandler
 
 public abstract class MessageHandler : IMessageHandler
 {
-    // Thread-safe set of known causation pairs: "IncomingType->OutgoingType"
-    // Static per concrete handler type via the dictionary keyed by handler type
-    private static readonly ConcurrentDictionary<string, byte> _knownCausation = new();
-
     public HandlerChain? Chain { get; set; }
 
     public abstract Task HandleAsync(MessageContext context, CancellationToken cancellation);
@@ -85,10 +80,9 @@ public abstract class MessageHandler : IMessageHandler
             var outgoingType = outgoingMessageType.FullName;
             if (string.IsNullOrEmpty(outgoingType)) continue;
 
-            var key = $"{incomingType}->{outgoingType}@{handlerType}";
-
-            // Latch: only report each unique causation pair once
-            if (!_knownCausation.TryAdd(key, 0)) continue;
+            // Latch: only report each unique causation pair once. The store is shared with
+            // EndpointCausation so an edge is reported once no matter which path first sees it.
+            if (!CausationLatch.ShouldReport(incomingType, outgoingType!, handlerType)) continue;
 
             observer.MessageCausedBy(incomingType, outgoingType, handlerType, endpointUri);
         }


### PR DESCRIPTION
Closes #3869.

## Problem

`MessageHandler.RecordCauseAndEffect` latches its reporting so each unique causation edge reaches `IWolverineObserver.MessageCausedBy` once per node lifetime. `EndpointCausation.RecordEndpointCauseAndEffect` — the path taken for HTTP and gRPC endpoints — had no such latch, so an HTTP service that sends one message per request reported the same `(endpoint → message)` edge on **every request, forever**, while the equivalent message-handler path reported it once.

The causation edge set is topology, not telemetry — it only grows when a code path first executes — so the intended semantics are the latched ones and the asymmetry was an oversight.

Observers can't cheaply assume the call is rare. In CritterWatch's case each report costs the monitoring console a `FetchForWriting` against a per-service event stream, so an unlatched edge from a service doing nothing but serving ordinary HTTP requests is sustained write pressure on a contended stream.

## Fix

Both paths now share one `CausationLatch` (`src/Wolverine/Runtime/CausationLatch.cs`), so an edge first seen through a message handler isn't re-reported when the endpoint path sees the same triple.

The key shape is unchanged: `MessageHandler` never included the endpoint Uri in its key, and the endpoint path always passes `null` for it, so identity is the `(cause, effect, handler)` triple in both cases. The endpoint path puts the endpoint origin in the cause slot and `handlerType ?? endpointOrigin` in the handler slot, exactly as it already passed them to the observer.

## Tests

`endpoint_originated_causation_edge_is_only_reported_once` in `endpoint_message_causation_tracking.cs` — three identical `POST /cause/publish` requests, one observed report. Verified it fails (3 reports) with the latch removed.

The latch is static for the life of the process, so both runtime tests in that class now call `CausationLatch.Clear()` first; without it they would be order-dependent on each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKfy5EzLX1i149gjUb3Tfg