### PR TITLE
GH-3892: short-circuiting Before + Finally on one middleware class works instead of NRE-ing at codegen

### DIFF
--- a/src/Http/Wolverine.Http.Tests/short_circuiting_middleware_with_finally_3892.cs
+++ b/src/Http/Wolverine.Http.Tests/short_circuiting_middleware_with_finally_3892.cs
@@ -1,0 +1,115 @@
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests;
+
+// GH-3892: a middleware class declaring BOTH a short-circuiting Before
+// (return type includes IResult) and a Finally/FinallyAsync method used to
+// throw NullReferenceException during HTTP chain code generation
+public class short_circuiting_middleware_with_finally_3892 : IntegrationContext
+{
+    public short_circuiting_middleware_with_finally_3892(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    private Recorder recorder()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+        return recorder;
+    }
+
+    [Fact]
+    public async Task continue_path_runs_body_and_finally()
+    {
+        var recorder = this.recorder();
+
+        var body = await Scenario(x =>
+        {
+            x.Get.Url("/middleware/shortcircuit-finally");
+            x.StatusCodeShouldBeOk();
+        });
+
+        recorder.Actions.ShouldHaveTheSameElementsAs(
+            "ShortCircuit.Before",
+            "ShortCircuit.Action",
+            "ShortCircuit.Finally");
+    }
+
+    [Fact]
+    public async Task short_circuit_path_writes_result_skips_body_and_still_runs_finally()
+    {
+        var recorder = this.recorder();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/shortcircuit-finally?stop=true");
+            x.StatusCodeShouldBe(418);
+        });
+
+        recorder.Actions.ShouldHaveTheSameElementsAs(
+            "ShortCircuit.Before",
+            "ShortCircuit.Finally");
+    }
+
+    [Fact]
+    public async Task exception_path_still_runs_finally()
+    {
+        var recorder = this.recorder();
+
+        try
+        {
+            await Scenario(x =>
+            {
+                x.Get.Url("/middleware/shortcircuit-finally/throws");
+                x.IgnoreStatusCode();
+            });
+        }
+        catch (Exception)
+        {
+            // The endpoint throws on purpose; depending on hosting the exception
+            // either surfaces here or as a 500. Either way Finally must have run.
+        }
+
+        recorder.Actions.ShouldHaveTheSameElementsAs(
+            "ShortCircuit.Before",
+            "ShortCircuit.Throws",
+            "ShortCircuit.Finally");
+    }
+
+    [Fact]
+    public async Task tuple_carrying_before_with_finally_async_continue_path()
+    {
+        var recorder = this.recorder();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/shortcircuit-finally/tuple");
+            x.StatusCodeShouldBeOk();
+        });
+
+        recorder.Actions.ShouldHaveTheSameElementsAs(
+            "TupleShortCircuit.Before",
+            "TupleShortCircuit.Action",
+            "TupleShortCircuit.FinallyAsync:reserved");
+    }
+
+    [Fact]
+    public async Task tuple_carrying_before_with_finally_async_short_circuit_path()
+    {
+        var recorder = this.recorder();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/shortcircuit-finally/tuple?stop=true");
+            x.StatusCodeShouldBe(419);
+        });
+
+        recorder.Actions.ShouldHaveTheSameElementsAs(
+            "TupleShortCircuit.Before",
+            "TupleShortCircuit.FinallyAsync:reserved");
+    }
+}

--- a/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
+++ b/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
@@ -127,3 +127,75 @@ public class AuthenticatedEndpoint
         return "All good.";
     }
 }
+
+// GH-3892: one middleware class that declares BOTH a short-circuiting Before
+// (return type includes IResult) and a Finally used to blow up HTTP chain
+// code generation with a NullReferenceException
+public class ShortCircuitBeforeWithFinallyMiddleware
+{
+    public static Task<IResult> Before(HttpContext httpContext, Recorder recorder)
+    {
+        recorder.Actions.Add("ShortCircuit.Before");
+        return httpContext.Request.Query.ContainsKey("stop")
+            ? Task.FromResult(Results.StatusCode(418))
+            : Task.FromResult<IResult>(WolverineContinue.Result());
+    }
+
+    public static Task Finally(HttpContext httpContext, Recorder recorder)
+    {
+        recorder.Actions.Add("ShortCircuit.Finally");
+        return Task.CompletedTask;
+    }
+}
+
+public class MiddlewareReservation
+{
+    public string Value { get; set; } = "reserved";
+}
+
+// GH-3892 variant: instance middleware, synchronous Before returning a tuple
+// that carries the IResult, paired with FinallyAsync
+public class TupleShortCircuitFinallyAsyncMiddleware
+{
+    public (IResult, MiddlewareReservation) Before(HttpContext httpContext, Recorder recorder)
+    {
+        recorder.Actions.Add("TupleShortCircuit.Before");
+        var reservation = new MiddlewareReservation();
+        return httpContext.Request.Query.ContainsKey("stop")
+            ? (Results.StatusCode(419), reservation)
+            : (WolverineContinue.Result(), reservation);
+    }
+
+    public Task FinallyAsync(MiddlewareReservation reservation, Recorder recorder)
+    {
+        recorder.Actions.Add($"TupleShortCircuit.FinallyAsync:{reservation.Value}");
+        return Task.CompletedTask;
+    }
+}
+
+public class ShortCircuitFinallyEndpoints
+{
+    [Wolverine.Attributes.Middleware(typeof(ShortCircuitBeforeWithFinallyMiddleware))]
+    [WolverineGet("/middleware/shortcircuit-finally")]
+    public string Get(Recorder recorder)
+    {
+        recorder.Actions.Add("ShortCircuit.Action");
+        return "ok";
+    }
+
+    [Wolverine.Attributes.Middleware(typeof(ShortCircuitBeforeWithFinallyMiddleware))]
+    [WolverineGet("/middleware/shortcircuit-finally/throws")]
+    public string GetThrows(Recorder recorder)
+    {
+        recorder.Actions.Add("ShortCircuit.Throws");
+        throw new DivideByZeroException("boom");
+    }
+
+    [Wolverine.Attributes.Middleware(typeof(TupleShortCircuitFinallyAsyncMiddleware))]
+    [WolverineGet("/middleware/shortcircuit-finally/tuple")]
+    public string GetTuple(Recorder recorder)
+    {
+        recorder.Actions.Add("TupleShortCircuit.Action");
+        return "ok";
+    }
+}

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -256,14 +256,16 @@ public class MiddlewarePolicy : IChainPolicy
             }
             else
             {
-                if (rules.TryFindContinuationHandler(chain, call, out var frame))
-                {
-                    call.Next = frame;
-                }
+                // GH-3892: the continuation frame (IResult / HandlerContinuation short-circuit)
+                // is handed to the wrapper so that it is generated *inside* the try block and
+                // has its variables resolved. Hanging it off call.Next left its variables
+                // unresolved (NRE at codegen time) and would have skipped the Finally methods
+                // when the middleware short-circuited.
+                rules.TryFindContinuationHandler(chain, call, out var continuation);
 
                 var finals = _finals.Select(x => new MethodCall(MiddlewareType, x)).OfType<Frame>().ToArray();
 
-                yield return new TryFinallyWrapperFrame(call, finals);
+                yield return new TryFinallyWrapperFrame(call, continuation, finals);
             }
         }
 
