### PR TITLE
GH-3888: release agents that exhaust node-local auto-restarts to a healthy capable peer

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/released_agent_failover.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/released_agent_failover.cs
@@ -1,0 +1,311 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Coverage for GH-3888: an event-subscription agent whose node-local auto-restart budget is exhausted
+/// (see <c>stalled_agent_auto_restart</c> for the agent-side half) is RELEASED by the failed-agent
+/// sweep so the leader can place it on a healthy peer advertising the same capability — instead of
+/// being retried on the same sick node forever.
+///
+/// The field failure this pins: a node in a memory-starved state keeps writing heartbeats (the
+/// heartbeat loop is deliberately cheap and isolated, GH-3604/D1), so it never looks stale to its
+/// peers, and the node-local restart loop was the only recovery its stalled shards ever got. 53 shards
+/// of a shared projection version froze for sixteen minutes next to a healthy fleet advertising the
+/// same capability, until a manual pod restart.
+///
+/// The anti-bounce half: a released agent's URI goes under a capability embargo — the node re-registers
+/// itself WITHOUT that capability — so the leader's capability-matched distribution cannot hand the
+/// agent straight back. The embargo lapses after <see cref="DurabilitySettings.AgentReleaseCooldown" />.
+/// </summary>
+public class released_agent_failover
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly IWolverineObserver _observer = Substitute.For<IWolverineObserver>();
+    private readonly INodeAgentPersistence _persistence = Substitute.For<INodeAgentPersistence>();
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly List<WolverineNode> _reregistrations = new();
+
+    private static readonly Uri AgentUri = new("event-subscriptions://marten/invoices/all/v16/01009333");
+
+    public released_agent_failover()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false;
+        _options.Durability.CheckAssignmentPeriod = 1.Hours();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(_observer);
+
+        // The node's own row exists throughout — otherwise every heartbeat write takes the GH-3604/D2
+        // resurrection path and re-registers, polluting the capture below.
+        _persistence.MarkHealthCheckAsync(Arg.Any<WolverineNode>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Capture every node-row rewrite so the tests can assert on the advertised capability set.
+        _persistence
+            .When(x => x.ReregisterNodeAsync(Arg.Any<WolverineNode>(), Arg.Any<CancellationToken>()))
+            .Do(call => _reregistrations.Add(call.Arg<WolverineNode>()));
+    }
+
+    private void nodeStateHas(params WolverineNode[] peers)
+    {
+        _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new NodeAgentState(peers.ToList(), new AgentRestrictions([])));
+    }
+
+    private static WolverineNode peer(bool advertisesAgent, TimeSpan? heartbeatAge = null)
+    {
+        var node = new WolverineNode
+        {
+            NodeId = Guid.NewGuid(),
+            AssignedNodeNumber = 2,
+            LastHealthCheck = DateTimeOffset.UtcNow.Subtract(heartbeatAge ?? TimeSpan.Zero)
+        };
+
+        if (advertisesAgent)
+        {
+            node.Capabilities.Add(AgentUri);
+        }
+
+        return node;
+    }
+
+    private async Task<(NodeAgentController Controller, ReleasableFakeAgent Agent)> controllerWithExhaustedAgentAsync()
+    {
+        var agent = new ReleasableFakeAgent(AgentUri);
+        var family = new ReleasableFakeAgentFamily("event-subscriptions");
+        family.Add(agent);
+
+        var controller = new NodeAgentController(_runtime, _persistence, [family],
+            NullLogger<NodeAgentController>.Instance, _cancellation.Token);
+
+        // Captures the node's advertised capabilities (this is what a real Balanced node does at
+        // startup), so releasing can be observed as a capability set that shrinks and later grows back.
+        await controller.StartLocalAgentProcessingAsync(_options);
+
+        await controller.StartAgentAsync(AgentUri);
+        agent.SimulateExhaustedLocalRestarts();
+
+        return (controller, agent);
+    }
+
+    [Fact]
+    public async Task releases_an_exhausted_agent_when_a_live_peer_advertises_the_capability()
+    {
+        var (controller, agent) = await controllerWithExhaustedAgentAsync();
+        nodeStateHas(peer(advertisesAgent: true));
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        // The agent let go locally: stopped, deregistered, and its assignment row removed so the next
+        // leader evaluation sees it unassigned.
+        agent.StopCount.ShouldBe(1);
+        controller.Agents.ContainsKey(AgentUri).ShouldBeFalse();
+        await _persistence.Received(1)
+            .RemoveAssignmentAsync(_options.UniqueNodeId, AgentUri, Arg.Any<CancellationToken>());
+
+        // The anti-bounce half, persisted BEFORE the agent is let go: this node's row no longer
+        // advertises the capability, so the leader cannot hand the agent straight back.
+        _reregistrations.ShouldNotBeEmpty();
+        _reregistrations.Last().Capabilities.ShouldNotContain(AgentUri);
+
+        await _observer.Received(1).AgentReleased(AgentUri, Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task keeps_local_retries_when_no_live_peer_advertises_the_capability()
+    {
+        var (controller, agent) = await controllerWithExhaustedAgentAsync();
+
+        // A live peer exists, but it cannot run this agent. Releasing would strand the shard entirely,
+        // so the sweep declines, refunds the local restart budget, and the agent stays put.
+        nodeStateHas(peer(advertisesAgent: false));
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        agent.StopCount.ShouldBe(0);
+        agent.BudgetResets.ShouldBe(1);
+        controller.Agents.ContainsKey(AgentUri).ShouldBeTrue();
+        _reregistrations.ShouldBeEmpty();
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task a_stale_peer_advertising_the_capability_does_not_count()
+    {
+        var (controller, agent) = await controllerWithExhaustedAgentAsync();
+
+        // The only capable peer stopped heartbeating long ago — releasing to it would freeze the shard
+        // in a different place. Same outcome as having no capable peer at all.
+        nodeStateHas(peer(advertisesAgent: true, heartbeatAge: 10.Minutes()));
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        agent.StopCount.ShouldBe(0);
+        agent.BudgetResets.ShouldBe(1);
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task the_capability_is_advertised_again_after_the_release_cooldown()
+    {
+        var clock = new FrozenClock(DateTimeOffset.UtcNow);
+        var (controller, _) = await controllerWithExhaustedAgentAsync();
+        controller.TimeProvider = clock;
+        nodeStateHas(peer(advertisesAgent: true));
+
+        await controller.ReportFailedLocalAgentsAsync();
+        _reregistrations.Last().Capabilities.ShouldNotContain(AgentUri);
+
+        // Before the cooldown lapses, the embargo holds.
+        await controller.RestoreExpiredReleaseEmbargoesAsync();
+        _reregistrations.Last().Capabilities.ShouldNotContain(AgentUri);
+
+        // After it lapses, the node advertises the capability again and becomes an ordinary candidate.
+        clock.Advance(_options.Durability.AgentReleaseCooldown + 1.Minutes());
+        await controller.RestoreExpiredReleaseEmbargoesAsync();
+        _reregistrations.Last().Capabilities.ShouldContain(AgentUri);
+    }
+
+    [Fact]
+    public async Task release_report_fires_once_not_once_per_tick_when_declined()
+    {
+        var (controller, agent) = await controllerWithExhaustedAgentAsync();
+        nodeStateHas(peer(advertisesAgent: false));
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        // ResetLocalRestartBudget cleared the exhaustion, so subsequent sweeps see an ordinary agent
+        // again until it burns another full budget.
+        await controller.ReportFailedLocalAgentsAsync();
+        await controller.ReportFailedLocalAgentsAsync();
+
+        agent.BudgetResets.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// The placement half of the story, at the assignment-grid level: once the releasing node stops
+    /// advertising the capability, the blue/green distribution places the freed agent on the peer that
+    /// does advertise it — never back on the node that just failed it.
+    /// </summary>
+    public class released_agent_placement
+    {
+        [Fact]
+        public void a_released_agent_lands_on_the_capable_peer_not_back_on_the_releasing_node()
+        {
+            var shared = new Uri("event-subscriptions://marten/incidents/all");
+
+            var sick = new WolverineNode { NodeId = Guid.NewGuid(), AssignedNodeNumber = 1 };
+            sick.Capabilities.Add(shared); // released AgentUri: no longer advertised here
+
+            var healthy = new WolverineNode { NodeId = Guid.NewGuid(), AssignedNodeNumber = 2 };
+            healthy.Capabilities.Add(shared);
+            healthy.Capabilities.Add(AgentUri);
+
+            var grid = new AssignmentGrid();
+            grid.WithNode(sick);
+            grid.WithNode(healthy);
+            grid.WithAgents(AgentUri, shared);
+
+            grid.DistributeEvenlyWithBlueGreenSemantics("event-subscriptions");
+
+            grid.AgentFor(AgentUri).AssignedNode.ShouldNotBeNull().AssignedId.ShouldBe(2);
+        }
+    }
+
+    private sealed class FrozenClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    private class ReleasableFakeAgentFamily : IStaticAgentFamily
+    {
+        private readonly Dictionary<Uri, ReleasableFakeAgent> _agents = new();
+
+        public ReleasableFakeAgentFamily(string scheme) => Scheme = scheme;
+
+        public void Add(ReleasableFakeAgent agent) => _agents[agent.Uri] = agent;
+
+        public string Scheme { get; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => ValueTask.FromResult<IAgent>(_agents[uri]);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    private class ReleasableFakeAgent : IEventSubscriptionAgent
+    {
+        public ReleasableFakeAgent(Uri uri) => Uri = uri;
+
+        public int StopCount { get; private set; }
+        public int BudgetResets { get; private set; }
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+        public ShardFailure? Failure { get; private set; }
+        public bool LocalRestartsExhausted { get; private set; }
+
+        public void SimulateExhaustedLocalRestarts()
+        {
+            // A stalled shard still reads Running — that is precisely why the sweep must check the
+            // exhaustion flag before the Running short-circuit.
+            Status = AgentStatus.Running;
+            Failure = new ShardFailure
+            {
+                Category = ShardFailureCategory.Other,
+                ExceptionType = "System.OutOfMemoryException",
+                RootExceptionType = "System.OutOfMemoryException",
+                Message = "Exception of type 'System.OutOfMemoryException' was thrown.",
+                Detail = "System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.",
+                OccurredAt = DateTimeOffset.UtcNow
+            };
+            LocalRestartsExhausted = true;
+        }
+
+        public void ResetLocalRestartBudget()
+        {
+            BudgetResets++;
+            LocalRestartsExhausted = false;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCount++;
+            Status = AgentStatus.Stopped;
+            return Task.CompletedTask;
+        }
+
+        public Task RebuildAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RewindAsync(long? sequenceFloor, DateTimeOffset? timestamp,
+            CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/stalled_agent_auto_restart.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/stalled_agent_auto_restart.cs
@@ -125,7 +125,34 @@ public class stalled_agent_auto_restart
         }
     }
 
-    [Fact(Skip = "GH-3888: the retry is node-local, so a node-level fault never moves the agent to a healthy peer")]
+    /// <summary>
+    /// Run the clock through stalled health checks. The auto-restart itself runs on a background task,
+    /// so whenever a check reports that it dispatched one, wait for that restart to complete before the
+    /// next check — the loop then observes a settled agent every iteration instead of racing it.
+    /// </summary>
+    private async Task<HealthCheckResult> stallThroughChecksAsync(int iterations)
+    {
+        HealthCheckResult result = default;
+        for (var i = 0; i < iterations; i++)
+        {
+            _clock.Advance(TimeSpan.FromSeconds(61));
+            var restartsBefore = Volatile.Read(ref _restarts);
+            result = await checkAsync();
+
+            if (result.Description?.Contains("Attempting auto-restart") == true)
+            {
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (Volatile.Read(ref _restarts) <= restartsBefore && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(10);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    [Fact]
     public async Task a_failure_that_survives_local_restarts_stops_being_retried_locally()
     {
         // Measured on a 512-database cluster: the warming fleet ran out of memory holding 53 agents of a
@@ -133,21 +160,80 @@ public class stalled_agent_auto_restart
         // failed identically; the serving fleet advertised the capability, was healthy, and never received
         // them. Those read models sat frozen for sixteen minutes with a capable node beside them.
         //
-        // After a handful of failed local restarts the agent should stop being retried here and release its
-        // assignment, so the leader can place it elsewhere. RemoveAssignmentAsync already exists in the stop
-        // path; what is missing is the policy that reaches for it — including whatever keeps the leader from
-        // handing the agent straight back to the node that just failed it.
+        // GH-3888: after MaxLocalRestartsBeforeRelease restarts with no observed progress, the agent stops
+        // being retried here and flags itself exhausted, which is what asks NodeAgentController's
+        // failed-agent sweep to release its assignment so the leader can place it on a capable peer.
         _inner.Failure.Returns(FailureOf(ShardFailureCategory.Other));
 
         await stallUntilRestartAsync();
-        for (var i = 0; i < 20; i++)
-        {
-            _clock.Advance(TimeSpan.FromSeconds(61));
-            await checkAsync();
-        }
+        var last = await stallThroughChecksAsync(20);
 
-        // Today this keeps climbing for as long as the node stays broken.
-        _restarts.ShouldBeLessThanOrEqualTo(5);
+        last.Status.ShouldBe(HealthStatus.Unhealthy);
+        last.Description.ShouldNotBeNull().ShouldContain("exhausted");
+        _agent.LocalRestartsExhausted.ShouldBeTrue();
+
+        // Before GH-3888 this climbed for as long as the node stayed broken; the budget caps it.
+        _restarts.ShouldBeLessThanOrEqualTo(_agent.MaxLocalRestartsBeforeRelease);
+    }
+
+    [Fact]
+    public async Task observed_progress_refunds_the_local_restart_budget()
+    {
+        _inner.Failure.Returns(FailureOf(ShardFailureCategory.Other));
+
+        await stallUntilRestartAsync();
+        await stallThroughChecksAsync(20);
+        _agent.LocalRestartsExhausted.ShouldBeTrue();
+
+        // The shard advances — whatever was starving this node has passed, and restarting here worked
+        // after all. The budget refunds and the agent goes back to ordinary stall tracking.
+        _inner.Position.Returns(HighWater - 50);
+        _clock.Advance(TimeSpan.FromSeconds(61));
+        await checkAsync();
+
+        _agent.LocalRestartsExhausted.ShouldBeFalse();
+
+        // And a NEW stall episode gets a fresh budget: the restart branch fires again rather than
+        // staying latched on the exhausted state.
+        var restartsBefore = _restarts;
+        var tripped = await stallThroughChecksAsync(4);
+        tripped.Description.ShouldNotBeNull();
+        _restarts.ShouldBeGreaterThan(restartsBefore);
+    }
+
+    [Fact]
+    public async Task reset_local_restart_budget_re_arms_local_restarts()
+    {
+        _inner.Failure.Returns(FailureOf(ShardFailureCategory.Other));
+
+        await stallUntilRestartAsync();
+        await stallThroughChecksAsync(20);
+        _agent.LocalRestartsExhausted.ShouldBeTrue();
+
+        // What NodeAgentController calls when it declines the release because no live peer advertises
+        // the capability: local retries remain the least-bad option and must keep happening.
+        _agent.ResetLocalRestartBudget();
+
+        _agent.LocalRestartsExhausted.ShouldBeFalse();
+
+        var restartsBefore = _restarts;
+        await stallThroughChecksAsync(4);
+        _restarts.ShouldBeGreaterThan(restartsBefore);
+    }
+
+    [Fact]
+    public async Task a_nonpositive_budget_disables_release_and_keeps_unbounded_local_retries()
+    {
+        // The pre-GH-3888 behavior, kept reachable as a kill switch through
+        // DurabilitySettings.MaxLocalAgentRestartsBeforeRelease <= 0.
+        _agent.MaxLocalRestartsBeforeRelease = 0;
+        _inner.Failure.Returns(FailureOf(ShardFailureCategory.Other));
+
+        await stallUntilRestartAsync();
+        await stallThroughChecksAsync(20);
+
+        _agent.LocalRestartsExhausted.ShouldBeFalse();
+        _restarts.ShouldBeGreaterThan(3);
     }
 
     /// <summary>A clock the test moves by hand; the stall detector reads nothing else.</summary>

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -344,6 +344,31 @@ public class DurabilitySettings : IDescribeMyself
     public TimeSpan AgentStartRetryDelay { get; set; } = 250.Milliseconds();
 
     /// <summary>
+    ///     GH-3888: how many node-local auto-restarts a stalled event-subscription agent may burn
+    ///     without its sequence advancing before it gives up on this node. Once the budget is exhausted,
+    ///     the node releases the agent's assignment — provided another live node advertises the
+    ///     capability to run it — so the leader can place it on a healthy peer instead of retrying the
+    ///     same conditions in the same place forever. Any observed progress resets the budget. Only a
+    ///     self-healing failure (<c>ShardFailureCategory.Other</c>) ever reaches the auto-restart path
+    ///     at all; per-event failures are surfaced and left alone (GH-3638). Set to 0 or a negative
+    ///     number to disable release entirely and keep unbounded local retries (the pre-GH-3888
+    ///     behavior). Default 3.
+    /// </summary>
+    public int MaxLocalAgentRestartsBeforeRelease { get; set; } = 3;
+
+    /// <summary>
+    ///     GH-3888: how long a node withholds a released agent's URI from its advertised capabilities
+    ///     after exhausting local restarts on it. While the embargo is live, the leader's
+    ///     capability-matched distribution cannot hand the agent straight back to the node that just
+    ///     failed it — the anti-bounce half of the release policy. After it lapses, the node advertises
+    ///     the capability again and becomes an ordinary candidate; a node that is still sick will burn
+    ///     another full restart budget before releasing again, so the worst case is one bounded move per
+    ///     cooldown rather than a reassignment storm. A process restart clears all embargoes, since
+    ///     capabilities are recaptured at startup. Default 10 minutes.
+    /// </summary>
+    public TimeSpan AgentReleaseCooldown { get; set; } = 10.Minutes();
+
+    /// <summary>
     /// Opt-in switch for the dynamic listener registry: persisted listener URIs that
     /// are activated at runtime in addition to the listeners declared statically
     /// through <see cref="WolverineOptions"/>. When <c>true</c>, <c>IMessageStore.Listeners</c>
@@ -509,6 +534,8 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(NodeEventRecordExpirationTime), NodeEventRecordExpirationTime);
         desc.AddValue(nameof(NodeRecordRetention), NodeRecordRetention);
         desc.AddValue(nameof(NodeRecordPruningPeriod), NodeRecordPruningPeriod);
+        desc.AddValue(nameof(MaxLocalAgentRestartsBeforeRelease), MaxLocalAgentRestartsBeforeRelease);
+        desc.AddValue(nameof(AgentReleaseCooldown), AgentReleaseCooldown);
         desc.AddValue(nameof(SendingAgentIdleTimeout), SendingAgentIdleTimeout);
         desc.AddValue(nameof(DrainTimeout), DrainTimeout);
         desc.AddValue(nameof(EnableInboxPartitioning), EnableInboxPartitioning);

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgent.cs
@@ -35,6 +35,37 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
     private static readonly TimeSpan StallTimeout = TimeSpan.FromSeconds(60);
     private const int MaxConsecutiveStallsBeforeRestart = 3;
 
+    // GH-3888: auto-restarts attempted since the sequence last advanced. Unlike _consecutiveStallCount,
+    // which resets on every restart, this only resets on observed progress — it is the evidence that
+    // restarting HERE is not working.
+    private int _restartsSinceProgress;
+
+    // GH-3888: 0=idle, 1=a restart is executing. Health checks arriving while a restart is still in
+    // flight used to dispatch ANOTHER concurrent restart on every tick; with the release budget spent
+    // at dispatch, that would also burn budget slots on restarts that never got a chance to work.
+    private int _restartInFlight;
+
+    /// <summary>
+    /// GH-3888: how many node-local auto-restarts this agent may attempt without its sequence advancing
+    /// before it declares its local restart budget exhausted and asks to be released to another capable
+    /// node. Stamped from <see cref="DurabilitySettings.MaxLocalAgentRestartsBeforeRelease" /> by
+    /// <see cref="EventSubscriptionAgentFamily.BuildAgentAsync" />; zero or negative disables release
+    /// and keeps unbounded local retries.
+    /// </summary>
+    public int MaxLocalRestartsBeforeRelease { get; set; } = 3;
+
+    /// <inheritdoc cref="IEventSubscriptionAgent.LocalRestartsExhausted" />
+    public bool LocalRestartsExhausted { get; private set; }
+
+    /// <inheritdoc cref="IEventSubscriptionAgent.ResetLocalRestartBudget" />
+    public void ResetLocalRestartBudget()
+    {
+        _restartsSinceProgress = 0;
+        _consecutiveStallCount = 0;
+        LocalRestartsExhausted = false;
+        _lastAdvancedAt = TimeProvider.GetUtcNow();
+    }
+
     /// <summary>
     /// Callback fired when the agent is auto-restarted due to stalls.
     /// Parameters: agentUri, reason, timestamp
@@ -253,10 +284,13 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
 
         if (currentSequence != _lastKnownSequence)
         {
-            // Sequence has advanced, reset stall tracking
+            // Sequence has advanced, reset stall tracking. Progress also refunds the GH-3888 release
+            // budget: the point of the budget is "restarting here is not working", and it just worked.
             _lastKnownSequence = currentSequence;
             _lastAdvancedAt = TimeProvider.GetUtcNow();
             _consecutiveStallCount = 0;
+            _restartsSinceProgress = 0;
+            LocalRestartsExhausted = false;
         }
         else if (currentSequence < highWaterMark &&
                  TimeProvider.GetUtcNow() - _lastAdvancedAt > StallTimeout)
@@ -278,8 +312,31 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
                         $" -- stalled for {_consecutiveStallCount} consecutive health checks. Auto-restart suppressed: this failure will recur on the same event until it is resolved."));
                 }
 
-                // Trigger auto-restart
-                _ = Task.Run(() => AttemptAutoRestartAsync(cancellationToken), cancellationToken);
+                // GH-3888: restarting in place has already been tried MaxLocalRestartsBeforeRelease
+                // times since the sequence last advanced, and the shard is stalled again. The fault is
+                // evidently not one another local restart will clear — it is a property of this node or
+                // its process, not of the shard — so stop churning the daemon's start path and flag the
+                // agent for release instead. NodeAgentController's failed-agent sweep picks the flag up
+                // and, when a live peer advertises the capability, releases the assignment so the leader
+                // can place the shard there.
+                if (MaxLocalRestartsBeforeRelease > 0 && _restartsSinceProgress >= MaxLocalRestartsBeforeRelease)
+                {
+                    LocalRestartsExhausted = true;
+                    return Task.FromResult(HealthCheckResult.Unhealthy(
+                        $"Projection {Uri} has stalled through {_restartsSinceProgress} auto-restarts on this node without advancing. Local restarts are exhausted; the agent is eligible for release to another capable node. See GH-3888."));
+                }
+
+                // Trigger auto-restart. GH-3888: the budget is spent at dispatch, synchronously with
+                // the rest of the stall bookkeeping, so the exhaustion decision above never races the
+                // background restart task — and a restart that throws still counts, which is even
+                // stronger evidence that restarting here is not working. The in-flight guard keeps a
+                // health check that lands mid-restart from piling a second concurrent restart (and a
+                // second spent budget slot) on top of the one still running.
+                if (Interlocked.CompareExchange(ref _restartInFlight, 1, 0) == 0)
+                {
+                    _restartsSinceProgress++;
+                    _ = Task.Run(() => AttemptAutoRestartAsync(cancellationToken), cancellationToken);
+                }
 
                 return Task.FromResult(HealthCheckResult.Unhealthy(
                     $"Projection {Uri} has been stalled for {_consecutiveStallCount} consecutive health checks. Attempting auto-restart."));
@@ -323,6 +380,10 @@ public class EventSubscriptionAgent : IEventSubscriptionAgent
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to auto-restart projection {Uri}", Uri);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _restartInFlight, 0);
         }
     }
 

--- a/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
+++ b/src/Wolverine/Runtime/Agents/EventSubscriptionAgentFamily.cs
@@ -198,7 +198,14 @@ public class EventSubscriptionAgentFamily : IStaticAgentFamily, IEventSubscripti
             // run on; the daemon stamps it onto every published ShardState (running_on_node telemetry).
             store.AssignedNodeNumber = wolverineRuntime.Options.Durability.AssignedNodeNumber;
 
-            return await store.BuildAgentAsync(uri, databaseId, shardPath);
+            var agent = await store.BuildAgentAsync(uri, databaseId, shardPath);
+
+            // GH-3888: the local auto-restart budget comes from durability settings; the wrapper itself
+            // has no runtime reference.
+            agent.MaxLocalRestartsBeforeRelease =
+                wolverineRuntime.Options.Durability.MaxLocalAgentRestartsBeforeRelease;
+
+            return agent;
         }
 
         throw new AgentStartingException(uri, wolverineRuntime.Options.UniqueNodeId, new ArgumentOutOfRangeException(nameof(uri), "Unknown event projection or subscription"));

--- a/src/Wolverine/Runtime/Agents/IEventSubscriptionAgent.cs
+++ b/src/Wolverine/Runtime/Agents/IEventSubscriptionAgent.cs
@@ -43,4 +43,26 @@ public interface IEventSubscriptionAgent : IAgent
     /// See GH-3637 / GH-3638 and JasperFx/jasperfx#565.</para>
     /// </summary>
     ShardFailure? Failure => null;
+
+    /// <summary>
+    /// GH-3888: whether this agent has burned through its budget of node-local auto-restarts without
+    /// its sequence advancing. The auto-restart in <see cref="EventSubscriptionAgent" /> is node-local
+    /// — nothing about a stop/start moves the shard anywhere — so when the fault is a property of the
+    /// NODE (memory starvation, a bad disk, a wedged runtime) every retry re-runs the same conditions
+    /// while a healthy peer advertising the same capability never gets a chance at the shard. An agent
+    /// reporting <c>true</c> here is asking <see cref="NodeAgentController.ReportFailedLocalAgentsAsync" />
+    /// to release its assignment so the leader can place it on another capable node. Any observed
+    /// progress resets it. Default false so existing implementations are unaffected.
+    /// </summary>
+    bool LocalRestartsExhausted => false;
+
+    /// <summary>
+    /// GH-3888: give the node-local auto-restart loop a fresh budget. Called by the assignment plane
+    /// when it declines to release an exhausted agent — no live peer advertises the capability, so
+    /// retrying here remains the least-bad option and must keep happening rather than freezing the
+    /// shard. Default no-op so existing implementations are unaffected.
+    /// </summary>
+    void ResetLocalRestartBudget()
+    {
+    }
 }

--- a/src/Wolverine/Runtime/Agents/IWolverineObserver.cs
+++ b/src/Wolverine/Runtime/Agents/IWolverineObserver.cs
@@ -42,7 +42,16 @@ public interface IWolverineObserver
     /// </summary>
     Task AgentPaused(Uri agentUri, ShardFailure? failure) => Task.CompletedTask;
 
-    // Loop through and decide what you want here. 
+    /// <summary>
+    /// A locally-owned agent was released from this node after exhausting its node-local auto-restart
+    /// budget on a stall that never advanced, so the leader can place it on a healthy peer that
+    /// advertises the same capability. <paramref name="failure" /> is the last classified failure the
+    /// agent reported, when it reported one. Default no-op so existing observers are unaffected.
+    /// See GH-3888.
+    /// </summary>
+    Task AgentReleased(Uri agentUri, ShardFailure? failure) => Task.CompletedTask;
+
+    // Loop through and decide what you want here.
     Task AssignmentsChanged(AssignmentGrid grid, AgentCommands commands);
     
     // TODO -- more for listener stopped/started
@@ -226,6 +235,28 @@ internal class PersistenceWolverineObserver : IWolverineObserver
         {
             // NullMessageStore does not support node persistence; a storeless Solo node can still run
             // event-subscription agents, and losing the record must not break the health-check sweep.
+        }
+    }
+
+    public async Task AgentReleased(Uri agentUri, ShardFailure? failure)
+    {
+        var record = NodeRecord.For(_runtime.Options, NodeRecordType.AgentReleased, agentUri);
+
+        // Same shape and same reasoning as AgentPaused above: the classified reason takes the
+        // Description slot when there is one, truncated to the narrowest column any store provisions.
+        if (failure != null)
+        {
+            record.Description = truncate(failure.ToString(), DescriptionLength);
+        }
+
+        try
+        {
+            await _runtime.Storage.Nodes.LogRecordsAsync(record);
+        }
+        catch (NotSupportedException)
+        {
+            // NullMessageStore does not support node persistence; losing the diagnostic record must not
+            // break the release sweep.
         }
     }
 

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -87,11 +87,16 @@ public partial class NodeAgentController
     // Build a full picture of THIS node's identity as the process currently knows it: the assigned node
     // number, the capabilities captured at startup, and the agents registered on it right now. Used both to
     // refresh the heartbeat and, on a miss, to re-register the node with its real identity.
+    //
+    // GH-3888: capabilities under a live release embargo are withheld. _capabilities stays the captured
+    // source of truth; the embargo is applied at every point the node's identity is (re)persisted, so a
+    // row resurrection after a peer ejection keeps the shrunk capability set too instead of quietly
+    // re-advertising an agent this node just released for failing here.
     private WolverineNode buildLocalNode()
     {
         var node = WolverineNode.For(_runtime.Options);
         node.AssignedNodeNumber = _runtime.Options.Durability.AssignedNodeNumber;
-        node.Capabilities.AddRange(_capabilities);
+        node.Capabilities.AddRange(_capabilities.Where(x => !_releasedAgents.ContainsKey(x)));
         node.AssignAgents(Agents.Keys.ToArray());
         return node;
     }
@@ -145,9 +150,13 @@ public partial class NodeAgentController
         // GH-3637 / GH-3638: before any leadership work, surface this node's OWN agents that stopped or
         // paused on a failure. Deliberately here rather than in the leader-only branch below -- the daemon
         // pauses a shard on whichever node owns it, and a follower has to be able to report its own.
-        // Wrapped so a reporting fault can never cost this node its heartbeat or its leadership lease.
+        // GH-3888: the same sweep also releases agents that exhausted their local auto-restart budget,
+        // and the tick first lifts any release embargo whose cooldown has lapsed. All follower-capable
+        // work, for the same reason. Wrapped so a fault here can never cost this node its heartbeat or
+        // its leadership lease.
         try
         {
+            await RestoreExpiredReleaseEmbargoesAsync();
             await ReportFailedLocalAgentsAsync();
         }
         catch (Exception e)

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -38,6 +38,25 @@ public partial class NodeAgentController
     // reports the new failure.
     private readonly ConcurrentDictionary<Uri, byte> _reportedFailures = new();
 
+    // GH-3888: agents this node has released after exhausting local auto-restarts, mapped to when this
+    // node may advertise their capability again. While an entry is live, buildLocalNode() withholds the
+    // agent's URI from the node's advertised capabilities — which is what keeps the leader's
+    // capability-matched distribution from handing the agent straight back to the node that just failed
+    // it. A ConcurrentDictionary because the independent heartbeat loop reads it (through
+    // buildLocalNode on a row-resurrection) while the serialized health-check path mutates it.
+    private readonly ConcurrentDictionary<Uri, DateTimeOffset> _releasedAgents = new();
+
+    // GH-3888: agents that exhausted their local restart budget while NO live peer advertised the
+    // capability to run them, so the release was declined. Used to log that once per episode rather
+    // than on every sweep tick. Only touched from the serialized health-check path.
+    private readonly HashSet<Uri> _reportedUnreleasable = new();
+
+    /// <summary>
+    /// GH-3888: clock for the release-embargo bookkeeping. Tests substitute it so the cooldown can be
+    /// exercised without waiting it out; everything else uses the system clock.
+    /// </summary>
+    internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
     // 0=free, 1=busy; guards against concurrent DoHealthChecksAsync calls
     // from the heartbeat loop and a CheckAgentHealth message arriving
     // simultaneously. Prevents a race on _lastLockIndex / _lastLockETag in
@@ -484,10 +503,21 @@ public partial class NodeAgentController
     /// </summary>
     internal async Task ReportFailedLocalAgentsAsync()
     {
+        List<(Uri Uri, IEventSubscriptionAgent Agent)>? exhausted = null;
+
         foreach (var entry in Agents.ToArray())
         {
             if (entry.Value is not IEventSubscriptionAgent subscription)
             {
+                continue;
+            }
+
+            // GH-3888: an agent that burned through its local auto-restart budget without ever
+            // advancing is asking to be placed somewhere else. Checked BEFORE the Running
+            // short-circuit below — a stalled shard still reads Running.
+            if (subscription.LocalRestartsExhausted)
+            {
+                (exhausted ??= new()).Add((entry.Key, subscription));
                 continue;
             }
 
@@ -497,6 +527,7 @@ public partial class NodeAgentController
             if (status == AgentStatus.Running)
             {
                 _reportedFailures.TryRemove(entry.Key, out _);
+                _reportedUnreleasable.Remove(entry.Key);
                 continue;
             }
 
@@ -509,6 +540,188 @@ public partial class NodeAgentController
             }
 
             await reportAgentPausedAsync(entry.Key, failure);
+        }
+
+        if (exhausted != null)
+        {
+            await tryReleaseExhaustedAgentsAsync(exhausted);
+        }
+    }
+
+    /// <summary>
+    /// GH-3888: release agents whose node-local auto-restart budget is exhausted, so the leader can
+    /// place them on a healthy peer. The field failure this exists for: a node in a memory-starved /
+    /// GC-death-spiral state keeps writing heartbeats (the heartbeat loop is deliberately cheap and
+    /// isolated, GH-3604/D1), so it never looks stale to its peers — and the only recovery its stalled
+    /// shards ever get is EventSubscriptionAgent's node-local stop/start, which re-runs the same starved
+    /// conditions forever. 53 shards of a shared projection version sat frozen for sixteen minutes next
+    /// to a healthy fleet advertising the same capability until a manual pod restart.
+    ///
+    /// <para>Release only happens when at least one other live node advertises the agent's URI as a
+    /// capability — otherwise there is nowhere better to go, and the agent's budget is refunded so local
+    /// retries continue rather than freezing the shard. A released agent's URI goes under a capability
+    /// embargo (<see cref="DurabilitySettings.AgentReleaseCooldown" />): this node stops advertising it,
+    /// which is what stops the leader's capability-matched distribution handing the agent straight back.
+    /// The embargo is written to the node row FIRST, then the assignment is dropped, so no evaluation can
+    /// observe the freed agent while this node still advertises for it.</para>
+    /// </summary>
+    private async Task tryReleaseExhaustedAgentsAsync(List<(Uri Uri, IEventSubscriptionAgent Agent)> exhausted)
+    {
+        IReadOnlyList<WolverineNode> nodes;
+        try
+        {
+            (nodes, _) = await _persistence.LoadNodeAgentStateAsync(_cancellation.Token);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error loading node state while evaluating stalled-agent release on node {NodeNumber}",
+                _runtime.Options.Durability.AssignedNodeNumber);
+            return;
+        }
+
+        var staleTime = DateTimeOffset.UtcNow.Subtract(_runtime.Options.Durability.StaleNodeTimeout);
+        var selfId = _runtime.Options.UniqueNodeId;
+        var peers = nodes
+            .Where(x => x.NodeId != selfId && x.LastHealthCheck >= staleTime)
+            .ToArray();
+
+        var releasable = new List<(Uri Uri, IEventSubscriptionAgent Agent)>();
+        foreach (var pair in exhausted)
+        {
+            if (peers.Any(p => p.Capabilities.Contains(pair.Uri)))
+            {
+                releasable.Add(pair);
+            }
+            else
+            {
+                // Nowhere better to go: no live peer advertises this agent, so releasing it would
+                // strand the shard entirely. Keep the pre-existing local retries — the least-bad
+                // option — and say so once per episode rather than on every tick.
+                if (_reportedUnreleasable.Add(pair.Uri))
+                {
+                    _logger.LogWarning(
+                        "Agent {AgentUri} on node {NodeNumber} exhausted its local auto-restart budget, but no live peer advertises the capability to run it. Local restarts continue.",
+                        pair.Uri, _runtime.Options.Durability.AssignedNodeNumber);
+                }
+
+                pair.Agent.ResetLocalRestartBudget();
+            }
+        }
+
+        if (releasable.Count == 0)
+        {
+            return;
+        }
+
+        // Embargo first, then persist the shrunk capability set, and only then let go of the agents:
+        // the leader must never observe the released assignment gone while this node's row still
+        // advertises the capability, or the very next evaluation hands the agent straight back.
+        var embargoUntil = TimeProvider.GetUtcNow().Add(_runtime.Options.Durability.AgentReleaseCooldown);
+        foreach (var pair in releasable)
+        {
+            _releasedAgents[pair.Uri] = embargoUntil;
+        }
+
+        try
+        {
+            await _persistence.ReregisterNodeAsync(buildLocalNode(), _cancellation.Token);
+        }
+        catch (Exception e)
+        {
+            // Roll the embargo back: the persisted row still advertises these capabilities, so letting
+            // the agents go now would just bounce them back here. Try again on a later sweep tick.
+            foreach (var pair in releasable)
+            {
+                _releasedAgents.TryRemove(pair.Uri, out _);
+            }
+
+            _logger.LogError(e,
+                "Error persisting the reduced capability set while releasing stalled agents on node {NodeNumber}; release deferred",
+                _runtime.Options.Durability.AssignedNodeNumber);
+            return;
+        }
+
+        foreach (var (uri, agent) in releasable)
+        {
+            var failure = agent.Failure;
+            _logger.LogWarning(
+                "Agent {AgentUri} on node {NodeNumber} is being released after exhausting its local auto-restart budget without advancing. A live peer advertises the same capability, and the leader will reassign it there. This node will not advertise the capability again before {EmbargoUntil:u}. Last reported failure: {Failure}",
+                uri, _runtime.Options.Durability.AssignedNodeNumber, embargoUntil,
+                failure?.ToString() ?? "none reported");
+
+            try
+            {
+                await StopAgentAsync(uri);
+            }
+            catch (Exception e)
+            {
+                // The agent stays registered locally, so the next sweep sees it still exhausted and
+                // retries the release; the embargo entry is simply refreshed then.
+                _logger.LogError(e, "Error stopping agent {AgentUri} while releasing it from node {NodeNumber}",
+                    uri, _runtime.Options.Durability.AssignedNodeNumber);
+                continue;
+            }
+
+            _reportedFailures.TryRemove(uri, out _);
+            _reportedUnreleasable.Remove(uri);
+
+            try
+            {
+                await _observer.AgentReleased(uri, failure);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error notifying observers that agent {AgentUri} was released", uri);
+            }
+        }
+    }
+
+    /// <summary>
+    /// GH-3888: lift release embargoes whose cooldown has lapsed and advertise those capabilities
+    /// again. A node that has genuinely recovered (the transient node-level fault passed) becomes an
+    /// ordinary candidate; one that is still sick will burn another full local restart budget before it
+    /// releases again, so the steady-state worst case is one bounded move per cooldown rather than a
+    /// reassignment storm.
+    /// </summary>
+    internal async Task RestoreExpiredReleaseEmbargoesAsync()
+    {
+        if (_releasedAgents.IsEmpty)
+        {
+            return;
+        }
+
+        var now = TimeProvider.GetUtcNow();
+        var expired = _releasedAgents.Where(x => x.Value <= now).Select(x => x.Key).ToArray();
+        if (expired.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var uri in expired)
+        {
+            _releasedAgents.TryRemove(uri, out _);
+        }
+
+        try
+        {
+            await _persistence.ReregisterNodeAsync(buildLocalNode(), _cancellation.Token);
+
+            _logger.LogInformation(
+                "Node {NodeNumber} is advertising {Count} previously released agent capability(ies) again now that the release cooldown has lapsed",
+                _runtime.Options.Durability.AssignedNodeNumber, expired.Length);
+        }
+        catch (Exception e)
+        {
+            // Put the entries back (already due) so the next tick retries the re-advertisement;
+            // otherwise the in-memory state would say "advertising" while the persisted row still
+            // carries the shrunk capability set.
+            foreach (var uri in expired)
+            {
+                _releasedAgents.TryAdd(uri, now);
+            }
+
+            _logger.LogError(e, "Error re-advertising released agent capabilities on node {NodeNumber}",
+                _runtime.Options.Durability.AssignedNodeNumber);
         }
     }
 

--- a/src/Wolverine/Runtime/Agents/NodeRecordType.cs
+++ b/src/Wolverine/Runtime/Agents/NodeRecordType.cs
@@ -30,7 +30,15 @@ public enum NodeRecordType
     /// root exception) so the failure is readable after the fact, and from another
     /// process, instead of only in this node's logs. See GH-3637 / GH-3638.
     /// </summary>
-    AgentPaused
+    AgentPaused,
+
+    /// <summary>
+    /// A node released one of its own agents after exhausting the node-local auto-restart budget on a
+    /// stall that never advanced, so the leader could place the agent on a healthy peer advertising
+    /// the same capability. The record's Description carries the last classified failure when the
+    /// agent reported one. See GH-3888.
+    /// </summary>
+    AgentReleased
 }
 
 // This is marked as ISerializable so that it can go to CritterWatch w/o


### PR DESCRIPTION
Closes #3888. Builds directly on the `TimeProvider` seam from #3890 and replaces its skipped test with real coverage.

## Root cause

The issue title says "a node that dies", but the dying half is already covered: an abruptly dead process stops heartbeating, stale-node detection drops it from the assignment grid within `StaleNodeTimeout`, and the leader redistributes (pinned by the `eject_a_stale_node` / stale-leader-takeover compliance tests, which still pass). If the *leader* dies, the freed advisory lock lets a follower take over on its next tick and evaluate assignments on the spot.

What the existing machinery genuinely does not cover is the **live-but-sick node** — and that is what the field evidence describes. The jasperfx#644 poller puts the process into a memory-starved crawl long before exit 139, and the heartbeat loop is *deliberately* cheap and isolated from all agent work (GH-3604/D1, so a busy leader can't look dead). A starved process therefore keeps writing heartbeats: the node never looks stale, its 53 agents stay assigned to it, and the only recovery any of them ever get is `EventSubscriptionAgent.AttemptAutoRestartAsync` — a node-local stop/start that re-runs the same starved conditions on the same node, forever. Detection never fired because, by the assignment plane's definition, nothing was wrong. That is the sixteen-minutes-flat signature.

So the fix is the policy the issue asked for, not a detection change: after a run of failed local restarts, release the agent so the leader can place it on a peer that advertises the same capability — plus the thing the issue deliberately left open, what stops the leader handing it straight back.

## The policy

**1. A local restart budget on the agent** (`EventSubscriptionAgent`). A new restarts-since-progress counter — unlike the existing stall counter, it only resets on an observed sequence advance. After `DurabilitySettings.MaxLocalAgentRestartsBeforeRelease` auto-restarts with zero progress (default 3, `<= 0` disables release and restores the old unbounded local retries), the agent stops restarting and flags itself `LocalRestartsExhausted`. The budget is spent at dispatch, synchronously with the rest of the stall bookkeeping, and a new in-flight guard stops health checks that land mid-restart from piling concurrent restarts (a pre-existing thundering behavior that would otherwise burn budget spuriously).

**2. Release from the failed-agent sweep** (`NodeAgentController.ReportFailedLocalAgentsAsync`, every node, every tick — a follower can release its own agents). An exhausted agent is released — stopped, deregistered, `RemoveAssignmentAsync` — **only when another live (non-stale) node advertises the agent's URI as a capability**. That is the issue title's own condition. With no capable peer, releasing would strand the shard entirely, so the sweep refunds the budget and local retries continue; it logs that once per episode.

**3. Anti-bounce through the capability system itself, not a new grid rule.** Before letting go, the node re-registers its row *without* the released capability (`ReregisterNodeAsync` is already an upsert that rewrites capabilities on every backend — no schema change, no new persistence API). `buildLocalNode()` withholds embargoed URIs everywhere the node's identity is persisted, including the GH-3604/D2 row-resurrection path, so an ejection/resurrection can't quietly re-advertise. The capability sets now differ across nodes, which flips the distribution into its existing blue/green capability-matched path, and the freed agent's only candidates are the peers that advertise it. Nothing new in the distribution code at all.

The embargo lapses after `DurabilitySettings.AgentReleaseCooldown` (default 10 minutes), after which the node advertises again and is an ordinary candidate — a genuinely recovered node can take work back, while a still-sick one must burn a full fresh budget before it can release again. Worst case is one bounded move per cooldown, not the reassignment storm the issue was (rightly) worried about at 13k agents. A process restart clears all embargoes, since capabilities are recaptured at startup.

Also: an `AgentReleased` observer hook + `NodeRecordType.AgentReleased`, mirroring `AgentPaused`, so the release is visible from another process and to CritterWatch. All interface additions are default members; existing implementations are unaffected.

## The smaller thing from the issue

The "It will be left alone until the underlying problem is resolved" log that lied for `Category == Other` now has a truthful sibling: exhaustion returns *"Local restarts are exhausted; the agent is eligible for release to another capable node"*, and the release itself logs exactly what happened and until when the capability is withheld.

## Tests

- `stalled_agent_auto_restart` — the #3890 skipped test is now real and passing: restarts cap at the budget and the agent flags exhausted. Plus: progress refunds the budget; `ResetLocalRestartBudget` re-arms; `<= 0` disables (kill switch).
- `released_agent_failover` (new) — controller-level, same NSubstitute harness as `paused_shard_failure_surfacing`: release happens with a live capable peer (assignment removed, capability withheld *before* the agent is let go, observer notified); declined with no capable peer (budget refunded, once-per-episode logging); a *stale* peer advertising the capability doesn't count; the capability comes back after the cooldown (via the controller's new `TimeProvider` seam); and a grid-level test pinning that the freed agent lands on the capable peer, never back on the releasing node.
- Full `Runtime.Agents` filter: **347 passed, 0 skipped** (was 324 passed / 1 skipped).
- Full CoreTests (net9.0): **2349 passed, 0 failed**.
- `PostgresqlTests.LeaderElection` compliance (real multi-node hosts, incl. `eject_a_stale_node` and both stale-leader takeovers): **15 passed** — the dead-node machinery is untouched.

## Deliberately not done

- No change to how `CheckHealthAsync` is driven: the stall detector (and therefore this policy) runs only when something invokes the agent health checks, exactly as the auto-restart itself always has. Wiring it into the controller's own tick would light up auto-restarts for apps that never mapped health checks — a behavior change worth its own discussion.
- No leader-side failure ledger. The capability embargo makes the releasing node authoritative about its own sickness, which survives leader failover for free (a new leader reads capabilities from the node rows) — an in-memory leader ledger would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)