### PR TITLE
#3877: make agent distribution aware of cross-family node load

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/cross_family_load_awareness.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/cross_family_load_awareness.cs
@@ -1,0 +1,110 @@
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-3877: each agent family distributes its own scheme in its own pass, so a distribution pass has to
+/// take the load a node already carries from the *other* passes into account when it is otherwise free to
+/// choose. The motivating case is GlobalPartitioned slot listeners (wolverine-listener://) whose slot count
+/// does not divide evenly across the nodes: the node holding fewer slots should be the one that picks up
+/// the next family's work.
+/// </summary>
+public class cross_family_load_awareness
+{
+    // Stands in for GlobalPartitioned slot listeners: 5 slots is a legal PartitionSlots value, and 5 over
+    // 3 nodes is the uneven case that makes one node the "hot" slot holder.
+    private readonly Uri slot1 = new("wolverine-listener://rabbitmq/orders1");
+    private readonly Uri slot2 = new("wolverine-listener://rabbitmq/orders2");
+    private readonly Uri slot3 = new("wolverine-listener://rabbitmq/orders3");
+    private readonly Uri slot4 = new("wolverine-listener://rabbitmq/orders4");
+    private readonly Uri slot5 = new("wolverine-listener://rabbitmq/orders5");
+
+    private readonly Uri evaluator1 = new("evaluator://1");
+    private readonly Uri evaluator2 = new("evaluator://2");
+
+    [Fact]
+    public void second_family_prefers_the_node_holding_fewer_partition_slots()
+    {
+        var grid = new AssignmentGrid();
+        var node1 = grid.WithNode(1, Guid.NewGuid());
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+        var node3 = grid.WithNode(3, Guid.NewGuid());
+
+        // The partition slot family goes first, exactly as ExclusiveListenerFamily does
+        grid.WithAgents(slot1, slot2, slot3, slot4, slot5);
+        grid.DistributeEvenly("wolverine-listener");
+
+        // 5 slots over 3 nodes cannot be even -- somebody ends up with one
+        node1.Agents.Count.ShouldBe(2);
+        node2.Agents.Count.ShouldBe(2);
+        node3.Agents.Count.ShouldBe(1);
+
+        // Now a second, unrelated family with fewer agents than nodes. Every one of these lands in the
+        // remainder pass, where the pass is completely free to choose -- so it should choose the node that
+        // is not already holding two slots.
+        grid.WithAgents(evaluator1, evaluator2);
+        grid.DistributeEvenly("evaluator");
+
+        node3.Agents.Select(x => x.Uri).ShouldContain(evaluator1);
+
+        // ...and the totals are balanced rather than 3/3/1
+        node1.Agents.Count.ShouldBe(3);
+        node2.Agents.Count.ShouldBe(2);
+        node3.Agents.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void minimum_fill_pass_also_prefers_the_least_loaded_node()
+    {
+        var grid = new AssignmentGrid();
+        var node1 = grid.WithNode(1, Guid.NewGuid());
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+        var node3 = grid.WithNode(3, Guid.NewGuid());
+
+        grid.WithAgents(slot1, slot2, slot3, slot4, slot5);
+        grid.DistributeEvenly("wolverine-listener");
+
+        // 6 agents over 3 nodes has a minimum of 2, so this exercises the fill-to-minimum pass rather
+        // than the remainder pass. Balance within the scheme is unconditional, but the node that was
+        // already carrying the fewest slots should be filled first.
+        var evaluators = Enumerable.Range(1, 6).Select(i => new Uri($"evaluator://{i}")).ToArray();
+        grid.WithAgents(evaluators);
+        grid.DistributeEvenly("evaluator");
+
+        node1.Agents.Count(x => x.Uri.Scheme == "evaluator").ShouldBe(2);
+        node2.Agents.Count(x => x.Uri.Scheme == "evaluator").ShouldBe(2);
+        node3.Agents.Count(x => x.Uri.Scheme == "evaluator").ShouldBe(2);
+
+        // The least loaded node was served first
+        node3.Agents.Select(x => x.Uri).ShouldContain(evaluators[0]);
+    }
+
+    [Fact]
+    public void does_not_move_already_assigned_agents_when_re_evaluated()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithNode(3, Guid.NewGuid());
+
+        grid.WithAgents(slot1, slot2, slot3, slot4, slot5);
+        grid.DistributeEvenly("wolverine-listener");
+
+        grid.WithAgents(evaluator1, evaluator2);
+        grid.DistributeEvenly("evaluator");
+
+        var before = grid.AllAgents.ToDictionary(x => x.Uri, x => x.AssignedNode);
+
+        // Re-running the same evaluation on a settled grid must be a no-op. The load-aware ordering is a
+        // tie-break over placements that are otherwise free, so it cannot cause reassignment churn.
+        grid.DistributeEvenly("wolverine-listener");
+        grid.DistributeEvenly("evaluator");
+
+        foreach (var agent in grid.AllAgents)
+        {
+            agent.AssignedNode.ShouldBeSameAs(before[agent.Uri]);
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -56,6 +56,24 @@ public partial class AssignmentGrid
         var minimum = (int)Math.Floor(spread);
         var maximum = (int)Math.Ceiling(spread); // this is helpful to reduce the number of assignments
 
+        // GH-3877: every family distributes its own scheme in its own pass, so countOn() above is blind
+        // to everything else a node is already carrying. A node holding two GlobalPartitioned slot
+        // listeners looks exactly as empty as an idle node to the next family that distributes, and the
+        // insertion-ordered passes below would happily stack more work onto it while the idle node sits
+        // out. Order the nodes by the load they carry from *other* passes so the placements this pass is
+        // free to make land on the least loaded nodes first.
+        //
+        // This is strictly a tie-break. The per-node count of *this* pass's agents is still floor/ceiling
+        // balanced, and neither pass below moves an already-assigned agent — pass one only sheds above the
+        // ceiling, passes two and three only place agents that are currently unassigned. So a steady grid
+        // still produces zero commands and this cannot induce reassignment churn. The ordering is a
+        // snapshot taken before any assignment, which keeps a single pass filling nodes in blocks rather
+        // than round-robining, and AssignedId keeps it deterministic when the foreign load ties.
+        var ordered = _nodes
+            .OrderBy(x => x.Agents.Count(a => !agentSet.Contains(a)))
+            .ThenBy(x => x.AssignedId)
+            .ToList();
+
         // First, pair down number of running agents if necessary. Might have to steal some later
         foreach (var node in _nodes)
         {
@@ -69,7 +87,7 @@ public partial class AssignmentGrid
         var missing = new Queue<Agent>(agents.Where(x => x.AssignedNode == null));
 
         // 2nd pass
-        foreach (var node in _nodes)
+        foreach (var node in ordered)
         {
             if (missing.Count == 0)
             {
@@ -95,7 +113,7 @@ public partial class AssignmentGrid
         {
             var agent = missing.Dequeue();
 
-            var node = _nodes.FirstOrDefault(x => !x.IsLeader && countOn(x) < maximum) ?? _nodes.FirstOrDefault(x => !x.IsLeader) ?? _nodes.First();
+            var node = ordered.FirstOrDefault(x => !x.IsLeader && countOn(x) < maximum) ?? ordered.FirstOrDefault(x => !x.IsLeader) ?? ordered.First();
             node.Assign(agent);
         }
     }


### PR DESCRIPTION
Closes #3877 by taking the cheapest of the four options sketched there — "expose slot ownership as assignment input ... a simple *prefer nodes with fewer partition slots* tiebreak would capture most of the benefit with no new user-facing concepts."

## The actual defect

`GlobalPartitioned` slots are not their own agent family. Each slot endpoint is marked `ListenerScope.Exclusive` (`PartitionedMessageTopology.cs:103-118`), so they become `wolverine-listener://` agents distributed by `ExclusiveListenerFamily`, which calls `DistributeEvenly`.

`NodeAgentController.EvaluateAssignments` hands the same grid to each family **in turn**, and every distribution method scopes its per-node counts to its own pass:

```csharp
var agentSet = agents.ToHashSet();
int countOn(Node node) => node.Agents.Count(agentSet.Contains);
var spread = (double)agents.Count / _nodes.Count;
```

So `spread` is *this scheme's* agents over nodes. A node carrying two partition slots is indistinguishable from an idle node when the next family distributes, and both the fill-to-minimum and remainder passes then walk `_nodes` in **grid insertion order** — so they stack onto the already-loaded node.

Concretely, 5 slots over 3 nodes lands 2/2/1. A second family with 2 agents currently goes to nodes 1 and 2, for totals of **3/3/1** — the node holding one slot gets nothing. That is the issue's scenario.

## The change

Order the candidate nodes by the load they carry from *other* passes, then use that order for the fill and remainder passes. Same example now lands 3/2/2.

Three properties keep this safe:

- **It is only a tie-break.** The per-node count of this pass's agents is still floor/ceiling balanced; only *which* node receives an otherwise-free placement changes.
- **It cannot churn.** Pass one only sheds above the ceiling; passes two and three only place agents that are currently unassigned. No already-assigned agent moves, so a settled grid still emits zero commands. There is an explicit regression test for this.
- **It is order-independent across families.** Because the ordering reads live grid state, total balance improves whichever family happens to distribute first — no need to reorder the family loop.

The snapshot is taken once before assigning (so one pass fills in blocks rather than round-robining) and ties break on `AssignedId` for determinism, matching the precedent in `DistributeByGroupAffinity`.

## Scope

Deliberately limited to `DistributeEvenly`, the path partition slots actually take. `DistributeByGroupAffinity` already places groups on the least-loaded node within its pass; seeding its `load` dictionary from foreign load would interact with its `maximum` ceiling and is a larger change than this issue warrants. The weighted-agents and anti-affinity options in the issue are not attempted.

## Testing

New `cross_family_load_awareness.cs`. **Verified as a red baseline** — with the production change stashed, 2 of the 3 fail, and the failure output is the defect verbatim:

```
node3.Agents.Select(x => x.Uri) should contain evaluator://1/
but was actually [wolverine-listener://rabbitmq/orders3]
```

The third test (no-churn on re-evaluation) passes both before and after by design — it is a regression guard, not a demonstration.

The Explore pass over the repo found **no existing test** asserting how sharded-topology slots distribute across nodes, and none running two families over one grid and asserting total per-node load, so this closes a real coverage gap.

- Full `CoreTests`: 2325 passed, 0 failed, 2 skipped
- `dotnet build wolverine.slnx -c Release -f net9.0`: 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mofjPV3wURRbcnVSe16tY