### PR TITLE
#3871 follow-up: narrow the system endpoint compile to Rabbit MQ

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -345,6 +345,16 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
             deadLetterQueue.ConfigureExchange?.Invoke(dlqExchange);
 
             dlq.BindExchange(dlqExchange.Name, deadLetterQueue.BindingName);
+
+            // These two were created after the caller's Compile() loop had already run, so they are
+            // the only endpoints in the transport that would otherwise never have the endpoint
+            // policies applied to them. Resource setup declares whatever it finds here without
+            // compiling anything, so leaving them uncompiled means UseQuorumQueues() (which targets
+            // every Application role queue, and the lazily created DLQ is one) does not reach the
+            // dead letter queue until start up redeclares it -- and Rabbit MQ rejects a second
+            // declaration that changes a queue's type. See GH-3871.
+            dlq.Compile(runtime);
+            dlqExchange.Compile(runtime);
         }
     }
 

--- a/src/Wolverine/Transports/BrokerTransport.cs
+++ b/src/Wolverine/Transports/BrokerTransport.cs
@@ -126,17 +126,12 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
             endpoint.Compile(runtime);
         }
 
+        // A transport that builds system endpoints needing the endpoint policies applied to them --
+        // a dead letter queue whose type must match what the runtime declares later, say -- has to
+        // compile them here itself. BrokerResource.Setup() declares whatever it finds in Endpoints()
+        // without compiling anything, so an uncompiled system endpoint gets declared with pre-policy
+        // settings and then redeclared with the policy applied at start up. See GH-3871.
         tryBuildSystemEndpoints(runtime);
-
-        // The system endpoints just built -- dead letter queues especially -- have never had the
-        // endpoint policies applied to them, and BrokerResource.Setup() declares whatever it finds
-        // here without compiling anything. Leaving them uncompiled means resource setup declares a
-        // dead letter queue with pre-policy settings and the runtime start up later redeclares the
-        // same queue with the policy applied, which the broker rejects. See GH-3871.
-        foreach (var endpoint in endpoints())
-        {
-            endpoint.Compile(runtime);
-        }
 
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
Follow-up to #3874.

## What changes

The #3871 fix compiled **every** endpoint in `BrokerTransport.InitializeEndpointsAsync`, which changed start-up behavior for all ten broker transports in order to solve a RabbitMQ problem.

`Endpoint.Compile()` is latched by `_hasCompiled`, so the only endpoints actually affected were the ones created inside `tryBuildSystemEndpoints` — for RabbitMQ the dead letter queue and its exchange, for Kafka the `wolverine.topics` endpoint, and so on for the rest. Only the RabbitMQ ones needed it.

This moves the compile into `RabbitMqTransport.tryBuildSystemEndpoints`, right where those two endpoints are created, and leaves every other transport on the code path it had before. The base class keeps a comment describing the contract so the next transport that builds system endpoints knows it owns compiling them.

No behavior change for RabbitMQ — `Bug_3871_quorum_queues_with_native_dead_lettering` passes on both shapes.

## Why now, and what is *not* established

This was prompted by `CIKafka` hitting its 20-minute cap on the #3871 PR — 18.5 minutes of test execution against ~8.5 minutes on a passing main run, with the job cancelled before it could report.

**I have not established that the #3871 change caused that**, and the evidence is genuinely mixed:

| Probe | Result |
|---|---|
| CIKafka on 5 recent main runs | ~10m20s, tight cluster |
| CIKafka on #3874 (with the change) | 18.5 min → timeout |
| CIKafka control on #3875 (no `BrokerTransport` change), same hour | **10m14s, normal** — rules out "slow runners today" |
| Local A/B, 75 Kafka tests (compliance + DLQ + broadcast) | **4m49s with the change vs 4m54s without** — a tie, the reverted run marginally slower |

The control says CI was healthy; the local A/B says this code costs nothing on the tests I can run. Those pull in opposite directions. The local subset is 75 of 301 tests and excludes the per-tenant tests, which need a second broker at `localhost:9192` that the repo's compose file doesn't provide — so a regression confined to that portion would not show up in my measurement.

CIKafka on main post-merge is the outstanding probe; it has been stuck in the GitHub queue and had not run at the time of writing.

**The narrowing is worth doing on scope grounds regardless of how that lands**: fixing a RabbitMQ declaration bug inside `RabbitMqTransport` is better-scoped than changing start-up for ten transports. If CIKafka on main turns out to be fine, this PR is still the right shape; if it times out again, this removes the change from Kafka's path entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKfy5EzLX1i149gjUb3Tfg