### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/guide/durability/managing.md
+++ b/docs/guide/durability/managing.md
@@ -203,7 +203,7 @@ where `export.sql` should be a file name.
 
 ### Marten integration
 
-When integrating with Marten, scripts must be generated seperately for both Marten and Wolverine resources.  
+When integrating with Marten, scripts must be generated separately for both Marten and Wolverine resources.  
 Resources are separated into databases and can be listed as below:
 
 ```bash

--- a/docs/guide/http/metadata.md
+++ b/docs/guide/http/metadata.md
@@ -346,7 +346,7 @@ For whatever reason, the source generator for OpenAPI tries to start the entire 
 
 Chances are good that one of the things preventing a successful startup is that Marten and Wolverine will, by default, begin performing their usual tasks immediately  upon startup. This entails connecting to the database, as well as to any external messaging providers you may be using. Since those connections are probably not going to be possible in your build environment, they will need to be disabled while the OpenApi generation is being done.
 
-Microsoft's recomendation for detecting whether the application is running for the purpose of document generation is to use this code:
+Microsoft's recommendation for detecting whether the application is running for the purpose of document generation is to use this code:
 ```cs
 var generatingOpenApi = Assembly.GetEntryAssembly()?.GetName().Name == "GetDocument.Insider"
 ```


### PR DESCRIPTION
Two small typos in the docs:

- `docs/guide/durability/managing.md`: "seperately" -> "separately"
- `docs/guide/http/metadata.md`: "recomendation" -> "recommendation"
