### PR TITLE
Fail fast when an Audit() expression is not a direct member access

### DIFF
--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -259,6 +259,11 @@ opts.Policies.ForMessagesOfType<IAccountMessage>().Audit(x => x.AccountId);
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/auditing_determination.cs#L73-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_explicit_registration_of_audit_properties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+Each expression has to be a direct member access on the message type, because Wolverine writes the member
+straight into the generated code. Anything else -- a coalesce like `x => x.Name ?? string.Empty`, a method call,
+or a nested member like `x => x.Inner.Name` -- is rejected with an `ArgumentOutOfRangeException` at configuration
+time. Use a computed property on the message type marked with `[Audit]` instead.
+
 This will extend your log entries to like this:
 
 ```text

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -259,10 +259,12 @@ opts.Policies.ForMessagesOfType<IAccountMessage>().Audit(x => x.AccountId);
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Testing/CoreTests/Configuration/auditing_determination.cs#L73-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_explicit_registration_of_audit_properties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Each expression has to be a direct member access on the message type, because Wolverine writes the member
-straight into the generated code. Anything else -- a coalesce like `x => x.Name ?? string.Empty`, a method call,
-or a nested member like `x => x.Inner.Name` -- is rejected with an `ArgumentOutOfRangeException` at configuration
+::: warning
+**Each expression has to be a direct member access on the message type**, because Wolverine writes the member
+straight into the generated code. Anything else — a coalesce like `x => x.Name ?? string.Empty`, a method call,
+or a nested member like `x => x.Inner.Name` — is rejected with an `ArgumentOutOfRangeException` at configuration
 time. Use a computed property on the message type marked with `[Audit]` instead.
+:::
 
 This will extend your log entries to like this:
 

--- a/src/Testing/CoreTests/Configuration/auditing_determination.cs
+++ b/src/Testing/CoreTests/Configuration/auditing_determination.cs
@@ -82,6 +82,19 @@ public class auditing_determination : IntegrationContext
     }
 
     [Fact]
+    public void reject_audit_expressions_that_are_not_a_direct_member_access()
+    {
+        var options = new WolverineOptions();
+
+        // This used to resolve to String.Empty -- the last member visited anywhere in the
+        // expression tree -- and emit uncompilable code like auditedMessage.Empty
+        var ex = Should.Throw<ArgumentOutOfRangeException>(() =>
+            options.Policies.ForMessagesOfType<AuditedMessage>().Audit(x => x.Name ?? string.Empty));
+
+        ex.Message.ShouldContain("x.Name ?? String.Empty");
+    }
+
+    [Fact]
     public async Task use_audit_member_named_id_and_disambiguate()
     {
         await with(opts => opts.Policies.LogMessageStarting(LogLevel.Information));

--- a/src/Testing/CoreTests/Configuration/auditing_determination.cs
+++ b/src/Testing/CoreTests/Configuration/auditing_determination.cs
@@ -86,7 +86,7 @@ public class auditing_determination : IntegrationContext
     {
         var options = new WolverineOptions();
 
-        // This used to resolve to String.Empty -- the last member visited anywhere in the
+        // This used to resolve to String.Empty — the last member visited anywhere in the
         // expression tree -- and emit uncompilable code like auditedMessage.Empty
         var ex = Should.Throw<ArgumentOutOfRangeException>(() =>
             options.Policies.ForMessagesOfType<AuditedMessage>().Audit(x => x.Name ?? string.Empty));

--- a/src/Wolverine/MessageTypePolicies.cs
+++ b/src/Wolverine/MessageTypePolicies.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Reflection;
 using JasperFx.Core.Reflection;
 using Wolverine.ErrorHandling;
 using Wolverine.Logging;
@@ -21,15 +22,38 @@ public class MessageTypePolicies<T>
     ///     to type T should be audited as part of telemetry, logging, and metrics
     ///     data exported from this application
     /// </summary>
-    /// <param name="members"></param>
+    /// <param name="memberExpressions">Direct member access expressions on the message type, e.g. <c>x => x.AccountId</c></param>
     /// <typeparam name="T"></typeparam>
+    /// <exception cref="ArgumentOutOfRangeException">One of the expressions is not a direct member access on the message type</exception>
     public MessageTypePolicies<T> Audit(params Expression<Func<T, object>>[] memberExpressions)
     {
-        var members = memberExpressions.Select(expr => FindMembers.Determine(expr).First()).ToArray();
+        var members = memberExpressions.Select(determineAuditedMember).ToArray();
 
         var policy = new AuditMembersPolicy<T>(members);
         _parent.RegisteredPolicies.Insert(0, policy);
         return this;
+
+        // The generated code writes the audited member as "{message}.{MemberName}", so only a direct
+        // member access on the message type can be audited
+        static MemberInfo determineAuditedMember(Expression<Func<T, object>> expression)
+        {
+            // Boxing a value type member to object shows up as a Convert() around the member access
+            var body = expression.Body;
+            while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+            {
+                body = unary.Operand;
+            }
+
+            if (body is MemberExpression { Expression: ParameterExpression } member)
+            {
+                return member.Member;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(memberExpressions),
+                $"'{expression}' is not a direct member access on {typeof(T).FullNameInCode()} and cannot be audited. " +
+                "Audit a single public field or property of the message type, or use a computed member on the " +
+                "message type itself and mark it with [Audit].");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
`MessageTypePolicies.Audit()` resolves the audited member with `FindMembers.Determine(expr).First()`:

```csharp
var members = memberExpressions.Select(expr => FindMembers.Determine(expr).First()).ToArray();
```

`FindMembers` is a visitor that collects *every* `MemberExpression` in the tree, and it prepends each one (`Members.Insert(0, node.Member)`), so the list comes back in reverse visit order. `.First()` is therefore the last member the visitor reached anywhere in the expression — not the member being accessed on the message:

| Expression | Members collected | `.First()` |
|---|---|---|
| `x => x.DeviceImsi` | `[DeviceImsi]` | `DeviceImsi` |
| `x => x.DeviceImsi ?? string.Empty` | `[Empty, DeviceImsi]` | **`Empty`** |
| `x => x.DeviceId.ToString(CultureInfo.InvariantCulture)` | `[InvariantCulture, DeviceId]` | **`InvariantCulture`** |

The resulting `AuditedMember` is written straight into the generated code — `AuditToActivityFrame` and `LogStartingActivity` both emit `{input}.{Member.Name}` verbatim — so the first case above produces `auditedMessage.Empty`, which does not compile. `codegen write` fails on a member that does not exist on the message type, and the failure names the generated file rather than the `Audit()` call that caused it.

The quieter case is worse: `x => x.A ?? x.B` compiles and runs, and silently audits `B`.

## The change

`Audit()` now parses the expression itself instead of asking for every member in the tree. A `Convert`/`ConvertChecked` wrapper is unwrapped first — boxing a value type member to `object` puts one there, and the existing `x => x.AccountId` sample in the docs relies on it — then the body has to be a `MemberExpression` whose own `Expression` is the lambda parameter. Anything else throws `ArgumentOutOfRangeException` at configuration time, with the offending expression and the workaround (`[Audit]` on a computed member of the message type) in the message.

There is exactly one call site, so nothing else changes behaviour.

`docs/guide/logging.md` states the constraint next to the `Audit()` sample, since the sample is the only thing that documented the accepted shape.

## Behaviour change worth vetoing if you disagree

`x => x.Inner.Name` compiles today, audits `Inner`, and generates working code. After this it throws.

That is the intended direction — auditing `Inner` is not what the expression asks for — but it is a break for anyone who wrote a nested path and did not notice which member came out. Supporting paths properly would mean `AuditedMember` carrying a path rather than a single `MemberInfo`, plus changes in both codegen frames; happy to extend it that way instead if you would rather not reject them.

## Tests

`reject_audit_expressions_that_are_not_a_direct_member_access` in `src/Testing/CoreTests/Configuration/auditing_determination.cs`, asserting on the message so it cannot pass by throwing something incidental.

Confirmed red at unmodified `HEAD`: `should throw System.ArgumentOutOfRangeException but did not`. A throwaway probe over the old code path also confirmed the mechanism directly — `FindMembers.Determine(x => x.Name ?? string.Empty).First().Name` came back as `Empty`.

No test was added for the `Convert` unwrap: the pre-existing `use_audit_members_from_explicit_interface_adds` at `:75` audits `x => x.AccountId` (a `Guid`, so boxed) and covers it end to end through generated code, which is stronger than asserting the shape.

## Verification

| Suite | Result |
|---|---|
| `CoreTests --filter FullyQualifiedName~auditing_determination` (net10.0) | 7/7 |
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |

Full `CoreTests` was not run locally (broker and database dependencies), and the tests were not executed against net9.0 — no .NET 9 runtime on this machine, though the pinned net9.0 build above is clean.
