### PR TITLE
GH-3907: assert what [Storage] actually promises against a Marten ancillary store

### DIFF
--- a/src/Persistence/MartenTests/AncillaryStores/storage_attribute_routes_to_marten_store.cs
+++ b/src/Persistence/MartenTests/AncillaryStores/storage_attribute_routes_to_marten_store.cs
@@ -1,6 +1,10 @@
 using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
 using JasperFx.Resources;
 using Marten;
+using Marten.Events.Aggregation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
@@ -13,7 +17,16 @@ namespace MartenTests.AncillaryStores;
 
 // GH-3109: the provider-agnostic [Storage(typeof(IMyStore))] attribute must route a handler to a Marten
 // ancillary store exactly like [MartenStore], by resolving the Marten IAncillaryStoreFrameProvider from
-// the store marker type. The Marten half of the same coverage the Polecat tests give.
+// the store marker type. The Marten half of the same coverage the Polecat tests give
+// (PolecatTests/AncillaryStores/storage_attribute_routes_to_polecat_store).
+//
+// GH-3907: extended past "the document landed somewhere" to the two behaviors StorageAttribute's own
+// doc comment promises, because downstream consumers (CritterWatch) are adopting [Storage] wholesale
+// against Marten ancillary stores:
+//   1. the work commits through the TARGETED store's session -- and demonstrably NOT the main store;
+//   2. inline-projection side effects relayed by that store flow through the Wolverine outbox.
+// Both are asserted for the injected-IDocumentSession handler shape as well as the IMartenOp shape,
+// since [Storage] has to supply the ancillary store's outbox-enrolled session either way.
 public class storage_attribute_routes_to_marten_store : IAsyncLifetime
 {
     private IHost theHost = null!;
@@ -27,16 +40,30 @@ public class storage_attribute_routes_to_marten_store : IAsyncLifetime
                 opts.Durability.Mode = DurabilityMode.Solo;
                 opts.Policies.AutoApplyTransactions();
 
-                opts.Services.AddMarten(Servers.PostgresConnectionString).IntegrateWithWolverine();
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "storage_attr_main";
+                    m.Events.DatabaseSchemaName = "storage_attr_main";
+                }).IntegrateWithWolverine();
 
                 opts.Services.AddMartenStore<IStorageAttrStore>(m =>
                     {
                         m.Connection(Servers.PostgresConnectionString);
                         m.DatabaseSchemaName = "storage_attr_players";
+                        m.Events.DatabaseSchemaName = "storage_attr_players";
+
+                        // An INLINE projection that publishes a Wolverine message from RaiseSideEffects.
+                        // EnableSideEffectsOnInlineProjections is the per-store opt-in.
+                        m.Events.EnableSideEffectsOnInlineProjections = true;
+                        m.Projections.Add(new StorageAttrScoreProjection(), ProjectionLifecycle.Inline);
                     })
                     .IntegrateWithWolverine();
 
-                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(StorageAttrPlayerHandler));
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StorageAttrPlayerHandler))
+                    .IncludeType(typeof(StorageAttrScoredHandler));
+
                 opts.Services.AddResourceSetupOnStartup();
             }).StartAsync();
     }
@@ -55,7 +82,52 @@ public class storage_attribute_routes_to_marten_store : IAsyncLifetime
 
         var store = theHost.DocumentStore<IStorageAttrStore>();
         await using var session = store.QuerySession();
-        (await session.LoadAsync<StorageAttrPlayer>(message.Id, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+        (await session.LoadAsync<StorageAttrPlayer>(message.Id, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull();
+
+        // ... and the main store never saw it. Without this the test would still pass if [Storage] were
+        // silently writing to both stores.
+        var mainStore = theHost.Services.GetRequiredService<IDocumentStore>();
+        await using var mainSession = mainStore.QuerySession();
+        (await mainSession.LoadAsync<StorageAttrPlayer>(message.Id, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task storage_attribute_injects_the_ancillary_stores_session()
+    {
+        // Same assertion, but for a handler that takes IDocumentSession as a parameter rather than
+        // returning an IMartenOp -- the shape the Polecat mirror uses, and the shape a store-agnostic
+        // consumer writes. [Storage] must resolve the injected session to the ancillary store.
+        var message = new StorageAttrInjectedMessage(Guid.NewGuid().ToString());
+        await theHost.InvokeMessageAndWaitAsync(message);
+
+        var store = theHost.DocumentStore<IStorageAttrStore>();
+        await using var session = store.QuerySession();
+        (await session.LoadAsync<StorageAttrPlayer>(message.Id, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull();
+
+        var mainStore = theHost.Services.GetRequiredService<IDocumentStore>();
+        await using var mainSession = mainStore.QuerySession();
+        (await mainSession.LoadAsync<StorageAttrPlayer>(message.Id, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task inline_projection_side_effects_flow_through_the_wolverine_outbox()
+    {
+        // The session [Storage] hands the handler has to be the ancillary store's OUTBOX-ENROLLED
+        // session, not merely a session against the right database. Appending an event through it must
+        // drive the inline projection's RaiseSideEffects -> PublishMessage back out through Wolverine.
+        var streamId = Guid.NewGuid();
+
+        var tracked = await theHost
+            .TrackActivity()
+            .Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(new StorageAttrRecordScore(streamId));
+
+        tracked.Executed.MessagesOf<StorageAttrScored>()
+            .ShouldContain(m => m.StreamId == streamId);
     }
 }
 
@@ -68,12 +140,65 @@ public class StorageAttrPlayer
 
 public record StorageAttrPlayerMessage(string Id);
 
-// The provider-agnostic [Storage] attribute routes this handler to the Marten ancillary store.
+public record StorageAttrInjectedMessage(string Id);
+
+public record StorageAttrRecordScore(Guid StreamId);
+
+public record StorageAttrScoreRecorded;
+
+public record StorageAttrScored(Guid StreamId, int Score);
+
+public class StorageAttrScore
+{
+    public Guid Id { get; set; }
+    public int Score { get; set; }
+
+    public void Apply(StorageAttrScoreRecorded _) => Score++;
+}
+
+public class StorageAttrScoreProjection : SingleStreamProjection<StorageAttrScore, Guid>
+{
+    public static StorageAttrScore Create(StorageAttrScoreRecorded _, IEvent metadata) =>
+        new() { Id = metadata.StreamId, Score = 1 };
+
+    public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<StorageAttrScore> slice)
+    {
+        if (slice.Snapshot is not null)
+        {
+            slice.PublishMessage(new StorageAttrScored(slice.Snapshot.Id, slice.Snapshot.Score));
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+#region sample_generic_storage_attribute_handler_marten
+// The provider-agnostic [Storage] attribute -- works for Marten, Polecat, ... -- routes every handler on
+// this class to the IStorageAttrStore ancillary store.
 [Storage(typeof(IStorageAttrStore))]
 public static class StorageAttrPlayerHandler
 {
     public static IMartenOp Handle(StorageAttrPlayerMessage message)
     {
         return MartenOps.Store(new StorageAttrPlayer { Id = message.Id });
+    }
+
+    public static void Handle(StorageAttrInjectedMessage message, IDocumentSession session)
+    {
+        session.Store(new StorageAttrPlayer { Id = message.Id });
+    }
+
+    public static void Handle(StorageAttrRecordScore message, IDocumentSession session)
+    {
+        session.Events.StartStream<StorageAttrScore>(message.StreamId, new StorageAttrScoreRecorded());
+    }
+}
+
+#endregion
+
+public static class StorageAttrScoredHandler
+{
+    public static void Handle(StorageAttrScored message)
+    {
     }
 }


### PR DESCRIPTION
Part of #3907 ("Also in scope: the provider-agnostic ancillary-store attribute", item 2).

## The stated gap is not real — but a smaller one was

#3907 says the only test naming `[Storage(typeof(...))]` is `PolecatTests/AncillaryStores/storage_attribute_routes_to_polecat_store`. That isn't so: **`MartenTests/AncillaryStores/storage_attribute_routes_to_marten_store` already exists and landed in the same commit** (`c790a5d7f`, GH-3109 / #3112). It passes today on net9.0 and net10.0. No mirror file was needed, so this PR doesn't add one.

What *was* missing is that neither the Marten nor the Polecat test asserted the two behaviours `StorageAttribute`'s own doc comment promises:

> The handler will open and commit its work through the targeted store's outbox-enrolled session, and inline-projection side effects relayed by that store flow through the Wolverine outbox — the same behavior as the provider-specific attributes.

The existing Marten test only proved a document landed in the ancillary store's schema. That would still pass if `[Storage]` were writing to *both* stores, and it says nothing at all about outbox enrollment. Since CritterWatch is about to adopt `[Storage(typeof(ICritterWatchStore))]` across ~105 call sites against Marten, "a document landed somewhere" is thinner than what's about to depend on it.

## What this PR does

Strengthens the existing test in place rather than duplicating it, reusing the one host:

- the existing test now also asserts the document is **not** in the main store;
- a second test covers the **injected-`IDocumentSession`** handler shape — what the Polecat mirror uses, and what a store-agnostic consumer actually writes — rather than only the `IMartenOp` return shape;
- a third appends an event through the `[Storage]`-supplied session and asserts the ancillary store's **inline projection side effect comes back out through the Wolverine outbox** to a Wolverine handler. That only holds if the session `[Storage]` handed the handler is the outbox-enrolled one, which is the property the doc comment claims and nothing was checking.

The main store also gets an explicit schema name so it stops sharing `public` with the rest of the suite.

## Verdict: `[Storage]` works against Marten

Nothing needed fixing. Every shape tested behaves correctly, including the outbox relay.

## Non-vacuousness

Both new assertions were mutation-checked rather than assumed:

| mutation | result |
|---|---|
| comment out `[Storage(typeof(IStorageAttrStore))]` | all 3 tests fail |
| `EnableSideEffectsOnInlineProjections = false` | the outbox test fails, other 2 pass |

## Verification

- `storage_attribute_routes_to_marten_store` — 3/3 green on **net9.0 and net10.0**
- `MartenTests.AncillaryStores` — 22/22 green
- full `MartenTests` — **554 passed, 0 failed** (net9.0, 11m26s)

## Still not covered (deliberately, and it is symmetric)

The Polecat `[Storage]` test remains routing-only — its inline-projection outbox coverage lives in a separate test driven by `[PolecatStore]`, not `[Storage]`. Mirroring these three assertions onto the Polecat side would restore parity but is out of scope here; happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ri7jHRKhaFNBesQM1B5i1k