### PR TITLE
GlobalPartitionedMessageTopology.Except<T>() (#3867 follow-up)

### DIFF
--- a/src/Testing/CoreTests/Acceptance/global_partitioned_exclusions.cs
+++ b/src/Testing/CoreTests/Acceptance/global_partitioned_exclusions.cs
@@ -1,0 +1,104 @@
+using Wolverine;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+public class GlobalPartitionedExclusionTests
+{
+    public interface IThing;
+
+    public record ThingHappened(string Id) : IThing;
+
+    public record ThingBroadcast(string Id) : IThing;
+
+    public record Unrelated(string Id);
+
+    private static GlobalPartitionedMessageTopology topology()
+    {
+        return new GlobalPartitionedMessageTopology(new WolverineOptions());
+    }
+
+    [Fact]
+    public void excluded_type_does_not_match_a_broader_rule()
+    {
+        var t = topology();
+        t.MessagesImplementing<IThing>();
+        t.Except<ThingBroadcast>();
+
+        // The whole point: a broad MessagesImplementing rule stays in place so nothing silently
+        // drops out of the topology, and only the named type is carved out.
+        t.Matches(typeof(ThingHappened)).ShouldBeTrue();
+        t.Matches(typeof(ThingBroadcast)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exclusions_win_regardless_of_declaration_order()
+    {
+        var before = topology();
+        before.Except<ThingBroadcast>();
+        before.MessagesImplementing<IThing>();
+        before.Matches(typeof(ThingBroadcast)).ShouldBeFalse();
+
+        var after = topology();
+        after.MessagesImplementing<IThing>();
+        after.Except<ThingBroadcast>();
+        after.Matches(typeof(ThingBroadcast)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_exclusion_can_be_an_interface_and_carves_out_the_whole_family()
+    {
+        var t = topology();
+        t.MessagesImplementing<IThing>();
+        t.Except<IThing>();
+
+        t.Matches(typeof(ThingHappened)).ShouldBeFalse();
+        t.Matches(typeof(ThingBroadcast)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_explicitly_named_type_can_still_be_excluded()
+    {
+        var t = topology();
+        t.Message<ThingBroadcast>();
+        t.Except<ThingBroadcast>();
+
+        t.Matches(typeof(ThingBroadcast)).ShouldBeFalse();
+
+        // MatchesByMessageTypeName is the pre-deserialization path (Kafka), and it reads a separate
+        // name cache — an exclusion that only updated Matches() would leak through it.
+        t.MatchesByMessageTypeName(typeof(ThingBroadcast).ToMessageTypeName()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void excluding_before_naming_also_keeps_the_name_cache_clean()
+    {
+        var t = topology();
+        t.Except<ThingBroadcast>();
+        t.Message<ThingBroadcast>();
+
+        t.Matches(typeof(ThingBroadcast)).ShouldBeFalse();
+        t.MatchesByMessageTypeName(typeof(ThingBroadcast).ToMessageTypeName()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exclusions_do_not_affect_unrelated_types()
+    {
+        var t = topology();
+        t.MessagesImplementing<IThing>();
+        t.Except<ThingBroadcast>();
+
+        t.Matches(typeof(Unrelated)).ShouldBeFalse("never matched in the first place");
+
+        t.Message<Unrelated>();
+        t.Matches(typeof(Unrelated)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void null_type_is_rejected()
+    {
+        Should.Throw<ArgumentNullException>(() => topology().Except(null!));
+    }
+}

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedMessageTopology.cs
@@ -9,6 +9,7 @@ public class GlobalPartitionedMessageTopology
 {
     private readonly WolverineOptions _options;
     private readonly List<Subscription> _subscriptions = new();
+    private readonly List<Type> _exclusions = new();
     private readonly HashSet<string> _messageTypeNames = new(StringComparer.OrdinalIgnoreCase);
     private PartitionedMessageTopology? _externalTopology;
     private LocalPartitionedMessageTopology? _localTopology;
@@ -81,7 +82,14 @@ public class GlobalPartitionedMessageTopology
     public void Message(Type type)
     {
         _subscriptions.Add(Subscription.ForType(type));
-        _messageTypeNames.Add(type.ToMessageTypeName());
+
+        // Exclusions win regardless of declaration order, so don't seed the name cache that
+        // MatchesByMessageTypeName reads (the pre-deserialization path) for an excluded type.
+        // Except() performs the mirror-image removal for the other ordering.
+        if (!_exclusions.Any(x => x.IsAssignableFrom(type)))
+        {
+            _messageTypeNames.Add(type.ToMessageTypeName());
+        }
     }
 
     /// <summary>
@@ -163,8 +171,50 @@ public class GlobalPartitionedMessageTopology
         }
     }
 
+    /// <summary>
+    /// Exclude a message type — or everything assignable to <typeparamref name="T"/>, so an
+    /// interface or base class excludes its whole family — from this topology, even when a
+    /// broader rule such as <see cref="MessagesImplementing{T}"/> would otherwise match it.
+    /// Exclusions always win.
+    /// </summary>
+    /// <remarks>
+    /// <para>The case this exists for: a message type that legitimately belongs to the topology on
+    /// the way IN, but that the receiving application also re-publishes on its way somewhere else.
+    /// Because both sides configure their own topology, excluding it on the <em>receiving</em> side
+    /// keeps inbound partitioning intact while stopping that application's own re-publish from
+    /// re-entering the topology and coming straight back to the handler that published it — an
+    /// infinite loop that is invisible in configuration and shows up only as amplified load.</para>
+    ///
+    /// <para>Excluding a type does not stop this application <em>listening</em> for it on the
+    /// topology's slots: the companion-queue bridge is wired per endpoint, not per message type. It
+    /// only removes the type from this topology's publishing rules.</para>
+    /// </remarks>
+    public void Except<T>()
+    {
+        Except(typeof(T));
+    }
+
+    /// <summary>
+    /// Exclude a message type — or everything assignable to <paramref name="type"/> — from this
+    /// topology. See <see cref="Except{T}"/>.
+    /// </summary>
+    public void Except(Type type)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+
+        _exclusions.Add(type);
+        _messageTypeNames.Remove(type.ToMessageTypeName());
+    }
+
     internal bool Matches(Type messageType)
     {
+        // Exclusions are checked first and win outright, so an Except<T>() cannot be defeated by
+        // the order in which rules were declared.
+        if (_exclusions.Any(x => x.IsAssignableFrom(messageType)))
+        {
+            return false;
+        }
+
         return _subscriptions.Any(x => x.Matches(messageType));
     }
 


### PR DESCRIPTION
Follow-up to #3867 (parts 1 and 2 merged in #3868). Small addition, and it closes a real loop we hit immediately after adopting global partitioning.

## What

`GlobalPartitionedMessageTopology.Except<T>()` / `Except(Type)` — carve a message type, or a whole family when given an interface or base class, out of a topology even when a broader rule like `MessagesImplementing<T>()` would otherwise match it. Exclusions are checked first and win outright, so the result does not depend on declaration order.

```csharp
opts.MessagePartitioning.GlobalPartitioned(topology =>
{
    topology.UseShardedRabbitQueues("critterwatch", 5);
    topology.MessagesImplementing<ICritterWatchMessage>();

    // This family is what we forward to the browser; without the exemption our own
    // re-publish re-enters the topology and comes back to the handler that sent it.
    topology.Except<ICritterStackWebSocketMessage>();
});
```

## Why

A message type can legitimately belong to the topology on the way **in** while the receiving application also re-publishes it on its way somewhere else. Because each side configures its own topology, excluding it on the **receiving** side keeps inbound partitioning intact while stopping that application's own re-publish from re-entering the topology and arriving back at the handler that published it.

The loop is worth describing because it is invisible in configuration and shows up only as amplified load. In CritterWatch a handler ends with `bus.PublishAsync(message)` to forward the message to the UI over SignalR. The message implements an interface that extends the marker the topology matches, so that re-publish drew **two** routes — the intended SignalR one, and the topology one, which came straight back to the same handler.

Measured, same driver and rate, over two minutes:

| event type | appends | published | amplification |
|---|---|---|---|
| the re-publishing type | 2,607 | ~425 | **6.1x** |
| sibling type | 60 | ~425 | 1.0x |
| sibling type | 61 | ~425 | 1.0x |

With `Except` in place the same measurement is 429 appends from ~429 published — exactly 1.0x.

Note `MessageRouter.DeduplicateRoutes` does not catch this: it only removes explicit routes to sticky-handler local queues, never a transport route coexisting with a `GlobalPartitionedRoute`.

## Two things worth a reviewer's eye

**Excluding a type does not stop the application listening for it** on the topology's slots — the companion-queue bridge is wired per endpoint, not per message type. Only the publishing rules are affected. That asymmetry is the whole point, and it is documented on the method.

**`Message(Type)` now skips seeding the name cache for an already-excluded type**, and `Except` removes it. Without both halves, `MatchesByMessageTypeName` — the pre-deserialization path Kafka uses — would disagree with `Matches()` under one of the two declaration orders. There is a test for each ordering.

## Tests

7 new in `CoreTests.Acceptance.GlobalPartitionedExclusionTests`: broad-rule carve-out, both declaration orders, interface-family exclusion, the name-cache agreement under both orders, no effect on unrelated types, null guard.

Partitioning + batching suites on net9.0: 207 passed / 0 failed. Full CoreTests on the previous base: 2,322 passed / 0 failed.