### PR TITLE
GH-3887: saga diagnostics tolerate an unprovisioned saga table; fixtures provision their own storage

### DIFF
--- a/src/Persistence/PostgresqlTests/Sagas/postgres_saga_store_diagnostics_tests.cs
+++ b/src/Persistence/PostgresqlTests/Sagas/postgres_saga_store_diagnostics_tests.cs
@@ -1,11 +1,14 @@
 using IntegrationTests;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 using Shouldly;
 using Wolverine;
 using Wolverine.Configuration.Capabilities;
 using Wolverine.Persistence.Sagas;
 using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
 using Wolverine.Tracking;
 using Xunit;
 
@@ -30,7 +33,24 @@ public class postgres_saga_store_diagnostics_tests : IAsyncLifetime
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.Discovery.DisableConventionalDiscovery().IncludeType<PgDiagSaga>();
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<PgDiagSaga>()
+                    .IncludeType<UnprovisionedPgDiagSaga>();
+
+                // Registering the saga type is what puts its table into the
+                // message store's schema build, so the table exists as soon
+                // as the host starts. Without this, pgdiagsaga_saga only came
+                // into being when a sibling test persisted an instance first -
+                // an inter-test order dependency that turned
+                // read_saga_returns_null_for_missing_instance red on fresh
+                // infrastructure (GH-3887).
+                opts.AddSagaType<PgDiagSaga>();
+
+                // UnprovisionedPgDiagSaga is deliberately NOT registered via
+                // AddSagaType and never started: it pins the diagnostics
+                // API's graceful handling of a declared-but-never-provisioned
+                // saga (no table yet) below.
+
                 opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "saga_diag_pg");
                 opts.PublishAllMessages().Locally();
             })
@@ -105,9 +125,58 @@ public class postgres_saga_store_diagnostics_tests : IAsyncLifetime
         read.ShouldBeNull();
         list.ShouldBeEmpty();
     }
+
+    [Fact]
+    public async Task declared_but_never_provisioned_saga_reads_as_empty_instead_of_42P01()
+    {
+        // AddSagaType is optional, so a correctly configured application can
+        // have a known saga type whose table does not exist until the first
+        // instance is persisted. The diagnostics surface must treat that
+        // state as "no instances", not surface a raw undefined-table error
+        // (GH-3887). UnprovisionedPgDiagSaga is in the handler graph but is
+        // never registered via AddSagaType and never started - and to keep
+        // this deterministic on any infrastructure state, drop its table if
+        // some earlier run left one behind.
+        var tableName = new SagaTableDefinition(typeof(UnprovisionedPgDiagSaga), null).TableName;
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"drop table if exists saga_diag_pg.{tableName}";
+            await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var diagnostics = _host.GetRuntime().SagaStorage;
+
+        var read = await diagnostics.ReadSagaAsync(
+            typeof(UnprovisionedPgDiagSaga).FullName!, Guid.NewGuid().ToString("N"), CancellationToken.None);
+        var list = await diagnostics.ListSagaInstancesAsync(
+            typeof(UnprovisionedPgDiagSaga).FullName!, 10, CancellationToken.None);
+
+        read.ShouldBeNull();
+        list.ShouldBeEmpty();
+    }
 }
 
 public record StartPgDiagSaga(string Id, string Note);
+
+public record StartUnprovisionedPgDiagSaga(string Id);
+
+/// <summary>
+/// Deliberately never registered with <c>AddSagaType</c> and never started
+/// by any test: its table must not exist, pinning the graceful "declared
+/// but never provisioned" path in the saga diagnostics (GH-3887).
+/// </summary>
+public class UnprovisionedPgDiagSaga : Saga
+{
+    [SagaIdentity]
+    public string? Id { get; set; }
+
+    public static UnprovisionedPgDiagSaga Start(StartUnprovisionedPgDiagSaga cmd)
+    {
+        return new UnprovisionedPgDiagSaga { Id = cmd.Id };
+    }
+}
 
 public class PgDiagSaga : Saga
 {

--- a/src/Persistence/SqlServerTests/Sagas/sqlserver_saga_store_diagnostics_tests.cs
+++ b/src/Persistence/SqlServerTests/Sagas/sqlserver_saga_store_diagnostics_tests.cs
@@ -1,9 +1,12 @@
 using IntegrationTests;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Shouldly;
 using Wolverine;
 using Wolverine.Persistence.Sagas;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
 using Wolverine.SqlServer;
 using Wolverine.Tracking;
 using Xunit;
@@ -29,7 +32,20 @@ public class sqlserver_saga_store_diagnostics_tests : IAsyncLifetime
         _host = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.Discovery.DisableConventionalDiscovery().IncludeType<MsSqlDiagSaga>();
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<MsSqlDiagSaga>()
+                    .IncludeType<UnprovisionedMsSqlDiagSaga>();
+
+                // Same fix as the Postgres twin (GH-3887): registering the
+                // saga type puts its table into the message store's schema
+                // build so it exists deterministically at host start, rather
+                // than only after a sibling test persists an instance.
+                opts.AddSagaType<MsSqlDiagSaga>();
+
+                // UnprovisionedMsSqlDiagSaga is deliberately NOT registered
+                // via AddSagaType and never started - see the
+                // declared-but-never-provisioned test below.
+
                 opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "saga_diag_mssql");
                 opts.PublishAllMessages().Locally();
             })
