### PR TITLE
GH-3900: parallelize the sharded execution block's deserialize stage without giving up per-group FIFO

### DIFF
--- a/src/Testing/CoreTests/Runtime/Partitioning/sharded_execution_parallel_deserialization.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/sharded_execution_parallel_deserialization.cs
@@ -1,0 +1,299 @@
+using System.Collections.Concurrent;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Xunit;
+
+namespace CoreTests.Runtime.Partitioning;
+
+/// <summary>
+/// GH-3900: the decompress/deserialize stage in front of the sharded execution slots runs
+/// N-wide instead of single-threaded. These tests pin the two things that matter about that
+/// change: (1) per-GroupId FIFO ordering into the slots is preserved byte-for-byte -- including
+/// when the group can only be resolved AFTER deserialization by a message-based grouping rule --
+/// and (2) the deserialization work itself actually runs concurrently.
+/// </summary>
+public class sharded_execution_parallel_deserialization
+{
+    // Simulates the real HandlerPipeline.TryDeserializeEnvelope: the envelope's Message is null
+    // until this stage runs. An optional per-envelope delay stands in for decompress/parse cost
+    // and, when jittered, forces out-of-order completions that would expose any unordered fan-out
+    private class StubDeserializingPipeline : IHandlerPipeline
+    {
+        private readonly ConcurrentDictionary<Guid, object> _payloads = new();
+        private readonly Func<int> _delayInMilliseconds;
+        private int _active;
+        private int _maxActive;
+
+        public StubDeserializingPipeline(Func<int>? delayInMilliseconds = null)
+        {
+            _delayInMilliseconds = delayInMilliseconds ?? (() => 0);
+        }
+
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxActive);
+
+        public Envelope EnvelopeFor(object message, string? groupId = null)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.GroupId = groupId;
+            _payloads[envelope.Id] = message;
+            return envelope;
+        }
+
+        public Task InvokeAsync(Envelope envelope, Wolverine.Transports.IChannelCallback channel)
+            => throw new NotSupportedException();
+
+        public Task InvokeAsync(Envelope envelope, Wolverine.Transports.IChannelCallback channel,
+            System.Diagnostics.Activity activity)
+            => throw new NotSupportedException();
+
+        public async ValueTask<IContinuation> TryDeserializeEnvelope(Envelope envelope)
+        {
+            var current = Interlocked.Increment(ref _active);
+            InterlockedMax(ref _maxActive, current);
+
+            try
+            {
+                var delay = _delayInMilliseconds();
+                if (delay > 0)
+                {
+                    await Task.Delay(delay);
+                }
+                else
+                {
+                    // Still hop threads so completions can interleave
+                    await Task.Yield();
+                }
+
+                envelope.Message = _payloads[envelope.Id];
+                return NullContinuation.Instance;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _active);
+            }
+        }
+
+        private static void InterlockedMax(ref int location, int value)
+        {
+            int snapshot;
+            while (value > (snapshot = Volatile.Read(ref location)))
+            {
+                if (Interlocked.CompareExchange(ref location, value, snapshot) == snapshot) return;
+            }
+        }
+    }
+
+    public record OrderedCoffee(string Name, int Sequence) : ICoffee;
+
+    private static async Task<ConcurrentDictionary<string, List<int>>> runAsync(
+        StubDeserializingPipeline pipeline,
+        MessagePartitioningRules rules,
+        IReadOnlyList<Envelope> envelopes,
+        int numberOfSlots,
+        int? parallelism,
+        Func<Envelope, int>? overlapProbe = null)
+    {
+        var received = new ConcurrentDictionary<string, List<int>>();
+
+        var sharded = new ShardedExecutionBlock(numberOfSlots, rules, (e, _) =>
+        {
+            overlapProbe?.Invoke(e);
+            var coffee = (OrderedCoffee)e.Message!;
+            received.GetOrAdd(coffee.Name, _ => new List<int>()).Add(coffee.Sequence);
+            return Task.CompletedTask;
+        });
+
+        // runtime/channel are only touched on the non-NullContinuation path, which these
+        // stubbed deserializations never take
+        var block = parallelism.HasValue
+            ? sharded.DeserializeFirst(pipeline, null!, null!, parallelism.Value)
+            : sharded.DeserializeFirst(pipeline, null!, null!);
+
+        // Posting sequentially from one thread is what DEFINES the arrival order the
+        // sharded structure promises to preserve per group
+        foreach (var envelope in envelopes)
+        {
+            await block.PostAsync(envelope);
+        }
+
+        await block.WaitForCompletionAsync();
+
+        return received;
+    }
+
+    [Fact]
+    public async Task per_group_fifo_is_preserved_when_group_id_is_already_on_the_envelope()
+    {
+        // Jittered deserialization cost: with 8 parallel workers, later-arriving envelopes
+        // routinely finish deserializing before earlier ones. Any unordered fan-out ahead of
+        // the slot hash would scramble same-group sequences here
+        var pipeline = new StubDeserializingPipeline(() => Random.Shared.Next(0, 3));
+        var rules = new MessagePartitioningRules(new());
+
+        const int groups = 10;
+        const int perGroup = 200;
+
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < perGroup; i++)
+        {
+            for (var g = 0; g < groups; g++)
+            {
+                var name = $"group-{g}";
+                envelopes.Add(pipeline.EnvelopeFor(new OrderedCoffee(name, i), name));
+            }
+        }
+
+        var received = await runAsync(pipeline, rules, envelopes, 5, parallelism: 8);
+
+        received.Count.ShouldBe(groups);
+        foreach (var (_, sequences) in received)
+        {
+            sequences.ShouldBe(Enumerable.Range(0, perGroup));
+        }
+    }
+
+    [Fact]
+    public async Task per_group_fifo_is_preserved_when_group_is_only_resolvable_after_deserialization()
+    {
+        // The case that forbids hash-partitioning the deserialize stage itself: no GroupId
+        // header on the wire, and the ByMessage rule can only see a group once Message is
+        // populated. Ordering must still hold per group
+        var pipeline = new StubDeserializingPipeline(() => Random.Shared.Next(0, 3));
+        var rules = new MessagePartitioningRules(new());
+        rules.ByMessage<ICoffee>(x => x.Name);
+
+        const int groups = 10;
+        const int perGroup = 200;
+
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < perGroup; i++)
+        {
+            for (var g = 0; g < groups; g++)
+            {
+                envelopes.Add(pipeline.EnvelopeFor(new OrderedCoffee($"group-{g}", i)));
+            }
+        }
+
+        var received = await runAsync(pipeline, rules, envelopes, 5, parallelism: 8);
+
+        received.Count.ShouldBe(groups);
+        foreach (var (_, sequences) in received)
+        {
+            sequences.ShouldBe(Enumerable.Range(0, perGroup));
+        }
+    }
+
+    [Fact]
+    public async Task single_group_traffic_is_still_strictly_sequential_and_ordered()
+    {
+        var pipeline = new StubDeserializingPipeline(() => Random.Shared.Next(0, 2));
+        var rules = new MessagePartitioningRules(new());
+
+        const int count = 500;
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < count; i++)
+        {
+            envelopes.Add(pipeline.EnvelopeFor(new OrderedCoffee("the-only-group", i), "the-only-group"));
+        }
+
+        var activeExecutions = 0;
+        var maxActiveExecutions = 0;
+
+        var received = await runAsync(pipeline, rules, envelopes, 5, parallelism: 8, e =>
+        {
+            var current = Interlocked.Increment(ref activeExecutions);
+            if (current > Volatile.Read(ref maxActiveExecutions))
+            {
+                Interlocked.Exchange(ref maxActiveExecutions, current);
+            }
+
+            Thread.SpinWait(100);
+            return Interlocked.Decrement(ref activeExecutions);
+        });
+
+        received["the-only-group"].ShouldBe(Enumerable.Range(0, count));
+
+        // One group -> one slot -> one worker. Parallel deserialization must never leak
+        // into parallel EXECUTION of a single group
+        maxActiveExecutions.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task deserialization_actually_runs_in_parallel()
+    {
+        // A fixed per-envelope cost: serially this is 60 x 20ms = 1.2s minimum. The point is a
+        // coarse "faster than serial" assertion plus a direct observation of concurrency in the
+        // deserialize stage -- not a benchmark
+        var pipeline = new StubDeserializingPipeline(() => 20);
+        var rules = new MessagePartitioningRules(new());
+
+        const int count = 60;
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < count; i++)
+        {
+            var name = $"group-{i % 6}";
+            envelopes.Add(pipeline.EnvelopeFor(new OrderedCoffee(name, i / 6), name));
+        }
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var received = await runAsync(pipeline, rules, envelopes, 5, parallelism: 8);
+        stopwatch.Stop();
+
+        received.Values.Sum(x => x.Count).ShouldBe(count);
+
+        pipeline.MaxObservedConcurrency.ShouldBeGreaterThan(1);
+
+        // Generous bound: 8-wide over 1.2s of serial work should land near 150-300ms.
+        // Anything under 900ms proves the stage is no longer the serial choke point
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromMilliseconds(900));
+    }
+
+    [Fact]
+    public async Task default_overload_preserves_per_group_ordering()
+    {
+        // Whatever parallelism the default overload picks on this machine, the ordering
+        // contract must hold
+        var pipeline = new StubDeserializingPipeline(() => Random.Shared.Next(0, 2));
+        var rules = new MessagePartitioningRules(new());
+        rules.ByMessage<ICoffee>(x => x.Name);
+
+        const int groups = 6;
+        const int perGroup = 100;
+
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < perGroup; i++)
+        {
+            for (var g = 0; g < groups; g++)
+            {
+                envelopes.Add(pipeline.EnvelopeFor(new OrderedCoffee($"group-{g}", i)));
+            }
+        }
+
+        var received = await runAsync(pipeline, rules, envelopes, 5, parallelism: null);
+
+        received.Count.ShouldBe(groups);
+        foreach (var (_, sequences) in received)
+        {
+            sequences.ShouldBe(Enumerable.Range(0, perGroup));
+        }
+    }
+
+    [Fact]
+    public async Task serial_fallback_parallelism_of_one_still_works()
+    {
+        var pipeline = new StubDeserializingPipeline();
+        var rules = new MessagePartitioningRules(new());
+
+        const int count = 100;
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < count; i++)
+        {
+            envelopes.Add(pipeline.EnvelopeFor(new OrderedCoffee("solo", i), "solo"));
+        }
+
+        var received = await runAsync(pipeline, rules, envelopes, 3, parallelism: 1);
+
+        received["solo"].ShouldBe(Enumerable.Range(0, count));
+    }
+}

--- a/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
+++ b/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
@@ -29,7 +29,32 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
 
     public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime, IChannelCallback channel)
     {
-        return PushUpstream<Envelope>(async (e, _) =>
+        // Deserialize parallelism beyond the slot count buys nothing (the slots become the
+        // bottleneck again), and going wider than the machine can't help CPU-bound decompression
+        return DeserializeFirst(pipeline, runtime, channel, Math.Min(_numberOfSlots, Environment.ProcessorCount));
+    }
+
+    /// <summary>
+    /// Builds the upstream decompress/deserialize stage in front of the slot blocks (GH-3900).
+    ///
+    /// ORDERING INVARIANT: envelopes must reach the slot enqueue (<see cref="PostAsync"/>, where the
+    /// GroupId -> slot hash runs) in their exact arrival order. Each slot is a single-worker block, so
+    /// arrival-ordered slot enqueue is what yields the per-GroupId FIFO this whole structure exists for.
+    /// A naive N-worker stage (PushUpstream(parallelCount, ...)) would NOT preserve this: parallel
+    /// Block workers complete in arbitrary order, so two same-group envelopes could swap before the
+    /// slot hash ever sees them. Nor can the stage itself be hash-partitioned by group: the GroupId
+    /// header is only present when the sender set it, and receiver-side grouping rules (ByMessage,
+    /// ByPropertyNamed, inferred grouping) need the DESERIALIZED message to resolve a group at all.
+    ///
+    /// So instead: pipelined deserialization with ordered emission. A single-worker ingress stage
+    /// starts up to <paramref name="parallelism"/> concurrent deserialization tasks and posts
+    /// (envelope, task) pairs downstream in arrival order; a single-worker emit stage awaits each
+    /// task in that same order and hands the envelope to the slot hash. The CPU-bound work runs
+    /// N-wide, while the slot enqueue order stays byte-for-byte what the old serial stage produced.
+    /// </summary>
+    public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime, IChannelCallback channel, int parallelism)
+    {
+        async Task<Envelope?> deserializeAsync(Envelope e)
         {
             var continuation = await pipeline.TryDeserializeEnvelope(e);
             if (continuation is NullContinuation)
@@ -41,9 +66,70 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
             envelopeLifecycle.ReadEnvelope(e, channel);
             await continuation.ExecuteAsync(envelopeLifecycle, runtime, DateTimeOffset.UtcNow, Activity.Current);
 
-            return default!;
+            return null;
+        }
+
+        if (parallelism <= 1)
+        {
+            // The original serial stage: one worker deserializes and posts inline
+            return PushUpstream<Envelope>(async (e, _) => (await deserializeAsync(e))!);
+        }
+
+        // Caps the number of concurrent deserialization tasks. Released by each task itself on
+        // completion (success or failure), so the cap tracks actual in-flight CPU work. Never
+        // disposed on purpose: SemaphoreSlim only needs disposal when AvailableWaitHandle is used,
+        // and the ingress block owning the only waiter is torn down by the BlockSet
+        var gate = new SemaphoreSlim(parallelism, parallelism);
+
+        // Emit stage: single worker awaiting the pipelined tasks strictly in arrival order.
+        // Awaiting in order IS the re-sequencing -- out-of-order completions simply wait their turn
+        var emit = PushUpstream<DeserializationWork>(async (work, _) => (await work.Work)!);
+
+        // A deserialization failure surfaces here on the await. Route it to this block's OnError
+        // (which the receivers point at their logging) with the actual envelope -- the emit block's
+        // own default sink would only see the opaque work item. Read OnError at invocation time so
+        // the receiver's later assignment is honored. `work` is null when the emit block faults
+        // terminally (jasperfx#506): forward the null unchanged, because that null item is exactly
+        // how the receivers recognize a terminal block fault (HasFaulted / CritterWatch#942)
+        emit.OnError = (work, ex) => OnError(work?.Envelope!, ex);
+
+        return emit.PushUpstream<Envelope>(async (envelope, cancellation) =>
+        {
+            try
+            {
+                await gate.WaitAsync(cancellation);
+            }
+            catch (OperationCanceledException)
+            {
+                // Block shutdown; returning null skips the downstream post
+                return null!;
+            }
+
+            // Deliberately no cancellation token on Task.Run: the finally MUST run so the gate
+            // is always released, and the emit stage must always have a completed/faulted task
+            // to await rather than one that was never started
+            var work = Task.Run(async () =>
+            {
+                try
+                {
+                    return await deserializeAsync(envelope);
+                }
+                finally
+                {
+                    gate.Release();
+                }
+            });
+
+            return new DeserializationWork(envelope, work);
         });
     }
+
+    /// <summary>
+    /// An arrival-ordered handle to an in-flight deserialization. Deliberately a reference type:
+    /// PushUpstream skips posting null transformations, which is how a cancelled ingress item
+    /// avoids sending a default struct (with a null Task) into the emit stage
+    /// </summary>
+    private sealed record DeserializationWork(Envelope Envelope, Task<Envelope?> Work);
 
     public override async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
Closes #3900. Field context: JasperFx/CritterWatch#969 — on a listener carrying compressed telemetry payloads, the single-threaded deserialize stage caps ingest throughput in front of ALL execution slots, regardless of slot count.

## The ordering analysis (why this was never a one-liner)

`ShardedExecutionBlock.DeserializeFirst` built its upstream stage with the parameterless `PushUpstream`, i.e. a 1-worker `Block<Envelope>`. That single worker deserializes and then `await`s `PostAsync` inline, which means **envelopes reach the slot enqueue — where the GroupId → slot hash runs — in exact arrival order**. Since every slot is a single-worker block and all envelopes of a group hash to the same slot, arrival-ordered slot enqueue is precisely what yields the per-GroupId FIFO the sharded structure exists to provide.

Two tempting fixes are unsound:

1. **The issue's literal suggestion, `PushUpstream(parallelCount, ...)`** — a JasperFx `Block<T>` with `parallelCount = N` runs N independent `Task.Run` reader loops over one shared channel. Completion order (and therefore downstream `PostAsync` order) is unordered. Two same-group envelopes arriving back-to-back could swap before the slot hash ever sees them — a silent break of the ordering guarantee, exposed only under load. The issue's "no ordering hazard" claim is wrong: ordering is enforced *by* arrival-ordered slot enqueue, not downstream of it.

2. **Hash-partitioning the deserialize stage by group** (N serial deserialize lanes) — the `GroupId` wire header is only present when the *sender* set it. Receiver-side grouping rules (`ByMessage`, `ByPropertyNamed` — which NREs on a null `Message` — inferred grouping, custom `IGroupingRule`s) can only resolve a group **after** deserialization, so the lane key doesn't exist yet for exactly those workloads. It also breaks mixed header/no-header same-group traffic during rolling upgrades.

## The design: pipelined deserialization with ordered emission

- A **single-worker ingress** stage starts up to N concurrent deserialization tasks (gated by a `SemaphoreSlim`, N = `min(slotCount, ProcessorCount)` by default) and posts `(envelope, task)` pairs downstream **in arrival order**.
- A **single-worker emit** stage awaits each task **in that same order** and hands the envelope to the slot hash. Awaiting in order *is* the re-sequencing — an out-of-order completion simply waits its turn.

Slot-enqueue order is byte-for-byte what the old serial stage produced — for every case, including groups resolvable only post-deserialize — while the CPU-bound decompress/deserialize work runs N-wide. Throughput becomes pipelined (~N× when deserialize is the bottleneck) at the cost of head-of-line latency on a slow envelope, which is inherent to preserving order. No JasperFx Blocks change required; this composes from the existing `PushUpstream` primitives against JasperFx 2.46.0.

