### PR TITLE
Clear the SSH.NET advisory that is failing every build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -120,6 +120,10 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
     <PackageVersion Include="System.ComponentModel" Version="4.3.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <!-- Testcontainers pulls SSH.NET [2025.1.0, ); everything through 2025.1.0 carries
+         GHSA-q939-rpr3-3284. The test projects that use Testcontainers reference this directly so
+         the patched version wins. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="Testcontainers" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.CosmosDb" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Kafka" Version="4.12.0" />

--- a/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
+++ b/src/Persistence/CosmosDbTests/CosmosDbTests.csproj
@@ -17,6 +17,11 @@
         <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="Testcontainers" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
         <PackageReference Include="Testcontainers.CosmosDb" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Persistence/LeaderElection/CosmosDbTests.LeaderElection/CosmosDbTests.LeaderElection.csproj
+++ b/src/Persistence/LeaderElection/CosmosDbTests.LeaderElection/CosmosDbTests.LeaderElection.csproj
@@ -10,6 +10,11 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
         <PackageReference Include="Testcontainers" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
         <PackageReference Include="Testcontainers.CosmosDb" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/Wolverine.Kafka.Tests.csproj
@@ -22,6 +22,11 @@
         <PackageReference Include="Alba" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Testcontainers.Kafka" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.MQTT.Tests/Wolverine.MQTT.Tests.csproj
@@ -21,6 +21,11 @@
         </PackageReference>
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
         <PackageReference Include="Testcontainers" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/MQTT/Wolverine.Mqtt5.Tests/Wolverine.Mqtt5.Tests.csproj
+++ b/src/Transports/MQTT/Wolverine.Mqtt5.Tests/Wolverine.Mqtt5.Tests.csproj
@@ -21,6 +21,11 @@
         </PackageReference>
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
         <PackageReference Include="Testcontainers" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/Wolverine.Nats.Tests.csproj
@@ -23,6 +23,11 @@
         <PackageReference Include="Meziantou.Extensions.Logging.Xunit" />
         <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
         <PackageReference Include="Testcontainers.Nats" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/Wolverine.Pulsar.Tests.csproj
@@ -12,6 +12,11 @@
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
         <PackageReference Include="coverlet.collector" PrivateAssets="All" />
         <PackageReference Include="Testcontainers.Pulsar" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
         <PackageReference Include="Apache.Avro" />
     </ItemGroup>
 

--- a/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/Wolverine.Redis.Tests.csproj
@@ -21,6 +21,11 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Testcontainers.Redis" />
+        <!-- Testcontainers depends on SSH.NET [2025.1.0, ), and every version through 2025.1.0
+             carries GHSA-q939-rpr3-3284 (high severity), which TreatWarningsAsErrors turns into a
+             hard build failure. Referencing the patched 2026.0.0 directly satisfies the open-ended
+             range and clears the advisory. Drop this once Testcontainers floors it itself. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
`main` is red, and so is every open PR:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high severity
vulnerability, https://github.com/advisories/GHSA-q939-rpr3-3284
```

Nothing in this repo changed. [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) was published against SSH.NET — *ScpClient recursive download allows arbitrary file write via server-controlled SCP filenames* — and `TreatWarningsAsErrors` turns the resulting `NU1903` into a hard build failure the moment the advisory lands. Eight test projects hit it, all of them through Testcontainers.

## Why not just bump Testcontainers

| package | SSH.NET dependency |
|---|---|
| Testcontainers 4.12.0 (current) | `[2025.1.0, )` |
| Testcontainers 4.13.0 (latest) | `[2025.1.0, )` |

Every SSH.NET version through 2025.1.0 is in range of the advisory; **2026.0.0** is the first patched one. Testcontainers has not floored it, so the bump does not help.

## What this does

The dependency range is open-ended, so referencing the patched version directly from the eight projects that pull Testcontainers satisfies it and clears the advisory.

That is deliberately narrower than turning on `CentralPackageTransitivePinningEnabled`, which would change transitive resolution across the whole repo — not something to do on the way into a release. The `Microsoft.OpenApi` entry a few lines up in `Directory.Packages.props` is the same situation handled the same way.

Drop the direct references once Testcontainers floors SSH.NET itself.

`dotnet build wolverine.slnx -c Release -f net9.0` is clean with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC