### PR TITLE
#3878: pin and document that blanket durability policies skip system endpoints

### DIFF
--- a/src/Testing/CoreTests/Configuration/blanket_durability_policies_skip_system_endpoints.cs
+++ b/src/Testing/CoreTests/Configuration/blanket_durability_policies_skip_system_endpoints.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3878: the three blanket durability policies are a statement about the *application's* messages.
+/// Endpoints that Wolverine or one of its extensions configures for itself (<see cref="EndpointRole.System"/>)
+/// are infrastructure the application did not author, and are frequently high volume and deliberately cheap
+/// and droppable, so an app-wide "make everything durable" must not reach into them and silently multiply
+/// their cost.
+///
+/// <para>The role check lives in the <c>AllListeners</c> / <c>AllSenders</c> / <c>AllLocalQueues</c>
+/// primitives that all three policies are built on, rather than in the policies themselves, so these tests
+/// pin the behaviour at the level a user actually observes.</para>
+/// </summary>
+public class blanket_durability_policies_skip_system_endpoints
+{
+    private static IEndpointPolicy[] policiesFor(Action<WolverineOptions> configure)
+    {
+        var options = new WolverineOptions();
+        configure(options);
+        return options.Transports.EndpointPolicies.ToArray();
+    }
+
+    private static void apply(IEnumerable<IEndpointPolicy> policies, Endpoint endpoint)
+    {
+        var runtime = Substitute.For<IWolverineRuntime>();
+        foreach (var policy in policies)
+        {
+            policy.Apply(endpoint, runtime);
+        }
+
+        foreach (var configuration in endpoint.DelayedConfiguration.ToArray())
+        {
+            configuration.Apply();
+        }
+    }
+
+    [Theory]
+    [InlineData(EndpointRole.System, EndpointMode.BufferedInMemory)]
+    [InlineData(EndpointRole.Application, EndpointMode.Durable)]
+    public void use_durable_inbox_on_all_listeners(EndpointRole role, EndpointMode expected)
+    {
+        var policies = policiesFor(opts => opts.Policies.UseDurableInboxOnAllListeners());
+
+        var endpoint = new TestEndpoint(role) { IsListener = true };
+        endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+
+        apply(policies, endpoint);
+
+        endpoint.Mode.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(EndpointRole.System, EndpointMode.BufferedInMemory)]
+    [InlineData(EndpointRole.Application, EndpointMode.Durable)]
+    public void use_durable_outbox_on_all_sending_endpoints(EndpointRole role, EndpointMode expected)
+    {
+        var policies = policiesFor(opts => opts.Policies.UseDurableOutboxOnAllSendingEndpoints());
+
+        var endpoint = new TestEndpoint(role);
+        endpoint.Subscriptions.Add(Wolverine.Runtime.Routing.Subscription.All());
+        endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+
+        apply(policies, endpoint);
+
+        endpoint.Mode.ShouldBe(expected);
+    }
+
+    /// <summary>
+    /// The end-to-end shape of the GH-3878 report, exercised through the real <c>Endpoint.Compile()</c>
+    /// path rather than by invoking the policies directly. The local agent queue is a genuine
+    /// <see cref="EndpointRole.System"/> endpoint that Wolverine sets up for itself and deliberately
+    /// leaves buffered.
+    /// </summary>
+    [Fact]
+    public async Task use_durable_local_queues_leaves_wolverines_own_queues_alone()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.LocalQueue("app-queue");
+
+                opts.Policies.UseDurableLocalQueues();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var options = host.Services.GetRequiredService<IWolverineRuntime>().Options;
+        var queues = options.Transports.GetOrCreate<LocalTransport>();
+
+        // The application's own queue is what the policy is actually for
+        var appQueue = queues.AllQueues().Single(x => x.EndpointName == "app-queue");
+        appQueue.Role.ShouldBe(EndpointRole.Application);
+        appQueue.Mode.ShouldBe(EndpointMode.Durable);
+
+        // ...while Wolverine's own agent queue keeps the cheap, droppable mode it was built with
+        var agentQueue = queues.AllQueues().Single(x => x.EndpointName == TransportConstants.Agents);
+        agentQueue.Role.ShouldBe(EndpointRole.System);
+        agentQueue.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+    }
+}

--- a/src/Wolverine/IPolicies.cs
+++ b/src/Wolverine/IPolicies.cs
@@ -23,17 +23,24 @@ public interface IPolicies : IEnumerable<IWolverinePolicy>, IWithFailurePolicies
     void Add(IWolverinePolicy policy);
 
     /// <summary>
