### PR TITLE
GH-3886: route the durable inbox by endpoint for sticky handlers

### DIFF
--- a/src/Persistence/EfCoreTests/Bugs/Bug_3886_separate_databases.cs
+++ b/src/Persistence/EfCoreTests/Bugs/Bug_3886_separate_databases.cs
@@ -1,0 +1,235 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RabbitMQ;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Util;
+
+namespace EfCoreTests.Bugs;
+
+// GH-3886, in the configuration the reporter actually runs: the two modules are SEPARATE PHYSICAL
+// DATABASES, not two schemas in one database.
+//
+// This distinction is the whole point of the test, and it is worth keeping the more expensive setup
+// for. With both modules in one database the GH-3886 misrouting looks like a cosmetic misplacement,
+// because EfCoreEnvelopeTransaction.CommitAsync takes the SCHEMA from MessageContext.Storage (the
+// wrongly-routed store) while taking the CONNECTION from the handler's own DbContext -- and in a
+// single database that cross-wiring happens to succeed.
+//
+// Across real databases it cannot. Before the fix this test failed as:
+//
+//     Npgsql.PostgresException: 42P01: relation "..._wolverine.wolverine_incoming_envelopes" does not exist
+//        at EfCoreEnvelopeTransaction.CommitAsync(...)
+//     Envelope ... was moved to the error queue
+//
+// with module A's domain write rolled back and its message dead-lettered on the FIRST delivery,
+// every time. A single-database test cannot catch that regression class.
+
+public record MessageForTwoDatabases3886(Guid Id);
+
+[StickyHandler(Bug_3886_separate_databases.QueueA)]
+[Storage(typeof(DbA3886DbContext))]
+public sealed class MessageForTwoDatabases3886AHandler
+{
+    public void Handle(MessageForTwoDatabases3886 message, DbA3886DbContext dbContext)
+    {
+        dbContext.SomeModels.Add(new DbA3886Model { Id = message.Id });
+    }
+}
+
+[StickyHandler(Bug_3886_separate_databases.QueueB)]
+[Storage(typeof(DbB3886DbContext))]
+public sealed class MessageForTwoDatabases3886BHandler
+{
+    public void Handle(MessageForTwoDatabases3886 message, DbB3886DbContext dbContext)
+    {
+        dbContext.SomeModels.Add(new DbB3886Model { Id = message.Id });
+    }
+}
+
+public sealed class DbA3886Model
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class DbB3886Model
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class DbA3886DbContext : DbContext
+{
+    public DbA3886DbContext(DbContextOptions<DbA3886DbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<DbA3886Model> SomeModels => Set<DbA3886Model>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("x3886_a");
+        modelBuilder.Entity<DbA3886Model>().ToTable("some_models");
+    }
+}
+
+public sealed class DbB3886DbContext : DbContext
+{
+    public DbB3886DbContext(DbContextOptions<DbB3886DbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<DbB3886Model> SomeModels => Set<DbB3886Model>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("x3886_b");
+        modelBuilder.Entity<DbB3886Model>().ToTable("some_models");
+    }
+}
+
+public class Bug_3886_separate_databases : IAsyncLifetime
+{
+    public const string QueueA = "bug3886x-a-queue";
+    public const string QueueB = "bug3886x-b-queue";
+    private const string Exchange = "bug3886x-exchange";
+
+    // Derived from the lane's own database rather than a fixed literal, so parallelized CI lanes
+    // sharing one server do not collide on the sibling database. See Servers.PostgresDatabaseName.
+    private static readonly string DatabaseBName = $"{Servers.PostgresDatabaseName}_bug3886b";
+
+    private static readonly string DatabaseB = Servers.PostgresConnectionString
+        .Replace($"Database={Servers.PostgresDatabaseName}", $"Database={DatabaseBName}");
+
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await createModuleBDatabaseAsync();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MessageForTwoDatabases3886AHandler>()
+                    .IncludeType<MessageForTwoDatabases3886BHandler>();
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+                opts.Durability.MessageIdentity = MessageIdentity.IdAndDestination;
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.PublishMessage<MessageForTwoDatabases3886>()
+                    .ToRabbitExchange(Exchange, e =>
+                    {
+                        e.BindQueue(QueueA);
+                        e.BindQueue(QueueB);
+                    })
+                    .UseDurableOutbox();
+
+                opts.ListenToRabbitQueue(QueueA).Named(QueueA).UseDurableInbox();
+                opts.ListenToRabbitQueue(QueueB).Named(QueueB).UseDurableInbox();
+
+                opts.Policies.AutoApplyTransactions();
+                opts.UseEntityFrameworkCoreTransactions();
+
+                opts.Services.AddDbContextWithWolverineIntegration<DbA3886DbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "x3886_a_wolverine");
+                opts.Services.AddDbContextWithWolverineIntegration<DbB3886DbContext>(
+                    x => x.UseNpgsql(DatabaseB), "x3886_b_wolverine");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "x3886_main");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "x3886_a_wolverine", MessageStoreRole.Ancillary).Enroll<DbA3886DbContext>();
+                opts.PersistMessagesWithPostgresql(DatabaseB,
+                    "x3886_b_wolverine", MessageStoreRole.Ancillary).Enroll<DbB3886DbContext>();
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    private static async Task createModuleBDatabaseAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        await using var exists = conn.CreateCommand();
+        exists.CommandText = "select 1 from pg_database where datname = @name";
+        exists.Parameters.AddWithValue("name", DatabaseBName);
+
+        if (await exists.ExecuteScalarAsync() != null) return;
+
+        await using var create = conn.CreateCommand();
+        // No parameters and no IF NOT EXISTS in PostgreSQL DDL; the name is derived from our own
+        // connection string, not user input.
+        create.CommandText = $"create database \"{DatabaseBName}\"";
+        await create.ExecuteNonQueryAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task each_module_commits_its_inbox_row_in_its_own_database()
+    {
+        var runtime = _host.GetRuntime();
+        var messageTypeName = typeof(MessageForTwoDatabases3886).ToMessageTypeName();
+        var id = Guid.NewGuid();
+
+        await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .PublishMessageAndWaitAsync(new MessageForTwoDatabases3886(id));
+
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
+
+        var storeA = runtime.Stores!.FindAncillaryStore(typeof(DbA3886DbContext));
+        var storeB = runtime.Stores.FindAncillaryStore(typeof(DbB3886DbContext));
+
+        var inA = (await storeA.Admin.AllIncomingAsync()).Where(x => x.MessageType == messageTypeName).ToArray();
+        var inB = (await storeB.Admin.AllIncomingAsync()).Where(x => x.MessageType == messageTypeName).ToArray();
+
+        inA.Length.ShouldBe(1, "The module A delivery belongs in module A's own database");
+        inB.Length.ShouldBe(1, "The module B delivery belongs in module B's own database");
+
+        inA.Single().Destination.ShouldBe(new Uri($"rabbitmq://queue/{QueueA}"));
+        inB.Single().Destination.ShouldBe(new Uri($"rabbitmq://queue/{QueueB}"));
+
+        // The sharpest signal: when the inbox row is routed to the wrong database the mark-as-handled
+        // throws 42P01, the surrounding transaction rolls back, and the domain write is lost with the
+        // message dead-lettered. A missing business row here means that has regressed.
+        //
+        // Asserted by id rather than by row count: ResetResourceState clears Wolverine's own stores
+        // but not the application's model tables, so counts accumulate across runs.
+        var token = TestContext.Current.CancellationToken;
+        await using var scope = _host.Services.CreateAsyncScope();
+
+        (await scope.ServiceProvider.GetRequiredService<DbA3886DbContext>()
+                .SomeModels.AnyAsync(x => x.Id == id, token))
+            .ShouldBeTrue("Module A's domain write must survive -- a miss here means its transaction rolled back");
+        (await scope.ServiceProvider.GetRequiredService<DbB3886DbContext>()
+                .SomeModels.AnyAsync(x => x.Id == id, token))
+            .ShouldBeTrue();
+    }
+}

--- a/src/Persistence/EfCoreTests/Bugs/Bug_3886_sticky_handlers_ancillary_store.cs
+++ b/src/Persistence/EfCoreTests/Bugs/Bug_3886_sticky_handlers_ancillary_store.cs
@@ -1,0 +1,221 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RabbitMQ;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Util;
+
+namespace EfCoreTests.Bugs;
+
+// Regression test for GH-3886. Reported by @fadrian23, and a direct follow-on to GH-3870.
+//
+// One message type is delivered to two Rabbit MQ queues. Each queue has its own sticky handler, and
+// each sticky handler names a different enrolled DbContext with [Storage]. Each delivery's inbox row
+// belongs in its own module's store.
+//
+// Root cause: MessageStoreCollection._messageTypeToAncillaryStore was keyed by message type name
+// ALONE, and WolverineRuntime.HostService wrote one entry per chain with AddOrUpdate. Two sticky
+// chains naming different stores therefore collided on a single key and the last chain iterated won
+// globally, for every endpoint. Both chains carried the correct AncillaryStoreType the whole time --
+// the map simply could not represent a per-endpoint answer.
+//
+// Different schemas in one database here for test convenience. See Bug_3886_separate_databases for
+// what this same misrouting does when the modules really are separate databases.
+
+public record MessageForTwoModules3886(Guid Id);
+
+[StickyHandler(Bug_3886_sticky_handlers_ancillary_store.QueueA)]
+[Storage(typeof(ModuleA3886DbContext))]
+public sealed class MessageForTwoModules3886AHandler
+{
+    public void Handle(MessageForTwoModules3886 message, ModuleA3886DbContext dbContext)
+    {
+        dbContext.SomeModels.Add(new ModuleA3886Model { Id = message.Id });
+    }
+}
+
+[StickyHandler(Bug_3886_sticky_handlers_ancillary_store.QueueB)]
+[Storage(typeof(ModuleB3886DbContext))]
+public sealed class MessageForTwoModules3886BHandler
+{
+    public void Handle(MessageForTwoModules3886 message, ModuleB3886DbContext dbContext)
+    {
+        dbContext.SomeModels.Add(new ModuleB3886Model { Id = message.Id });
+    }
+}
+
+public sealed class ModuleA3886Model
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class ModuleB3886Model
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class ModuleA3886DbContext : DbContext
+{
+    public ModuleA3886DbContext(DbContextOptions<ModuleA3886DbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<ModuleA3886Model> SomeModels => Set<ModuleA3886Model>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("bug3886_module_a");
+        modelBuilder.Entity<ModuleA3886Model>().ToTable("some_models");
+    }
+}
+
+public sealed class ModuleB3886DbContext : DbContext
+{
+    public ModuleB3886DbContext(DbContextOptions<ModuleB3886DbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<ModuleB3886Model> SomeModels => Set<ModuleB3886Model>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("bug3886_module_b");
+        modelBuilder.Entity<ModuleB3886Model>().ToTable("some_models");
+    }
+}
+
+public class Bug_3886_sticky_handlers_ancillary_store : IAsyncLifetime
+{
+    public const string QueueA = "bug3886-module-a-queue";
+    public const string QueueB = "bug3886-module-b-queue";
+    private const string Exchange = "bug3886-exchange";
+
+    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
+
+    public Bug_3886_sticky_handlers_ancillary_store(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Other handlers in this assembly need persistence providers this host does not
+                // register; only the two handlers under test matter here.
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MessageForTwoModules3886AHandler>()
+                    .IncludeType<MessageForTwoModules3886BHandler>();
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                // One logical message, two physical deliveries: the destination has to be part of the
+                // inbox identity or the second delivery is rejected as a duplicate
+                opts.Durability.MessageIdentity = MessageIdentity.IdAndDestination;
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.PublishMessage<MessageForTwoModules3886>()
+                    .ToRabbitExchange(Exchange, e =>
+                    {
+                        e.BindQueue(QueueA);
+                        e.BindQueue(QueueB);
+                    })
+                    .UseDurableOutbox();
+
+                opts.ListenToRabbitQueue(QueueA).Named(QueueA).UseDurableInbox();
+                opts.ListenToRabbitQueue(QueueB).Named(QueueB).UseDurableInbox();
+
+                opts.Policies.AutoApplyTransactions();
+                opts.UseEntityFrameworkCoreTransactions();
+
+                opts.Services.AddDbContextWithWolverineIntegration<ModuleA3886DbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "bug3886_module_a_wolverine");
+                opts.Services.AddDbContextWithWolverineIntegration<ModuleB3886DbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "bug3886_module_b_wolverine");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "bug3886_main");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "bug3886_module_a_wolverine", MessageStoreRole.Ancillary).Enroll<ModuleA3886DbContext>();
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "bug3886_module_b_wolverine", MessageStoreRole.Ancillary).Enroll<ModuleB3886DbContext>();
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task each_sticky_handler_stores_its_envelope_in_its_own_module_store()
+    {
+        var runtime = _host.GetRuntime();
+        var messageTypeName = typeof(MessageForTwoModules3886).ToMessageTypeName();
+
+        // If this ever regresses, these two dumps say immediately whether the chains lost their
+        // store association (an attribute-discovery bug, as in GH-2576/2944/3870) or whether the
+        // chains are right and the routing lost the per-endpoint distinction (GH-3886).
+        foreach (var chain in runtime.Handlers.AllChains()
+                     .Where(x => x.MessageType == typeof(MessageForTwoModules3886)))
+        {
+            _output.WriteLine(
+                $"chain endpoints=[{chain.Endpoints.Select(x => x.EndpointName).Join(", ")}] " +
+                $"AncillaryStoreType={chain.AncillaryStoreType?.Name ?? "null"}");
+        }
+
+        foreach (var queue in new[] { QueueA, QueueB })
+        {
+            var uri = new Uri($"rabbitmq://queue/{queue}");
+            _output.WriteLine(
+                $"routed store for {queue} => {runtime.Stores!.TryFindAncillaryStoreForMessageType(uri, messageTypeName)?.Uri.ToString() ?? "MAIN"}");
+        }
+
+        await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .PublishMessageAndWaitAsync(new MessageForTwoModules3886(Guid.NewGuid()));
+
+        // The mark-as-handled write is asynchronous relative to the tracked session completing
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
+
+        var storeA = runtime.Stores!.FindAncillaryStore(typeof(ModuleA3886DbContext));
+        var storeB = runtime.Stores.FindAncillaryStore(typeof(ModuleB3886DbContext));
+
+        var inA = (await storeA.Admin.AllIncomingAsync()).Where(x => x.MessageType == messageTypeName).ToArray();
+        var inB = (await storeB.Admin.AllIncomingAsync()).Where(x => x.MessageType == messageTypeName).ToArray();
+        var inMain = (await runtime.Storage.Admin.AllIncomingAsync())
+            .Where(x => x.MessageType == messageTypeName).ToArray();
+
+        inA.Length.ShouldBe(1, "The module-a-queue delivery belongs in the ModuleA store");
+        inB.Length.ShouldBe(1, "The module-b-queue delivery belongs in the ModuleB store");
+        inMain.ShouldBeEmpty("Neither delivery belongs in the main store");
+
+        // Each store got the delivery from ITS OWN queue, not just one row apiece
+        inA.Single().Destination.ShouldBe(new Uri($"rabbitmq://queue/{QueueA}"));
+        inB.Single().Destination.ShouldBe(new Uri($"rabbitmq://queue/{QueueB}"));
+    }
+}

--- a/src/Persistence/EfCoreTests/Bugs/sticky_handler_ancillary_store_routing.cs
+++ b/src/Persistence/EfCoreTests/Bugs/sticky_handler_ancillary_store_routing.cs
@@ -1,0 +1,342 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Util;
+
+namespace EfCoreTests.Bugs;
+
+// Permutation coverage for how a handler chain's ancillary store is resolved for the durable inbox,
+// across the ways a chain can be sticky and the ways it can name (or not name) a store. Grew out of
+// GH-3886; the bug fixed there was only one cell of this matrix.
+//
+// These assert the routing DECISION -- what MessageStoreCollection answers for a given (endpoint,
+// message type) -- rather than driving messages end to end, so one host covers the whole matrix. The
+// end-to-end proof that the decision reaches the database lives in Bug_3886_sticky_handlers_ancillary_store
+// (external Rabbit endpoints, DurableReceiver) and sticky_local_queue_ancillary_stores (local queues,
+// DurableLocalQueue). Sticky handlers here name endpoints that do not otherwise exist, so Wolverine
+// creates local queues for them and no broker is needed.
+//
+// NOTE for anyone adding a permutation: HandlerChain only splits into per-endpoint ByEndpoint chains
+// when a message type has MORE THAN ONE handler (HandlerChain.cs, `if (grouping.Count() > 1)`). A lone
+// [StickyHandler] handler produces no sticky chain at all, so every sticky permutation below needs a
+// second handler for the same message type to be testing what it claims to test.
+
+#region stores
+
+public sealed class PermAModel
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class PermBModel
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class PermADbContext : DbContext
+{
+    public PermADbContext(DbContextOptions<PermADbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<PermAModel> Models => Set<PermAModel>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("perm_a");
+        modelBuilder.Entity<PermAModel>().ToTable("models");
+    }
+}
+
+public sealed class PermBDbContext : DbContext
+{
+    public PermBDbContext(DbContextOptions<PermBDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<PermBModel> Models => Set<PermBModel>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("perm_b");
+        modelBuilder.Entity<PermBModel>().ToTable("models");
+    }
+}
+
+#endregion
+
+#region permutation: two sticky chains naming DIFFERENT stores (the GH-3886 shape)
+
+public record PermSplitMessage(Guid Id);
+
+[StickyHandler("perm-split-a")]
+[Storage(typeof(PermADbContext))]
+public sealed class PermSplitAHandler
+{
+    public void Handle(PermSplitMessage message, PermADbContext db) => db.Models.Add(new PermAModel { Id = message.Id });
+}
+
+[StickyHandler("perm-split-b")]
+[Storage(typeof(PermBDbContext))]
+public sealed class PermSplitBHandler
+{
+    public void Handle(PermSplitMessage message, PermBDbContext db) => db.Models.Add(new PermBModel { Id = message.Id });
+}
+
+#endregion
+
+#region permutation: one sticky chain on an ancillary store, one on the MAIN store
+
+public record PermMixedMessage(Guid Id);
+
+[StickyHandler("perm-mixed-ancillary")]
+[Storage(typeof(PermADbContext))]
+public sealed class PermMixedAncillaryHandler
+{
+    public void Handle(PermMixedMessage message, PermADbContext db) => db.Models.Add(new PermAModel { Id = message.Id });
+}
+
+// Deliberately names no store and depends on no DbContext: this chain belongs to the MAIN store, and
+// must not inherit its sibling's ancillary store through the message-type-wide fallback.
+[StickyHandler("perm-mixed-main")]
+public sealed class PermMixedMainHandler
+{
+    public static void Handle(PermMixedMessage message)
+    {
+    }
+}
+
+#endregion
+
+#region permutation: sticky chains whose stores are INFERRED from enrolled DbContexts (GH-3870 x GH-3886)
+
+public record PermInferredMessage(Guid Id);
+
+// Neither handler carries a [Storage] attribute: taking the enrolled DbContext as a dependency is the
+// only thing associating each chain with a store, and they must still be told apart per endpoint.
+[StickyHandler("perm-inferred-b")]
+public sealed class PermInferredHandler
+{
+    public void Handle(PermInferredMessage message, PermBDbContext db) => db.Models.Add(new PermBModel { Id = message.Id });
+}
+
+[StickyHandler("perm-inferred-a")]
+public sealed class PermInferredOtherHandler
+{
+    public void Handle(PermInferredMessage message, PermADbContext db) => db.Models.Add(new PermAModel { Id = message.Id });
+}
+
+#endregion
+
+#region permutation: a sticky chain alongside a non-sticky default chain
+
+public record PermFallbackMessage(Guid Id);
+
+[StickyHandler("perm-fallback-sticky")]
+[Storage(typeof(PermADbContext))]
+public sealed class PermFallbackStickyHandler
+{
+    public void Handle(PermFallbackMessage message, PermADbContext db) => db.Models.Add(new PermAModel { Id = message.Id });
+}
+
+public sealed class PermFallbackDefaultHandler
+{
+    public static void Handle(PermFallbackMessage message)
+    {
+    }
+}
+
+#endregion
+
+#region permutation: two sticky chains AGREEING on one store (the GH-2576 shape)
+
+public record PermAgreeMessage(Guid Id);
+
+[StickyHandler("perm-agree-1")]
+[Storage(typeof(PermADbContext))]
+public sealed class PermAgreeOneHandler
+{
+    public void Handle(PermAgreeMessage message, PermADbContext db) => db.Models.Add(new PermAModel { Id = message.Id });
+}
+
+[StickyHandler("perm-agree-2")]
+[Storage(typeof(PermADbContext))]
+public sealed class PermAgreeTwoHandler
+{
+    public void Handle(PermAgreeMessage message, PermADbContext db) => db.Models.Add(new PermAModel { Id = message.Id });
+}
+
+#endregion
+
+#region permutation: a plain non-sticky chain on an ancillary store
+
+public record PermPlainMessage(Guid Id);
+
+[Storage(typeof(PermBDbContext))]
+public sealed class PermPlainHandler
+{
+    public void Handle(PermPlainMessage message, PermBDbContext db) => db.Models.Add(new PermBModel { Id = message.Id });
+}
+
+#endregion
+
+public class sticky_handler_ancillary_store_routing : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private WolverineRuntime _runtime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<PermSplitAHandler>()
+                    .IncludeType<PermSplitBHandler>()
+                    .IncludeType<PermMixedAncillaryHandler>()
+                    .IncludeType<PermMixedMainHandler>()
+                    .IncludeType<PermInferredHandler>()
+                    .IncludeType<PermInferredOtherHandler>()
+                    .IncludeType<PermFallbackStickyHandler>()
+                    .IncludeType<PermFallbackDefaultHandler>()
+                    .IncludeType<PermAgreeOneHandler>()
+                    .IncludeType<PermAgreeTwoHandler>()
+                    .IncludeType<PermPlainHandler>();
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                opts.Policies.AutoApplyTransactions();
+                opts.Policies.UseDurableLocalQueues();
+                opts.UseEntityFrameworkCoreTransactions();
+
+                opts.Services.AddDbContextWithWolverineIntegration<PermADbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "perm_a_wolverine");
+                opts.Services.AddDbContextWithWolverineIntegration<PermBDbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "perm_b_wolverine");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "perm_main");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "perm_a_wolverine", MessageStoreRole.Ancillary).Enroll<PermADbContext>();
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "perm_b_wolverine", MessageStoreRole.Ancillary).Enroll<PermBDbContext>();
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+            }).StartAsync();
+
+        _runtime = _host.GetRuntime();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private IMessageStore StoreA => _runtime.Stores!.FindAncillaryStore(typeof(PermADbContext));
+    private IMessageStore StoreB => _runtime.Stores!.FindAncillaryStore(typeof(PermBDbContext));
+
+    /// <summary>
+    /// The endpoint a sticky handler was pinned to. Read off the chain rather than reconstructed from
+    /// the endpoint name so the assertions use exactly the Uri the runtime registered.
+    /// </summary>
+    private Uri endpointFor<THandler>(Type messageType)
+    {
+        var chain = _runtime.Handlers.AllChains()
+            .Single(c => c.MessageType == messageType &&
+                         c.Handlers.Any(h => h.HandlerType == typeof(THandler)));
+
+        chain.Endpoints.ShouldNotBeEmpty($"{typeof(THandler).Name} was expected to be a sticky handler");
+
+        return chain.Endpoints.Single().Uri;
+    }
+
+    private IMessageStore? routedStore(Uri endpoint, Type messageType)
+    {
+        return _runtime.Stores!.TryFindAncillaryStoreForMessageType(endpoint, messageType.ToMessageTypeName());
+    }
+
+    [Fact]
+    public void sticky_chains_naming_different_stores_each_route_to_their_own()
+    {
+        routedStore(endpointFor<PermSplitAHandler>(typeof(PermSplitMessage)), typeof(PermSplitMessage))
+            .ShouldBeSameAs(StoreA);
+
+        routedStore(endpointFor<PermSplitBHandler>(typeof(PermSplitMessage)), typeof(PermSplitMessage))
+            .ShouldBeSameAs(StoreB);
+    }
+
+    [Fact]
+    public void a_sticky_chain_on_the_main_store_does_not_inherit_its_siblings_ancillary_store()
+    {
+        routedStore(endpointFor<PermMixedAncillaryHandler>(typeof(PermMixedMessage)), typeof(PermMixedMessage))
+            .ShouldBeSameAs(StoreA);
+
+        // The whole point: this endpoint's handler names no store, so its inbox row belongs in the main
+        // store. Falling through to the message-type-wide entry would hand it PermA's store instead.
+        routedStore(endpointFor<PermMixedMainHandler>(typeof(PermMixedMessage)), typeof(PermMixedMessage))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void sticky_chains_infer_their_stores_from_enrolled_dbcontext_dependencies()
+    {
+        routedStore(endpointFor<PermInferredHandler>(typeof(PermInferredMessage)), typeof(PermInferredMessage))
+            .ShouldBeSameAs(StoreB);
+
+        routedStore(endpointFor<PermInferredOtherHandler>(typeof(PermInferredMessage)), typeof(PermInferredMessage))
+            .ShouldBeSameAs(StoreA);
+    }
+
+    [Fact]
+    public void an_endpoint_with_no_sticky_chain_falls_back_to_the_message_type_answer()
+    {
+        var sticky = endpointFor<PermFallbackStickyHandler>(typeof(PermFallbackMessage));
+        routedStore(sticky, typeof(PermFallbackMessage)).ShouldBeSameAs(StoreA);
+
+        // Any other endpoint -- here one that has no chain of its own for this message type -- keeps
+        // resolving through the message-type keyed map exactly as it did before GH-3886
+        routedStore(new Uri("rabbitmq://queue/some-unrelated-queue"), typeof(PermFallbackMessage))
+            .ShouldBeSameAs(StoreA);
+    }
+
+    [Fact]
+    public void sticky_chains_agreeing_on_one_store_both_route_to_it()
+    {
+        routedStore(endpointFor<PermAgreeOneHandler>(typeof(PermAgreeMessage)), typeof(PermAgreeMessage))
+            .ShouldBeSameAs(StoreA);
+
+        routedStore(endpointFor<PermAgreeTwoHandler>(typeof(PermAgreeMessage)), typeof(PermAgreeMessage))
+            .ShouldBeSameAs(StoreA);
+    }
+
+    [Fact]
+    public void a_non_sticky_chain_still_routes_by_message_type_from_any_endpoint()
+    {
+        routedStore(new Uri("rabbitmq://queue/anything"), typeof(PermPlainMessage)).ShouldBeSameAs(StoreB);
+        routedStore(new Uri("local://whatever"), typeof(PermPlainMessage)).ShouldBeSameAs(StoreB);
+    }
+
+    [Fact]
+    public void a_message_type_with_no_ancillary_association_stays_on_the_main_store()
+    {
+        _runtime.Stores!.TryFindAncillaryStoreForMessageType(new Uri("rabbitmq://queue/anything"),
+            typeof(PermUnmappedMessage).ToMessageTypeName()).ShouldBeNull();
+    }
+}
+
+public record PermUnmappedMessage(Guid Id);

--- a/src/Persistence/EfCoreTests/Bugs/sticky_local_queue_ancillary_stores.cs
+++ b/src/Persistence/EfCoreTests/Bugs/sticky_local_queue_ancillary_stores.cs
@@ -1,0 +1,177 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+using Wolverine.Util;
+
+namespace EfCoreTests.Bugs;
+
+// The GH-3886 companion for LOCAL queues. Bug_3886_sticky_handlers_ancillary_store drives the same
+// shape through external Rabbit queues, which is DurableReceiver; sticky handlers pinned to local
+// queues go through DurableLocalQueue instead, a separate call site with its own copy of
+// assignAncillaryStoreIfNeeded. Both had to start resolving the store by endpoint, so both need an
+// end-to-end test that the resolved store is the one actually written to.
+
+public record LocalStickyMessage(Guid Id);
+
+[StickyHandler("local-sticky-a")]
+[Storage(typeof(LocalStickyADbContext))]
+public sealed class LocalStickyAHandler
+{
+    public void Handle(LocalStickyMessage message, LocalStickyADbContext db)
+    {
+        db.Models.Add(new LocalStickyAModel { Id = message.Id });
+    }
+}
+
+[StickyHandler("local-sticky-b")]
+[Storage(typeof(LocalStickyBDbContext))]
+public sealed class LocalStickyBHandler
+{
+    public void Handle(LocalStickyMessage message, LocalStickyBDbContext db)
+    {
+        db.Models.Add(new LocalStickyBModel { Id = message.Id });
+    }
+}
+
+public sealed class LocalStickyAModel
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class LocalStickyBModel
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class LocalStickyADbContext : DbContext
+{
+    public LocalStickyADbContext(DbContextOptions<LocalStickyADbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<LocalStickyAModel> Models => Set<LocalStickyAModel>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("local_sticky_a");
+        modelBuilder.Entity<LocalStickyAModel>().ToTable("models");
+    }
+}
+
+public sealed class LocalStickyBDbContext : DbContext
+{
+    public LocalStickyBDbContext(DbContextOptions<LocalStickyBDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<LocalStickyBModel> Models => Set<LocalStickyBModel>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("local_sticky_b");
+        modelBuilder.Entity<LocalStickyBModel>().ToTable("models");
+    }
+}
+
+public class sticky_local_queue_ancillary_stores : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<LocalStickyAHandler>()
+                    .IncludeType<LocalStickyBHandler>();
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                // The one message fans out to both sticky local queues, so the destination has to be
+                // part of the inbox identity or the second queue's row collides with the first
+                opts.Durability.MessageIdentity = MessageIdentity.IdAndDestination;
+
+                opts.Policies.AutoApplyTransactions();
+                opts.Policies.UseDurableLocalQueues();
+                opts.UseEntityFrameworkCoreTransactions();
+
+                opts.Services.AddDbContextWithWolverineIntegration<LocalStickyADbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "local_sticky_a_wolverine");
+                opts.Services.AddDbContextWithWolverineIntegration<LocalStickyBDbContext>(
+                    x => x.UseNpgsql(Servers.PostgresConnectionString), "local_sticky_b_wolverine");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "local_sticky_main");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "local_sticky_a_wolverine", MessageStoreRole.Ancillary).Enroll<LocalStickyADbContext>();
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString,
+                    "local_sticky_b_wolverine", MessageStoreRole.Ancillary).Enroll<LocalStickyBDbContext>();
+
+                opts.Services.AddResourceSetupOnStartup();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task each_sticky_local_queue_persists_its_envelope_in_its_own_store()
+    {
+        var runtime = _host.GetRuntime();
+        var messageTypeName = typeof(LocalStickyMessage).ToMessageTypeName();
+        var id = Guid.NewGuid();
+
+        await _host
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(new LocalStickyMessage(id));
+
+        // The mark-as-handled write is asynchronous relative to the tracked session completing
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
+
+        var storeA = runtime.Stores!.FindAncillaryStore(typeof(LocalStickyADbContext));
+        var storeB = runtime.Stores.FindAncillaryStore(typeof(LocalStickyBDbContext));
+
+        var inA = (await storeA.Admin.AllIncomingAsync()).Where(x => x.MessageType == messageTypeName).ToArray();
+        var inB = (await storeB.Admin.AllIncomingAsync()).Where(x => x.MessageType == messageTypeName).ToArray();
+        var inMain = (await runtime.Storage.Admin.AllIncomingAsync())
+            .Where(x => x.MessageType == messageTypeName).ToArray();
+
+        inA.Length.ShouldBe(1, "The local-sticky-a delivery belongs in the LocalStickyA store");
+        inB.Length.ShouldBe(1, "The local-sticky-b delivery belongs in the LocalStickyB store");
+        inMain.ShouldBeEmpty("Neither delivery belongs in the main store");
+
+        inA.Single().Destination.ShouldBe(new Uri("local://local-sticky-a"));
+        inB.Single().Destination.ShouldBe(new Uri("local://local-sticky-b"));
+
+        // Asserted by id, not row count: ResetResourceState clears Wolverine's stores but not the
+        // application's own model tables, so counts accumulate across runs.
+        var token = TestContext.Current.CancellationToken;
+        await using var scope = _host.Services.CreateAsyncScope();
+
+        (await scope.ServiceProvider.GetRequiredService<LocalStickyADbContext>()
+            .Models.AnyAsync(x => x.Id == id, token)).ShouldBeTrue();
+        (await scope.ServiceProvider.GetRequiredService<LocalStickyBDbContext>()
+            .Models.AnyAsync(x => x.Id == id, token)).ShouldBeTrue();
+    }
+}

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -544,6 +544,77 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         if (messageTypeName == null) return null;
         return _messageTypeToAncillaryStore.TryFind(messageTypeName, out var store) ? store : null;
     }
+
+    private ImHashMap<string, IMessageStore> _endpointMessageTypeToAncillaryStore =
+        ImHashMap<string, IMessageStore>.Empty;
+
+    // Every (endpoint, message type) pair that a sticky handler chain has spoken for, including the
+    // ones that target the MAIN store and therefore have no entry in the map above.
+    private ImHashMap<string, bool> _endpointMessageTypeIsStickyRouted = ImHashMap<string, bool>.Empty;
+
+    private static string endpointMessageTypeKey(Uri endpointUri, string messageTypeName)
+    {
+        return $"{endpointUri}|{messageTypeName}";
+    }
+
+    /// <summary>
+    /// Register the store that owns a message type's inbox row <i>at one specific endpoint</i>. A message
+    /// type handled by several sticky handlers has a different answer per endpoint, which the message
+    /// type keyed map above cannot represent -- there the chains collide on one key and the last one
+    /// registered wins for every endpoint. See GH-3886.
+    /// </summary>
+    /// <param name="ancillaryMarkerType">
+    /// Null when the sticky chain targets the main store. The pair is still recorded so that
+    /// <see cref="TryFindAncillaryStoreForMessageType(Uri?,string?)"/> answers "main" rather than falling
+    /// through to a sibling endpoint's ancillary store.
+    /// </param>
+    internal void MapEndpointMessageTypeToAncillaryStore(Uri endpointUri, string messageTypeName,
+        Type? ancillaryMarkerType)
+    {
+        var key = endpointMessageTypeKey(endpointUri, messageTypeName);
+
+        // First chain registered wins, to agree with the handler that will actually run:
+        // HandlerGraph.HandlerFor(messageType, endpoint) selects ByEndpoint.FirstOrDefault(), and this
+        // loop walks the chains in that same order. Routing the envelope to a store chosen by a chain
+        // that never executes is how GH-3870 left envelopes stranded in the wrong database.
+        if (_endpointMessageTypeIsStickyRouted.Contains(key)) return;
+        _endpointMessageTypeIsStickyRouted = _endpointMessageTypeIsStickyRouted.AddOrUpdate(key, true);
+
+        if (ancillaryMarkerType != null && _ancillaryStores.TryFind(ancillaryMarkerType, out var store))
+        {
+            _endpointMessageTypeToAncillaryStore = _endpointMessageTypeToAncillaryStore.AddOrUpdate(key, store);
+        }
+    }
+
+    /// <summary>
+    /// Try to find the ancillary store that should persist an incoming envelope, preferring the answer
+    /// registered for the endpoint the envelope actually arrived on. Falls back to the message type wide
+    /// answer for any endpoint that has no sticky handler of its own. Returns null when the main store
+    /// should be used.
+    /// </summary>
+    public IMessageStore? TryFindAncillaryStoreForMessageType(Uri? endpointUri, string? messageTypeName)
+    {
+        if (messageTypeName == null) return null;
+
+        if (endpointUri != null)
+        {
+            var key = endpointMessageTypeKey(endpointUri, messageTypeName);
+
+            if (_endpointMessageTypeToAncillaryStore.TryFind(key, out var byEndpoint))
+            {
+                return byEndpoint;
+            }
+
+            // A sticky handler here that targets the main store must not inherit a sibling endpoint's
+            // ancillary store from the message type keyed fallback
+            if (_endpointMessageTypeIsStickyRouted.Contains(key))
+            {
+                return null;
+            }
+        }
+
+        return TryFindAncillaryStoreForMessageType(messageTypeName);
+    }
 }
 
 public class InvalidWolverineStorageConfigurationException : Exception

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -500,9 +500,21 @@ public partial class WolverineRuntime
             foreach (var chain in Handlers.AllChains())
             {
                 var storeType = chain.AncillaryStoreType ?? inferAncillaryStoreType(chain, markerTypes);
+                var messageTypeName = chain.MessageType.ToMessageTypeName();
+
+                // A sticky chain speaks only for its own endpoints. Record it per endpoint as well,
+                // because one message type handled by several sticky handlers targeting different
+                // stores collapses onto a single key in the message type keyed map below, where the
+                // last chain registered silently wins for every endpoint. Registered even when
+                // storeType is null so that a sticky chain on the main store is not handed a sibling
+                // endpoint's ancillary store by the fallback. See GH-3886.
+                foreach (var endpoint in chain.Endpoints)
+                {
+                    Stores.MapEndpointMessageTypeToAncillaryStore(endpoint.Uri, messageTypeName, storeType);
+                }
+
                 if (storeType == null) continue;
 
-                var messageTypeName = chain.MessageType.ToMessageTypeName();
                 Stores.MapMessageTypeToAncillaryStore(messageTypeName, storeType);
             }
         }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -223,7 +223,10 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     private void assignAncillaryStoreIfNeeded(Envelope envelope)
     {
         if (_runtime.Stores == null) return;
-        var store = _runtime.Stores.TryFindAncillaryStoreForMessageType(envelope.MessageType);
+
+        // Uri, not just the message type: a sticky handler makes the owning store endpoint specific,
+        // and this receiver only ever feeds the handler chain for its own endpoint (GH-3886).
+        var store = _runtime.Stores.TryFindAncillaryStoreForMessageType(Uri, envelope.MessageType);
         if (store != null)
         {
             envelope.Store = store;

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -259,7 +259,10 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
     private void assignAncillaryStoreIfNeeded(Envelope envelope)
     {
         if (_runtime.Stores == null) return;
-        var store = _runtime.Stores.TryFindAncillaryStoreForMessageType(envelope.MessageType);
+
+        // Uri, not just the message type: a sticky handler makes the owning store endpoint specific,
+        // and a local queue only ever feeds the handler chain for its own endpoint (GH-3886).
+        var store = _runtime.Stores.TryFindAncillaryStoreForMessageType(Uri, envelope.MessageType);
         if (store != null)
         {
             envelope.Store = store;


### PR DESCRIPTION
Fixes #3886.

## The bug

When one message type is handled by several sticky handlers targeting different ancillary stores, **every** delivery of that message type is persisted in a single store — whichever chain happened to be registered last.

The routing map is keyed by message type **name alone**:

```csharp
// MessageStoreCollection.cs
_messageTypeToAncillaryStore.AddOrUpdate(messageTypeName, store);
```

and `WolverineRuntime.HostService` writes one entry per chain over `AllChains()`, which includes the per-endpoint sticky children. Two sticky chains naming different stores collide on one key and the last one wins globally. `DurableReceiver` and `DurableLocalQueue` both already knew which endpoint the envelope arrived on and had no way to say so.

Instrumenting the reporter's repro showed **both chains carried the correct `AncillaryStoreType` the whole time**:

```
chain endpoints=[module-a-queue] AncillaryStoreType=ModuleADbContext
chain endpoints=[module-b-queue] AncillaryStoreType=ModuleBDbContext
MAPPED STORE => .../module_b_wolverine        <-- one entry, module B wins
```

So unlike #2576 / #2944 / #3870, nothing was wrong with attribute discovery. The map simply could not represent a per-endpoint answer.

**Not a regression from #3870.** Verified at `6f642021f^` that the misrouting is identical there. #3870 only changed the downstream symptom — because `MessageContext.ReadEnvelope` now adopts `envelope.Store`, the wrongly-routed rows read `Handled` instead of sitting `Incoming`.

## Severity is higher than the issue reports

The reporter's repro uses two schemas in one database, where the bug looks like cosmetic misplacement. That is an artifact of the repro: `EfCoreEnvelopeTransaction.CommitAsync` takes the **schema** from `MessageContext.Storage` (the wrongly-routed store) and the **connection** from the handler's own `DbContext`, and in a single database that cross-wiring happens to succeed.

Across real databases it cannot. Before this fix:

```
Npgsql.PostgresException: 42P01: relation "x3886_b_wolverine.wolverine_incoming_envelopes" does not exist
   at EfCoreEnvelopeTransaction.CommitAsync(...)
Envelope ... was moved to the error queue
```

with the domain write rolled back and the message dead-lettered on the **first** delivery, every time. Database-per-module is not subtly non-atomic for this shape — it is non-functional.

## The fix

A second map keyed by `(endpoint Uri, message type name)`, plus a `TryFindAncillaryStoreForMessageType(Uri?, string?)` overload that prefers it and falls back to the existing type-keyed map. Both receivers pass the endpoint they already hold.

The type-keyed map and its last-wins semantics are **untouched**, so any configuration without sticky handlers resolves exactly as before; the endpoint map only ever supplies a more specific answer.

Two details that are load-bearing:

1. A sticky chain is registered **even when it has no ancillary store**. Otherwise an endpoint whose sticky handler targets the main store falls through to the fallback and inherits its sibling's ancillary store — the same bug wearing a different hat.
2. Registration is **first-chain-wins** per (endpoint, message type), to agree with the handler that actually runs: `HandlerGraph.HandlerFor` selects `ByEndpoint.FirstOrDefault()` and the HostService loop walks that same order. Routing an envelope to a store chosen by a chain that never executes is the #3870 failure mode.

## Coverage

Every sticky × ancillary-store permutation was previously untested — only single-handler cases had tests (#2155, #2944, #3870 external; #2669 local). Added:

| Permutation | Previously covered? |
|---|---|
| Two sticky chains, different stores | no — this issue |
| Sticky chain on a store + sticky chain on MAIN | no — and broken by the naive fix |
| Two sticky chains, stores inferred from enrolled DbContexts, no attributes | no — #3870 × #3886 |
| Sticky chain + non-sticky default chain | no |
| Two sticky chains agreeing on one store | indirectly (#2576) |

plus end-to-end coverage of sticky **local** queues, where `DurableLocalQueue` was broken identically to `DurableReceiver` (red on `HEAD`, green here), and `Bug_3886_separate_databases`, which provisions its own second database and is the only test able to catch the cross-database failure above.

Note for future permutations: `HandlerChain` only splits into `ByEndpoint` chains when a message type has **more than one handler** (`if (grouping.Count() > 1)`). A lone `[StickyHandler]` handler produces no sticky chain, so a sticky permutation written with one handler silently tests nothing.

## Verification

New tests were confirmed **red at unmodified `HEAD`** first.

| Suite | Result |
|---|---|
| `EfCoreTests` full (incl. #3870 + all new tests) | 198/198 |
| Rabbit `Bug_2155`, `Bug_2944`, `Bug_1684`, `fanout_from_external_to_separated_local_handlers` | 4/4 |
| Marten `Bug_2669` | 1/1 |
| `CoreTests` sticky / separated / partitioning / local-queue config | 13/13 |
| `MessageRoutingTests` | 25/25 |
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
