### PR TITLE
Never export empty metrics snapshots; evict idle tenants from per-tenant tracking

### DIFF
--- a/src/Testing/MetricsTests/empty_snapshot_suppression_and_idle_tenant_eviction.cs
+++ b/src/Testing/MetricsTests/empty_snapshot_suppression_and_idle_tenant_eviction.cs
@@ -1,0 +1,287 @@
+using System.Collections.Immutable;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Logging;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Metrics;
+using Wolverine.Runtime.Routing;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+
+namespace MetricsTests;
+
+/// <summary>
+/// CritterWatch #963 phase 4 — the upstream half of "99.6% of persisted metric samples are
+/// all-zero rows". An accumulator window that saw no activity must export nothing (the
+/// MetricsAccumulator XML doc always claimed this; now it is true), and a tenant idle for a
+/// bounded number of export cycles must be evicted from tracking rather than emitting a zero
+/// row forever.
+/// </summary>
+public class empty_snapshot_suppression_and_idle_tenant_eviction
+{
+    private static MessageTypeMetricsAccumulator theAccumulator()
+        => new("m1", new Uri("stub://one"));
+
+    // Applies activity synchronously through the public Process entry rather than the batching
+    // pipeline: Block.WaitForCompletionAsync() permanently completes the pipeline, so tests that
+    // span multiple accumulation windows cannot drain it more than once.
+    private static void publishExecution(MessageTypeMetricsAccumulator accumulator, string tenantId)
+    {
+        accumulator.Process([new RecordExecutionTime(100, tenantId)]);
+    }
+
+    [Fact]
+    public void export_with_no_activity_at_all_is_empty()
+    {
+        var accumulator = theAccumulator();
+
+        var metrics = accumulator.TriggerExport(1);
+
+        metrics.IsEmpty.ShouldBeTrue();
+        metrics.PerTenant.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void tracked_but_idle_tenant_contributes_no_zero_row()
+    {
+        var accumulator = theAccumulator();
+        publishExecution(accumulator, "t1");
+
+        // First export carries the activity
+        var first = accumulator.TriggerExport(1);
+        first.IsEmpty.ShouldBeFalse();
+        first.PerTenant.Single().TenantId.ShouldBe("t1");
+
+        // The tenant is still tracked, but the next window saw nothing — no zero row
+        var second = accumulator.TriggerExport(1);
+        second.IsEmpty.ShouldBeTrue();
+        second.PerTenant.ShouldBeEmpty();
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void snapshot_contains_only_the_tenants_with_activity()
+    {
+        var accumulator = theAccumulator();
+        publishExecution(accumulator, "t1");
+        publishExecution(accumulator, "t2");
+
+        // both exported once
+        accumulator.TriggerExport(1).PerTenant.Select(x => x.TenantId).ShouldBe(["t1", "t2"]);
+
+        // only t2 is active in the next window; t1 stays tracked but emits nothing
+        publishExecution(accumulator, "t2");
+        var metrics = accumulator.TriggerExport(1);
+        metrics.PerTenant.Single().TenantId.ShouldBe("t2");
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("execution")]
+    [InlineData("effective")]
+    [InlineData("sent")]
+    [InlineData("received")]
+    [InlineData("failure")]
+    [InlineData("dead_letter")]
+    public async Task any_single_kind_of_activity_makes_the_snapshot_non_empty(string kind)
+    {
+        var accumulator = theAccumulator();
+
+        IHandlerMetricsData data = kind switch
+        {
+            "execution" => new RecordExecutionTime(50, "t1"),
+            "effective" => new RecordEffectiveTime(50.5, "t1"),
+            "sent" => new RecordSent("t1", "stub://source"),
+            "received" => new RecordReceived("t1", "stub://source"),
+            "failure" => new RecordFailure(typeof(DivideByZeroException).FullNameInCode(), "t1"),
+            "dead_letter" => new RecordDeadLetter(typeof(DivideByZeroException).FullNameInCode(), "t1"),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+
+        await accumulator.EntryPoint.PostAsync(data);
+        await accumulator.EntryPoint.WaitForCompletionAsync();
+
+        var metrics = accumulator.TriggerExport(1);
+        metrics.IsEmpty.ShouldBeFalse();
+        metrics.PerTenant.Single().TenantId.ShouldBe("t1");
+
+        // and the window after it is empty again
+        accumulator.TriggerExport(1).IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void tenant_is_evicted_after_the_configured_number_of_idle_export_cycles()
+    {
+        var accumulator = theAccumulator();
+        publishExecution(accumulator, "t1");
+
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3).IsEmpty.ShouldBeFalse();
+
+        // two idle cycles — still tracked
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+
+        // third consecutive idle cycle — evicted
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void evicted_tenant_is_retracked_on_new_activity()
+    {
+        var accumulator = theAccumulator();
+        publishExecution(accumulator, "t1");
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 1);
+
+        // one idle cycle at threshold 1 evicts immediately
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 1);
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeFalse();
+
+        // new activity re-creates the tracking entry and exports normally
+        publishExecution(accumulator, "t1");
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+
+        var metrics = accumulator.TriggerExport(1, idleTenantEvictionCycles: 1);
+        metrics.PerTenant.Single().TenantId.ShouldBe("t1");
+        metrics.PerTenant.Single().Executions.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void new_activity_resets_the_idle_cycle_count()
+    {
+        var accumulator = theAccumulator();
+        publishExecution(accumulator, "t1");
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+
+        // two idle cycles...
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+
+        // ...then activity resets the clock...
+        publishExecution(accumulator, "t1");
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+
+        // ...so two more idle cycles do NOT evict
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+
+        // but the third does
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 3);
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void zero_or_negative_threshold_disables_eviction()
+    {
+        var accumulator = theAccumulator();
+        publishExecution(accumulator, "t1");
+        accumulator.TriggerExport(1, idleTenantEvictionCycles: 0);
+
+        for (var i = 0; i < 50; i++)
+        {
+            accumulator.TriggerExport(1, idleTenantEvictionCycles: 0);
+        }
+
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+
+        for (var i = 0; i < 50; i++)
+        {
+            accumulator.TriggerExport(1, idleTenantEvictionCycles: -1);
+        }
+
+        accumulator.Counts.PerTenant.Contains("t1").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task background_export_loop_publishes_activity_but_not_idle_windows()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Metrics.Mode = WolverineMetricsMode.CritterWatch;
+                opts.Metrics.SamplingPeriod = 250.Milliseconds();
+                opts.OnAnyException().RetryTimes(3).Then.MoveToErrorQueue();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.GetRuntime();
+        var observer = new InstanceCapturingObserver();
+        runtime.Observer = observer;
+
+        var bus = host.MessageBus();
+        for (var i = 0; i < 10; i++)
+        {
+            await bus.PublishAsync(new M1(Guid.CreateVersion7()));
+        }
+
+        // the export tick following the activity publishes a non-empty snapshot
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (observer.Collected.IsEmpty && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        observer.Collected.ShouldNotBeEmpty();
+        observer.Collected.ShouldAllBe(x => !x.IsEmpty);
+
+        // now go quiet: several full sampling periods with no traffic publish nothing at all,
+        // even though the accumulator for M1 still exists
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+        observer.Clear();
+        await Task.Delay(1500, TestContext.Current.CancellationToken);
+
+        observer.Collected.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Instance-scoped capture (unlike the static <see cref="MetricsCollectionHandler"/>) so this
+    /// class's host-level assertions cannot be polluted by other test classes running in parallel.
+    /// </summary>
+    private class InstanceCapturingObserver : IWolverineObserver
+    {
+        private readonly object _lock = new();
+
+        public ImmutableArray<MessageHandlingMetrics> Collected { get; private set; }
+            = ImmutableArray<MessageHandlingMetrics>.Empty;
+
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                Collected = ImmutableArray<MessageHandlingMetrics>.Empty;
+            }
+        }
+
+        public void MessageHandlingMetricsExported(MessageHandlingMetrics metrics)
+        {
+            lock (_lock)
+            {
+                Collected = Collected.Add(metrics);
+            }
+        }
+
+        public Task AssumedLeadership() => Task.CompletedTask;
+        public Task NodeStarted() => Task.CompletedTask;
+        public Task NodeStopped() => Task.CompletedTask;
+        public Task AgentStarted(Uri agentUri) => Task.CompletedTask;
+        public Task AgentStopped(Uri agentUri) => Task.CompletedTask;
+        public Task AssignmentsChanged(AssignmentGrid grid, AgentCommands commands) => Task.CompletedTask;
+        public Task StaleNodes(IReadOnlyList<WolverineNode> staleNodes) => Task.CompletedTask;
+        public Task RuntimeIsFullyStarted() => Task.CompletedTask;
+        public void EndpointAdded(Endpoint endpoint) { }
+        public void MessageRouted(Type messageType, IMessageRouter router) { }
+        public Task BackPressureTriggered(Endpoint endpoint, IListeningAgent agent) => Task.CompletedTask;
+        public Task BackPressureLifted(Endpoint endpoint) => Task.CompletedTask;
+        public Task ListenerLatched(Endpoint endpoint) => Task.CompletedTask;
+        public Task CircuitBreakerTripped(Endpoint endpoint, CircuitBreakerOptions options) => Task.CompletedTask;
+        public Task CircuitBreakerReset(Endpoint endpoint) => Task.CompletedTask;
+        public void PersistedCounts(Uri storeUri, PersistedCounts counts) { }
+    }
+}

--- a/src/Wolverine/Runtime/Metrics/MessageHandlingMetrics.cs
+++ b/src/Wolverine/Runtime/Metrics/MessageHandlingMetrics.cs
@@ -4,7 +4,7 @@ namespace Wolverine.Runtime.Metrics;
 
 /// <summary>
 /// Immutable snapshot of message handling metrics for a specific message type and destination
-/// combination over a time range. Produced by <see cref="MessageTypeMetricsAccumulator.TriggerExport"/>
+/// combination over a time range. Produced by <see cref="MessageTypeMetricsAccumulator.TriggerExport(int, int)"/>
 /// on each sampling period. Contains per-tenant breakdowns of execution counts, effective times,
 /// and exception counts.
 /// </summary>
@@ -27,6 +27,14 @@ public record MessageHandlingMetrics(
     /// </summary>
     /// <returns>A composite key string.</returns>
     public string Key() => $"{MessageType}@{Destination}";
+
+    /// <summary>
+    /// True when this snapshot carries no tenant data points at all — i.e. no message was sent,
+    /// received, executed, completed, failed, or dead-lettered for this message type and
+    /// destination during the time range. Empty snapshots are not published to
+    /// <see cref="Wolverine.Runtime.Agents.IWolverineObserver"/> by <see cref="MetricsAccumulator"/>.
+    /// </summary>
+    public bool IsEmpty => PerTenant.Length == 0;
 
     /// <summary>
     /// Combines multiple <see cref="MessageHandlingMetrics"/> snapshots into a single aggregate.

--- a/src/Wolverine/Runtime/Metrics/MessageTypeMetricsAccumulator.cs
+++ b/src/Wolverine/Runtime/Metrics/MessageTypeMetricsAccumulator.cs
@@ -8,7 +8,7 @@ namespace Wolverine.Runtime.Metrics;
 /// Accumulates handler metrics for a single message type and destination combination using
 /// a batching pipeline. <see cref="IHandlerMetricsData"/> records are posted to <see cref="EntryPoint"/>
 /// which batches them (up to 500 items or 250ms) before applying to the underlying
-/// <see cref="MessageHandlingCounts"/>. On each sampling period, <see cref="TriggerExport"/>
+/// <see cref="MessageHandlingCounts"/>. On each sampling period, <see cref="TriggerExport(int, int)"/>
 /// snapshots the accumulated counters into an immutable <see cref="MessageHandlingMetrics"/>
 /// record and resets the counters for the next period.
 /// </summary>
@@ -44,7 +44,7 @@ public class MessageTypeMetricsAccumulator
 
     /// <summary>
     /// The start of the current accumulation time window. Reset to <c>DateTimeOffset.UtcNow</c>
-    /// after each <see cref="TriggerExport"/> call.
+    /// after each <see cref="TriggerExport(int, int)"/> call.
     /// </summary>
     public DateTimeOffset Starting { get; private set; } = DateTimeOffset.UtcNow;
 
@@ -86,20 +86,73 @@ public class MessageTypeMetricsAccumulator
     /// Snapshots the accumulated counters into an immutable <see cref="MessageHandlingMetrics"/>
     /// record spanning from <see cref="Starting"/> to now, then resets the counters and advances
     /// <see cref="Starting"/> to the current time for the next accumulation window. Called by
-    /// <see cref="MetricsAccumulator"/> on each sampling period.
+    /// <see cref="MetricsAccumulator"/> on each sampling period. Uses the default idle-tenant
+    /// eviction threshold of <see cref="MetricsOptions.DefaultTenantIdleEvictionCycles"/>.
     /// </summary>
     /// <param name="nodeNumber">The assigned node number for this Wolverine instance.</param>
     /// <returns>An immutable metrics snapshot for the completed accumulation window.</returns>
     public MessageHandlingMetrics TriggerExport(int nodeNumber)
     {
+        return TriggerExport(nodeNumber, MetricsOptions.DefaultTenantIdleEvictionCycles);
+    }
+
+    /// <summary>
+    /// Snapshots the accumulated counters into an immutable <see cref="MessageHandlingMetrics"/>
+    /// record spanning from <see cref="Starting"/> to now, then resets the counters and advances
+    /// <see cref="Starting"/> to the current time for the next accumulation window. Called by
+    /// <see cref="MetricsAccumulator"/> on each sampling period.
+    ///
+    /// Only tenants with recorded activity in the window contribute a
+    /// <see cref="PerTenantMetrics"/> entry — idle tenants emit nothing rather than an all-zero
+    /// row. A tenant that stays idle for <paramref name="idleTenantEvictionCycles"/> consecutive
+    /// exports is evicted from tracking entirely (and re-tracked automatically on its next
+    /// activity), so the per-tenant series set stays bounded by recently-active tenants.
+    /// </summary>
+    /// <param name="nodeNumber">The assigned node number for this Wolverine instance.</param>
+    /// <param name="idleTenantEvictionCycles">The number of consecutive idle export cycles after
+    /// which a tenant's tracking entry is evicted. Zero or negative disables eviction.</param>
+    /// <returns>An immutable metrics snapshot for the completed accumulation window. The
+    /// <see cref="MessageHandlingMetrics.PerTenant"/> array is empty when no tenant recorded any
+    /// activity in the window.</returns>
+    public MessageHandlingMetrics TriggerExport(int nodeNumber, int idleTenantEvictionCycles)
+    {
         lock (_syncLock)
         {
             var time = DateTimeOffset.UtcNow;
 
+            var perTenant = new List<PerTenantMetrics>();
+            List<string>? evictions = null;
+
+            foreach (var tracking in Counts.PerTenant.OrderBy(x => x.TenantId))
+            {
+                if (tracking.HasActivity)
+                {
+                    tracking.ConsecutiveIdleExports = 0;
+                    perTenant.Add(tracking.CompileAndReset());
+                }
+                else
+                {
+                    tracking.ConsecutiveIdleExports++;
+                    if (idleTenantEvictionCycles > 0 && tracking.ConsecutiveIdleExports >= idleTenantEvictionCycles)
+                    {
+                        evictions ??= new List<string>();
+                        evictions.Add(tracking.TenantId);
+                    }
+                }
+            }
+
+            if (evictions != null)
+            {
+                foreach (var tenantId in evictions)
+                {
+                    Counts.PerTenant.Remove(tenantId);
+                }
+            }
+
             var metrics = new MessageHandlingMetrics(MessageType,
                 Destination,
                 new TimeRange(Starting, time),
-                Counts.PerTenant.OrderBy(x => x.TenantId).Select(x => x.CompileAndReset()).ToArray());
+                perTenant.ToArray());
 
             Starting = time;
 

--- a/src/Wolverine/Runtime/Metrics/MetricsAccumulator.cs
+++ b/src/Wolverine/Runtime/Metrics/MetricsAccumulator.cs
@@ -11,7 +11,10 @@ namespace Wolverine.Runtime.Metrics;
 /// (message type, destination) pair. Runs a background loop that periodically (every
 /// <c>WolverineOptions.Metrics.SamplingPeriod</c>, default 5 seconds) triggers each
 /// accumulator to export its snapshot via <see cref="IWolverineObserver.MessageHandlingMetricsExported"/>.
-/// Only snapshots with at least one tenant data point are published.
+/// Only snapshots with at least one tenant data point are published — an accumulator whose window
+/// saw no activity at all exports nothing rather than an all-zero snapshot, and tenants idle for
+/// <c>WolverineOptions.Metrics.TenantIdleEvictionCycles</c> consecutive exports are evicted from
+/// tracking (re-tracked automatically on next activity).
 /// </summary>
 // TODO -- make this lazy on WolverineRuntime
 public class MetricsAccumulator : IAsyncDisposable
@@ -112,9 +115,19 @@ public class MetricsAccumulator : IAsyncDisposable
                     await Task.Delay(_runtime.Options.Metrics.SamplingPeriod);
                     try
                     {
+                        var idleTenantEvictionCycles = _runtime.Options.Metrics.TenantIdleEvictionCycles;
                         foreach (var accumulator in _accumulators)
                         {
-                            var metrics = accumulator.TriggerExport(_runtime.DurabilitySettings.AssignedNodeNumber);
+                            var metrics = accumulator.TriggerExport(
+                                _runtime.DurabilitySettings.AssignedNodeNumber,
+                                idleTenantEvictionCycles);
+
+                            // An idle window exports nothing. Because these snapshots carry
+                            // per-window delta counts (not cumulative counters), absence reads
+                            // as zero downstream — no consumer needs an explicit all-zero row
+                            // to compute rates.
+                            if (metrics.IsEmpty) continue;
+
                             _runtime.Observer.MessageHandlingMetricsExported(metrics);
                         }
                     }

--- a/src/Wolverine/Runtime/Metrics/PerTenantTracking.cs
+++ b/src/Wolverine/Runtime/Metrics/PerTenantTracking.cs
@@ -68,6 +68,30 @@ public class PerTenantTracking
     public Dictionary<string, int> Failures { get; } = new();
 
     /// <summary>
+    /// The number of consecutive export cycles in which this tenant recorded no activity at all.
+    /// Maintained by <see cref="MessageTypeMetricsAccumulator.TriggerExport(int, int)"/> — reset
+    /// to zero whenever the tenant has activity, incremented on each idle export. When it reaches
+    /// the configured eviction threshold (<c>WolverineOptions.Metrics.TenantIdleEvictionCycles</c>),
+    /// the tenant entry is removed from tracking altogether and will be re-created on its next
+    /// recorded activity.
+    /// </summary>
+    public int ConsecutiveIdleExports { get; set; }
+
+    /// <summary>
+    /// Whether any activity at all has been recorded in the current accumulation window — any
+    /// non-zero counter or duration, or any failure or dead-letter entry. A tenant with no
+    /// activity contributes nothing to the exported snapshot.
+    /// </summary>
+    public bool HasActivity => Executions != 0
+                               || TotalExecutionTime != 0
+                               || Completions != 0
+                               || TotalEffectiveTime != 0
+                               || Sent != 0
+                               || Received != 0
+                               || DeadLetterCounts.Count > 0
+                               || Failures.Count > 0;
+
+    /// <summary>
     /// Snapshots the current counter values into an immutable <see cref="PerTenantMetrics"/>
     /// record, then resets all counters to zero. The exception counts are compiled by taking
     /// the union of exception types across <see cref="Failures"/> and <see cref="DeadLetterCounts"/>.

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -134,6 +134,23 @@ public class MetricsOptions
     public TimeSpan SamplingPeriod { get; set; } = 5.Seconds();
 
     /// <summary>
+    /// Default value for <see cref="TenantIdleEvictionCycles"/> (12 sampling periods, i.e. one
+    /// minute at the default <see cref="SamplingPeriod"/> of 5 seconds).
+    /// </summary>
+    public const int DefaultTenantIdleEvictionCycles = 12;
+
+    /// <summary>
+    /// If using either CritterWatch or Hybrid metrics publishing, the number of consecutive
+    /// sampling periods a tenant may go without any recorded activity for a given message type and
+    /// destination before its per-tenant tracking entry is evicted. Evicted tenants are re-tracked
+    /// automatically on their next activity. This bounds the per-tenant metrics series set in
+    /// high-tenant-count systems instead of letting it grow monotonically. The idle window in wall
+    /// clock time is roughly this value times <see cref="SamplingPeriod"/> (default: 12 cycles ~= 1
+    /// minute). Set to zero or a negative number to never evict idle tenants.
+    /// </summary>
+    public int TenantIdleEvictionCycles { get; set; } = DefaultTenantIdleEvictionCycles;
+
+    /// <summary>
     /// Default explicit histogram bucket boundaries (in milliseconds) applied to the
     /// <c>wolverine-execution-time</c> and <c>wolverine-effective-time</c> histograms. The
     /// OpenTelemetry SDK's default buckets are poor for millisecond-scale latencies; these are tuned for


### PR DESCRIPTION
Upstream half of JasperFx/CritterWatch#963 (99.6% of persisted metric samples in idle fleets were all-zero rows). Targets 6.25.5.

## What changed

1. **Empty-snapshot suppression.** `MessageTypeMetricsAccumulator.TriggerExport` now compiles a `PerTenantMetrics` entry only for tenants whose window had activity, via a new `PerTenantTracking.HasActivity` covering every counter and duration (`Executions`, `TotalExecutionTime`, `Completions`, `TotalEffectiveTime`, `Sent`, `Received`, `Failures`, `DeadLetterCounts`). `MessageHandlingMetrics` gained `IsEmpty`, and `MetricsAccumulator`'s export loop skips empty snapshots — making its XML-doc claim true for the first time.
2. **Idle-tenant eviction.** A tenant idle for N consecutive export cycles is removed from `MessageHandlingCounts.PerTenant` (a `LightweightCache`, so it re-creates on next activity). Configurable via `WolverineOptions.Metrics.TenantIdleEvictionCycles` — default 12 (~1 minute at the default 5 s `SamplingPeriod`); `<= 0` disables. Activity resets the idle count. The old `TriggerExport(int)` overload remains as a delegating overload, so existing callers stay source- and binary-compatible.

## Semantics: full suppression, no first-zero edge

These snapshots carry per-window **delta** counts (all counters reset at every export), not cumulative series — absence is semantically identical to zero, and no consumer computes deltas between consecutive snapshots. On the CritterWatch side the rollup extends every window's denominator to wall-clock now on read, so displayed rates decay to zero without an explicit zero row (CritterWatch's #963 phases 1–2 already made presence-derived quantities wall-clock-derived). A last-nonzero→zero edge publish would buy nothing.

## Tests

14 new tests in `src/Testing/MetricsTests/empty_snapshot_suppression_and_idle_tenant_eviction.cs`: no-activity export is empty; tracked-but-idle tenant emits no zero row; only active tenants appear; a Theory proving each of the six activity kinds alone makes a snapshot non-empty; eviction exactly at threshold; re-tracking after eviction; activity resetting the idle clock; `<= 0` disabling eviction; and a host-level test that the background export loop publishes during activity and nothing during idle windows. MetricsTests suite: **39/39 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)