### PR TITLE
#3871: apply endpoint policies to broker system endpoints

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3871_quorum_queues_with_native_dead_lettering.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3871_quorum_queues_with_native_dead_lettering.cs
@@ -1,0 +1,57 @@
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+// GH-3871. The shared dead letter queue endpoint is created lazily inside
+// RabbitMqTransport.tryBuildSystemEndpoints(), which BrokerTransport.InitializeEndpointsAsync() runs
+// *after* its Compile() loop -- so the DLQ endpoint was the one endpoint in the transport that had
+// never had the endpoint policies applied to it. Resource setup declares whatever it finds there
+// without compiling anything, so with AddResourceSetupOnStartup() the DLQ was declared classic and
+// then redeclared as quorum at runtime start up. Rabbit MQ answers the second declaration with a
+// channel-level 406 (queue type is immutable), which kills the channel, and the listener then died
+// on an ObjectDisposedException from BasicQosAsync with no trace of the real cause.
+public class Bug_3871_quorum_queues_with_native_dead_lettering
+{
+    [Fact]
+    public async Task quorum_queues_and_native_dead_lettering_declare_consistently()
+    {
+        // A DLQ name no other test or run has declared: the failure is a *mismatch* between two
+        // declarations, so a queue left over as either type would mask it.
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var queueName = "orders_" + suffix;
+        var dlqName = "dlq_" + suffix;
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseRabbitMq()
+                    .CustomizeDeadLetterQueueing(new DeadLetterQueue(dlqName))
+                    .UseQuorumQueues()
+                    .AutoProvision();
+
+                opts.ListenToRabbitQueue(queueName);
+
+                // The missing ingredient in the original report. Without resource setup the DLQ
+                // endpoint is only ever declared from BrokerTransport.startupAsync(), which compiles
+                // each endpoint immediately before declaring it, so the mismatch never appears.
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var transport = host.GetRuntime().Options.Transports.GetOrCreate<RabbitMqTransport>();
+
+        // UseQuorumQueues() applies to every Application role queue, and the shared DLQ is one, so
+        // the DLQ has to be quorum in both declarations rather than classic in the first.
+        transport.Queues[dlqName].QueueType.ShouldBe(QueueType.quorum);
+        transport.Queues[queueName].QueueType.ShouldBe(QueueType.quorum);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -355,7 +355,14 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
         {
             if (e.Message.Contains("inequivalent arg"))
             {
-                logger.LogDebug("Queue {Queue} exists with different configuration", QueueName);
+                // Rabbit MQ answers a mismatched declaration with a channel level 406, so this channel
+                // is closed and unusable even though Wolverine is choosing to tolerate the mismatch.
+                // Whatever the caller does with it next -- BasicQosAsync, for a listener -- throws an
+                // ObjectDisposedException that says nothing about what the broker actually objected to.
+                // Log the broker's own complaint here at a level someone will see. See GH-3871.
+                logger.LogWarning(e,
+                    "Rabbit MQ rejected the declaration of queue '{Queue}' because it already exists with a different configuration. Wolverine will use the existing queue, but the broker has closed this channel.",
+                    QueueName);
                 return;
             }
 

--- a/src/Wolverine/Transports/BrokerTransport.cs
+++ b/src/Wolverine/Transports/BrokerTransport.cs
@@ -128,6 +128,16 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
 
         tryBuildSystemEndpoints(runtime);
 
+        // The system endpoints just built -- dead letter queues especially -- have never had the
+        // endpoint policies applied to them, and BrokerResource.Setup() declares whatever it finds
+        // here without compiling anything. Leaving them uncompiled means resource setup declares a
+        // dead letter queue with pre-policy settings and the runtime start up later redeclares the
+        // same queue with the policy applied, which the broker rejects. See GH-3871.
+        foreach (var endpoint in endpoints())
+        {
+            endpoint.Compile(runtime);
+        }
+
         return ValueTask.CompletedTask;
     }
 


### PR DESCRIPTION
Closes #3871.

## Reproducing it

The reporter's snippet doesn't reproduce on its own — I ran exactly what they posted against a fresh broker and it started clean, DLQ declared quorum. The missing ingredient is **`AddResourceSetupOnStartup()`** (or any `resources setup` / `ResetResourceState()` pass), which their real integration host has. With that added, the reported 406 reproduces every time.

## Root cause

`RabbitMqTransport.tryBuildSystemEndpoints()` creates the shared DLQ lazily through `Queues[deadLetterQueue.QueueName]`, and `BrokerTransport.InitializeEndpointsAsync()` runs it **after** its `Compile()` loop:

```csharp
foreach (var endpoint in explicitEndpoints()) endpoint.Compile(runtime);  // policies applied here
tryBuildSystemEndpoints(runtime);                                          // DLQ created HERE — never compiled
```

So the DLQ was the one endpoint in the transport that never had the endpoint policies applied to it. The `LightweightCache` factory also hands it back with the default `EndpointRole.Application`, so `UseQuorumQueues()` does target it. Then:

1. Resource setup → `BrokerResource.Setup()` iterates `Endpoints()` calling `SetupAsync` — **no `Compile()` anywhere in that path** → DLQ declared **classic**.
2. Runtime startup → `startupAsync` compiles each endpoint immediately before declaring → DLQ is now **quorum** → redeclare → `406 PRECONDITION_FAILED`.
3. The 406 closes the channel. The listener's next `BasicQosAsync` throws `ObjectDisposedException` — the secondary symptom the reporter noted.

Nothing to do with RabbitMQ.Client 7.2.2 or RabbitMQ 3.11.

## Fix

Compile the endpoints built by `tryBuildSystemEndpoints` so both declarations agree. This is transport-agnostic — every `BrokerTransport` that infers dead letter endpoints this way had the same latent bug.

The DLQ ends up **quorum** under `UseQuorumQueues()`. That is already what happens today for anyone not using resource setup, so it's the option that doesn't break existing brokers: making the DLQ classic instead would hit apps that already have a quorum DLQ declared with the same 406 in reverse on upgrade.

## Also in this PR

`RabbitMqQueue.DeclareAsync` swallowed the `"inequivalent arg"` failure at `LogDebug`. Rabbit answers a mismatched declaration with a channel-level 406, so the channel is dead even though Wolverine chooses to tolerate the mismatch — and everything downstream fails with an opaque `ObjectDisposedException`. Now a `LogWarning` carrying the broker's own text and saying the channel is closed. This is precisely why the original report had to guess at the cause.

## Testing

`Bugs/Bug_3871_quorum_queues_with_native_dead_lettering.cs` — passes with the fix, reproduces the 406 without it.

Full local `Wolverine.RabbitMQ.Tests` suite (494 tests, unfiltered — note CI excludes `Category=Flaky`, a bare `dotnet run` does not): 20 failures, of which **19 fail identically on `origin/main`** (SQL Server isn't running locally, which accounts for most). The 20th, `Bug_189_...be_able_to_start_up_with_large_number_of_messages_waiting_on_you`, passes 3/3 in isolation with the fix applied; its suite failure was a RabbitMQ.Client channel-recovery race under load (`KeyNotFoundException` in `SessionManager.Lookup`), not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKfy5EzLX1i149gjUb3Tfg