@@ -409,11 +411,25 @@ public class MiddlewarePolicy : IChainPolicy
 public class TryFinallyWrapperFrame : Frame
 {
     private readonly Frame _inner;
+    private readonly Frame? _continuation;
     private readonly Frame[] _finallys;
 
-    public TryFinallyWrapperFrame(Frame inner, Frame[] finallys) : base(inner.IsAsync)
+    public TryFinallyWrapperFrame(Frame inner, Frame[] finallys) : this(inner, null, finallys)
+    {
+    }
+
+    /// <summary>
+    /// GH-3892: overload that carries the short-circuiting continuation frame
+    /// (IResult / HandlerContinuation evaluation) produced by the same Before
+    /// method that owns the finallys. The continuation is generated inside the
+    /// try block so the Finally methods still run when the middleware stops the
+    /// rest of the chain
+    /// </summary>
+    public TryFinallyWrapperFrame(Frame inner, Frame? continuation, Frame[] finallys)
+        : base(inner.IsAsync || continuation is { IsAsync: true } || finallys.Any(x => x.IsAsync))
     {
         _inner = inner;
+        _continuation = continuation;
         _finallys = finallys;
 
         creates.AddRange(inner.Creates.Select(x => new Variable(x.VariableType, x.Usage)));
@@ -424,7 +440,17 @@ public class TryFinallyWrapperFrame : Frame
         _inner.GenerateCode(method, writer);
         writer.Write("BLOCK:try");
 
-        Next?.GenerateCode(method, writer);
+        if (_continuation != null)
+        {
+            // The short-circuit evaluation goes inside the try block so that a
+            // stopped chain still unwinds through the finally below (GH-3892)
+            _continuation.Next = Next;
+            _continuation.GenerateCode(method, writer);
+        }
+        else
+        {
+            Next?.GenerateCode(method, writer);
+        }
 
         writer.FinishBlock();
         writer.Write("BLOCK:finally");
@@ -447,7 +473,15 @@ public class TryFinallyWrapperFrame : Frame
         _inner.GenerateFSharpCode(method, writer);
         writer.Write("BLOCK:try");
 
-        Next?.GenerateFSharpCode(method, writer);
+        if (_continuation != null)
+        {
+            _continuation.Next = Next;
+            _continuation.GenerateFSharpCode(method, writer);
+        }
+        else
+        {
+            Next?.GenerateFSharpCode(method, writer);
+        }
 
         writer.FinishBlock();
         writer.Write("BLOCK:finally");
@@ -470,6 +504,17 @@ public class TryFinallyWrapperFrame : Frame
         foreach (var variable in _inner.FindVariables(chain))
         {
             yield return variable;
+        }
+
+        // The continuation frame is generated from within this frame, so it never
+        // has its variables resolved by the normal frame arrangement. Leaving this
+        // out is the GH-3892 NullReferenceException
+        if (_continuation != null)
+        {
+            foreach (var variable in _continuation.FindVariables(chain))
+            {
+                yield return variable;
+            }
         }
 
         // NOT letting the finallys get involved with ordering frames


### PR DESCRIPTION
Closes #3892

## Root cause

When one middleware class declares both a `Before` whose return type includes `IResult` (or `HandlerContinuation`) and a `Finally`/`FinallyAsync`, `MiddlewarePolicy.wrapBeforeFrame` hung the continuation frame off `call.Next` inside the `TryFinallyWrapperFrame`. Frames nested behind another frame's `Next` are invisible to `MethodFrameArranger.compileFrames`, which only calls `ResolveVariables` on top-level frames — so `MaybeEndWithResultFrame.FindVariables` never ran, its `HttpContext` variable stayed null, and `GenerateCode` threw the reported `NullReferenceException` at `ResultContinuationPolicy.cs:69`.

There was a second, latent defect in the same placement: `TryFinallyWrapperFrame.GenerateCode` emits `_inner` (and therefore its whole `Next` chain) *before* opening the `try` block, so even with the variable resolved, a short-circuiting `Before` would have `return`ed before the `try` — silently skipping the `Finally` methods, the opposite of what a reserve-in-Before / release-in-Finally middleware needs.

## Fix — make the pairing work

`wrapBeforeFrame` now hands the continuation frame to `TryFinallyWrapperFrame` explicitly, and the wrapper:

- forwards the continuation's `FindVariables` alongside the inner call's (fixes the NRE);
- generates the continuation *inside* the `try` block, chaining the rest of the frames through it, so a non-continue `IResult` is executed, the chain body is skipped, and the `finally` still runs on the unwind;
- reports `IsAsync` when the continuation or any finally frame is async (none of them are visible to the arranger's async-mode scan — matters for a sync tuple-returning `Before` paired with `FinallyAsync`).

The existing `(Frame inner, Frame[] finallys)` constructor is kept and delegates, so no public API breaks. The same mechanism serves the handler pipeline's `HandlerContinuation` continuation, which had the identical inside-the-wrapper placement.

## Semantics

`Before` short-circuits → the `IResult` is written, the endpoint body is skipped, and `Finally`/`FinallyAsync` still execute — the reservation-release shape from the issue. Continue and exception paths are unchanged (`Finally` runs in both, as documented).

## Tests

New `short_circuiting_middleware_with_finally_3892` in Wolverine.Http.Tests, with fixtures in WolverineWebApi covering the reporter's exact shape (`Task<IResult> Before(HttpContext)` + `Task Finally(HttpContext)`, static) and an instance variant with a sync tuple-carrying `Before` + `FinallyAsync`:

- continue path runs body + Finally
- short-circuit path writes the result, skips the body, still runs Finally
- exception path still runs Finally
- tuple-carrying Before, continue + short-circuit, with `FinallyAsync` receiving the middleware-created carrier

All five failed before the fix with exactly the reported stack; all pass after. Also green: the middleware-related Wolverine.Http.Tests classes (`using_middleware`, `OnExceptionTests`, problem-details/fluent-validation/data-annotations middleware, `using_IResult_in_endpoints`, CodeGeneration folder), CoreTests' `middleware_usage` / `compound_handlers` / `on_exception_convention` / `requirement_result_validation_handlers` / `Bug_614` on net9.0 + net10.0, and the F# core compile gate (the wrapper's F# emission path).

## Credit

Full credit to @esond for the isolation work in the issue and the standalone repro at https://github.com/esond/wolverine-idempotency — the one-line trigger, sync/async `Finally` both reproducing, and independence from response types and bare-vs-tuple `IResult` pointed straight at the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)