Failure-path behavior is preserved: a deserialization failure surfaces on the emit await and is routed to the sharded block's `OnError` (the receivers' logging) with the actual envelope; a terminal block fault (jasperfx#506) still reports with a null item so `HasFaulted` detection in the receivers (CritterWatch#942/#922) keeps working. `parallelism <= 1` (e.g. a 1-core container) falls back to the original serial stage.

## Tests (`sharded_execution_parallel_deserialization`)

- **Ordering stress, header case**: 10 groups × 200 interleaved envelopes, jittered deserialize cost, parallelism 8 — per-group sequences must come out exactly in posted order.
- **Ordering stress, rules case**: same, but no GroupId on the wire; the group is resolvable only after deserialization via `ByMessage` — the case that forbids lane-hashing.
- **Single-group traffic**: strictly sequential, ordered, and never executed concurrently (max observed execution concurrency == 1).
- **Parallelism pin**: fixed 20 ms per-envelope deserialize cost; asserts observed deserialize concurrency > 1 and a coarse wall-time bound well under the serial floor (not a benchmark).
- **Default overload + serial fallback** covered.

All 6 pass on net9.0 and net10.0, along with the full `CoreTests.Runtime.Partitioning` suite (90/90 both TFMs). The Postgres-backed `SlowTests.Bug_2580_tenant_partitioning_with_inferred_grouping` — end-to-end through the sharded receiver with a rules-resolved group — also passes. `SlowTests.Bug_concurrency_with_global_partitioning` failed locally only because it needs a live Kafka broker at localhost:9092 (died in `BrokerTransport.InitializeAsync`/`KafkaTopic.SetupAsync` at startup, before any envelope reaches the deserialize stage) — environmental, not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
