### PR TITLE
Build the outgoing batch's contiguous buffer only when something reads it

### DIFF
--- a/src/Testing/CoreTests/Transports/outgoing_message_batch_serialization.cs
+++ b/src/Testing/CoreTests/Transports/outgoing_message_batch_serialization.cs
@@ -1,0 +1,81 @@
+using Shouldly;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+/// <see cref="OutgoingMessageBatch" /> used to serialize the whole batch into one contiguous buffer in its
+/// constructor. Only the TCP protocol ever reads that buffer; SQS, Rabbit, Service Bus and Kafka all read
+/// <see cref="Envelope.Data" /> per message and chunk to their own limits, so for them it was a large
+/// allocation that was built and thrown away.
+///
+/// That is not only waste. Measured on a production projection rebuild sending metrics over SQS: at the
+/// default MessageBatchSize of 100 with large payloads, that single allocation threw
+/// <c>OutOfMemoryException</c> from <c>MemoryStream.set_Capacity</c> and took the process down at ~1.5 GB
+/// working set against an 8 GB limit — nowhere near heap exhaustion, because the failure is one contiguous
+/// buffer rather than the heap as a whole.
+/// </summary>
+public class outgoing_message_batch_serialization
+{
+    private static Envelope envelopeWith(int payloadBytes) => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = "metrics",
+        Data = new byte[payloadBytes]
+    };
+
+    [Fact]
+    public void does_not_serialize_until_the_buffer_is_actually_read()
+    {
+        var batch = new OutgoingMessageBatch(new Uri("sqs://critterwatch"),
+            [envelopeWith(1024), envelopeWith(1024)]);
+
+        // Nothing has asked for the contiguous buffer, so nothing should have been built. Reaching
+        // through the property would defeat the point of the test, so check the backing field.
+        var field = typeof(OutgoingMessageBatch)
+            .GetField("_data", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field.ShouldNotBeNull();
+        field!.GetValue(batch).ShouldBeNull();
+    }
+
+    [Fact]
+    public void still_serializes_correctly_when_the_buffer_is_read()
+    {
+        var batch = new OutgoingMessageBatch(new Uri("tcp://localhost:2222"),
+            [envelopeWith(64), envelopeWith(64)]);
+
+        batch.Data.ShouldNotBeNull();
+        batch.Data.Length.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void reads_the_same_buffer_twice_without_rebuilding_it()
+    {
+        var batch = new OutgoingMessageBatch(new Uri("tcp://localhost:2222"), [envelopeWith(64)]);
+
+        batch.Data.ShouldBeSameAs(batch.Data);
+    }
+
+    [Fact]
+    public void an_explicitly_assigned_buffer_wins()
+    {
+        // WireProtocol assigns Data on the receiving side; that path must keep working.
+        var batch = new OutgoingMessageBatch(new Uri("tcp://localhost:2222"), [envelopeWith(64)])
+        {
+            Data = [1, 2, 3]
+        };
+
+        batch.Data.ShouldBe([1, 2, 3]);
+    }
+
+    [Fact]
+    public void the_destination_is_stamped_on_every_envelope_regardless()
+    {
+        // This happened in the constructor alongside the serialization; it must not have moved with it.
+        var destination = new Uri("sqs://critterwatch");
+        var batch = new OutgoingMessageBatch(destination, [envelopeWith(64), envelopeWith(64)]);
+
+        batch.Messages.ShouldAllBe(e => e.Destination == destination);
+    }
+}

--- a/src/Wolverine/Transports/OutgoingMessageBatch.cs
+++ b/src/Wolverine/Transports/OutgoingMessageBatch.cs
@@ -11,10 +11,24 @@ public class OutgoingMessageBatch
 
         foreach (var message in messages) message.Destination = destination;
 
-        Data = EnvelopeSerializer.Serialize(Messages);
     }
 
-    public byte[] Data { get; set; }
+    private byte[]? _data;
+
+    /// <summary>
+    ///     The whole batch serialized as one contiguous buffer. Materialized on first read rather
+    ///     than in the constructor: only the TCP protocol consumes it, while every other transport
+    ///     reads <see cref="Envelope.Data" /> per message and chunks to its own limits.
+    ///     Building it eagerly meant every SQS, Rabbit or Service Bus batch paid for a buffer it
+    ///     never read -- and at MessageBatchSize 100 with large payloads that single allocation is
+    ///     enough to take the process down with an OutOfMemoryException from
+    ///     <c>MemoryStream.set_Capacity</c>, long before the heap itself is anywhere near full.
+    /// </summary>
+    public byte[] Data
+    {
+        get => _data ??= EnvelopeSerializer.Serialize(Messages);
+        set => _data = value;
+    }
 
     public Uri Destination { get; }
 


### PR DESCRIPTION
`OutgoingMessageBatch` serializes every envelope into one contiguous `byte[]` in its constructor:

```csharp
public OutgoingMessageBatch(Uri destination, IReadOnlyList<Envelope> messages)
{
    ...
    Data = EnvelopeSerializer.Serialize(Messages);
}
```

Only `SocketSenderProtocol` ever reads that buffer. SQS, Rabbit, Service Bus and Kafka all read `Envelope.Data` per message and chunk to their own limits — `SqsSenderProtocol` in particular already splits on both of SQS's constraints (10 entries, 240 KB) and never touches `batch.Data`. So for every non-TCP transport the buffer is built and thrown away.

## Why it is worth fixing rather than tolerating

We hit it on production. A projection rebuild across 512 shard databases was emitting metrics over SQS, and the sender went down with:

```
System.OutOfMemoryException
  at System.IO.MemoryStream.set_Capacity(Int32 value)
  at System.IO.MemoryStream.EnsureCapacity(Int32 value)
  at Wolverine.Runtime.Serialization.EnvelopeSerializer.writeSingle(BinaryWriter, Envelope)
  at Wolverine.Runtime.Serialization.EnvelopeSerializer.Serialize(IList<Envelope>)
  at Wolverine.Transports.OutgoingMessageBatch..ctor(Uri, IReadOnlyList<Envelope>)
  at Wolverine.AmazonSqs.Internal.SqsSenderProtocol.SendBatchAsync(ISenderCallback, OutgoingMessageBatch)
```

followed by a hard `Out of memory.` and exit 139, taking every projection agent on that node with it.

The instructive part is the memory at the time: **~1.5 GB working set against an 8 GB container limit**. The heap was nowhere near full. This fails on a single contiguous allocation, so raising the memory limit does not help — we tried, on an earlier run, and it only moved the failure later.

At `MessageBatchSize` 100 (the default) it takes payloads averaging a few MB to get there, which a metrics or event-heavy stream reaches without difficulty when the destination is slower than the producer and batches keep forming.

## The change

`Data` is materialized on first read and cached. TCP behaves exactly as before — it reads the property, which builds the buffer then. Every other transport never touches it and stops paying for it, both in allocation and in CPU.

The setter stays: `WireProtocol` assigns `Data` on the receiving side.

## Tests

`src/Testing/CoreTests/Transports/outgoing_message_batch_serialization.cs` — five tests: the buffer is not built until read (checked on the backing field, since reading the property would defeat the test), it still serializes correctly when read, it is not rebuilt on a second read, an explicitly assigned buffer wins, and the destination is still stamped on every envelope in the constructor.

Full `CoreTests`: 2386 passed, 2 skipped, 0 failed.

## Possibly worth a separate look

Even lazily, one batch is still one contiguous buffer, so TCP keeps the original exposure. Bounding a batch by serialized bytes rather than message count would close that too, but it changes the batching contract and I would rather not guess at the shape you want.