### PR TITLE
Make the stalled-agent auto-restart path testable, and cover it

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/stalled_agent_auto_restart.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/stalled_agent_auto_restart.cs
@@ -1,0 +1,160 @@
+using JasperFx;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+using IProjectionDaemon = JasperFx.Events.Daemon.IProjectionDaemon;
+using JasperFxSubscriptionAgent = JasperFx.Events.Daemon.ISubscriptionAgent;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Coverage for the auto-restart branch of <see cref="EventSubscriptionAgent.CheckHealthAsync" />, which
+/// until now had none: reaching it takes three consecutive stalls sixty seconds apart, and the clock was
+/// <c>DateTimeOffset.UtcNow</c> read inline. With <see cref="EventSubscriptionAgent.TimeProvider" /> the
+/// branch is reachable in milliseconds.
+///
+/// The distinction under test is the one an operator acts on. A failure bound to a specific event will
+/// reproduce on every start, so restarting is churn that also resets their view of when it broke
+/// (GH-3638) — those are surfaced and left alone. A <see cref="ShardFailureCategory.Other" /> failure is
+/// what auto-restart exists for, and is retried.
+///
+/// The last test is skipped and states the behaviour GH-3888 asks for: that retry is node-local, so a
+/// node-level fault (memory pressure, a bad disk) reproduces on every attempt while a healthy peer
+/// advertising the same capability never gets a chance at the shard.
+/// </summary>
+public class stalled_agent_auto_restart
+{
+    private const long HighWater = 10_000;
+
+    private readonly IProjectionDaemon _daemon = Substitute.For<IProjectionDaemon>();
+    private readonly JasperFxSubscriptionAgent _inner = Substitute.For<JasperFxSubscriptionAgent>();
+    private readonly FrozenClock _clock = new(DateTimeOffset.UtcNow);
+    private readonly EventSubscriptionAgent _agent;
+    private int _restarts;
+
+    public stalled_agent_auto_restart()
+    {
+        _daemon.StartAgentAsync(Arg.Any<ShardName>(), Arg.Any<CancellationToken>()).Returns(_inner);
+        _agent = new EventSubscriptionAgent(
+            new Uri("event-subscriptions://marten/invoices/all/v16/01009333"),
+            new ShardName("invoices", "all", 16, "01009333"), _daemon) { TimeProvider = _clock };
+        _agent.OnRestarted = (_, _, _) => Interlocked.Increment(ref _restarts);
+    }
+
+    private static ShardFailure FailureOf(ShardFailureCategory category) => new()
+    {
+        Category = category,
+        ExceptionType = "System.OutOfMemoryException",
+        RootExceptionType = "System.OutOfMemoryException",
+        Message = "Exception of type 'System.OutOfMemoryException' was thrown.",
+        Detail = "System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.",
+        OccurredAt = DateTimeOffset.UtcNow
+    };
+
+    private Task<HealthCheckResult> checkAsync()
+        => _agent.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+    /// <summary>
+    /// Park the agent behind the high-water mark and run the clock past StallTimeout often enough to trip
+    /// MaxConsecutiveStallsBeforeRestart. Returns the result of the check that trips it.
+    /// </summary>
+    private async Task<HealthCheckResult> stallUntilRestartAsync()
+    {
+        _inner.Status.Returns(AgentStatus.Running);
+        // Just behind, deliberately: a bigger gap trips the warning/critical branches first and the
+        // health check returns before the stall detector is ever consulted.
+        _inner.Position.Returns(HighWater - 100);
+        _inner.HighWaterMark.Returns(HighWater);
+
+        await _agent.StartAsync(CancellationToken.None);
+        await checkAsync();                       // anchors the first observation
+
+        HealthCheckResult result = default;
+        for (var i = 0; i < 3; i++)
+        {
+            _clock.Advance(TimeSpan.FromSeconds(61));
+            result = await checkAsync();
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public async Task an_infrastructure_failure_is_retried_because_that_is_what_auto_restart_is_for()
+    {
+        _inner.Failure.Returns(FailureOf(ShardFailureCategory.Other));
+
+        var result = await stallUntilRestartAsync();
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull().ShouldContain("Attempting auto-restart");
+    }
+
+    [Fact]
+    public async Task a_failure_bound_to_one_event_is_surfaced_instead_of_restart_looped()
+    {
+        // GH-3638: restarting re-runs the identical failure and resets the operator's view every time.
+        _inner.Failure.Returns(FailureOf(ShardFailureCategory.ApplyEvent));
+
+        var result = await stallUntilRestartAsync();
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull().ShouldContain("Auto-restart suppressed");
+    }
+
+    [Fact]
+    public async Task an_agent_that_is_keeping_up_never_reaches_the_restart_branch()
+    {
+        // The counterweight to the two above: without this, a test that always trips the detector would
+        // pass just as happily against a detector that fires unconditionally.
+        _inner.Status.Returns(AgentStatus.Running);
+        _inner.Position.Returns(HighWater);
+        _inner.HighWaterMark.Returns(HighWater);
+
+        await _agent.StartAsync(CancellationToken.None);
+        await checkAsync();
+
+        for (var i = 0; i < 5; i++)
+        {
+            _clock.Advance(TimeSpan.FromSeconds(61));
+            (await checkAsync()).Status.ShouldBe(HealthStatus.Healthy);
+        }
+    }
+
+    [Fact(Skip = "GH-3888: the retry is node-local, so a node-level fault never moves the agent to a healthy peer")]
+    public async Task a_failure_that_survives_local_restarts_stops_being_retried_locally()
+    {
+        // Measured on a 512-database cluster: the warming fleet ran out of memory holding 53 agents of a
+        // projection version the serving fleet also runs. Every retry landed on the same starved node and
+        // failed identically; the serving fleet advertised the capability, was healthy, and never received
+        // them. Those read models sat frozen for sixteen minutes with a capable node beside them.
+        //
+        // After a handful of failed local restarts the agent should stop being retried here and release its
+        // assignment, so the leader can place it elsewhere. RemoveAssignmentAsync already exists in the stop
+        // path; what is missing is the policy that reaches for it — including whatever keeps the leader from
+        // handing the agent straight back to the node that just failed it.
+        _inner.Failure.Returns(FailureOf(ShardFailureCategory.Other));
+
+        await stallUntilRestartAsync();
+        for (var i = 0; i < 20; i++)
+        {
+            _clock.Advance(TimeSpan.FromSeconds(61));
+            await checkAsync();
+        }
+
+        // Today this keeps climbing for as long as the node stays broken.
+        _restarts.ShouldBeLessThanOrEqualTo(5);
+    }
+
+    /// <summary>A clock the test moves by hand; the stall detector reads nothing else.</summary>
+    private sealed class FrozenClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
@@ -16,7 +16,13 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
 
     // Health check stall tracking
     private long _lastKnownSequence;
-    private DateTimeOffset _lastAdvancedAt = DateTimeOffset.UtcNow;
+    private DateTimeOffset _lastAdvancedAt;
+
+    /// <summary>
+    /// Clock used by the stall detector. Defaults to the system clock; tests substitute it so the
+    /// auto-restart path can be exercised without waiting out StallTimeout three times over.
+    /// </summary>
+    public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
     private int _consecutiveStallCount;
 
     // Configurable thresholds (loaded from progression table, with defaults)
@@ -237,15 +243,23 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
         }
 
         // Check for stalled projection
+        if (_lastAdvancedAt == default)
+        {
+            // First observation. Anchored here rather than in the constructor so a substituted
+            // TimeProvider is the one that sets it -- otherwise the baseline comes from the system
+            // clock and every later comparison against a test clock reads as stalled since year one.
+            _lastAdvancedAt = TimeProvider.GetUtcNow();
+        }
+
         if (currentSequence != _lastKnownSequence)
         {
             // Sequence has advanced, reset stall tracking
             _lastKnownSequence = currentSequence;
-            _lastAdvancedAt = DateTimeOffset.UtcNow;
+            _lastAdvancedAt = TimeProvider.GetUtcNow();
             _consecutiveStallCount = 0;
         }
         else if (currentSequence < highWaterMark &&
-                 DateTimeOffset.UtcNow - _lastAdvancedAt > StallTimeout)
+                 TimeProvider.GetUtcNow() - _lastAdvancedAt > StallTimeout)
         {
             // Sequence hasn't changed, there are events ahead, and it's been stalled
             _consecutiveStallCount++;
@@ -290,7 +304,7 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
             await StartAsync(cancellationToken);
 
             _consecutiveStallCount = 0;
-            _lastAdvancedAt = DateTimeOffset.UtcNow;
+            _lastAdvancedAt = TimeProvider.GetUtcNow();
 
             _logger.LogInformation("Projection {Uri} auto-restart completed successfully", Uri);
 
@@ -299,7 +313,7 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
                 OnRestarted?.Invoke(
                     Uri.ToString(),
                     $"Auto-restarted after {MaxConsecutiveStallsBeforeRestart} consecutive stalled health checks",
-                    DateTimeOffset.UtcNow);
+                    TimeProvider.GetUtcNow());
             }
             catch (Exception callbackEx)
             {


### PR DESCRIPTION
Groundwork for #3888, split out so the policy discussion there isn't tangled up with a testability change.

## The problem

`EventSubscriptionAgent.CheckHealthAsync` has an auto-restart branch that nothing covers, and nothing *could* cover: reaching it takes `MaxConsecutiveStallsBeforeRestart` (3) stalls at `StallTimeout` (60s) apart, and the clock was `DateTimeOffset.UtcNow` read inline. The existing agent tests all stop at the `Degraded` branch just short of it.

That is also why the GH-3638 distinction — retry an infrastructure blip, surface a poison event — has never been asserted anywhere.

## The change

A `TimeProvider` property defaulting to `TimeProvider.System`, and the three inline clock reads routed through it.

One subtlety worth flagging: `_lastAdvancedAt` moved out of its field initialiser into a first-observation anchor inside the health check. Initialising it at construction takes the value from the system clock, so a substituted clock afterwards compares against a baseline on a different timeline and every check reads as stalled since year one. Anchoring on first use means whichever clock is in place sets the baseline.

## The tests

Three passing:

- an `Other`-category failure is retried — that is what auto-restart exists for, per `canSelfHeal`'s own doc comment
- an `ApplyEvent` failure is surfaced with "Auto-restart suppressed" instead of restart-looped (GH-3638)
- an agent that is keeping up never reaches the branch at all — the counterweight, so the first two cannot pass against a detector that fires unconditionally

One skipped, stating what #3888 asks for: after a run of failed local restarts the agent should stop being retried on the node that keeps failing it. The comment carries the measurement — a warming fleet held 53 agents of a shared projection version, went down on memory, and every retry landed on the same starved node while a healthy peer advertising the same capability stood idle. Those read models were frozen for sixteen minutes.

I have deliberately not implemented that policy. The mechanism is easy — `RemoveAssignmentAsync` is already in the stop path — but what keeps the leader from handing the agent straight back is a real design decision about the assignment grid, and I would be guessing at which shape you want. Happy to build it once you say.

`dotnet test --filter FullyQualifiedName~Runtime.Agents`: 324 passed, 1 skipped, 0 failed.