@@ -93,9 +109,67 @@ public class sqlserver_saga_store_diagnostics_tests : IAsyncLifetime
         read.ShouldBeNull();
         list.ShouldBeEmpty();
     }
+
+    [Fact]
+    public async Task read_saga_returns_null_for_missing_instance()
+    {
+        // Parity with the Postgres twin: reads a known saga type without
+        // persisting an instance first. Only safe on fresh infrastructure
+        // because the fixture now calls AddSagaType (GH-3887).
+        var diagnostics = _host.GetRuntime().SagaStorage;
+        var state = await diagnostics.ReadSagaAsync(
+            typeof(MsSqlDiagSaga).FullName!, Guid.NewGuid().ToString("N"), CancellationToken.None);
+        state.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task declared_but_never_provisioned_saga_reads_as_empty_instead_of_invalid_object_name()
+    {
+        // The SQL Server flavor of the GH-3887 product half: a known saga
+        // type with no table yet (AddSagaType omitted, nothing persisted)
+        // must read as "no instances" rather than surfacing error 208
+        // "Invalid object name". Drop the table first so the precondition
+        // holds on any infrastructure state.
+        var tableName = new SagaTableDefinition(typeof(UnprovisionedMsSqlDiagSaga), null).TableName;
+        await using (var conn = new SqlConnection(Servers.SqlServerConnectionString))
+        {
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"drop table if exists saga_diag_mssql.{tableName}";
+            await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var diagnostics = _host.GetRuntime().SagaStorage;
+
+        var read = await diagnostics.ReadSagaAsync(
+            typeof(UnprovisionedMsSqlDiagSaga).FullName!, Guid.NewGuid().ToString("N"), CancellationToken.None);
+        var list = await diagnostics.ListSagaInstancesAsync(
+            typeof(UnprovisionedMsSqlDiagSaga).FullName!, 10, CancellationToken.None);
+
+        read.ShouldBeNull();
+        list.ShouldBeEmpty();
+    }
 }
 
 public record StartMsSqlDiagSaga(string Id, string Note);
+
+public record StartUnprovisionedMsSqlDiagSaga(string Id);
+
+/// <summary>
+/// Deliberately never registered with <c>AddSagaType</c> and never started
+/// by any test: its table must not exist, pinning the graceful "declared
+/// but never provisioned" path in the saga diagnostics (GH-3887).
+/// </summary>
+public class UnprovisionedMsSqlDiagSaga : Saga
+{
+    [SagaIdentity]
+    public string? Id { get; set; }
+
+    public static UnprovisionedMsSqlDiagSaga Start(StartUnprovisionedMsSqlDiagSaga cmd)
+    {
+        return new UnprovisionedMsSqlDiagSaga { Id = cmd.Id };
+    }
+}
 
 public class MsSqlDiagSaga : Saga
 {

--- a/src/Persistence/Wolverine.RDBMS/Sagas/DatabaseSagaStoreDiagnostics.cs
+++ b/src/Persistence/Wolverine.RDBMS/Sagas/DatabaseSagaStoreDiagnostics.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using JasperFx.Core.Reflection;
@@ -77,6 +78,16 @@ public sealed class DatabaseSagaStoreDiagnostics : ISagaStoreDiagnostics
             var body = readBody(reader, 0);
             return buildInstance(definition, identity!, body);
         }
+        catch (DbException e) when (isMissingTableException(e))
+        {
+            // AddSagaType is explicitly optional, so a correctly configured
+            // application can have a saga type whose table has not been
+            // provisioned yet (the runtime creates it lazily on first
+            // persist). To a diagnostic caller that state is
+            // indistinguishable from "no instances", so report null rather
+            // than surfacing the provider's undefined-table error (GH-3887).
+            return null;
+        }
         finally
         {
             await conn.CloseAsync().ConfigureAwait(false);
@@ -109,10 +120,50 @@ public sealed class DatabaseSagaStoreDiagnostics : ISagaStoreDiagnostics
             }
             return list;
         }
+        catch (DbException e) when (isMissingTableException(e))
+        {
+            // Same contract as ReadSagaAsync: a declared-but-never-persisted
+            // saga has no table yet, which reads as "no instances" (GH-3887).
+            return Array.Empty<SagaInstanceState>();
+        }
         finally
         {
             await conn.CloseAsync().ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// True when the exception is the backing database's flavor of
+    /// "relation / table does not exist". Kept dialect-agnostic - same
+    /// rationale as <see cref="renderTopNQuery"/>: this class works
+    /// against every RDBMS message store without referencing the
+    /// dialect packages, so it recognises each provider's shape rather
+    /// than catching a provider-specific exception type.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Best-effort probe of the provider exception's 'Number' property (SqlClient 208, " +
+                        "MySqlConnector 1146, Oracle 942). Provider exception types survive trimming in " +
+                        "practice; if the property were removed the check falls through to the " +
+                        "SqlState / message checks and, at worst, the exception propagates exactly as " +
+                        "it did before this handling existed.")]
+    private static bool isMissingTableException(DbException ex)
+    {
+        // Postgres: 42P01 undefined_table. MySQL: ER_NO_SUCH_TABLE surfaces
+        // the ODBC-standard 42S02 ("base table or view not found").
+        if (ex.SqlState is "42P01" or "42S02") return true;
+
+        // SQL Server (208 "Invalid object name"), MySQL (1146), and Oracle
+        // (ORA-00942) expose the provider error number on a 'Number'
+        // property, but there is no shared base member for it.
+        if (ex.GetType().GetProperty("Number")?.GetValue(ex) is int number &&
+            number is 208 or 1146 or 942)
+        {
+            return true;
+        }
+
+        // SQLite only reports the generic error code 1 (SQLITE_ERROR) for a
+        // missing table; its (non-localised) message is the discriminator.
+        return ex.Message.Contains("no such table", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3887.

## Root cause

Two halves, one underlying fact: `AddSagaType` is explicitly optional, so a saga's table may legitimately not exist until the first instance is persisted.

**Test infra:** `postgres_saga_store_diagnostics_tests` never called `AddSagaType<PgDiagSaga>()`, so `saga_diag_pg.pgdiagsaga_saga` was only created when a sibling test happened to persist an instance first. `read_saga_returns_null_for_missing_instance` — the one test that reads a known saga type without persisting — therefore failed with a raw `42P01` on fresh infrastructure and passed by accident forever after. The SQL Server twin had the identical latent gap; it only stayed green because it lacked the missing-instance read test.

**Product:** `DatabaseSagaStoreDiagnostics.ReadSagaAsync` / `ListSagaInstancesAsync` (shared `Wolverine.RDBMS` code serving Postgres, SQL Server, MySQL, SQLite, and Oracle) had no handling for a missing relation, so a declared-but-never-run saga surfaced the provider's undefined-table exception to diagnostics consumers (e.g. CritterWatch's saga explorer).

## Changes

- **`DatabaseSagaStoreDiagnostics`**: a missing saga table now reads as *no instances* — `ReadSagaAsync` returns `null`, `ListSagaInstancesAsync` returns empty — matching the interface's documented `null` / empty semantics for "no instance" / "not owned". Detection is dialect-agnostic (same spirit as `renderTopNQuery`): SQLSTATE `42P01`/`42S02`, provider error number 208 (SqlClient) / 1146 (MySQL) / 942 (Oracle) probed reflectively with a trim-safe fallback, and SQLite's `no such table` message. Any other `DbException` propagates unchanged.
- **Postgres + SQL Server fixtures**: now call `AddSagaType<...>()` so the schema build creates the saga table deterministically at host start, removing the inter-test order dependency.
- **New pin tests** (both dialects): `declared_but_never_provisioned_saga_reads_as_empty_*` deliberately targets a saga in the handler graph whose table is dropped first, pinning the graceful degradation. Also added `read_saga_returns_null_for_missing_instance` to the SQL Server class for parity — the missing test that had been hiding its fixture gap.

MySQL / SQLite / Oracle diagnostics fixtures were left untouched: they have no missing-instance read test, so no virgin-infra red, and the product fix is shared code that covers them.

## Test evidence

All runs against **dropped schemas** (the issue's virgin-infrastructure repro):

- `read_saga_returns_null_for_missing_instance` solo on a dropped `saga_diag_pg`: **passed** (previously `42P01`).
- Negative control: with the product half reverted to `origin/main`, the new Postgres pin test fails with exactly `42P01: relation "saga_diag_pg.unprovisionedpgdiagsaga_saga" does not exist`; with the fix, green.
- `PostgresqlTests.Sagas`: 51/51 passed. `SqlServerTests.Sagas`: 56 passed / 1 skipped. `sqlite_saga_store_diagnostics_tests`: 4/4 passed (cross-dialect check of the shared code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)