### PR TITLE
GH-3911: the store op policies mark their chains transactional, and the ordering fix that lets them

### DIFF
--- a/src/Persistence/MartenTests/marten_op_chains_are_transactional.cs
+++ b/src/Persistence/MartenTests/marten_op_chains_are_transactional.cs
@@ -1,0 +1,171 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+/// <summary>
+///     GH-3911: a chain that <c>MartenOpPolicy</c> gave transaction support must also <b>report</b>
+///     itself transactional.
+/// </summary>
+/// <remarks>
+///     <para>
+///     Same disagreement GH-3893 fixed for <c>[WriteAggregate]</c>: the policy ends the generated code in
+///     <c>SaveChangesAsync</c>, so a chain answering <c>IsTransactional = false</c> is lying to every
+///     <c>IChainPolicy</c> / <c>IHttpPolicy</c> keying on the flag.
+///     </para>
+///     <para>
+///     It was left alone until now for a real reason — setting the flag from an <c>IChainPolicy</c> made
+///     whether <c>EagerIdempotencyOnNonTransactionalChains</c> fired depend on the order the user called
+///     <c>AutoApplyIdempotencyOnNonTransactionalHandlers()</c> relative to <c>IntegrateWithWolverine()</c>,
+///     i.e. generated code varying by registration order. That policy is now always applied last, so
+///     <b>both orders are asserted here</b>: the ordering guarantee is the thing that makes the flag safe,
+///     and a regression in it would otherwise only show up as somebody's idempotency check quietly
+///     appearing or disappearing.
+///     </para>
+/// </remarks>
+public class marten_op_chains_are_transactional
+{
+    private static async Task<IHost> hostAsync(bool idempotencyFirst)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StartTheStreamHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                if (idempotencyFirst)
+                {
+                    opts.Policies.AutoApplyIdempotencyOnNonTransactionalHandlers();
+                }
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "marten_op_transactional";
+                }).IntegrateWithWolverine();
+
+                if (!idempotencyFirst)
+                {
+                    opts.Policies.AutoApplyIdempotencyOnNonTransactionalHandlers();
+                }
+            }).StartAsync();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task a_marten_op_return_marks_the_chain_transactional(bool idempotencyFirst)
+    {
+        using var host = await hostAsync(idempotencyFirst);
+
+        // Chains compile lazily
+        await host.InvokeAsync(new StartTheStream(Guid.NewGuid()));
+
+        var chain = host.GetRuntime().Handlers.ChainFor<StartTheStream>()!;
+
+        chain.Postprocessors.OfType<JasperFx.CodeGeneration.Frames.MethodCall>()
+            .Any(x => x.Method.Name == nameof(IDocumentSession.SaveChangesAsync))
+            .ShouldBeTrue();
+
+        chain.IsTransactional.ShouldBeTrue();
+    }
+}
+
+public record StartTheStream(Guid Id);
+
+public record StreamStarted(Guid Id);
+
+public static class StartTheStreamHandler
+{
+    // A single IMartenOp return: an ISideEffect that MartenOpPolicy gives transaction support to
+    public static IMartenOp Handle(StartTheStream command)
+        => MartenOps.StartStream<OpStreamMarker>(command.Id, new StreamStarted(command.Id));
+}
+
+public class OpStreamMarker
+{
+    public Guid Id { get; set; }
+
+    public void Apply(StreamStarted _)
+    {
+    }
+}
+
+/// <summary>
+///     GH-3911: <c>[NonTransactional]</c> does not suppress the aggregate workflow's commit, and the
+///     chain still reports itself transactional.
+/// </summary>
+/// <remarks>
+///     Pinned rather than left to be rediscovered, because the surprising reading is the plausible one.
+///     <c>[NonTransactional]</c> opts a chain out of <c>AutoApplyTransactions()</c> and nothing else —
+///     <c>AutoApplyTransactions</c> is the only thing in Wolverine that reads it. The aggregate workflow
+///     commits as part of its own contract: it loads a stream, hands you the state, and appends what you
+///     return. Honouring the attribute there would silently discard those events.
+/// </remarks>
+public class non_transactional_does_not_suppress_the_aggregate_commit
+{
+    [Fact]
+    public async Task the_aggregate_workflow_still_commits_and_still_reports_transactional()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(NonTransactionalDepositHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "non_transactional_aggregate";
+                }).IntegrateWithWolverine();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = host.DocumentStore().LightweightSession())
+        {
+            session.Events.StartStream<OpAccount>(streamId, new OpDeposited(10m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await host.InvokeAsync(new NonTransactionalDeposit(streamId, 5m));
+
+        // The event was committed despite [NonTransactional]
+        await using var verify = host.DocumentStore().LightweightSession();
+        var account = await verify.Events.AggregateStreamAsync<OpAccount>(streamId,
+            token: TestContext.Current.CancellationToken);
+        account!.Balance.ShouldBe(15m);
+
+        host.GetRuntime().Handlers.ChainFor<NonTransactionalDeposit>()!
+            .IsTransactional.ShouldBeTrue();
+    }
+}
+
+public record NonTransactionalDeposit(Guid OpAccountId, decimal Amount);
+
+public record OpDeposited(decimal Amount);
+
+public class OpAccount
+{
+    public Guid Id { get; set; }
+    public decimal Balance { get; set; }
+
+    public void Apply(OpDeposited e) => Balance += e.Amount;
+}
+
+public static class NonTransactionalDepositHandler
+{
+    [Wolverine.Attributes.NonTransactional]
+    public static OpDeposited Handle(NonTransactionalDeposit command,
+        [Wolverine.Persistence.EventSourcing.WriteModel] OpAccount account)
+        => new(command.Amount);
+}

--- a/src/Persistence/Wolverine.Marten/IMartenOp.cs
+++ b/src/Persistence/Wolverine.Marten/IMartenOp.cs
@@ -58,6 +58,18 @@ internal class MartenOpPolicy : IChainPolicy
             if (collections.Any() || singles.Any() || appendsToEventStream)
             {
                 new MartenPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
+
+                // GH-3911: mark the chain too, not just apply the middleware. ApplyTransactionSupport
+                // ends the generated code in SaveChangesAsync, so a chain that reports
+                // IsTransactional = false there is lying to every IChainPolicy / IHttpPolicy keying on
+                // the flag - the same disagreement GH-3893 fixed for [WriteAggregate].
+                //
+                // This was previously left alone because setting it from an IChainPolicy made whether
+                // EagerIdempotencyOnNonTransactionalChains fired depend on the order the user called
+                // AutoApplyIdempotencyOnNonTransactionalHandlers() relative to IntegrateWithWolverine().
+                // That policy is now always applied LAST (HandlerGraph.handlerPolicies), so the order
+                // no longer decides anything and the flag can be honest.
+                chain.IsTransactional = true;
             }
 
             // Only collections need the explicit foreach-Execute frame; single IMartenOp returns are

--- a/src/Persistence/Wolverine.Polecat/IPolecatOp.cs
+++ b/src/Persistence/Wolverine.Polecat/IPolecatOp.cs
@@ -31,6 +31,18 @@ internal class PolecatOpPolicy : IChainPolicy
             if (candidates.Any())
             {
                 new PolecatPersistenceFrameProvider().ApplyTransactionSupport(chain, container);
+
+                // GH-3911: mark the chain too, not just apply the middleware. ApplyTransactionSupport
+                // ends the generated code in SaveChangesAsync, so a chain that reports
+                // IsTransactional = false there is lying to every IChainPolicy / IHttpPolicy keying on
+                // the flag - the same disagreement GH-3893 fixed for [WriteAggregate].
+                //
+                // This was previously left alone because setting it from an IChainPolicy made whether
+                // EagerIdempotencyOnNonTransactionalChains fired depend on the order the user called
+                // AutoApplyIdempotencyOnNonTransactionalHandlers() relative to IntegrateWithWolverine().
+                // That policy is now always applied LAST (HandlerGraph.handlerPolicies), so the order
+                // no longer decides anything and the flag can be honest.
+                chain.IsTransactional = true;
             }
 
             foreach (var collection in candidates)

--- a/src/Wolverine/Attributes/NonTransactionalAttribute.cs
+++ b/src/Wolverine/Attributes/NonTransactionalAttribute.cs
@@ -4,5 +4,20 @@ namespace Wolverine.Attributes;
 ///     Explicitly opts out a handler or HTTP endpoint from having transactional
 ///     middleware applied automatically by <c>AutoApplyTransactions()</c>.
 /// </summary>
+/// <remarks>
+///     <para>
+///     <b>That is its entire scope</b>, and the distinction matters. It suppresses the <em>automatic</em>
+///     policy; it does not suppress a commit that some other feature owns as part of its own contract.
+///     </para>
+///     <para>
+///     In particular it does <b>not</b> stop the event sourcing workflows — <c>[WriteModel]</c>,
+///     <c>[DeciderFunction]</c>, <c>[DcbModel]</c> and their store-named spellings — from committing.
+///     Those load a stream, hand you the state, and append whatever events you return; the commit is the
+///     back half of that bargain, not a policy layered on top. Suppressing it would silently discard the
+///     events the handler just produced, which is the one outcome worth ruling out. A chain in that shape
+///     therefore still reports <c>IsTransactional = true</c>, because its generated code does in fact end
+///     in a commit. GH-3911.
+///     </para>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public class NonTransactionalAttribute : Attribute;

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging.Debug;
 using Microsoft.Extensions.Options;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
+using Wolverine.Persistence;
 using Wolverine.ErrorHandling;
 using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime.Agents;
@@ -558,9 +559,22 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
         }
     }
 
+    /// <remarks>
+    ///     GH-3911: <see cref="EagerIdempotencyOnNonTransactionalChains" /> is deliberately pulled to the
+    ///     END, whatever order it was registered in. Its whole semantic is "for chains that nothing else
+    ///     made transactional", so it can only answer that question once every other policy has had its
+    ///     say. Left in registration order it produced generated code that varied by the order the user
+    ///     happened to call <c>AutoApplyIdempotencyOnNonTransactionalHandlers()</c> relative to a store's
+    ///     <c>IntegrateWithWolverine()</c> — which is why the store op policies could not set
+    ///     <c>IsTransactional</c> at all before this.
+    /// </remarks>
     private IEnumerable<IHandlerPolicy> handlerPolicies(WolverineOptions options)
     {
-        foreach (var policy in options.RegisteredPolicies)
+        var registered = options.RegisteredPolicies
+            .OrderBy(x => x is EagerIdempotencyOnNonTransactionalChains ? 1 : 0)
+            .ToArray();
+
+        foreach (var policy in registered)
         {
             if (policy is IHandlerPolicy h)
             {


### PR DESCRIPTION
The two items #3911 listed as *"also still open"* — plus the reason the first one was open at all.

## 1. `IsTransactional` on the op policies

`MartenOpPolicy` / `PolecatOpPolicy` call `ApplyTransactionSupport` — which ends the generated code in `SaveChangesAsync` — and never set `IChain.IsTransactional`. Same disagreement #3893 fixed for `[WriteAggregate]`: the chain reports `false` while its own generated code commits, so any `IChainPolicy` or `IHttpPolicy` keying on the flag gets a false negative.

**#3911 left this alone for a real reason, not an oversight.** Setting the flag from an `IChainPolicy` made whether `EagerIdempotencyOnNonTransactionalChains` fired depend on the order the user called `AutoApplyIdempotencyOnNonTransactionalHandlers()` relative to a store's `IntegrateWithWolverine()`. Generated code varying by registration order is worse than an inaccurate flag.

So this fixes the cause instead. **`EagerIdempotencyOnNonTransactionalChains` is now always applied last**, whatever order it was registered in:

```csharp
var registered = options.RegisteredPolicies
    .OrderBy(x => x is EagerIdempotencyOnNonTransactionalChains ? 1 : 0)
    .ToArray();
```

That isn't a workaround. Its entire semantic is *"for chains that nothing else made transactional"*, which it can only answer once every other policy has had its say. With the order settled, both op policies can set the flag honestly.

The test asserts **both registration orders**, because the ordering guarantee is the thing that makes the flag safe — a regression in it would otherwise surface as somebody's idempotency check quietly appearing or disappearing. Verified red first: **2/2 fail** without the change.

## 2. `[NonTransactional]` + `[WriteAggregate]` is not a defect

The attribute's documented scope is opting a chain out of `AutoApplyTransactions()`, and `AutoApplyTransactions` is the **only** thing in Wolverine that reads it.

The aggregate workflow's commit is the back half of its own bargain — load a stream, hand you the state, append what you return. Honouring the attribute there would silently discard the events the handler just produced, which is the one outcome worth ruling out. Documented on the attribute, and pinned with a test so the surprising-but-correct reading cannot drift into the surprising-and-wrong one.

## What this deliberately does *not* do

#3911 also lists `DocumentSessionOperationFrame`, `EventStoreFrame` and `SessionVariableSource` as remaining duplication. **They should stay duplicated.**

Each writes store-specific source — `session.Events`, `session.Insert(...)` — and increment 2's design decision is that such frames live behind `IEventSourcingFrameProvider` rather than in core. Three identical files are the *price* of that seam, not an oversight; moving them would put the store's spelling back in core, which is exactly what the seam exists to prevent. `LoadAggregateFrame` and `LoadBoundaryFrame` are store-side for the same reason.

## Verification

`MartenTests` **572/576**. The 4 failures are `MartenTests.Distribution` and fail **identically on clean `origin/main`** — environment, not this diff. CI's `CIMartenDistribution` passed on #3923.

Closes #3911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC