### PR TITLE
GH-3899: exempt message types from partitioned (GroupId-keyed) processing

### DIFF
--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -44,7 +44,7 @@ public interface IOrderCommand
 public record ApproveOrder(string OrderId) : IOrderCommand;
 public record CancelOrder(string OrderId) : IOrderCommand;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L171-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_commands_for_partitioning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L199-L208' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_commands_for_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If we were only running our system on a single node so we only care about a single process, we can do this:
@@ -287,7 +287,7 @@ public static IEnumerable<object> Handle(ApproveInvoice command)
     yield return new PayInvoice(command.Id).WithGroupId("aaa");
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L162-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_with_group_id_as_cascading_message' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L190-L196' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_with_group_id_as_cascading_message' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Partitioned Publishing Locally
@@ -365,6 +365,57 @@ builder.UseWolverine(opts =>
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L14-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_partitioned_processing_on_any_listener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Exempting Message Types from Partitioned Processing <Badge type="tip" text="6.26" />
+
+`PartitionProcessingByGroupId()` routes **every** message on the listener through a GroupId-keyed slot. That's
+exactly right for the message types that need per-group ordering, but when one GroupId dominates the traffic, the
+whole listener collapses toward sequential processing for *all* message types — including high-volume types
+(metrics, telemetry, counters) that never needed any ordering at all.
+
+You can exempt those message types from partitioned processing. Exempted types skip the GroupId slots entirely and
+execute on the endpoint's normal parallel execution lane (its `MaxDegreeOfParallelism`), while every other message
+type keeps its strict per-GroupId sequencing:
+
+<!-- snippet: sample_exempting_message_types_from_partitioned_processing -->
+<a id='snippet-sample_exempting_message_types_from_partitioned_processing'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    opts.UseRabbitMq();
+
+    // Group all order-related messages by their order id...
+    opts.MessagePartitioning
+        .ByMessage<IOrderCommand>(x => x.OrderId)
+
+        // ...but order telemetry needs no ordering guarantees at all, so
+        // exempt it from partitioned processing. Exempted message types
+        // execute at the endpoint's normal MaxDegreeOfParallelism instead
+        // of being serialized behind a GroupId slot, so one dominant
+        // GroupId can't collapse the whole listener to sequential
+        // processing for messages that never asked for ordering.
+        // There is also an overload taking a Func<Type, bool> filter.
+        .ExemptFromPartitionedProcessing<OrderTelemetry>();
+
+    opts.ListenToRabbitQueue("incoming")
+        .PartitionProcessingByGroupId(PartitionSlots.Seven);
+});
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L140-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_exempting_message_types_from_partitioned_processing' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The generic overload matches any message type that can be cast to the given type, so a marker interface or common
+base class works. A `Func<Type, bool>` overload is available for predicate-based matching, and exemptions are
+additive.
+
+Two things to be aware of:
+
+* This changes **only the in-process execution lane**. Durable inbox/outbox handling, message routing, sender-side
+  queue sharding, and GroupId stamping are all unaffected — an exempted message on a durable endpoint is persisted
+  to the inbox before execution exactly as before.
+* An exempted message may execute concurrently with a non-exempted message carrying the same GroupId. Only exempt
+  message types that truly require no ordering relative to the partitioned types.
 
 ## Partitioned Processing with Batched Handlers <Badge type="tip" text="6.25" />
 
@@ -477,7 +528,7 @@ opts.MessagePartitioning.PublishToShardedRabbitQueues("letters", 4, topology =>
     topology.ConfigureListening(x => x.BufferedInMemory());
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/concurrency_resilient_sharded_processing.cs#L71-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_defining_partitioned_routing_for_rabbitmq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/concurrency_resilient_sharded_processing.cs#L69-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_defining_partitioned_routing_for_rabbitmq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And for Amazon SQS:
@@ -498,7 +549,7 @@ opts.MessagePartitioning.PublishToShardedAmazonSqsQueues("letters", 4, topology 
 
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/concurrency_resilient_sharded_processing.cs#L73-L87' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_partitioned_publishing_through_amazon_sqs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/concurrency_resilient_sharded_processing.cs#L71-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_partitioned_publishing_through_amazon_sqs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Propagating GroupId to PartitionKey <Badge type="tip" text="5.17" />
@@ -526,7 +577,7 @@ builder.UseWolverine(opts =>
     opts.Policies.PropagateGroupIdToPartitionKey();
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L140-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_propagate_group_id_to_partition_key' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L168-L181' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_propagate_group_id_to_partition_key' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip

--- a/src/Samples/DocumentationSamples/PartitioningSamples.cs
+++ b/src/Samples/DocumentationSamples/PartitioningSamples.cs
@@ -135,6 +135,34 @@ public class PartitioningSamples
 
     #endregion
 
+    public static async Task exempting_message_types_from_partitioned_processing()
+    {
+        #region sample_exempting_message_types_from_partitioned_processing
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            opts.UseRabbitMq();
+
+            // Group all order-related messages by their order id...
+            opts.MessagePartitioning
+                .ByMessage<IOrderCommand>(x => x.OrderId)
+
+                // ...but order telemetry needs no ordering guarantees at all, so
+                // exempt it from partitioned processing. Exempted message types
+                // execute at the endpoint's normal MaxDegreeOfParallelism instead
+                // of being serialized behind a GroupId slot, so one dominant
+                // GroupId can't collapse the whole listener to sequential
+                // processing for messages that never asked for ordering.
+                // There is also an overload taking a Func<Type, bool> filter.
+                .ExemptFromPartitionedProcessing<OrderTelemetry>();
+
+            opts.ListenToRabbitQueue("incoming")
+                .PartitionProcessingByGroupId(PartitionSlots.Seven);
+        });
+
+        #endregion
+    }
+
     public static async Task propagate_group_id_to_partition_key()
     {
         #region sample_propagate_group_id_to_partition_key
@@ -178,3 +206,5 @@ public record ApproveOrder(string OrderId) : IOrderCommand;
 public record CancelOrder(string OrderId) : IOrderCommand;
 
 #endregion
+
+public record OrderTelemetry(string OrderId, double ElapsedMilliseconds);

--- a/src/Testing/CoreTests/Runtime/Partitioning/exempting_types_from_partitioned_processing.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/exempting_types_from_partitioned_processing.cs
@@ -1,0 +1,372 @@
+using JasperFx.Blocks;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.Hosting;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Runtime.Partitioning;
+using Xunit;
+
+namespace CoreTests.Runtime.Partitioning;
+
+// GH-3899: scope GroupId partitioning to the message types that need it. Message types exempted
+// from partitioned processing execute at the endpoint's normal parallelism instead of being
+// serialized behind a GroupId slot, so a single dominant GroupId cannot collapse the whole
+// listener to sequential processing for types that never asked for ordering.
+
+public class exemption_rules
+{
+    public interface INeedsNoOrdering;
+
+    public record ExemptByMarker(string Name) : INeedsNoOrdering;
+
+    public record NotExempt(string Name);
+
+    [Fact]
+    public void no_exemptions_by_default()
+    {
+        var rules = new MessagePartitioningRules(new());
+
+        rules.HasProcessingExemptions.ShouldBeFalse();
+        rules.IsExemptFromPartitionedProcessing(typeof(NotExempt)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exempt_by_marker_interface()
+    {
+        var rules = new MessagePartitioningRules(new());
+        rules.ExemptFromPartitionedProcessing<INeedsNoOrdering>();
+
+        rules.HasProcessingExemptions.ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(NotExempt)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exempt_by_concrete_type()
+    {
+        var rules = new MessagePartitioningRules(new());
+        rules.ExemptFromPartitionedProcessing<ExemptByMarker>();
+
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(NotExempt)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exempt_by_predicate()
+    {
+        var rules = new MessagePartitioningRules(new());
+        rules.ExemptFromPartitionedProcessing(type => type.Name.StartsWith("Not"));
+
+        rules.IsExemptFromPartitionedProcessing(typeof(NotExempt)).ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exemptions_are_additive_and_fluent()
+    {
+        var rules = new MessagePartitioningRules(new());
+        rules.ExemptFromPartitionedProcessing<ExemptByMarker>()
+            .ExemptFromPartitionedProcessing(type => type == typeof(NotExempt))
+            .ShouldBeSameAs(rules);
+
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(NotExempt)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void cached_answer_is_stable_across_repeated_lookups()
+    {
+        var calls = 0;
+        var rules = new MessagePartitioningRules(new());
+        rules.ExemptFromPartitionedProcessing(type =>
+        {
+            calls++;
+            return type == typeof(ExemptByMarker);
+        });
+
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeTrue();
+        rules.IsExemptFromPartitionedProcessing(typeof(ExemptByMarker)).ShouldBeTrue();
+
+        calls.ShouldBe(1);
+    }
+}
+
+public class sharded_execution_block_exempt_lane
+{
+    public interface INeedsNoOrdering;
+
+    public record UnorderedSample(string ServiceName) : INeedsNoOrdering;
+
+    public record OrderedAppend(string ServiceName, int Sequence);
+
+    private static MessagePartitioningRules rulesWithExemption()
+    {
+        var rules = new MessagePartitioningRules(new());
+        rules.ByMessage<OrderedAppend>(x => x.ServiceName);
+        rules.ByMessage<UnorderedSample>(x => x.ServiceName);
+        rules.ExemptFromPartitionedProcessing<INeedsNoOrdering>();
+        return rules;
+    }
+
+    private static Envelope envelopeFor(object message)
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Message = message;
+        return envelope;
+    }
+
+    [Fact]
+    public void no_exempt_lane_when_no_exemptions_are_registered()
+    {
+        var rules = new MessagePartitioningRules(new());
+        rules.ByMessage<OrderedAppend>(x => x.ServiceName);
+
+        var block = new ShardedExecutionBlock(5, rules, (_, _) => Task.CompletedTask);
+        block.HasExemptLane.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void builds_exempt_lane_when_exemptions_are_registered()
+    {
+        var block = new ShardedExecutionBlock(5, rulesWithExemption(), (_, _) => Task.CompletedTask);
+        block.HasExemptLane.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task exempt_messages_are_not_blocked_behind_a_dominated_slot()
+    {
+        // The CritterWatch#969 field case in miniature: one GroupId dominates and its slot is
+        // busy. Exempted messages carrying the SAME group key must still flow.
+        var blockerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBlocker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var exemptProcessed = 0;
+        var exemptDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        const int exemptCount = 20;
+
+        var block = new ShardedExecutionBlock(5, rulesWithExemption(), Block<Envelope>.DefaultBoundedCapacity,
+            async (e, _) =>
+            {
+                if (e.Message is OrderedAppend)
+                {
+                    blockerEntered.TrySetResult();
+                    await releaseBlocker.Task;
+                }
+                else
+                {
+                    if (Interlocked.Increment(ref exemptProcessed) == exemptCount)
+                    {
+                        exemptDone.TrySetResult();
+                    }
+                }
+            });
+
+        try
+        {
+            await block.PostAsync(envelopeFor(new OrderedAppend("the-one-service", 1)));
+            await blockerEntered.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+            for (var i = 0; i < exemptCount; i++)
+            {
+                await block.PostAsync(envelopeFor(new UnorderedSample("the-one-service")));
+            }
+
+            // All exempt messages complete while the dominant group's slot is still blocked
+            await exemptDone.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+            exemptProcessed.ShouldBe(exemptCount);
+        }
+        finally
+        {
+            releaseBlocker.TrySetResult();
+        }
+
+        block.Complete();
+        await block.WaitForCompletionAsync();
+    }
+
+    [Fact]
+    public async Task exempt_messages_execute_in_parallel_at_the_configured_parallelism()
+    {
+        // Rendezvous barrier: all 4 handlers must be in flight simultaneously for any of them
+        // to complete. Sequential (slot-style) execution would deadlock and time the test out.
+        const int parallelism = 4;
+        var arrivals = 0;
+        var allArrived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var block = new ShardedExecutionBlock(5, rulesWithExemption(), Block<Envelope>.DefaultBoundedCapacity,
+            async (_, _) =>
+            {
+                if (Interlocked.Increment(ref arrivals) == parallelism)
+                {
+                    allArrived.TrySetResult();
+                }
+
+                await allArrived.Task;
+            }, exemptLaneParallelism: parallelism);
+
+        for (var i = 0; i < parallelism; i++)
+        {
+            // Same group key on purpose — a slot would run these one at a time
+            await block.PostAsync(envelopeFor(new UnorderedSample("the-one-service")));
+        }
+
+        await allArrived.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        block.Complete();
+        await block.WaitForCompletionAsync();
+    }
+
+    [Fact]
+    public async Task non_exempt_messages_keep_strict_per_group_ordering_while_exempt_messages_interleave()
+    {
+        var executed = new List<int>();
+        var inFlightOrdered = 0;
+        var maxConcurrentOrdered = 0;
+        var gate = new object();
+
+        var block = new ShardedExecutionBlock(5, rulesWithExemption(), Block<Envelope>.DefaultBoundedCapacity,
+            async (e, _) =>
+            {
+                if (e.Message is OrderedAppend append)
+                {
+                    var now = Interlocked.Increment(ref inFlightOrdered);
+                    InterlockedMax(ref maxConcurrentOrdered, now);
+
+                    await Task.Delay(5);
+                    lock (gate)
+                    {
+                        executed.Add(append.Sequence);
+                    }
+
+                    Interlocked.Decrement(ref inFlightOrdered);
+                }
+                else
+                {
+                    await Task.Delay(1);
+                }
+            });
+
+        const int count = 15;
+        for (var i = 0; i < count; i++)
+        {
+            // Interleave: an ordered append followed by exempt noise with the same group key
+            await block.PostAsync(envelopeFor(new OrderedAppend("the-one-service", i)));
+            await block.PostAsync(envelopeFor(new UnorderedSample("the-one-service")));
+        }
+
+        block.Complete();
+        await block.WaitForCompletionAsync();
+
+        // The non-exempt messages for a single group stayed strictly sequential AND in posted order
+        maxConcurrentOrdered.ShouldBe(1);
+        executed.ShouldBe(Enumerable.Range(0, count).ToList());
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        while (value > (current = Volatile.Read(ref location)))
+        {
+            if (Interlocked.CompareExchange(ref location, value, current) == current)
+            {
+                return;
+            }
+        }
+    }
+}
+
+public class exempting_types_from_partitioned_processing_end_to_end
+{
+    public interface INeedsNoOrdering;
+
+    public record BlockingAppend(string ServiceName);
+
+    public record FastSample(string ServiceName) : INeedsNoOrdering;
+
+    public static class EndToEndHandlers
+    {
+        public static TaskCompletionSource BlockerEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public static TaskCompletionSource ReleaseBlocker = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public static TaskCompletionSource BlockerFinished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public static TaskCompletionSource SamplesDone = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public static int SampleCount;
+        public static int ExpectedSamples;
+
+        public static void Reset(int expectedSamples)
+        {
+            BlockerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            ReleaseBlocker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            BlockerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SamplesDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            SampleCount = 0;
+            ExpectedSamples = expectedSamples;
+        }
+
+        public static async Task Handle(BlockingAppend _)
+        {
+            BlockerEntered.TrySetResult();
+            await ReleaseBlocker.Task;
+            BlockerFinished.TrySetResult();
+        }
+
+        public static void Handle(FastSample _)
+        {
+            if (Interlocked.Increment(ref SampleCount) == ExpectedSamples)
+            {
+                SamplesDone.TrySetResult();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task exempt_type_rides_endpoint_parallelism_while_same_group_slot_is_busy()
+    {
+        const int samples = 10;
+        EndToEndHandlers.Reset(samples);
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(EndToEndHandlers));
+
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+
+                // Group everything by its service identifier — the CritterWatch usage shape
+                opts.MessagePartitioning.ByPropertyNamed("ServiceName");
+                opts.MessagePartitioning.ExemptFromPartitionedProcessing<INeedsNoOrdering>();
+
+                opts.LocalQueue("partitioned")
+                    .PartitionProcessingByGroupId(PartitionSlots.Five);
+
+                opts.PublishMessage<BlockingAppend>().ToLocalQueue("partitioned");
+                opts.PublishMessage<FastSample>().ToLocalQueue("partitioned");
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var bus = host.MessageBus();
+
+        try
+        {
+            // Occupy the dominant group's slot
+            await bus.PublishAsync(new BlockingAppend("the-one-service"));
+            await EndToEndHandlers.BlockerEntered.Task.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+
+            // Same GroupId, but exempted from partitioned processing — must complete while
+            // the slot is still occupied
+            for (var i = 0; i < samples; i++)
+            {
+                await bus.PublishAsync(new FastSample("the-one-service"));
+            }
+
+            await EndToEndHandlers.SamplesDone.Task.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+            EndToEndHandlers.SampleCount.ShouldBe(samples);
+            EndToEndHandlers.BlockerFinished.Task.IsCompleted.ShouldBeFalse();
+        }
+        finally
+        {
+            EndToEndHandlers.ReleaseBlocker.TrySetResult();
+        }
+
+        await EndToEndHandlers.BlockerFinished.Task.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Wolverine/Runtime/Partitioning/MessagePartitioningRules.cs
+++ b/src/Wolverine/Runtime/Partitioning/MessagePartitioningRules.cs
@@ -11,6 +11,8 @@ public class MessagePartitioningRules
 {
     private readonly WolverineOptions _options;
     private readonly List<IGroupingRule> _rules = new();
+    private readonly List<Func<Type, bool>> _processingExemptions = new();
+    private ImHashMap<Type, bool> _processingExemptionCache = ImHashMap<Type, bool>.Empty;
     private bool _useInferredGrouping;
 
     public MessagePartitioningRules(WolverineOptions options)
@@ -73,6 +75,59 @@ public class MessagePartitioningRules
     {
         topology = GlobalPartitionedTopologies.FirstOrDefault(x => x.Matches(messageType));
         return topology != null;
+    }
+
+    /// <summary>
+    /// Exempt any message type that can be cast to <typeparamref name="T"/> (including marker
+    /// interfaces and base classes) from partitioned, GroupId-keyed *processing* on listening
+    /// endpoints configured with <c>PartitionProcessingByGroupId()</c> (including the listening side
+    /// of partitioned/global partitioned topologies). Exempted message types execute on the
+    /// endpoint's normal parallel execution lane (its <c>MaxDegreeOfParallelism</c>) instead of a
+    /// sequential GroupId slot. Use this for high-volume message types that need no ordering
+    /// guarantees so a single dominant GroupId cannot collapse the whole listener to sequential
+    /// processing.
+    ///
+    /// This changes only the in-process execution lane — durable inbox/outbox handling, message
+    /// routing, sender-side queue sharding, and GroupId stamping are all unaffected. An exempted
+    /// message may execute concurrently with a non-exempted message carrying the same GroupId, so
+    /// only exempt types that truly require no ordering relative to the partitioned types.
+    /// </summary>
+    public MessagePartitioningRules ExemptFromPartitionedProcessing<T>()
+    {
+        return ExemptFromPartitionedProcessing(type => type.CanBeCastTo<T>());
+    }
+
+    /// <summary>
+    /// Exempt any message type matching the supplied filter from partitioned, GroupId-keyed
+    /// *processing* on listening endpoints configured with <c>PartitionProcessingByGroupId()</c>.
+    /// See <see cref="ExemptFromPartitionedProcessing{T}"/> for the semantics and caveats.
+    /// </summary>
+    /// <param name="filter">Evaluated once per concrete message type (results are cached)</param>
+    public MessagePartitioningRules ExemptFromPartitionedProcessing(Func<Type, bool> filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        _processingExemptions.Add(filter);
+        _processingExemptionCache = ImHashMap<Type, bool>.Empty;
+        return this;
+    }
+
+    internal bool HasProcessingExemptions => _processingExemptions.Count != 0;
+
+    internal bool IsExemptFromPartitionedProcessing(Type messageType)
+    {
+        if (_processingExemptions.Count == 0)
+        {
+            return false;
+        }
+
+        if (_processingExemptionCache.TryFind(messageType, out var exempt))
+        {
+            return exempt;
+        }
+
+        exempt = _processingExemptions.Any(filter => filter(messageType));
+        _processingExemptionCache = _processingExemptionCache.AddOrUpdate(messageType, exempt);
+        return exempt;
     }
 
     /// <summary>

--- a/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
+++ b/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
@@ -10,12 +10,18 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
     private readonly MessagePartitioningRules _rules;
     private readonly Block<Envelope>[] _slots;
 
+    // GH-3899: message types exempted from partitioned processing execute here at the endpoint's
+    // normal parallelism instead of being serialized behind a GroupId slot. Null when the
+    // application has registered no exemptions, so the default behavior is completely unchanged.
+    private readonly Block<Envelope>? _exemptLane;
+
     public ShardedExecutionBlock(int numberOfSlots, MessagePartitioningRules rules, Func<Envelope, CancellationToken, Task> processAsync)
         : this(numberOfSlots, rules, Block<Envelope>.DefaultBoundedCapacity, processAsync)
     {
     }
 
-    public ShardedExecutionBlock(int numberOfSlots, MessagePartitioningRules rules, int boundedCapacity, Func<Envelope, CancellationToken, Task> processAsync)
+    public ShardedExecutionBlock(int numberOfSlots, MessagePartitioningRules rules, int boundedCapacity,
+        Func<Envelope, CancellationToken, Task> processAsync, int? exemptLaneParallelism = null)
     {
         _numberOfSlots = numberOfSlots;
         _rules = rules;
@@ -25,6 +31,29 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
         {
             _slots[i] = new Block<Envelope>(1, boundedCapacity, processAsync);
         }
+
+        if (rules.HasProcessingExemptions)
+        {
+            _exemptLane = new Block<Envelope>(exemptLaneParallelism ?? numberOfSlots, boundedCapacity, processAsync);
+        }
+    }
+
+    internal bool HasExemptLane => _exemptLane != null;
+
+    private bool tryRouteToExemptLane(Envelope item, out Block<Envelope> lane)
+    {
+        // Envelope.Message is guaranteed to be populated on this path for real listeners because
+        // DeserializeFirst() runs upstream of the slot routing, but stay defensive: an envelope
+        // without a resolved message keeps the (safe) partitioned path.
+        if (_exemptLane != null && item.Message != null &&
+            _rules.IsExemptFromPartitionedProcessing(item.Message.GetType()))
+        {
+            lane = _exemptLane;
+            return true;
+        }
+
+        lane = default!;
+        return false;
     }
 
     public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime, IChannelCallback channel)
@@ -45,9 +74,22 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
         });
     }
 
-    public override async ValueTask DisposeAsync()
+    private IEnumerable<Block<Envelope>> allBlocks()
     {
         foreach (var slot in _slots)
+        {
+            yield return slot;
+        }
+
+        if (_exemptLane != null)
+        {
+            yield return _exemptLane;
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        foreach (var slot in allBlocks())
         {
             try
             {
@@ -62,7 +104,7 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
 
     public override async Task WaitForCompletionAsync()
     {
-        foreach (var slot in _slots)
+        foreach (var slot in allBlocks())
         {
             await slot.WaitForCompletionAsync();
         }
@@ -70,13 +112,13 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
 
     public override void Complete()
     {
-        foreach (var slot in _slots)
+        foreach (var slot in allBlocks())
         {
             slot.Complete();
         }
     }
 
-    public override uint Count => (uint)_slots.Sum(x => x.Count);
+    public override uint Count => (uint)allBlocks().Sum(x => x.Count);
 
     /// <summary>
     /// Propagates to every slot block. Without this, a slot's escaping exception falls to the
@@ -87,7 +129,7 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
         get => _slots[0].OnError;
         set
         {
-            foreach (var slot in _slots)
+            foreach (var slot in allBlocks())
             {
                 slot.OnError = value;
             }
@@ -96,6 +138,14 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
 
     public override ValueTask PostAsync(Envelope item)
     {
+        // GH-3899: message types that are explicitly exempted from partitioned processing skip
+        // the GroupId slots entirely and execute at the endpoint's normal parallelism, so one
+        // dominant GroupId cannot serialize message types that need no ordering
+        if (tryRouteToExemptLane(item, out var lane))
+        {
+            return lane.PostAsync(item);
+        }
+
         // This first uses new "message grouping rules" to determine a GroupId
         // for an envelope if there's not already one, then...
         // Does a deterministic hash of the GroupId, then a modulo of the number
@@ -110,6 +160,12 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
 
     public override void Post(Envelope item)
     {
+        if (tryRouteToExemptLane(item, out var lane))
+        {
+            lane.Post(item);
+            return;
+        }
+
         var index = item.SlotForProcessing(_numberOfSlots, _rules);
         _slots[index].Post(item);
     }

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -67,7 +67,10 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         else
         {
             var sharded = new ShardedExecutionBlock((int)endpoint.GroupShardingSlotNumber,
-                runtime.Options.MessagePartitioning, boundedCapacity, executeAsync);
+                runtime.Options.MessagePartitioning, boundedCapacity, executeAsync,
+                // GH-3899: message types exempted from partitioned processing run at the
+                // endpoint's normal parallelism instead of a sequential GroupId slot
+                endpoint.MaxDegreeOfParallelism);
             sharded.OnError = onBlockError;
             _receivingBlock = sharded.DeserializeFirst(pipeline, runtime, this);
         }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -137,7 +137,10 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         else
         {
             var sharded = new ShardedExecutionBlock((int)endpoint.GroupShardingSlotNumber,
-                runtime.Options.MessagePartitioning, boundedCapacity, execute);
+                runtime.Options.MessagePartitioning, boundedCapacity, execute,
+                // GH-3899: message types exempted from partitioned processing run at the
+                // endpoint's normal parallelism instead of a sequential GroupId slot
+                endpoint.MaxDegreeOfParallelism);
             sharded.OnError = onBlockError;
             _receiver = sharded.DeserializeFirst(pipeline, runtime, this);
         }


### PR DESCRIPTION
Closes #3899. Field case: JasperFx/CritterWatch#969.

## Problem

`PartitionProcessingByGroupId()` routes **every** message on the listener through a GroupId-keyed slot. That is exactly right for the types that need per-group ordering — but when one GroupId dominates the traffic, the whole listener collapses toward sequential processing for *all* message types, including high-volume document/accumulator types (metrics samples, progression updates, DLQ counts) that never asked for ordering. In the CritterWatch#969 fleet (GroupId = ServiceName, **one** monitored service, 2,173 tenants), effectively every envelope landed on one slot: ~207 msg/min drained against ~7,870/min arriving on an 8-core pod, listener permanently latched.

## API chosen: a per-type exemption on `MessagePartitioningRules`

```csharp
opts.MessagePartitioning
    .ByMessage<IOrderCommand>(x => x.OrderId)
    // marker interface / base class / concrete type…
    .ExemptFromPartitionedProcessing<OrderTelemetry>()
    // …or predicate form; exemptions are additive
    .ExemptFromPartitionedProcessing(type => type.CanBeCastTo<ISomeMarker>());
```

Exempted message types skip the GroupId slots entirely and execute on a dedicated lane inside `ShardedExecutionBlock` running at the endpoint's `MaxDegreeOfParallelism` — the same parallelism the listener would have had without partitioning. Every non-exempt type keeps strict per-GroupId sequencing, unchanged.

**Why this shape:**

- **Global, on the rules object** — "this type needs no ordering" is a property of the message type, not of one endpoint, and it lives next to the grouping rules that create the ordering in the first place. It also automatically covers every way partitioned processing gets applied: direct `PartitionProcessingByGroupId()`, `Policies.AllListeners(...)`, and the listening side of `PublishToPartitionedLocalMessaging` / `GlobalPartitioned` topologies (which compile down to the same `GroupShardingSlotNumber`).
- **Smallest orthogonal surface** — one new public method (two overloads), no endpoint plumbing, no new policy object, fluent like the surrounding `ByMessage`/`ByPropertyNamed`/`Except<T>()` (#3867) idioms.
- **Fully additive** — when no exemptions are registered the exempt lane is not even constructed and the routing check is a single `count == 0` early-out; existing configurations behave bit-for-bit as before.

**Alternative considered: per-message-type slot-key derivation** (e.g. re-key metrics by service+store to spread the dominant group). Listener-side re-derivation already *almost* exists via `ByMessage<T>(func)`, but a sender-stamped `Envelope.GroupId` deliberately wins over listener rules (`DetermineGroupId` short-circuits), and GroupId also drives sender-side queue-shard hashing, `GroupIdMessageBatcher` batch identity, and the cluster-wide single-writer guarantee of `GlobalPartitioned` topologies — a type-scoped listener-local re-key would silently diverge from all of those. The exemption is the clean orthogonal lever for types that need *no* ordering; a "spread" key can be a follow-up if a real case needs partial ordering within a dominant group.

## Durability is unaffected

The slot dispatch sits strictly downstream of durable inbox persistence: `DurableReceiver.receiveOneAsync` / `ProcessReceivedMessagesAsync` call `_inbox.StoreIncomingAsync(...)` **before** `EnqueueAsync` posts into the sharded block, and the exempt lane runs the same `execute` closure (pipeline invoke → `_markAsHandled` / dead-letter paths) as the slots. The exemption changes only which in-process execution lane an envelope rides — inbox/outbox handling, routing, and sender-side queue sharding are untouched. The caveat (documented on the API and in the docs page): an exempted message may execute concurrently with a non-exempted message carrying the same GroupId, so only types that truly need no ordering should be exempted.

## Tests

New `CoreTests.Runtime.Partitioning.exempting_types_from_partitioned_processing`:

- rules unit tests (marker/concrete/predicate matching, additive + fluent, per-type cache, no exemptions by default)
- `ShardedExecutionBlock` tests: no exempt lane constructed without exemptions; **exempt messages complete while the dominant group's slot is blocked** (the #969 case in miniature); exempt messages provably run in parallel (rendezvous barrier that deadlocks under sequential execution); **ordering-sensitive interleave** — 15 non-exempt + 15 exempt messages sharing one group key, asserting the non-exempt ones executed strictly sequentially and in posted order
- end-to-end host test: local queue + `PartitionProcessingByGroupId(Five)` + `ByPropertyNamed("ServiceName")` (the CritterWatch usage shape); exempt type completes at endpoint parallelism while a same-GroupId blocking handler still occupies its slot

Results: partitioning classes 96/96 green on net9.0 + net10.0; batching classes 15/15; full CoreTests 2360/2363 passed with 1 unrelated flake (`remembered_application_assembly_reuse_warning.a_normal_single_assembly_host_does_not_warn`, passes 4/4 re-run in isolation; no connection to partitioning). DocumentationSamples builds; `docs/guide/messaging/partitioning.md` gains an "Exempting Message Types from Partitioned Processing" section with an mdsnippets-sourced sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)