### PR TITLE
GH-3898: grouped message batches enforce their members' DeliverBy expiry again

### DIFF
--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -253,6 +253,28 @@ that refers to the original message is completely processed. See [Durability and
 settlement](#durability-and-message-settlement) above for the full settlement model and why a durable listener
 is required for guaranteed delivery.
 
+## Message expiration (`DeliverBy` / `DeliverWithin`) <Badge type="tip" text="6.26" />
+
+Batched messages honor member-level [message expiration](/guide/messages) the same way unbatched messages do,
+just at two different points in the batching pipeline:
+
+1. **At batch assembly** — any member whose `DeliverBy` elapsed while it waited in the batching channel is shed
+   individually and never becomes part of the batch message. Only the still-live members are handed to the
+   batch handler. Each shed member is logged with the same "discarded expired envelope" log event a normal
+   expired message gets, and its inbox/back-pressure bookkeeping is settled exactly as if its batch had
+   completed.
+2. **At batch execution** — the assembled batch envelope carries the *latest* member expiry as its own
+   `DeliverBy` (only when *every* member has one; a single member with no expiration keeps the batch alive
+   forever). If the batch then sits on the local execution queue long enough for that latest expiry to pass,
+   every member is by definition expired, so the whole batch is discarded without invoking the handler and all
+   members settle normally. Keying on the latest member expiry means the whole-batch check can never
+   over-shed a live member.
+
+Members of one batch may carry different `DeliverBy` values (or none). A member that expires *after* assembly
+but before the batch executes will still be processed if any of its batch-mates are unexpired — per-member
+precision inside an already-built batch message isn't possible generically. If stale members must never reach
+your handler, check each item's staleness in the batch handler itself.
+
 ## De-duplicating a batch with `CoalesceBy`
 
 A very common batching workload is a "trigger storm": a bulk operation fires hundreds or thousands of

--- a/src/Testing/CoreTests/Acceptance/batch_deliver_by_expiry.cs
+++ b/src/Testing/CoreTests/Acceptance/batch_deliver_by_expiry.cs
@@ -1,0 +1,180 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+/// GH-3898 — member-level DeliverBy expiry for batched messages. The grouped batch envelope used to
+/// be created with a fresh SentAt and no DeliverBy, and member expiry is only ever checked at
+/// execution time — which for a batched member happens on the batch envelope, not the member. So
+/// member-level DeliverWithin could never fire for any message that rode a batch (the CritterWatch#969
+/// field failure: a console 40 minutes behind dutifully processed 40-minute-stale telemetry whose
+/// sender had set a 10-minute expiry).
+/// </summary>
+public class batch_deliver_by_expiry
+{
+    private static Task<IHost> hostWithTriggerTime(TimeSpan triggerTime)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.BatchMessagesOf<ExpiryItem>(batching =>
+                {
+                    batching.TriggerTime = triggerTime;
+                    batching.LocalExecutionQueueName = "expiry_items";
+                });
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task a_member_that_expires_awaiting_batching_is_shed_while_live_members_execute()
+    {
+        ExpiryItemHandler.Clear();
+
+        // A trigger time comfortably longer than the stale member's expiry, so the member
+        // passes the pipeline's execution-time check when it is handled into the batching
+        // channel, then expires while it waits there for the batch to assemble
+        using var host = await hostWithTriggerTime(3.Seconds());
+
+        var stale = new ExpiryItem("stale");
+        var fresh = new ExpiryItem("fresh");
+
+        var session = await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<ExpiryItem[]>(host)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async c =>
+            {
+                await c.PublishAsync(stale, new DeliveryOptions { DeliverWithin = 1.Seconds() });
+                await c.PublishAsync(fresh);
+            }));
+
+        // The batch that executed contains only the live member
+        var batch = session.Executed.SingleMessage<ExpiryItem[]>();
+        batch.ShouldBe([fresh]);
+
+        ExpiryItemHandler.Batches.Single().ShouldBe([fresh]);
+    }
+
+    [Fact]
+    public async Task an_all_expired_batch_is_discarded_without_invoking_the_handler()
+    {
+        ExpiryItemHandler.Clear();
+
+        using var host = await hostWithTriggerTime(3.Seconds());
+
+        var condition = new WaitForDiscardOf<ExpiryItem[]>();
+
+        await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForCondition(condition)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async c =>
+            {
+                await c.PublishAsync(new ExpiryItem("stale-one"),
+                    new DeliveryOptions { DeliverWithin = 1.Seconds() });
+                await c.PublishAsync(new ExpiryItem("stale-two"),
+                    new DeliveryOptions { DeliverWithin = 1.Seconds() });
+            }));
+
+        // The expired members reached a batch terminal (the discard), but no handler ever ran
+        condition.IsCompleted().ShouldBeTrue();
+        ExpiryItemHandler.Batches.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_batch_envelope_carries_the_latest_member_expiry_as_a_backstop()
+    {
+        ExpiryItemHandler.Clear();
+
+        using var host = await hostWithTriggerTime(250.Milliseconds());
+
+        var earlier = DateTimeOffset.UtcNow.AddHours(1);
+        var later = DateTimeOffset.UtcNow.AddHours(2);
+
+        var session = await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<ExpiryItem[]>(host)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async c =>
+            {
+                await c.PublishAsync(new ExpiryItem("one"), new DeliveryOptions { DeliverBy = earlier });
+                await c.PublishAsync(new ExpiryItem("two"), new DeliveryOptions { DeliverBy = later });
+            }));
+
+        // If every member can expire, the batch as a whole may expire once the LATEST member
+        // expiry has passed — at that point discarding the batch can never over-shed
+        session.Executed.SingleEnvelope<ExpiryItem[]>().DeliverBy.ShouldBe(later);
+    }
+
+    [Fact]
+    public async Task a_batch_containing_a_never_expiring_member_gets_no_backstop()
+    {
+        ExpiryItemHandler.Clear();
+
+        using var host = await hostWithTriggerTime(250.Milliseconds());
+
+        var session = await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<ExpiryItem[]>(host)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async c =>
+            {
+                await c.PublishAsync(new ExpiryItem("expiring"),
+                    new DeliveryOptions { DeliverBy = DateTimeOffset.UtcNow.AddHours(1) });
+                await c.PublishAsync(new ExpiryItem("immortal"));
+            }));
+
+        // A member with no DeliverBy never expires, so its batch must not either
+        session.Executed.SingleEnvelope<ExpiryItem[]>().DeliverBy.ShouldBeNull();
+    }
+
+    private class WaitForDiscardOf<T> : ITrackedCondition
+    {
+        private bool _completed;
+
+        public void Record(EnvelopeRecord record)
+        {
+            if (record.MessageEventType == MessageEventType.Discarded && record.Envelope?.Message is T)
+            {
+                _completed = true;
+            }
+        }
+
+        public bool IsCompleted() => _completed;
+
+        public override string ToString() => $"Wait for an envelope of {typeof(T).Name} to be discarded";
+    }
+}
+
+public record ExpiryItem(string Name);
+
+public static class ExpiryItemHandler
+{
+    private static readonly List<ExpiryItem[]> _batches = [];
+
+    public static IReadOnlyList<ExpiryItem[]> Batches
+    {
+        get
+        {
+            lock (_batches)
+            {
+                return _batches.ToArray();
+            }
+        }
+    }
+
+    public static void Clear()
+    {
+        lock (_batches)
+        {
+            _batches.Clear();
+        }
+    }
+
+    public static void Handle(ExpiryItem[] items)
+    {
+        lock (_batches)
+        {
+            _batches.Add(items);
+        }
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Batching/BatchDeliverByExpiryTests.cs
+++ b/src/Testing/CoreTests/Runtime/Batching/BatchDeliverByExpiryTests.cs
@@ -1,0 +1,187 @@
+using JasperFx.Core;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Batching;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Runtime.Batching;
+
+/// <summary>
+/// GH-3898 — grouped message batches used to drop their members' DeliverBy expiry entirely: the
+/// grouped envelope was created with a fresh SentAt and no DeliverBy, and member expiry is only
+/// checked at execution time, which for a batched member never happens on the member itself.
+/// These cover the assembly-time member shed and the latest-member-expiry batch backstop.
+/// </summary>
+public class BatchDeliverByExpiryTests
+{
+    public record Element(string Name);
+
+    private static Envelope liveEnvelope(TimeSpan? deliverWithin = null)
+    {
+        var envelope = new Envelope(new Element(Guid.NewGuid().ToString()));
+        if (deliverWithin.HasValue)
+        {
+            envelope.DeliverWithin = deliverWithin.Value;
+        }
+
+        return envelope;
+    }
+
+    private static Envelope expiredEnvelope(TimeSpan? expiredBy = null)
+    {
+        return new Envelope(new Element(Guid.NewGuid().ToString()))
+        {
+            DeliverBy = DateTimeOffset.UtcNow.Subtract(expiredBy ?? 1.Minutes())
+        };
+    }
+
+    [Fact]
+    public void partition_returns_the_original_array_when_nothing_is_expired()
+    {
+        var envelopes = new[] { liveEnvelope(), liveEnvelope(1.Hours()) };
+
+        var (live, expired) = BatchingProcessor<Element>.PartitionByExpiration(envelopes);
+
+        live.ShouldBeSameAs(envelopes);
+        expired.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void partition_splits_expired_members_from_live_members()
+    {
+        var staleOne = expiredEnvelope();
+        var staleTwo = expiredEnvelope(5.Minutes());
+        var fresh = liveEnvelope();
+        var freshWithExpiry = liveEnvelope(1.Hours());
+
+        var (live, expired) =
+            BatchingProcessor<Element>.PartitionByExpiration([staleOne, fresh, staleTwo, freshWithExpiry]);
+
+        live.ShouldBe([fresh, freshWithExpiry]);
+        expired.ShouldBe([staleOne, staleTwo]);
+    }
+
+    [Fact]
+    public void partition_can_expire_every_member()
+    {
+        var staleOne = expiredEnvelope();
+        var staleTwo = expiredEnvelope();
+
+        var (live, expired) = BatchingProcessor<Element>.PartitionByExpiration([staleOne, staleTwo]);
+
+        live.ShouldBeEmpty();
+        expired.ShouldBe([staleOne, staleTwo]);
+    }
+
+    [Fact]
+    public void carrier_holds_the_expired_members_and_is_itself_expired()
+    {
+        var staleOne = expiredEnvelope(10.Minutes());
+        var staleTwo = expiredEnvelope(2.Minutes()); // the latest member expiry
+        var staleThree = expiredEnvelope(30.Minutes());
+
+        var carrier = BatchingProcessor<Element>.BuildExpiredMemberCarrier([staleOne, staleTwo, staleThree]);
+
+        // The members ride in Batch so the batch terminal (CompleteAsync) settles their
+        // back-pressure counts and marks them handled through the normal machinery
+        carrier.Batch.ShouldBe(new[] { staleOne, staleTwo, staleThree });
+
+        // Already expired — the handler pipeline's execution-time check discards it
+        // before any handler could ever run
+        carrier.IsExpired().ShouldBeTrue();
+        carrier.DeliverBy.ShouldBe(staleTwo.DeliverBy);
+
+        // Never executed, but present and of the element array shape so nothing downstream
+        // chokes on a null message
+        carrier.Message.ShouldBeOfType<Element[]>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void carrier_marks_its_members_as_in_batch()
+    {
+        var stale = expiredEnvelope();
+
+        BatchingProcessor<Element>.BuildExpiredMemberCarrier([stale]);
+
+        // The InBatch flag is what routes the members' own CompleteAsync calls to the
+        // batch-terminal path instead of completing them individually
+        stale.InBatch.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void settling_the_carrier_drains_the_members_back_pressure_counts()
+    {
+        var address = new Uri("stub://one");
+        var otherAddress = new Uri("stub://two");
+        var counts = new BatchingPendingCounts();
+
+        var one = expiredEnvelope();
+        one.Listener = new StubListener(address);
+        var two = expiredEnvelope();
+        two.Listener = new StubListener(address);
+        var three = expiredEnvelope();
+        three.Listener = new StubListener(otherAddress);
+
+        counts.Increment(address);
+        counts.Increment(address);
+        counts.Increment(otherAddress);
+
+        var carrier = BatchingProcessor<Element>.BuildExpiredMemberCarrier([one, two, three]);
+
+        // What the batch terminal (BufferedReceiver/DurableReceiver CompleteAsync) does when the
+        // carrier's discard completes — shedding must not leak the listeners' pending counts
+        counts.SettleBatch(carrier);
+
+        counts.PendingFor(address).ShouldBe(0);
+        counts.PendingFor(otherAddress).ShouldBe(0);
+    }
+
+    [Fact]
+    public void backstop_is_the_latest_member_expiry_when_every_member_has_one()
+    {
+        var earliest = liveEnvelope(5.Minutes());
+        var latest = liveEnvelope(20.Minutes());
+        var middle = liveEnvelope(10.Minutes());
+
+        BatchingProcessor<Element>.LatestMemberExpiry([earliest, latest, middle])
+            .ShouldBe(latest.DeliverBy);
+    }
+
+    [Fact]
+    public void backstop_is_null_when_any_member_never_expires()
+    {
+        var expiring = liveEnvelope(5.Minutes());
+        var immortal = liveEnvelope();
+
+        // A member with no DeliverBy never expires, so the batch as a whole must never
+        // expire either — a batch-level DeliverBy here would over-shed
+        BatchingProcessor<Element>.LatestMemberExpiry([expiring, immortal]).ShouldBeNull();
+    }
+
+    [Fact]
+    public void backstop_is_null_for_a_missing_or_empty_member_array()
+    {
+        BatchingProcessor<Element>.LatestMemberExpiry(null).ShouldBeNull();
+        BatchingProcessor<Element>.LatestMemberExpiry([]).ShouldBeNull();
+    }
+
+    private class StubListener : IListener
+    {
+        public StubListener(Uri address)
+        {
+            Address = address;
+        }
+
+        public Uri Address { get; }
+
+        public IHandlerPipeline? Pipeline => null;
+
+        public ValueTask CompleteAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+        public ValueTask StopAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Wolverine/Runtime/Batching/BatchingOptions.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingOptions.cs
@@ -214,7 +214,7 @@ public class BatchingOptions : IAsyncDisposable
             var queues = buildExecutionQueues(runtime, options, localQueue);
 
             return new BatchingProcessor<T>(parentChain, batcher, options, localQueue, queues,
-                runtime.DurabilitySettings, runtime.BatchingPendingCounts);
+                runtime.DurabilitySettings, runtime.BatchingPendingCounts, runtime.Logger);
         }
 
         /// <summary>

--- a/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
@@ -1,4 +1,6 @@
 using JasperFx.Blocks;
+using Microsoft.Extensions.Logging;
+using Wolverine.Logging;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Runtime.WorkerQueues;
 
@@ -14,16 +16,20 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
 
     private readonly IBatchExecutionQueues _queues;
 
+    private readonly ILogger? _logger;
+
     public BatchingProcessor(HandlerChain chain, IMessageBatcher batcher, BatchingOptions options, ILocalQueue queue,
-        DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null)
-        : this(chain, batcher, options, queue, new SingleBatchExecutionQueue(queue), settings, pendingCounts)
+        DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null, ILogger? logger = null)
+        : this(chain, batcher, options, queue, new SingleBatchExecutionQueue(queue), settings, pendingCounts, logger)
     {
     }
 
     internal BatchingProcessor(HandlerChain chain, IMessageBatcher batcher, BatchingOptions options, ILocalQueue queue,
-        IBatchExecutionQueues queues, DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null)
+        IBatchExecutionQueues queues, DurabilitySettings settings, BatchingPendingCounts? pendingCounts = null,
+        ILogger? logger = null)
     {
         _pendingCounts = pendingCounts;
+        _logger = logger;
         Chain = chain ?? throw new ArgumentOutOfRangeException(nameof(chain));
 
         _options = options;
@@ -76,7 +82,31 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
 
     private async Task processEnvelopes(Envelope[] envelopes, CancellationToken _)
     {
-        foreach (var grouped in Batcher.Group(envelopes))
+        // GH-3898 — member-level DeliverBy enforcement. An unbatched envelope's expiry is checked at
+        // execution time, but a batched member executes as part of a grouped envelope, so any member
+        // whose DeliverBy elapsed while it waited in the batching channel has to be shed here, at
+        // batch assembly — after this point its payload is baked into the batch message and cannot be
+        // removed generically. Shed members still need their terminal bookkeeping (inbox mark-handled
+        // and back-pressure settlement), so they ride an already-expired carrier envelope through the
+        // pipeline: its execution-time expiry check discards the carrier before any handler runs, and
+        // the discard's CompleteAsync is a normal batch terminal.
+        var (live, expired) = PartitionByExpiration(envelopes);
+
+        if (expired.Length > 0)
+        {
+            // Same observability an unbatched expiry discard gets (event id 208), once per member
+            _logger?.DiscardedExpired(expired);
+
+            var carrier = BuildExpiredMemberCarrier(expired);
+            var carrierQueue = _queues.SelectQueue(carrier);
+            carrier.Destination = carrierQueue.Uri;
+            carrier.MessageType = Chain!.TypeName;
+            carrier.SentAt = DateTimeOffset.UtcNow;
+
+            await carrierQueue.EnqueueAsync(carrier);
+        }
+
+        foreach (var grouped in Batcher.Group(live))
         {
             // GH-3867 — the destination is per batch, not per processor: a batch that carries a group
             // id lands on that group's partition slot, so it is sequenced against the unbatched
@@ -87,7 +117,94 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
             grouped.MessageType = Chain!.TypeName;
             grouped.SentAt = DateTimeOffset.UtcNow;
 
+            // GH-3898 — whole-batch backstop for expiry that elapses while the assembled batch waits
+            // on the (deliberately unbounded, GH-3287) execution queue. Only the LATEST member expiry
+            // is safe as a batch-level DeliverBy: by the time it has passed, every member is expired,
+            // so discarding the whole batch never over-sheds. Any member without a DeliverBy keeps
+            // the batch alive (null). The discard path settles all members exactly like a success.
+            grouped.DeliverBy = LatestMemberExpiry(grouped.Batch);
+
             await queue.EnqueueAsync(grouped);
         }
+    }
+
+    /// <summary>
+    /// GH-3898 — split a flush of the batching channel into still-deliverable members and members
+    /// whose DeliverBy elapsed while they waited to be batched. Single pass, so a member cannot
+    /// land in both (or neither) bucket when the clock ticks mid-partition.
+    /// </summary>
+    internal static (Envelope[] Live, Envelope[] Expired) PartitionByExpiration(Envelope[] envelopes)
+    {
+        List<Envelope>? expired = null;
+        var live = new List<Envelope>(envelopes.Length);
+
+        foreach (var envelope in envelopes)
+        {
+            if (envelope.IsExpired())
+            {
+                (expired ??= []).Add(envelope);
+            }
+            else
+            {
+                live.Add(envelope);
+            }
+        }
+
+        return expired == null
+            ? (envelopes, [])
+            : (live.ToArray(), expired.ToArray());
+    }
+
+    /// <summary>
+    /// GH-3898 — a degenerate batch envelope that exists only to carry expired members to a batch
+    /// terminal. Its DeliverBy is the latest member expiry, which is already past, so the handler
+    /// pipeline's execution-time check discards it before any handler could run — and the discard's
+    /// CompleteAsync settles back-pressure counts and marks every member handled through the same
+    /// machinery a successful batch uses.
+    /// </summary>
+    internal static Envelope BuildExpiredMemberCarrier(Envelope[] expired)
+    {
+        var latest = default(DateTimeOffset);
+        foreach (var member in expired)
+        {
+            // IsExpired() == true implies DeliverBy.HasValue
+            if (member.DeliverBy!.Value > latest)
+            {
+                latest = member.DeliverBy.Value;
+            }
+        }
+
+        return new Envelope(Array.Empty<T>(), expired)
+        {
+            DeliverBy = latest
+        };
+    }
+
+    /// <summary>
+    /// GH-3898 — the batch-level DeliverBy backstop: the latest member expiry when every member
+    /// carries one, else null (a member with no DeliverBy never expires, so neither may its batch).
+    /// </summary>
+    internal static DateTimeOffset? LatestMemberExpiry(Envelope[]? members)
+    {
+        if (members is not { Length: > 0 })
+        {
+            return null;
+        }
+
+        var latest = default(DateTimeOffset);
+        foreach (var member in members)
+        {
+            if (member.DeliverBy is not { } deliverBy)
+            {
+                return null;
+            }
+
+            if (deliverBy > latest)
+            {
+                latest = deliverBy;
+            }
+        }
+
+        return latest;
     }
 }


### PR DESCRIPTION
Closes #3898. Field impact: JasperFx/CritterWatch#969.

## The bug

`BatchingProcessor` created the grouped batch envelope with a fresh `SentAt` and no `DeliverBy`, and member expiry is only checked at execution time — which for a batched member happens on the *batch* envelope, never the member. So member-level `DeliverWithin`/`DeliverBy` could never fire for any message that rode a batch. In the CritterWatch#969 field failure, a console 40+ minutes behind dutifully processed 40-minute-stale telemetry whose sender had set a 10-minute expiry; the intended load-shedding was silently defeated.

## Chosen semantics (member-level, both proposed options combined)

Members of one batch may carry **different** `DeliverBy` values (or none), so whole-batch expiry keyed on the earliest member would over-shed and the issue's option 1 alone would under-report. This PR does both halves:

1. **Member-level shed at batch assembly** (`processEnvelopes`): members whose `DeliverBy` elapsed while waiting in the batching channel are partitioned out before `IMessageBatcher.Group(...)` ever sees them — only live members become the batch message. Assembly is the last point where per-member precision is possible generically; after `Group(...)` the member payloads are baked into an arbitrary, batcher-specific message.
2. **Whole-batch backstop at execution**: the grouped envelope now carries the **latest** member expiry as its own `DeliverBy` — and only when *every* member has one (a member with no expiry never expires, so neither may its batch). If the batch outlives that on the (deliberately unbounded, GH-3287) execution queue, every member is by definition expired, so the existing `HandlerPipeline` expiry check discards the whole batch without invoking the handler. Keying on the latest member means the batch-level check can never over-shed.

## Settlement / back-pressure accounting

Shed members must still settle, or the durable inbox rows stay `Incoming` forever and the CritterWatch#942 per-listener pending counts leak (permanently latching back-pressure). Rather than duplicating receiver internals, shed members ride an **already-expired carrier envelope** (`DeliverBy` = latest shed-member expiry, guaranteed past) through the normal pipeline: the execution-time expiry check turns it into `DiscardEnvelope` before any handler could run, and the discard's `CompleteAsync` is a normal batch terminal — `BatchingPendingCounts.SettleBatch` plus per-member mark-as-handled in `BufferedReceiver`/`DurableReceiver`, the identical machinery a successful batch uses. Same story when the execution-time backstop fires on a full batch.

## Observability

Each shed member is logged with the same `DiscardedExpired` log event (id 208, `TransportLoggerExtensions`) that every other expired-envelope discard in Wolverine uses; the carrier/backstop discard additionally produces the standard `EnvelopeDiscarded` activity event, discard fault-publish hook, and `Discarded` tracking record.

## Tests (all green, plus full CoreTests: 2362 passed / 0 failed on net9.0)

- `batch_deliver_by_expiry` (acceptance): member expiring in-channel is shed while live members execute; all-expired batch is discarded without invoking the handler (and reaches a terminal — asserted via the `Discarded` tracking record); batch envelope carries latest member expiry as backstop; a never-expiring member suppresses the backstop.
- `BatchDeliverByExpiryTests` (unit): single-pass partition; carrier holds members/`IsExpired`/latest expiry/`InBatch`; settling the carrier drains per-listener back-pressure counts; backstop = latest / null-on-immortal-member / null-on-empty.
- Existing batching + expiry suites unchanged and green (`batch_processing`, `batch_coalescing_and_context`, `group_id_message_batcher`, `batch_execution_topology_resolution`, `BatchReplayTests`, `BatchingPendingCountsTests`, `separated_batch_routing`, `discarding_expired_envelopes`, `configuring_deliver_within_rules`, …) — non-batched `DeliverBy` behavior untouched.

Docs: new "Message expiration" section in `docs/guide/handlers/batching.md` spelling out the two enforcement points and the documented limitation (a member expiring *after* assembly executes if any batch-mate is live — check staleness in the handler if that matters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