-    ///     Set all non local listening endpoints to be enrolled into durable inbox
+    ///     Set all non local listening endpoints to be enrolled into durable inbox.
+    ///     <para>Endpoints with <see cref="EndpointRole.System" /> are skipped: they are infrastructure that
+    ///     Wolverine or one of its extensions configures for itself, are often high volume, and are
+    ///     deliberately cheap and droppable. See <see cref="AllListeners" />.</para>
     /// </summary>
     void UseDurableInboxOnAllListeners();
 
     /// <summary>
-    ///     Set all local queues to be enrolled into durability
+    ///     Set all local queues to be enrolled into durability.
+    ///     <para>Wolverine's own <see cref="EndpointRole.System" /> queues (the agent queue, for example) are
+    ///     skipped. See <see cref="AllLocalQueues" />.</para>
     /// </summary>
     void UseDurableLocalQueues();
 
     /// <summary>
-    ///     Set all outgoing, external endpoints to be enrolled into durable outbox sending
+    ///     Set all outgoing, external endpoints to be enrolled into durable outbox sending.
+    ///     <para>Endpoints with <see cref="EndpointRole.System" /> are skipped for the same reasons as
+    ///     <see cref="UseDurableInboxOnAllListeners" />. See <see cref="AllSenders" />.</para>
     /// </summary>
     void UseDurableOutboxOnAllSendingEndpoints();
 


### PR DESCRIPTION
Re #3878. **The proposed behaviour is already implemented** — but it is invisible at the call site and completely untested, which is almost certainly how the issue came to be filed. This PR pins it and makes it visible rather than changing it.

## Why the issue's premise doesn't hold

The issue is right that the three durability methods don't consult `Endpoint.Role`. But they are implemented purely in terms of `AllListeners` / `AllSenders` / `AllLocalQueues`, and **each of those returns early on `EndpointRole.System`**:

| Primitive | Role check |
|---|---|
| `AllListeners` | `WolverineOptions.Policies.cs:122` |
| `AllSenders` | `WolverineOptions.Policies.cs:155` |
| `AllLocalQueues` | `WolverineOptions.Policies.cs:183` |

`git log -S` puts the checks in `49149d601` ("Preparatory refactoring before centralizing the policy registration"), so this is long-standing, not a recent fix.

Verified against a running host rather than by reading — with all three policies enabled:

```
local://agents/       role=System        mode=BufferedInMemory
local://app-queue/    role=Application   mode=Durable
local://blue/         role=Application   mode=Durable
...
```

`Role` is also a required constructor parameter on `Endpoint`, so there is no path where an endpoint silently defaults into the wrong role.

## What this PR does

- **Regression tests** (`blanket_durability_policies_skip_system_endpoints.cs`) for all three policies. Each is a `[Theory]` over both roles, so the `Application` case proves the policy genuinely applies and the `System` case proves it is skipped — a test that only asserted "System stays buffered" would pass vacuously if the policy did nothing at all. `UseDurableLocalQueues` is covered end-to-end through the real `Endpoint.Compile()` path using Wolverine's own agent queue; the other two are covered at the policy level. No infrastructure required, so it runs in `CoreTests`.
- **Doc comments** on the three `IPolicies` methods stating the exclusion and pointing at the primitive that enforces it.

No production behaviour changes.

## The part that is still open

The issue's "Related" note — that the CritterWatch role stamp happens in an activator, after endpoint compilation — is the half that actually bites, and it is **not** fixed here because it isn't a Wolverine-side defect. Endpoint policies run inside `Endpoint.Compile()` (`Endpoint.cs:522`), and several `EndpointCollection` paths compile lazily on first use. Any extension that stamps `Role` after its endpoints have compiled will have missed the check no matter what the policy does. The fix is for the extension to set `Role` at endpoint construction/configuration time — which the `Endpoint(uri, role)` constructor already makes the natural thing to do.

So I'd suggest closing #3878 on the Wolverine side and keeping the CritterWatch companion issue open. Happy to add the `includeSystemEndpoints: true` opt-in overload instead if you want the escape hatch, but nothing today needs it.

## Testing

- Full `CoreTests`: 2330 passed, 0 failed, 2 skipped
- `dotnet build wolverine.slnx -c Release -f net9.0`: 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mofjPV3wURRbcnVSe16tY