### PR TITLE
6.26.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.25.5</Version>
+        <Version>6.26.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Version bump for the 6.26.0 release. `Directory.Build.props` only.

Ships:
- **#3901** (GH-3893) — a `[WriteAggregate]`-only chain reports `IsTransactional` correctly. Thanks @esond.
- **#3909** (GH-3905) — `WolverineFx.DataAnnotationsValidation` and `WolverineFx.FluentValidation.Grpc` are packed for the first time, plus a `ValidatePackList` build check so the `PackageId` and `Pack` lists cannot drift apart again.
- **#3910** (GH-3907, increment one) — JasperFx 2.47.0 / Marten 9.23.0 / Polecat 5.12.0, the aggregate workflow drift reconciliation, the `IEventSourcingFrameProvider` seam, and the name-collision invariant.
- **#3906** — outgoing batches only build their contiguous buffer when something reads it.
- **#3908** (GH-3907) — pins what `[Storage(typeof(...))]` promises against a Marten ancillary store.

The bump has to land on `main` before the publish workflow is dispatched: `publish_nugets.yml` checks out `main` with no ref and reads the version from there, and `dotnet nuget push --skip-duplicate` makes a re-publish of an already-published version a silent no-op.

**This release publishes 46 packages rather than 44**, and `Pack` now depends on `ValidatePackList`, which is a new gate in the release path. Verified locally: `All 46 projects declaring a <PackageId> are in the Pack list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC