### PR TITLE
GH-3893: the aggregate handler workflow marks its chain as transactional

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/write_aggregate_chain_is_transactional.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/write_aggregate_chain_is_transactional.cs
@@ -1,0 +1,30 @@
+using JasperFx.CodeGeneration.Frames;
+using Shouldly;
+
+namespace Wolverine.Http.Tests.Marten;
+
+// GH-3893: an HTTP chain whose only Marten shape is [WriteAggregate] gets a
+// SaveChangesAsync postprocessor from the aggregate handler workflow, but the workflow
+// never set IChain.IsTransactional. AutoApplyTransactions doesn't cover the gap either -
+// MartenPersistenceFrameProvider.CanApply deliberately ignores [WriteAggregate] - so the
+// flag and the generated code disagreed, and an IHttpPolicy keying on IsTransactional got
+// a false negative.
+public class write_aggregate_chain_is_transactional(AppFixture fixture) : IntegrationContext(fixture)
+{
+    [Fact]
+    public void write_aggregate_only_chain_is_marked_as_transactional()
+    {
+        // POST /orders/ship3 is Ship3(ShipOrder command, [WriteAggregate] Order order) - no
+        // IDocumentSession parameter, so [WriteAggregate] is the only thing attracting Marten
+        var chain = HttpChains.ChainFor("POST", "/orders/ship3");
+        chain.ShouldNotBeNull();
+
+        // What codegen actually does with this chain
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(global::Marten.IDocumentSession.SaveChangesAsync))
+            .ShouldBeTrue();
+
+        // ...and what the chain reports about itself. These have to agree.
+        chain.IsTransactional.ShouldBeTrue();
+    }
+}

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/write_aggregate_marks_chain_as_transactional.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/write_aggregate_marks_chain_as_transactional.cs
@@ -1,0 +1,96 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration.Frames;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.AggregateHandlerWorkflow;
+
+// GH-3893: a chain whose only Marten shape is [WriteAggregate] gets a SaveChangesAsync
+// postprocessor from the aggregate handler workflow, but the workflow never marked the chain
+// as transactional. AutoApplyTransactions doesn't cover the gap either - CanApply deliberately
+// ignores [WriteAggregate] because this workflow applies transaction support itself - so the flag
+// and the generated code disagreed. This pins the two together.
+public class write_aggregate_marks_chain_as_transactional : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(PostLedgerEntryHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "write_aggregate_transactional";
+                }).IntegrateWithWolverine();
+
+                // Deliberately NOT calling AutoApplyTransactions(). The aggregate handler workflow
+                // commits on its own, so the flag has to be right without that policy too.
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task chain_is_transactional_and_actually_commits()
+    {
+        var streamId = Guid.NewGuid();
+        await using (var session = theHost.DocumentStore().LightweightSession())
+        {
+            session.Events.StartStream<Ledger>(streamId, new LedgerEntryPosted(10m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await theHost.InvokeAsync(new PostLedgerEntry(streamId, 5m));
+
+        // The generated code really did commit the appended event
+        await using (var session = theHost.DocumentStore().LightweightSession())
+        {
+            var ledger = await session.Events.AggregateStreamAsync<Ledger>(streamId,
+                token: TestContext.Current.CancellationToken);
+            ledger!.Balance.ShouldBe(15m);
+        }
+
+        var chain = theHost.GetRuntime().Handlers.ChainFor<PostLedgerEntry>()!;
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .Any(x => x.Method.Name == nameof(IDocumentSession.SaveChangesAsync))
+            .ShouldBeTrue();
+
+        chain.IsTransactional.ShouldBeTrue();
+    }
+}
+
+public record LedgerEntryPosted(decimal Amount);
+
+public record PostLedgerEntry(Guid LedgerId, decimal Amount);
+
+public class Ledger
+{
+    public Guid Id { get; set; }
+    public decimal Balance { get; set; }
+
+    public void Apply(LedgerEntryPosted posted)
+    {
+        Balance += posted.Amount;
+    }
+}
+
+public static class PostLedgerEntryHandler
+{
+    public static LedgerEntryPosted Handle(PostLedgerEntry command, [WriteAggregate] Ledger ledger)
+    {
+        return new LedgerEntryPosted(command.Amount);
+    }
+}

--- a/src/Persistence/Wolverine.Marten/AggregateHandling.cs
+++ b/src/Persistence/Wolverine.Marten/AggregateHandling.cs
@@ -42,7 +42,13 @@ internal record AggregateHandling(IDataRequirement Requirement)
 
         declareAggregateIdRouteParameter(chain);
 
+        // GH-3893: the aggregate handler workflow applies transaction support on its own rather than
+        // waiting for AutoApplyTransactions - MartenPersistenceFrameProvider.CanApply deliberately
+        // ignores [WriteAggregate]/[AggregateHandler] for exactly that reason. Mark the chain here too,
+        // or IChain.IsTransactional reports false on a chain whose generated code ends in
+        // SaveChangesAsync, and an IHttpPolicy/IChainPolicy keying on the flag gets a false negative.
         new MartenPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
+        chain.IsTransactional = true;
 
         var loader = new LoadAggregateFrame(this);
         chain.Middleware.Add(loader);

--- a/src/Persistence/Wolverine.Marten/BoundaryModelAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/BoundaryModelAttribute.cs
@@ -86,6 +86,7 @@ public class BoundaryModelAttribute : WolverineParameterAttribute, IDataRequirem
         }
 
         new MartenPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
+        chain.IsTransactional = true;
 
         // One fetch per (chain, aggregate type). A second [BoundaryModel] of
         // the same type (e.g. on Validate plus Handle) reuses the same frame,

--- a/src/Persistence/Wolverine.Polecat/AggregateHandling.cs
+++ b/src/Persistence/Wolverine.Polecat/AggregateHandling.cs
@@ -40,7 +40,13 @@ internal record AggregateHandling(IDataRequirement Requirement)
 
         declareAggregateIdRouteParameter(chain);
 
+        // GH-3893: the aggregate handler workflow applies transaction support on its own rather than
+        // waiting for AutoApplyTransactions - PolecatPersistenceFrameProvider.CanApply deliberately
+        // ignores [WriteAggregate]/[AggregateHandler] for exactly that reason. Mark the chain here too,
+        // or IChain.IsTransactional reports false on a chain whose generated code ends in
+        // SaveChangesAsync, and an IHttpPolicy/IChainPolicy keying on the flag gets a false negative.
         new PolecatPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
+        chain.IsTransactional = true;
 
         var loader = new LoadAggregateFrame(this);
         chain.Middleware.Add(loader);

--- a/src/Persistence/Wolverine.Polecat/BoundaryModelAttribute.cs
+++ b/src/Persistence/Wolverine.Polecat/BoundaryModelAttribute.cs
@@ -79,6 +79,7 @@ public class BoundaryModelAttribute : WolverineParameterAttribute, IDataRequirem
         }
 
         new PolecatPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
