### PR TITLE
GH-3884: apply PolecatIntegration.TransportSchemaName to the SQL Server transport

### DIFF
--- a/src/Persistence/PolecatTests/polecat_applies_transport_schema.cs
+++ b/src/Persistence/PolecatTests/polecat_applies_transport_schema.cs
@@ -1,0 +1,179 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Polecat;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Wolverine.SqlServer.Transport;
+
+namespace PolecatTests;
+
+/// <summary>
+/// GH-3884, the mirror image of GH-3883 on the Marten side (see
+/// MartenTests.marten_does_not_clobber_transport_schema). <c>PolecatIntegration.TransportSchemaName</c>
+/// was public and documented but never read by anything, so an explicit assignment silently did
+/// nothing and the SQL Server transport's queue tables stayed wherever the transport itself was
+/// configured. Now the integration stamps an explicitly assigned schema onto the registered SQL
+/// Server transport at host build (authoritative, like the Marten twin), while an unconfigured
+/// default never overwrites an explicit
+/// <c>UseSqlServerPersistenceAndTransport(..., transportSchema: ...)</c>.
+/// </summary>
+public class polecat_applies_transport_schema
+{
+    private static IHost buildHost(Action<WolverineOptions> configure)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Durability.Mode = DurabilityMode.Solo;
+                configure(opts);
+            })
+            .Build(); // Build, not Start — extensions apply at build and no database is touched.
+    }
+
+    private static SqlServerTransport transportOf(IHost host)
+    {
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        return runtime.Options.Transports.OfType<SqlServerTransport>().Single();
+    }
+
+    [Fact]
+    public void an_explicit_schema_on_the_polecat_integration_is_applied_to_the_transport()
+    {
+        // The heart of GH-3884 — this assignment used to be inert.
+        using var host = buildHost(opts =>
+        {
+            opts.UseSqlServerPersistenceAndTransport(
+                    Servers.SqlServerConnectionString,
+                    "myapp",
+                    "myapp_queues",
+                    MessageStoreRole.Ancillary)
+                .AutoProvision();
+
+            opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat3884";
+                })
+                .IntegrateWithWolverine(x => x.TransportSchemaName = "polecat_chosen");
+        });
+
+        transportOf(host).TransportSchemaName.ShouldBe("polecat_chosen");
+    }
+
+    [Fact]
+    public void an_explicit_transport_schema_survives_polecat_integration_when_unset()
+    {
+        using var host = buildHost(opts =>
+        {
+            opts.UseSqlServerPersistenceAndTransport(
+                    Servers.SqlServerConnectionString,
+                    "myapp",
+                    "myapp_queues",
+                    MessageStoreRole.Ancillary)
+                .AutoProvision();
+
+            opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat3884";
+                })
+                .IntegrateWithWolverine();
+        });
+
+        transportOf(host).TransportSchemaName.ShouldBe("myapp_queues");
+    }
+
+    [Fact]
+    public void the_explicit_integration_schema_wins_regardless_of_registration_order()
+    {
+        using var host = buildHost(opts =>
+        {
+            opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat3884";
+                })
+                .IntegrateWithWolverine(x => x.TransportSchemaName = "polecat_chosen");
+
+            opts.UseSqlServerPersistenceAndTransport(
+                    Servers.SqlServerConnectionString,
+                    "myapp",
+                    "myapp_queues",
+                    MessageStoreRole.Ancillary)
+                .AutoProvision();
+        });
+
+        transportOf(host).TransportSchemaName.ShouldBe("polecat_chosen");
+    }
+
+    [Fact]
+    public void the_transport_default_is_unchanged_when_nobody_configures_a_schema()
+    {
+        using var host = buildHost(opts =>
+        {
+            opts.UseSqlServerPersistenceAndTransport(
+                Servers.SqlServerConnectionString,
+                role: MessageStoreRole.Ancillary);
+
+            opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat3884";
+                })
+                .IntegrateWithWolverine();
+        });
+
+        // The SQL Server transport's own default ("dbo" via DatabaseSettings) is left alone.
+        transportOf(host).TransportSchemaName.ShouldBe("dbo");
+    }
+
+    [Fact]
+    public void an_explicit_message_storage_schema_is_stamped_onto_the_transport()
+    {
+        // Mirrors MartenIntegration.Configure(): the transport's envelope-table SQL must agree
+        // with where the integration actually places the message storage.
+        using var host = buildHost(opts =>
+        {
+            opts.UseSqlServerPersistenceAndTransport(
+                    Servers.SqlServerConnectionString,
+                    "myapp",
+                    "myapp_queues",
+                    MessageStoreRole.Ancillary)
+                .AutoProvision();
+
+            opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat3884";
+                })
+                .IntegrateWithWolverine(x => x.MessageStorageSchemaName = "polecat_storage");
+        });
+
+        transportOf(host).MessageStorageSchemaName.ShouldBe("polecat_storage");
+    }
+
+    [Fact]
+    public void the_integration_setting_is_inert_when_no_sql_server_transport_is_registered()
+    {
+        // A Polecat host with no SQL Server-backed queue endpoints has no transport tables to
+        // place — the setting is simply a no-op, and no transport is conjured up.
+        using var host = buildHost(opts =>
+        {
+            opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "polecat3884";
+                })
+                .IntegrateWithWolverine(x => x.TransportSchemaName = "polecat_chosen");
+        });
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        runtime.Options.Transports.OfType<SqlServerTransport>().ShouldBeEmpty();
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -15,6 +15,7 @@ using Wolverine.Persistence.Sagas;
 using Wolverine.RDBMS;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Routing;
+using Wolverine.SqlServer.Transport;
 using Wolverine.Util;
 using System.Diagnostics.CodeAnalysis;
 
@@ -66,7 +67,32 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
 
         options.Policies.ForwardHandledTypes(new EventWrapperForwarder());
 
-        // SQL Server transport will be configured when the message store is built
+        // GH-3884 (the mirror image of GH-3883 on the Marten side): only stamp the SQL Server
+        // transport with schema names the caller actually asked for on this integration. This
+        // Configure() runs at host build — AFTER an inline UseSqlServerPersistenceAndTransport(...)
+        // in the same options lambda — so an explicit assignment here is authoritative over the
+        // transport's own configuration, while leaving the property alone leaves the transport
+        // untouched (its default, or an explicit
+        // UseSqlServerPersistenceAndTransport(..., transportSchema: ...)). Unlike the Marten twin,
+        // this does NOT create the transport when none is registered: SqlServerTransport requires
+        // connection settings at construction, and with no SQL Server-backed queue endpoints there
+        // are no transport tables to place.
+        foreach (var transport in options.Transports.OfType<SqlServerTransport>())
+        {
+            if (_transportSchemaNameIsExplicit)
+            {
+                transport.TransportSchemaName = TransportSchemaName;
+            }
+
+            if (MessageStorageSchemaName.IsNotEmpty())
+            {
+                // Keep the transport's envelope-table references (its dequeue/send SQL targets
+                // wolverine_incoming_envelopes / wolverine_outgoing_envelopes by schema) aligned
+                // with where this integration actually places the message storage. Mirrors
+                // MartenIntegration.Configure().
+                transport.MessageStorageSchemaName = MessageStorageSchemaName;
+            }
+        }
 
         options.Policies.Add<PolecatOpPolicy>();
 
@@ -91,14 +117,25 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
     internal PolecatEventRouter EventRouter { get; } = new();
 
     private string _transportSchemaName = "wolverine_queues";
+    private bool _transportSchemaNameIsExplicit;
 
     /// <summary>
-    /// The database schema to place SQL Server-backed queues. The default is "wolverine_queues"
+    /// The database schema to place SQL Server-backed queues.
     /// </summary>
+    /// <remarks>
+    /// GH-3884: setting this is authoritative — it overwrites whatever the SQL Server transport was
+    /// configured with, because this integration applies at host build. Leaving it alone leaves the
+    /// transport's own configuration (its default, or an explicit
+    /// <c>UseSqlServerPersistenceAndTransport(..., transportSchema: ...)</c>) untouched.
+    /// </remarks>
     public string TransportSchemaName
     {
         get => _transportSchemaName;
-        set => _transportSchemaName = value.ToLowerInvariant();
+        set
+        {
+            _transportSchemaName = value.ToLowerInvariant();
+            _transportSchemaNameIsExplicit = true;
+        }
     }
 
     private string? _messageStorageSchemaName;

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -44,12 +44,19 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
     /// <summary>
     /// Schema name for the queue and scheduled message tables
     /// </summary>
-    public string TransportSchemaName { get; private set; } = "dbo";
+    /// <remarks>
+    /// GH-3884: settable post-construction (mirroring <c>PostgresqlTransport</c>) so the
+    /// Wolverine.Polecat integration can stamp an explicitly configured
+    /// <c>PolecatIntegration.TransportSchemaName</c> onto the transport at host build time.
+    /// The queue/scheduled tables are built lazily per queue, so reassignment before the
+    /// runtime initializes the transport is safe.
+    /// </remarks>
+    public string TransportSchemaName { get; set; } = "dbo";
 
     /// <summary>
     /// Schema name for the message storage tables
     /// </summary>
-    public string MessageStorageSchemaName { get; private set; } = "dbo";
+    public string MessageStorageSchemaName { get; set; } = "dbo";
 
     /// <summary>
     /// Opt into the higher-throughput queue table storage layout: queue and scheduled tables are


### PR DESCRIPTION
Closes #3884.

## Root cause

`PolecatIntegration.TransportSchemaName` (`src/Persistence/Wolverine.Polecat/PolecatIntegration.cs`) was public and documented but never read by anything. Unlike its Marten twin — `MartenIntegration.Configure()` stamps `options.Transports.GetOrCreate<PostgresqlTransport>()` with its schema names — `PolecatIntegration.Configure()` carried only the comment "SQL Server transport will be configured when the message store is built" and stamped nothing. So:

```csharp
opts.Services.AddPolecat(...).IntegrateWithWolverine(x =>
{
    x.TransportSchemaName = "myapp_queues"; // silently did nothing
});
```

left the SQL Server transport's queue/scheduled tables wherever the transport itself was configured (`UseSqlServerPersistenceAndTransport`'s `transportSchema`, or its `"dbo"` default), with no error and no warning. The sibling `MessageStorageSchemaName` *was* wired (through the message-store factory in `WolverineOptionsPolecatExtensions`), so the two adjacent knobs behaved differently with nothing at the call site to suggest it.

## The fix

Shape (1) from the issue — wire it, matching the corrected GH-3883 Marten semantics:

- `PolecatIntegration.TransportSchemaName` now tracks explicit assignment (same `_transportSchemaNameIsExplicit` pattern as `MartenIntegration` post-GH-3883).
- `PolecatIntegration.Configure()` stamps every registered `SqlServerTransport`:
  - `TransportSchemaName` **only when the caller explicitly assigned it** — authoritative when set (Configure runs at host build, after the inline transport registration), while an unconfigured default never overwrites an explicit `UseSqlServerPersistenceAndTransport(..., transportSchema: ...)`. This is exactly the Marten behavior, so neither of the two GH-3883/GH-3884 failure modes (default clobbers explicit / explicit ignored) exists on either integration now.
  - `MessageStorageSchemaName` when set, so the transport's envelope-table SQL (its dequeue/send statements target `wolverine_incoming_envelopes` / `wolverine_outgoing_envelopes` by schema) agrees with where the integration actually places the message storage — again mirroring `MartenIntegration.Configure()`.
- Deliberately **not** mirrored: conjuring the transport when none is registered. `GetOrCreate<SqlServerTransport>()` isn't possible (the transport requires connection settings at construction), and with no SQL Server queue endpoints there are no transport tables to place — the setting is a documented no-op in that case (pinned by a test).
- `SqlServerTransport.TransportSchemaName` / `MessageStorageSchemaName` setters widened from `private` to public to allow the host-build stamp, matching the `PostgresqlTransport` twin (both public-settable there). The queue/scheduled tables are built lazily per queue ("Gotta be lazy so the schema names … get set"), so pre-runtime reassignment is safe.

On the issue's open question — "which transport does this stamp": in this repo `Wolverine.Polecat` references only `Wolverine.SqlServer`, so the answer is *every registered `SqlServerTransport`* (there is at most one per host).

## Tests

`src/Persistence/PolecatTests/polecat_applies_transport_schema.cs`, mirroring `MartenTests/marten_does_not_clobber_transport_schema.cs` (build-only hosts, no database touched):

1. explicit schema on the integration is applied to the transport (the heart of GH-3884 — inert before)
2. explicit `UseSqlServerPersistenceAndTransport(..., transportSchema:)` survives when the integration knob is unset
3. the explicit integration schema wins regardless of registration order
4. transport default (`"dbo"`) unchanged when nobody configures a schema
5. explicit `MessageStorageSchemaName` is stamped onto the transport
6. the setting is inert (and conjures no transport) when no SQL Server transport is registered

Red-check: with the `PolecatIntegration.cs` change stashed, tests 1, 3, and 5 fail and the three parity tests still pass; with the fix, all 6 pass. Full `PolecatTests` suite run against local SQL Server: green (results below). `SqlServerTests` compiles clean against the widened setters; no existing test asserted these properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