+        chain.IsTransactional = true;
 
         var loader = chain.Middleware.OfType<LoadBoundaryFrame>()
             .FirstOrDefault(f => f.AggregateType == aggregateType);


### PR DESCRIPTION
The Marten and Polecat aggregate handler workflows append a `SaveChangesAsync` postprocessor but never set `IChain.IsTransactional`, so a `[WriteAggregate]` chain reports that it has no transactional middleware while its generated code commits. Four lines set the flag where those workflows already apply transaction support.

Fixes #3893.

## The change

`AggregateHandling.Apply` and `BoundaryModelAttribute.Modify` call `ApplyTransactionSupport(...)` themselves — the same call `TransactionalAttribute` and `AutoApplyTransactions` each pair with `chain.IsTransactional = true` — and skipped the second half. `MartenPersistenceFrameProvider.CanApply` deliberately ignores these shapes precisely because they apply support themselves, so nothing else set it either.

- `Wolverine.Marten/AggregateHandling.cs`, `Wolverine.Marten/BoundaryModelAttribute.cs`
- `Wolverine.Polecat/AggregateHandling.cs`, `Wolverine.Polecat/BoundaryModelAttribute.cs`

## Worth extra scrutiny

1. **`[NonTransactional]` + `[WriteAggregate]`.** `AutoApplyTransactions` skips `[NonTransactional]` chains, but the aggregate workflow never consulted the attribute and commits regardless. Such a chain now reports `true`. The flag is describing codegen accurately; whether the attribute ought to suppress the aggregate commit is a separate question.

2. **Saga chains.** `ApplyTransactionSupport` skips the `SaveChangesAsync` postprocessor when `chain is SagaChain`, so `[WriteAggregate]` on a saga handler sets the flag without that specific frame. It still commits — `CommitUnitOfWorkFrame` returns `DocumentSessionSaveChanges`.

3. **`MartenOpPolicy` / `PolecatOpPolicy` left alone deliberately.** Same disagreement for `IMartenOp` returns and `IEventStream<T>` parameters, but those are `IChainPolicy`s registered from `IntegrateWithWolverine()`. Setting the flag there would make whether `EagerIdempotencyOnNonTransactionalChains` fires depend on the order the user calls `AutoApplyIdempotencyOnNonTransactionalHandlers()` — generated code varying by registration order. That wants its own fix.

Also worth knowing: on handler chains the flag lands during `applyCustomizations` / `DetermineFrames`, which is after `IHandlerPolicy` runs. So it only becomes policy-visible on the HTTP path, where `WriteAggregateAttribute.Modify` runs at `HttpChain` construction.

## Tests

Both assert the `SaveChangesAsync` postprocessor **and** the flag, so neither can pass by quietly losing the commit:

- `Wolverine.Http.Tests/Marten/write_aggregate_chain_is_transactional` — `POST /orders/ship3`, an existing `[WriteAggregate]`-only endpoint.
- `MartenTests/AggregateHandlerWorkflow/write_aggregate_marks_chain_as_transactional` — a handler chain end to end, deliberately without `AutoApplyTransactions()`.

Both confirmed red at unmodified `HEAD`, failing on the flag assertion with the postprocessor assertion already passing.

## Verification

| Suite | Result |
|---|---|
| `MartenTests` | 553/553 |
| `PolecatTests` | 245 passed, 2 skipped |
| `CoreTests` | 2339 passed, 3 skipped |
| `Wolverine.Http.Tests` | 950 passed, 10 skipped |
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |
