### PR TITLE
GH-3926: an oversized SQS message is discarded rather than retried forever, plus opt-in fragmentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -220,7 +220,8 @@ const config: UserConfig<DefaultTheme.Config> = {
                                         {text: 'Interoperability', link:'/guide/messaging/transports/sqs/interoperability'},
                                         {text: 'MessageAttributes', link:'/guide/messaging/transports/sqs/message-attributes'},
                                         {text: 'FIFO Queues', link:'/guide/messaging/transports/sqs/fifo-queues'},
-                                        {text: 'Fair Queues', link:'/guide/messaging/transports/sqs/fair-queues'}
+                                        {text: 'Fair Queues', link:'/guide/messaging/transports/sqs/fair-queues'},
+                                        {text: 'Large Messages', link:'/guide/messaging/transports/sqs/large-messages'}
                                     ]},
                                 {text: 'Amazon SNS', link: '/guide/messaging/transports/sns'},
                                 {text: 'TCP', link: '/guide/messaging/transports/tcp'},

--- a/docs/guide/messaging/transports/sqs/large-messages.md
+++ b/docs/guide/messaging/transports/sqs/large-messages.md
@@ -1,0 +1,125 @@
+# Large Messages
+
+Amazon SQS caps a message at **256KB** — body and message attributes together. Go over it and SQS answers:
+
+```
+InvalidParameterValue - Message must be shorter than 262144 bytes. (SenderFault: true)
+```
+
+`SenderFault: true` means SQS is telling you the request itself is wrong, so the identical request will
+fail identically forever. Wolverine treats an oversized message accordingly: it is **logged and
+discarded** rather than retried, so a message that outgrew the limit produces one error rather than an
+endless flood of them.
+
+If you want the message to actually get through, there are two answers.
+
+## Claim Checks (recommended)
+
+A [claim check](/guide/durability/claim-checks) writes the payload to S3 and sends a small pointer through
+SQS, which is the pattern AWS itself recommends. It has no practical size ceiling, it works on standard
+queues with any number of competing consumers, and what travels through SQS stays an ordinary message
+that anything can consume.
+
+```bash
+dotnet add package WolverineFx.ClaimCheck.AmazonS3
+```
+
+```csharp
+opts.UseClaimCheck(claimCheck =>
+{
+    claimCheck.UseAmazonS3FromServices(bucketName: "wolverine-claim-checks");
+
+    // Anything whose serialized body is larger than 200KB is off-loaded whole
+    claimCheck.AutoOffloadPayloadsLargerThan(200 * 1024);
+});
+```
+
+**This is the right answer for almost everyone.** Reach for fragmentation below only when adding an S3
+bucket is genuinely not an option.
+
+## Message Fragmentation <Badge type="tip" text="6.27" />
+
+Fragmentation splits an oversized body across several SQS messages and reassembles it on the receiving
+side, with no extra infrastructure at all. It is opt-in per endpoint:
+
+```csharp
+opts.PublishMessage<BigDocumentReceived>()
+    .ToSqsQueue("documents")
+    .FragmentOversizedMessages();
+
+opts.ListenToSqsQueue("documents")
+    .FragmentOversizedMessages();
+```
+
+Nothing changes for messages that fit; only a body over the limit is split.
+
+### The constraint you have to design around
+
+**Reassembly happens in memory, on one listener.** SQS is a competing-consumer queue, so if several nodes
+poll the same standard queue, fragments of a single message can be handed to different nodes and no one of
+them ever holds the whole set. Those partial sets are abandoned after the reassembly timeout (5 minutes by
+default) and redelivered — the message may eventually get through, but only by luck, and meanwhile the
+queue churns.
+
+So only use fragmentation in one of these three shapes:
+
+| Topology | Why it is safe |
+|---|---|
+| A **FIFO queue** | SQS delivers a message group to one consumer at a time, and every fragment of a message shares a group id. |
+| A **globally partitioned** listener | The fragments carry the message's `GroupId`, so the whole message routes to the node that owns that group. |
+| A **single listening node** | There is nobody to compete with. |
+
+[Global partitioning](/guide/messaging/partitioning#global-partitioning) is the recommended shape — it
+keeps multiple nodes and still makes reassembly reliable rather than best-effort:
+
+```csharp
+opts.MessagePartitioning.ByMessage<IDocumentMessage>(x => x.GroupId);
+
+opts.MessagePartitioning.GlobalPartitioned(topology =>
+{
+    topology.UseShardedAmazonSqsQueues("documents", 4, sqs =>
+    {
+        sqs.ConfigureSender(x => x.FragmentOversizedMessages());
+        sqs.ConfigureListening(x => x.FragmentOversizedMessages());
+    });
+
+    topology.MessagesImplementing<IDocumentMessage>();
+});
+```
+
+### Other things worth knowing
+
+* **Wolverine to Wolverine only.** The fragments are Wolverine's own framing, carried in SQS message
+  attributes. A non-Wolverine consumer reading the queue sees N unintelligible messages rather than one.
+  That is exactly why this is opt-in rather than automatic.
+
+* **Configure both ends.** A listener reassembles fragments whether or not it was configured to send that
+  way — the framing is self-describing — but the same setting also governs requeues and the reassembly
+  timeout, so set it on the sending and listening endpoints alike.
+
+* **Nothing is acknowledged until the set is complete.** Fragments are never deleted from SQS until every
+  one of them is in hand, so a node that crashes holding two of three has told SQS nothing and all three
+  become visible again. Completing a reassembled message deletes all of its fragments together.
+
+* **Group ids are respected.** If the envelope already has a `GroupId` — from `DeliveryOptions` or
+  [message partitioning](/guide/messaging/partitioning) — every fragment carries it, so the message lands
+  where it was always going to land. Only a message with no group id at all gets a synthesized one, purely
+  to hold the set together.
+
+* **There is a ceiling.** A message needing more than 10 fragments is discarded with an error pointing at
+  claim checks. At that size this is a storage problem, not a framing one.
+
+* **On a FIFO queue** each fragment gets a distinct `MessageDeduplicationId` (the envelope's, suffixed with
+  the fragment index), since a shared one would have SQS keep exactly one fragment of the set.
+
+### Tuning the reassembly timeout
+
+```csharp
+opts.ListenToSqsQueue("documents")
+    .FragmentOversizedMessages(reassemblyTimeout: 2.Minutes());
+```
+
+A listener holding an incomplete set past this timeout abandons it and logs a warning naming the fragment
+id and how many of the set it held. Abandoning is local only — the fragments were never deleted from SQS,
+so they become visible again. Repeated warnings here are the signal that your topology is not one of the
+three above.

--- a/src/Testing/CoreTests/Persistence/Durability/durable_sender_discards_unsendable_envelopes_3926.cs
+++ b/src/Testing/CoreTests/Persistence/Durability/durable_sender_discards_unsendable_envelopes_3926.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Persistence.Durability;
+
+/// <summary>
+/// GH-3926. A transport that has decided an envelope can never be sent — SQS answers an oversized
+/// message with a permanent SenderFault — reports it through MarkSerializationFailureAsync. That used
+/// to only log, so on a durable endpoint the row stayed in the outgoing table and the durability agent
+/// re-read and re-sent it on every recovery sweep: the same endless retry the call exists to break.
+/// </summary>
+public class durable_sender_discards_unsendable_envelopes_3926
+{
+    private readonly IMessageOutbox _outbox = Substitute.For<IMessageOutbox>();
+    private readonly DurableSendingAgent _agent;
+    private readonly Uri _destination = new("stub://one");
+
+    public durable_sender_discards_unsendable_envelopes_3926()
+    {
+        var sender = Substitute.For<ISender>();
+        sender.Destination.Returns(_destination);
+
+        _agent = new DurableSendingAgent(sender, new DurabilitySettings(), NullLogger.Instance,
+            Substitute.For<IMessageTracker>(), _outbox, new UnsendableEndpoint(_destination));
+    }
+
+    private class UnsendableEndpoint : Endpoint
+    {
+        public UnsendableEndpoint(Uri uri) : base(uri, EndpointRole.Application)
+        {
+        }
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override ISender CreateSender(IWolverineRuntime runtime)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override bool supportsMode(EndpointMode mode) => true;
+    }
+
+    private static Envelope envelope()
+    {
+        return new Envelope { Id = Guid.NewGuid(), Data = [1, 2, 3], MessageType = "too.big" };
+    }
+
+    [Fact]
+    public async Task deletes_the_outgoing_rows_so_recovery_cannot_resend_them()
+    {
+        var one = envelope();
+        var two = envelope();
+
+        await ((ISenderCallback)_agent).MarkSerializationFailureAsync(
+            new OutgoingMessageBatch(_destination, [one, two]));
+
+        await _agent.DisposeAsync();
+
+        await _outbox.Received().DeleteOutgoingAsync(Arg.Is<Envelope[]>(x =>
+            x.Length == 2 && x.Contains(one) && x.Contains(two)));
+    }
+
+    [Fact]
+    public async Task does_not_re_queue_them_for_another_attempt()
+    {
+        var unsendable = envelope();
+
+        await ((ISenderCallback)_agent).MarkSerializationFailureAsync(
+            new OutgoingMessageBatch(_destination, [unsendable]));
+
+        await _agent.DisposeAsync();
+
+        // Storing it again is what a retry would look like from the outbox's side
+        await _outbox.DidNotReceive().StoreOutgoingAsync(Arg.Any<Envelope>(), Arg.Any<int>());
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/AmazonSqsQueueTests.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/AmazonSqsQueueTests.cs
@@ -88,18 +88,21 @@ public class AmazonSqsQueueTests
     }
 
     [Fact]
-    public void configure_request_does_not_set_message_attribute_names_when_null()
+    // GH-3926: an endpoint that names no attributes of its own still has to ask for Wolverine's
+    // fragment framing. SQS returns only the attributes a receive names, so leaving it off makes a
+    // fragmented message arrive as N unrelated messages that each fail to deserialize.
+    public void configure_request_still_asks_for_the_fragment_framing_when_null()
     {
         var endpoint = new AmazonSqsQueue("foo", new AmazonSqsTransport());
         var request = new ReceiveMessageRequest();
 
         endpoint.ConfigureRequest(request);
 
-        request.MessageAttributeNames.ShouldBeNull();
+        request.MessageAttributeNames.ShouldBe(SqsMessageFragments.AttributeNames);
     }
 
     [Fact]
-    public void configure_request_does_not_set_when_empty_list()
+    public void configure_request_still_asks_for_the_fragment_framing_when_empty()
     {
         var endpoint = new AmazonSqsQueue("foo", new AmazonSqsTransport())
         {
@@ -109,7 +112,39 @@ public class AmazonSqsQueueTests
 
         endpoint.ConfigureRequest(request);
 
-        request.MessageAttributeNames.ShouldBeNull();
+        request.MessageAttributeNames.ShouldBe(SqsMessageFragments.AttributeNames);
+    }
+
+    [Fact]
+    public void configure_request_appends_the_fragment_framing_to_what_the_endpoint_asked_for()
+    {
+        var endpoint = new AmazonSqsQueue("foo", new AmazonSqsTransport())
+        {
+            MessageAttributeNames = ["tenant-id"]
+        };
+        var request = new ReceiveMessageRequest();
+
+        endpoint.ConfigureRequest(request);
+
+        request.MessageAttributeNames.ShouldContain("tenant-id");
+        foreach (var name in SqsMessageFragments.AttributeNames)
+        {
+            request.MessageAttributeNames.ShouldContain(name);
+        }
+    }
+
+    [Fact]
+    public void configure_request_leaves_All_alone_since_it_already_covers_the_framing()
+    {
+        var endpoint = new AmazonSqsQueue("foo", new AmazonSqsTransport())
+        {
+            MessageAttributeNames = ["All"]
+        };
+        var request = new ReceiveMessageRequest();
+
+        endpoint.ConfigureRequest(request);
+
+        request.MessageAttributeNames.ShouldBe(["All"]);
     }
 }
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_fair_queue_message_groups.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_fair_queue_message_groups.cs
@@ -26,7 +26,7 @@ public class sqs_fair_queue_message_groups
 
     private static SendMessageBatchRequestEntryView FirstEntry(AmazonSqsQueue queue, Envelope envelope)
     {
-        var batch = new OutgoingSqsBatch(queue, NullLogger.Instance, [envelope]);
+        var batch = new OutgoingSqsBatch(queue, NullLogger.Instance, [SqsSendUnit.Whole(queue, envelope)]);
         var entry = batch.Request.Entries.ShouldHaveSingleItem();
         return new SendMessageBatchRequestEntryView(entry.MessageGroupId, entry.MessageDeduplicationId);
     }

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_fifo_deduplication_id_3793.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_fifo_deduplication_id_3793.cs
@@ -22,7 +22,7 @@ public class sqs_fifo_deduplication_id_3793
 
     private static string? DeduplicationIdFor(AmazonSqsQueue queue, Envelope envelope)
     {
-        var batch = new OutgoingSqsBatch(queue, NullLogger.Instance, [envelope]);
+        var batch = new OutgoingSqsBatch(queue, NullLogger.Instance, [SqsSendUnit.Whole(queue, envelope)]);
         return batch.Request.Entries.ShouldHaveSingleItem().MessageDeduplicationId;
     }
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_message_fragmentation_3926.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_message_fragmentation_3926.cs
@@ -1,0 +1,258 @@
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+/// <summary>
+/// GH-3926. SQS rejects any message over 256KB with a permanent SenderFault, so an endpoint can opt
+/// into splitting an oversized body across several SQS messages and putting it back together on the
+/// other side.
+/// </summary>
+public class sqs_message_fragmentation_3926
+{
+    private static string bodyOfSize(int length)
+    {
+        return new string('x', length);
+    }
+
+    [Fact]
+    public void only_a_body_sqs_would_reject_needs_splitting()
+    {
+        SqsMessageFragments.ExceedsLimit(bodyOfSize(SqsMessageFragments.MaximumBodyBytes)).ShouldBeFalse();
+        SqsMessageFragments.ExceedsLimit(bodyOfSize(SqsMessageFragments.MaximumBodyBytes + 1)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_body_between_the_fragment_size_and_the_sqs_limit_still_goes_as_one_message()
+    {
+        // Fragments are cut smaller than SQS's cap on purpose, but a body in that band is one SQS will
+        // happily take. Deciding on the fragment size instead of the real limit would split -- or worse,
+        // discard -- messages that have always sent perfectly well.
+        SqsMessageFragments.FragmentBodyBytes.ShouldBeLessThan(SqsMessageFragments.MaximumBodyBytes);
+
+        SqsMessageFragments.ExceedsLimit(bodyOfSize(SqsMessageFragments.FragmentBodyBytes + 1)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_body_allowance_leaves_room_for_attributes_under_the_hard_limit()
+    {
+        SqsMessageFragments.MaximumBodyBytes.ShouldBeLessThan(SqsMessageFragments.MaximumMessageBytes);
+    }
+
+    [Fact]
+    public void splitting_and_concatenating_round_trips_the_body()
+    {
+        var body = string.Concat(Enumerable.Range(0, 500_000).Select(i => (char)('a' + i % 26)));
+
+        var fragments = SqsMessageFragments.Split(body);
+
+        fragments.Length.ShouldBe(3);
+        fragments.ShouldAllBe(x => x.Length <= SqsMessageFragments.FragmentBodyBytes);
+        string.Concat(fragments).ShouldBe(body);
+    }
+
+    [Fact]
+    public void a_body_just_over_the_limit_splits_into_two()
+    {
+        SqsMessageFragments.Split(bodyOfSize(SqsMessageFragments.MaximumBodyBytes + 1)).Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void every_fragment_is_small_enough_for_sqs_to_accept()
+    {
+        var fragments = SqsMessageFragments.Split(bodyOfSize(SqsMessageFragments.FragmentBodyBytes * 4 + 17));
+
+        fragments.ShouldAllBe(x => x.Length <= SqsMessageFragments.MaximumBodyBytes);
+    }
+
+    [Fact]
+    public void reads_back_the_header_it_wrote()
+    {
+        var id = Guid.NewGuid();
+        var message = new Message { MessageAttributes = SqsMessageFragments.AttributesFor(id, 2, 5) };
+
+        SqsMessageFragments.TryReadHeader(message, out var header).ShouldBeTrue();
+
+        header.FragmentId.ShouldBe(id);
+        header.Index.ShouldBe(2);
+        header.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public void an_ordinary_message_has_no_fragment_header()
+    {
+        SqsMessageFragments.TryReadHeader(new Message(), out _).ShouldBeFalse();
+
+        SqsMessageFragments
+            .TryReadHeader(new Message { MessageAttributes = new Dictionary<string, MessageAttributeValue>() }, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_header_with_nonsense_values_is_rejected_rather_than_trusted()
+    {
+        // Index outside the set: reading this as a real header would index past the buffer.
+        var attributes = SqsMessageFragments.AttributesFor(Guid.NewGuid(), 0, 3);
+        attributes[SqsMessageFragments.FragmentIndexAttribute].StringValue = "7";
+
+        SqsMessageFragments.TryReadHeader(new Message { MessageAttributes = attributes }, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_envelopes_own_group_id_wins_over_the_fragment_id()
+    {
+        // The caller already said which partition this message belongs to; overriding that would send
+        // the fragments somewhere other than where the whole message was meant to go.
+        var envelope = new Envelope { GroupId = "tenant-3" };
+
+        SqsMessageFragments.GroupIdFor(envelope, Guid.NewGuid()).ShouldBe("tenant-3");
+    }
+
+    [Fact]
+    public void the_fragment_id_stands_in_when_there_is_no_group_id()
+    {
+        var id = Guid.NewGuid();
+
+        var groupId = SqsMessageFragments.GroupIdFor(new Envelope(), id);
+
+        groupId.ShouldContain(id.ToString());
+        groupId.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void every_fragment_of_one_message_shares_a_group_id()
+    {
+        var envelope = new Envelope();
+        var id = Guid.NewGuid();
+
+        Enumerable.Range(0, 4).Select(_ => SqsMessageFragments.GroupIdFor(envelope, id)).Distinct().Count().ShouldBe(1);
+    }
+}
+
+/// <summary>
+/// GH-3926. The receiving half: holding partial fragment sets in memory until they complete.
+/// </summary>
+public class sqs_fragment_reassembler_3926
+{
+    private readonly SqsFragmentReassembler _reassembler = new(5.Minutes(), NullLogger.Instance);
+    private readonly Guid _id = Guid.NewGuid();
+
+    private Message fragment(int index, int count, string body)
+    {
+        return new Message
+        {
+            Body = body,
+            ReceiptHandle = $"{_id}-{index}",
+            MessageAttributes = SqsMessageFragments.AttributesFor(_id, index, count)
+        };
+    }
+
+    private bool accept(Message message, out string body, out Message[] messages)
+    {
+        SqsMessageFragments.TryReadHeader(message, out var header).ShouldBeTrue();
+        return _reassembler.TryAccept(message, header, out body, out messages);
+    }
+
+    [Fact]
+    public void holds_an_incomplete_set_and_completes_on_the_last_fragment()
+    {
+        accept(fragment(0, 3, "one "), out _, out _).ShouldBeFalse();
+        _reassembler.PartialCount.ShouldBe(1);
+
+        accept(fragment(1, 3, "two "), out _, out _).ShouldBeFalse();
+        _reassembler.PartialCount.ShouldBe(1);
+
+        accept(fragment(2, 3, "three"), out var body, out var messages).ShouldBeTrue();
+
+        body.ShouldBe("one two three");
+        messages.Length.ShouldBe(3);
+
+        // The completed set is handed over, not retained
+        _reassembler.PartialCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void reassembles_in_index_order_regardless_of_arrival_order()
+    {
+        // SQS makes no ordering promise on a standard queue, so the index in the header is the only
+        // thing that says where a fragment belongs.
+        accept(fragment(2, 3, "three"), out _, out _).ShouldBeFalse();
+        accept(fragment(0, 3, "one "), out _, out _).ShouldBeFalse();
+        accept(fragment(1, 3, "two "), out var body, out _).ShouldBeTrue();
+
+        body.ShouldBe("one two three");
+    }
+
+    [Fact]
+    public void a_redelivered_fragment_is_not_an_error()
+    {
+        // Standard queues are at-least-once, so the same fragment arriving twice is expected.
+        accept(fragment(0, 2, "one "), out _, out _).ShouldBeFalse();
+        accept(fragment(0, 2, "one "), out _, out _).ShouldBeFalse();
+        _reassembler.PartialCount.ShouldBe(1);
+
+        accept(fragment(1, 2, "two"), out var body, out var messages).ShouldBeTrue();
+
+        body.ShouldBe("one two");
+        messages.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void hands_back_every_message_in_the_set_so_completion_can_delete_them_all()
+    {
+        accept(fragment(0, 2, "a"), out _, out _);
+        accept(fragment(1, 2, "b"), out _, out var messages).ShouldBeTrue();
+
+        messages.Select(x => x.ReceiptHandle).ShouldBe([$"{_id}-0", $"{_id}-1"]);
+    }
+
+    [Fact]
+    public void two_messages_being_reassembled_at_once_do_not_bleed_into_each_other()
+    {
+        accept(fragment(0, 2, "mine-"), out _, out _).ShouldBeFalse();
+
+        // A different fragment id is a separate set, and completing it must not disturb the first
+        var stranger = new Message
+        {
+            Body = "theirs",
+            MessageAttributes = SqsMessageFragments.AttributesFor(Guid.NewGuid(), 0, 1)
+        };
+
+        SqsMessageFragments.TryReadHeader(stranger, out var header).ShouldBeTrue();
+        _reassembler.TryAccept(stranger, header, out var body, out _).ShouldBeTrue();
+        body.ShouldBe("theirs");
+
+        _reassembler.PartialCount.ShouldBe(1);
+
+        accept(fragment(1, 2, "second"), out var mine, out _).ShouldBeTrue();
+        mine.ShouldBe("mine-second");
+    }
+
+    [Fact]
+    public void abandons_a_set_that_never_completes_within_the_timeout()
+    {
+        // Nothing is deleted from SQS while a set is incomplete, so abandoning it here just means the
+        // fragments become visible again rather than the buffer growing forever. A negative timeout puts
+        // the cutoff in the future, so the sweep is decided by the code under test rather than by how
+        // fast the test ran.
+        var reassembler = new SqsFragmentReassembler(-1.Minutes(), NullLogger.Instance);
+
+        SqsMessageFragments.TryReadHeader(fragment(0, 3, "one"), out var first).ShouldBeTrue();
+        reassembler.TryAccept(fragment(0, 3, "one"), first, out _, out _).ShouldBeFalse();
+
+        // A later arrival sweeps the expired set before recording itself
+        var later = new Message
+        {
+            Body = "x",
+            MessageAttributes = SqsMessageFragments.AttributesFor(Guid.NewGuid(), 0, 2)
+        };
+
+        SqsMessageFragments.TryReadHeader(later, out var header).ShouldBeTrue();
+        reassembler.TryAccept(later, header, out _, out _).ShouldBeFalse();
+
+        reassembler.PartialCount.ShouldBe(1);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_sender_fragmentation_3926.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_sender_fragmentation_3926.cs
@@ -1,0 +1,261 @@
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+/// <summary>
+/// GH-3926. What the sender does with a message too big for SQS: discard it when the endpoint has not
+/// opted in (SQS answers an oversized message with a permanent SenderFault, so retrying it produces a
+/// flood of identical errors), or split it into fragments when it has.
+/// </summary>
+public class sqs_sender_fragmentation_3926
+{
+    private readonly ISenderCallback _callback = Substitute.For<ISenderCallback>();
+    private readonly AmazonSqsQueue _queue;
+    private readonly IAmazonSQS _sqs = Substitute.For<IAmazonSQS>();
+    private readonly SqsSenderProtocol _protocol;
+
+    public sqs_sender_fragmentation_3926()
+    {
+        var transport = new AmazonSqsTransport { Client = _sqs };
+        _queue = new AmazonSqsQueue("big", transport) { Mapper = new DefaultSqsEnvelopeMapper() };
+
+        _sqs.GetQueueUrlAsync("big", Arg.Any<CancellationToken>())
+            .Returns(new GetQueueUrlResponse { QueueUrl = "https://sqs.local/big" });
+
+        _sqs.SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new SendMessageBatchResponse());
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+
+        _protocol = new SqsSenderProtocol(runtime, _queue, _sqs);
+    }
+
+    /// <summary>
+    /// The default mapper base64 encodes the serialized envelope, so the body is roughly 4/3 of the
+    /// payload. 400KB of data comfortably clears the fragment size and needs three fragments.
+    /// </summary>
+    private static Envelope oversized(int bytes = 400 * 1024)
+    {
+        return new Envelope
+        {
+            Id = Guid.NewGuid(),
+            Data = new byte[bytes],
+            MessageType = "big.message"
+        };
+    }
+
+    private static Envelope ordinary()
+    {
+        return new Envelope { Id = Guid.NewGuid(), Data = [1, 2, 3], MessageType = "small.message" };
+    }
+
+    private OutgoingMessageBatch batchFor(params Envelope[] envelopes)
+    {
+        return new OutgoingMessageBatch(_queue.Uri, envelopes);
+    }
+
+    private List<SendMessageBatchRequestEntry> sentEntries()
+    {
+        return _sqs.ReceivedCalls()
+            .Where(x => x.GetMethodInfo().Name == nameof(IAmazonSQS.SendMessageBatchAsync))
+            .Select(x => (SendMessageBatchRequest)x.GetArguments()[0]!)
+            .SelectMany(x => x.Entries)
+            .ToList();
+    }
+
+    [Fact]
+    public async Task an_oversized_message_is_discarded_rather_than_retried_forever_when_not_opted_in()
+    {
+        var envelope = oversized();
+
+        await _protocol.SendBatchAsync(_callback, batchFor(envelope));
+
+        // Not MarkProcessingFailureAsync -- that would re-queue it, and the next attempt gets the same
+        // SenderFault from SQS, forever.
+        await _callback.Received(1).MarkSerializationFailureAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 1 && b.Messages.Contains(envelope)));
+
+        await _callback.DidNotReceive().MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>());
+        await _callback.DidNotReceive()
+            .MarkProcessingFailureAsync(Arg.Any<OutgoingMessageBatch>(), Arg.Any<Exception>());
+
+        await _sqs.DidNotReceive().SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task the_rest_of_the_batch_still_goes_out_around_a_discarded_message()
+    {
+        var good1 = ordinary();
+        var bad = oversized();
+        var good2 = ordinary();
+
+        await _protocol.SendBatchAsync(_callback, batchFor(good1, bad, good2));
+
+        await _callback.Received(1).MarkSerializationFailureAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 1 && b.Messages.Contains(bad)));
+
+        await _callback.Received(1).MarkSuccessfulAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 2 && b.Messages.Contains(good1) && b.Messages.Contains(good2)));
+    }
+
+    [Fact]
+    public async Task an_oversized_message_is_split_into_fragments_when_opted_in()
+    {
+        _queue.FragmentOversizedMessages = true;
+        var envelope = oversized();
+
+        await _protocol.SendBatchAsync(_callback, batchFor(envelope));
+
+        var entries = sentEntries();
+        entries.Count.ShouldBeGreaterThan(1);
+
+        // Every entry carries the framing, all of it pointing at the one envelope
+        foreach (var entry in entries)
+        {
+            entry.MessageAttributes.ContainsKey(SqsMessageFragments.FragmentIdAttribute).ShouldBeTrue();
+            entry.MessageAttributes[SqsMessageFragments.FragmentIdAttribute].StringValue
+                .ShouldBe(envelope.Id.ToString());
+            entry.MessageAttributes[SqsMessageFragments.FragmentCountAttribute].StringValue
+                .ShouldBe(entries.Count.ToString());
+        }
+
+        entries.Select(x => x.MessageAttributes[SqsMessageFragments.FragmentIndexAttribute].StringValue)
+            .ShouldBe(Enumerable.Range(0, entries.Count).Select(i => i.ToString()));
+
+        // Entry ids have to be unique per fragment or SQS rejects the request outright
+        entries.Select(x => x.Id).Distinct().Count().ShouldBe(entries.Count);
+
+        await _callback.Received(1).MarkSuccessfulAsync(Arg.Any<OutgoingMessageBatch>());
+        await _callback.DidNotReceive().MarkSerializationFailureAsync(Arg.Any<OutgoingMessageBatch>());
+    }
+
+    [Fact]
+    public async Task the_fragments_reassemble_into_the_original_body()
+    {
+        _queue.FragmentOversizedMessages = true;
+        var envelope = oversized(300 * 1024);
+        envelope.Data = Enumerable.Range(0, 300 * 1024).Select(i => (byte)i).ToArray();
+
+        await _protocol.SendBatchAsync(_callback, batchFor(envelope));
+
+        // Concatenating the fragments in index order and reading them back through the mapper is exactly
+        // what the listener does, so this is the round trip that matters rather than string equality
+        // against a body built separately.
+        var reassembled = string.Concat(sentEntries().Select(x => x.MessageBody));
+
+        var received = new Envelope();
+        _queue.Mapper!.ReadEnvelopeData(received, reassembled, new Dictionary<string, MessageAttributeValue>());
+
+        received.Id.ShouldBe(envelope.Id);
+        received.MessageType.ShouldBe(envelope.MessageType);
+        received.Data.ShouldBe(envelope.Data);
+    }
+
+    [Fact]
+    public async Task each_fragment_gets_its_own_request_rather_than_blowing_the_batch_limit()
+    {
+        _queue.FragmentOversizedMessages = true;
+
+        await _protocol.SendBatchAsync(_callback, batchFor(oversized()));
+
+        var requests = _sqs.ReceivedCalls()
+            .Where(x => x.GetMethodInfo().Name == nameof(IAmazonSQS.SendMessageBatchAsync))
+            .Select(x => (SendMessageBatchRequest)x.GetArguments()[0]!)
+            .ToList();
+
+        requests.ShouldAllBe(r => r.Entries.Sum(e => e.MessageBody.Length)
+                                  <= SqsSenderProtocol.MaximumBatchPayloadBytes);
+    }
+
+    [Fact]
+    public async Task a_message_too_large_even_to_fragment_is_discarded()
+    {
+        _queue.FragmentOversizedMessages = true;
+
+        // Well past MaximumFragments once base64 inflation is applied
+        var envelope = oversized(4 * 1024 * 1024);
+
+        await _protocol.SendBatchAsync(_callback, batchFor(envelope));
+
+        await _callback.Received(1).MarkSerializationFailureAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Contains(envelope)));
+
+        await _sqs.DidNotReceive().SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task one_rejected_fragment_fails_the_whole_envelope()
+    {
+        _queue.FragmentOversizedMessages = true;
+        var envelope = oversized();
+
+        // Reject the second fragment. Half a message in SQS can never be reassembled, so the envelope
+        // has to be retried in full rather than reported as delivered.
+        _sqs.SendMessageBatchAsync(Arg.Any<SendMessageBatchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new SendMessageBatchResponse(),
+                call => new SendMessageBatchResponse
+                {
+                    Failed =
+                    [
+                        new BatchResultErrorEntry
+                        {
+                            Id = ((SendMessageBatchRequest)call[0]!).Entries[0].Id,
+                            Code = "ThrottlingException",
+                            Message = "Rate exceeded",
+                            SenderFault = false
+                        }
+                    ]
+                });
+
+        await _protocol.SendBatchAsync(_callback, batchFor(envelope));
+
+        await _callback.Received(1).MarkProcessingFailureAsync(Arg.Is<OutgoingMessageBatch>(b =>
+            b.Messages.Count == 1 && b.Messages.Contains(envelope)));
+
+        await _callback.DidNotReceive().MarkSuccessfulAsync(Arg.Any<OutgoingMessageBatch>());
+    }
+
+    [Fact]
+    public async Task fragments_of_one_message_share_a_group_id_on_a_fifo_queue()
+    {
+        var transport = new AmazonSqsTransport { Client = _sqs };
+        var fifo = new AmazonSqsQueue("big.fifo", transport)
+        {
+            Mapper = new DefaultSqsEnvelopeMapper(),
+            FragmentOversizedMessages = true
+        };
+
+        _sqs.GetQueueUrlAsync("big.fifo", Arg.Any<CancellationToken>())
+            .Returns(new GetQueueUrlResponse { QueueUrl = "https://sqs.local/big.fifo" });
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.LoggerFactory.Returns(NullLoggerFactory.Instance);
+
+        var protocol = new SqsSenderProtocol(runtime, fifo, _sqs);
+
+        var envelope = oversized();
+        envelope.DeduplicationId = "dedupe-me";
+
+        await protocol.SendBatchAsync(_callback, new OutgoingMessageBatch(fifo.Uri, [envelope]));
+
+        var entries = sentEntries();
+        entries.Count.ShouldBeGreaterThan(1);
+
+        // One group keeps the whole set on one consumer, in order...
+        entries.Select(x => x.MessageGroupId).Distinct().Count().ShouldBe(1);
+
+        // ...but a shared deduplication id would have FIFO keep exactly one of them
+        entries.Select(x => x.MessageDeduplicationId).Distinct().Count().ShouldBe(entries.Count);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/send_and_receive_oversized_messages_3926.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/send_and_receive_oversized_messages_3926.cs
@@ -1,0 +1,156 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Tracking;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+/// <summary>
+/// GH-3926. End to end over a real (LocalStack) queue: a message whose body is well past SQS's 256KB
+/// limit is split on the way out and put back together on the way in. A single listening node, which
+/// is one of the three topologies where in-memory reassembly is safe.
+/// </summary>
+public class OversizedMessageFixture : IAsyncLifetime
+{
+    public IHost Host { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        Host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToSqsQueue("oversized_3926");
+
+                opts.PublishAllMessages().ToSqsQueue("oversized_3926")
+                    .FragmentOversizedMessages();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Host.StopAsync();
+        Host.Dispose();
+    }
+}
+
+public class send_and_receive_oversized_messages_3926 : IClassFixture<OversizedMessageFixture>
+{
+    private readonly IHost _host;
+
+    // One host for the whole class rather than one per test. AutoPurgeOnStartup calls SQS PurgeQueue,
+    // and SQS allows that only once every 60 seconds -- a queue purged again inside that window swallows
+    // messages sent during it, which makes a per-test host look like a broken transport.
+    public send_and_receive_oversized_messages_3926(OversizedMessageFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    private static BigMessage bigMessageOf(int bytes)
+    {
+        // Random-ish content rather than a repeated character, so a fragment landing in the wrong slot
+        // cannot pass unnoticed.
+        var chars = new char[bytes];
+        for (var i = 0; i < bytes; i++)
+        {
+            chars[i] = (char)('a' + i % 26);
+        }
+
+        return new BigMessage(Guid.NewGuid(), new string(chars));
+    }
+
+    [Fact]
+    public async Task send_and_receive_a_message_over_the_sqs_limit()
+    {
+        // ~400KB of payload, which is over the 256KB cap before the envelope framing and base64 are
+        // even applied
+        var message = bigMessageOf(400 * 1024);
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(60.Seconds())
+            .SendMessageAndWaitAsync(message);
+
+        var received = session.Received.SingleMessage<BigMessage>();
+        received.Id.ShouldBe(message.Id);
+        received.Contents.Length.ShouldBe(message.Contents.Length);
+        received.Contents.ShouldBe(message.Contents);
+    }
+
+    [Fact]
+    public async Task an_ordinary_message_is_unaffected_on_a_fragmenting_endpoint()
+    {
+        var message = bigMessageOf(100);
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(60.Seconds())
+            .SendMessageAndWaitAsync(message);
+
+        session.Received.SingleMessage<BigMessage>().Id.ShouldBe(message.Id);
+    }
+
+    [Fact]
+    public async Task two_oversized_messages_in_flight_at_once_do_not_cross_contaminate()
+    {
+        var one = bigMessageOf(400 * 1024);
+        var two = bigMessageOf(350 * 1024);
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(60.Seconds())
+            .ExecuteAndWaitAsync(bus => Task.WhenAll(bus.PublishAsync(one).AsTask(),
+                bus.PublishAsync(two).AsTask()));
+
+        var received = session.Received.MessagesOf<BigMessage>().ToDictionary(x => x.Id);
+
+        received.Count.ShouldBe(2);
+        received[one.Id].Contents.ShouldBe(one.Contents);
+        received[two.Id].Contents.ShouldBe(two.Contents);
+    }
+
+    [Fact]
+    public async Task every_fragment_is_deleted_once_the_message_is_handled()
+    {
+        var message = bigMessageOf(400 * 1024);
+
+        await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(60.Seconds())
+            .SendMessageAndWaitAsync(message);
+
+        // Completing a reassembled envelope has to delete every SQS message that carried it. Missing one
+        // leaves an orphan fragment to reappear at the visibility timeout as a set that can never
+        // complete, so the queue has to be genuinely empty afterwards.
+        var transport = _host.GetRuntime().Options.Transports.GetOrCreate<AmazonSqsTransport>();
+        var queue = transport.Queues["oversized_3926"];
+
+        var remaining = -1;
+        for (var i = 0; i < 20; i++)
+        {
+            var attributes = await transport.Client!.GetQueueAttributesAsync(queue.QueueUrl,
+                ["ApproximateNumberOfMessages", "ApproximateNumberOfMessagesNotVisible"],
+                TestContext.Current.CancellationToken);
+
+            remaining = attributes.ApproximateNumberOfMessages + attributes.ApproximateNumberOfMessagesNotVisible;
+            if (remaining == 0) return;
+
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+
+        remaining.ShouldBe(0);
+    }
+}
+
+public record BigMessage(Guid Id, string Contents);
+
+public static class BigMessageHandler
+{
+    public static void Handle(BigMessage message)
+    {
+        // nothing
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -102,6 +102,43 @@ public class AmazonSqsListenerConfiguration : ListenerConfiguration<AmazonSqsLis
     }
 
     /// <summary>
+    ///     Split a message whose body would exceed SQS's hard 256KB limit into several SQS messages, and
+    ///     reassemble it on the receiving side. A listener reassembles fragments whether or not this is
+    ///     set -- the framing is self-describing -- so this only really matters on the sending side and
+    ///     for the reassembly timeout.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Wolverine to Wolverine only</b>, and reassembly happens <b>in memory on one listener</b>, so
+    ///     every fragment of a message has to reach the same node. SQS is a competing-consumer queue, so
+    ///     use this only on a FIFO queue, with a <c>GlobalPartitioning</c> listener, or with a single
+    ///     listening node. Prefer a claim check (<c>WolverineFx.ClaimCheck.AmazonS3</c>) otherwise -- it
+    ///     is the AWS-sanctioned answer and has none of these constraints.
+    ///     </para>
+    ///     <para>
+    ///     See <a href="https://wolverinefx.net/guide/messaging/transports/sqs/large-messages.html">Large
+    ///     messages in SQS</a>.
+    ///     </para>
+    /// </remarks>
+    /// <param name="reassemblyTimeout">
+    ///     How long this listener holds an incomplete set of fragments before abandoning it. Defaults to 5
+    ///     minutes. Abandoned fragments were never deleted from SQS, so they become visible again.
+    /// </param>
+    public AmazonSqsListenerConfiguration FragmentOversizedMessages(TimeSpan? reassemblyTimeout = null)
+    {
+        add(e =>
+        {
+            e.FragmentOversizedMessages = true;
+            if (reassemblyTimeout.HasValue)
+            {
+                e.FragmentReassemblyTimeout = reassemblyTimeout.Value;
+            }
+        });
+
+        return this;
+    }
+
+    /// <summary>
     ///     Configure how the queue should be created within SQS
     /// </summary>
     /// <param name="configure"></param>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsSubscriberConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsSubscriberConfiguration.cs
@@ -41,6 +41,42 @@ public class
         return this;
     }
 
+    /// <summary>
+    ///     Split a message whose body would exceed SQS's hard 256KB limit into several SQS messages, and
+    ///     reassemble it on the receiving side. Without this an oversized message is rejected by SQS with
+    ///     a permanent <c>SenderFault</c>, and Wolverine discards it rather than retrying forever.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Wolverine to Wolverine only</b>, and reassembly happens <b>in memory on one listener</b>, so
+    ///     every fragment of a message has to reach the same node. SQS is a competing-consumer queue, so
+    ///     use this only on a FIFO queue, with a <c>GlobalPartitioning</c> listener, or with a single
+    ///     listening node. Prefer a claim check (<c>WolverineFx.ClaimCheck.AmazonS3</c>) otherwise -- it
+    ///     is the AWS-sanctioned answer and has none of these constraints.
+    ///     </para>
+    ///     <para>
+    ///     See <a href="https://wolverinefx.net/guide/messaging/transports/sqs/large-messages.html">Large
+    ///     messages in SQS</a>.
+    ///     </para>
+    /// </remarks>
+    /// <param name="reassemblyTimeout">
+    ///     How long a listener holds an incomplete set of fragments before abandoning it. Defaults to 5
+    ///     minutes. Abandoned fragments were never deleted from SQS, so they become visible again.
+    /// </param>
+    public AmazonSqsSubscriberConfiguration FragmentOversizedMessages(TimeSpan? reassemblyTimeout = null)
+    {
+        add(e =>
+        {
+            e.FragmentOversizedMessages = true;
+            if (reassemblyTimeout.HasValue)
+            {
+                e.FragmentReassemblyTimeout = reassemblyTimeout.Value;
+            }
+        });
+
+        return this;
+    }
+
     /// Opt to send messages as raw JSON without any Wolverine metadata
     /// </summary>
     /// <param name="defaultMessageType">Optional. If both sending and receiving from this queue, you will want to specify a default message type</param>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsEnvelope.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsEnvelope.cs
@@ -4,11 +4,22 @@ namespace Wolverine.AmazonSqs.Internal;
 
 internal class AmazonSqsEnvelope : Envelope
 {
-    public AmazonSqsEnvelope(Message message)
+    public AmazonSqsEnvelope(Message message) : this([message])
     {
-        SqsMessage = message;
     }
 
-    public Message SqsMessage { get; }
+    /// <summary>
+    ///     GH-3926: a fragmented message arrives as several SQS messages, and completing the envelope has
+    ///     to delete all of them. Every other envelope holds exactly one.
+    /// </summary>
+    public AmazonSqsEnvelope(Message[] messages)
+    {
+        SqsMessages = messages;
+    }
+
+    public Message SqsMessage => SqsMessages[0];
+
+    public Message[] SqsMessages { get; }
+
     public bool WasDeleted { get; set; }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -89,6 +89,45 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     /// </summary>
     public bool EnableFairQueueMessageGroups { get; set; }
 
+    /// <summary>
+    ///     Split an outgoing message that would exceed SQS's 256KB limit into several SQS messages, and
+    ///     reassemble it on the receiving side. Default is <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Wolverine to Wolverine only.</b> The fragments are Wolverine's own framing carried in SQS
+    ///     message attributes, so a non-Wolverine consumer of this queue sees N unintelligible messages
+    ///     rather than one. That is why this is opt-in per endpoint rather than automatic.
+    ///     </para>
+    ///     <para>
+    ///     <b>Reassembly happens in memory, per listener</b>, so every fragment of a message has to reach
+    ///     the same listener. SQS is a competing-consumer queue, so use this only where that is
+    ///     guaranteed:
+    ///     </para>
+    ///     <list type="bullet">
+    ///         <item>a <b>FIFO queue</b> — SQS delivers a message group to one consumer at a time, and
+    ///         every fragment of a message shares a group id;</item>
+    ///         <item>a listener using <b>GlobalPartitioning</b> — the fragments carry the message's
+    ///         <see cref="Envelope.GroupId" />, so they are all routed to the node that owns that
+    ///         group;</item>
+    ///         <item>a <b>single listening node</b>.</item>
+    ///     </list>
+    ///     <para>
+    ///     On a standard queue with several unpartitioned nodes the fragments scatter, no node completes
+    ///     a set, and they are abandoned after <see cref="FragmentReassemblyTimeout" /> and redelivered.
+    ///     Prefer a <a href="https://wolverinefx.net/guide/durability/claim-checks.html">claim check</a>
+    ///     there.
+    ///     </para>
+    /// </remarks>
+    public bool FragmentOversizedMessages { get; set; }
+
+    /// <summary>
+    ///     How long a listener holds an incomplete set of fragments before abandoning it. Default is 5
+    ///     minutes. Abandoning forgets them locally; it does not delete them from SQS, so they become
+    ///     visible again.
+    /// </summary>
+    public TimeSpan FragmentReassemblyTimeout { get; set; } = 5.Minutes();
+
     // Set by the AmazonSqsTransport parent
     internal string? QueueUrl { get; private set; }
 
@@ -369,10 +408,46 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         Mapper ??= new DefaultSqsEnvelopeMapper();
 
         var body = Mapper!.BuildMessageBody(envelope);
+
+        if (!SqsMessageFragments.ExceedsLimit(body))
+        {
+            await _parent.Client!.SendMessageAsync(buildSendRequest(envelope, body, null, logger));
+            return;
+        }
+
+        // GH-3926: this is the one-at-a-time path (inline senders, requeues, dead letter forwarding), so
+        // there is a caller to throw back at rather than a sender callback to report to. Either way an
+        // oversized message can never be accepted by SQS, so failing loudly here beats letting SQS answer
+        // with a SenderFault that a retry block would repeat forever.
+        if (!FragmentOversizedMessages)
+        {
+            throw new SqsMessageTooLargeException(
+                $"Envelope {envelope.Id} of message type {envelope.MessageType} produced a {body.Length} byte body for queue {QueueName}, over the {SqsMessageFragments.MaximumBodyBytes} bytes Wolverine will send in one SQS message (SQS caps a message and its attributes together at {SqsMessageFragments.MaximumMessageBytes}). Use a claim check (WolverineFx.ClaimCheck.AmazonS3), or opt this endpoint into FragmentOversizedMessages().");
+        }
+
+        var bodies = SqsMessageFragments.Split(body);
+
+        if (bodies.Length > SqsMessageFragments.MaximumFragments)
+        {
+            throw new SqsMessageTooLargeException(
+                $"Envelope {envelope.Id} of message type {envelope.MessageType} produced a {body.Length} byte body for queue {QueueName}, which would need {bodies.Length} fragments against a maximum of {SqsMessageFragments.MaximumFragments}. A message this large is a claim check problem rather than a framing one; see WolverineFx.ClaimCheck.AmazonS3.");
+        }
+
+        for (var i = 0; i < bodies.Length; i++)
+        {
+            var header = new SqsFragmentHeader(envelope.Id, i, bodies.Length);
+            await _parent.Client!.SendMessageAsync(buildSendRequest(envelope, bodies[i], header, logger));
+        }
+    }
+
+    private SendMessageRequest buildSendRequest(Envelope envelope, string body, SqsFragmentHeader? fragment,
+        ILogger logger)
+    {
         var request = new SendMessageRequest(QueueUrl, body);
+
         if (IsFifoQueue)
         {
-            var groupId = Mapper.DetermineGroupId(envelope);
+            var groupId = groupIdFor(envelope, fragment);
             if (groupId.IsNotEmpty())
             {
                 request.MessageGroupId = groupId;
@@ -381,24 +456,37 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
             var deduplicationId = DetermineDeduplicationId(envelope);
             if (deduplicationId.IsNotEmpty())
             {
-                request.MessageDeduplicationId = deduplicationId;
+                // Every fragment of one envelope would otherwise carry the identical deduplication id,
+                // and a FIFO queue would keep exactly one of them.
+                request.MessageDeduplicationId = fragment is { } header
+                    ? $"{deduplicationId}-{header.Index}"
+                    : deduplicationId;
             }
         }
         else if (EnableFairQueueMessageGroups)
         {
             // SQS fair queues: a MessageGroupId on a standard queue improves tenant fairness.
             // No deduplication semantics apply to standard queues. See GH-2886.
-            var groupId = Mapper.DetermineGroupId(envelope);
+            var groupId = groupIdFor(envelope, fragment);
             if (groupId.IsNotEmpty())
             {
                 request.MessageGroupId = groupId;
             }
         }
 
-        foreach (var attribute in Mapper.ToAttributes(envelope))
+        foreach (var attribute in Mapper!.ToAttributes(envelope))
         {
             request.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
             request.MessageAttributes.Add(attribute.Key, attribute.Value);
+        }
+
+        if (fragment is { } h)
+        {
+            request.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
+            foreach (var pair in SqsMessageFragments.AttributesFor(h.FragmentId, h.Index, h.Count))
+            {
+                request.MessageAttributes[pair.Key] = pair.Value;
+            }
         }
 
         var delaySeconds = NativeDelaySecondsFor(envelope, DateTimeOffset.UtcNow, logger);
@@ -407,7 +495,14 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
             request.DelaySeconds = delaySeconds;
         }
 
-        await _parent.Client!.SendMessageAsync(request);
+        return request;
+    }
+
+    private string? groupIdFor(Envelope envelope, SqsFragmentHeader? fragment)
+    {
+        return fragment is { } header
+            ? SqsMessageFragments.GroupIdFor(envelope, header.FragmentId)
+            : Mapper!.DetermineGroupId(envelope);
     }
 
     public override async ValueTask InitializeAsync(ILogger logger)
@@ -609,6 +704,8 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         sibling.WaitTimeSeconds = WaitTimeSeconds;
         sibling.MaxNumberOfMessages = MaxNumberOfMessages;
         sibling.MessageAttributeNames = MessageAttributeNames;
+        sibling.FragmentOversizedMessages = FragmentOversizedMessages;
+        sibling.FragmentReassemblyTimeout = FragmentReassemblyTimeout;
 
         // Share the interop mapper strategy so tenant traffic serializes identically to the shared account.
         sibling.Mapper = Mapper;
@@ -645,10 +742,39 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         request.MaxNumberOfMessages = MaxNumberOfMessages;
         request.VisibilityTimeout = VisibilityTimeout;
 
-        if (MessageAttributeNames is { Count: > 0 })
+        request.MessageAttributeNames = _receivedAttributeNames ??= resolveAttributeNames();
+    }
+
+    private List<string>? _receivedAttributeNames;
+
+    /// <summary>
+    ///     Whatever the endpoint asked for, plus Wolverine's own fragment framing (GH-3926). SQS returns
+    ///     only the attributes a receive names, so leaving the framing off makes a fragmented message
+    ///     arrive as N unrelated messages that each fail to deserialize -- and a listener has to be able
+    ///     to read fragments whether or not this same endpoint is configured to send them.
+    ///     Resolved once and cached, since endpoint configuration is fixed by the time anything polls.
+    /// </summary>
+    private List<string> resolveAttributeNames()
+    {
+        var names = MessageAttributeNames is { Count: > 0 }
+            ? new List<string>(MessageAttributeNames)
+            : [];
+
+        // "All" already covers the framing
+        if (names.Contains("All"))
         {
-            request.MessageAttributeNames = MessageAttributeNames;
+            return names;
         }
+
+        foreach (var name in SqsMessageFragments.AttributeNames)
+        {
+            if (!names.Contains(name))
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
     }
 
     public async Task TeardownAsync(IAmazonSQS client, CancellationToken token)

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsFragmentReassembler.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsFragmentReassembler.cs
@@ -1,0 +1,133 @@
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.AmazonSqs.Internal;
+
+/// <summary>
+///     Holds partial fragment sets until they are complete, then hands back the reassembled body.
+/// </summary>
+/// <remarks>
+///     <para>
+///     In memory and per listener. That is safe exactly when every fragment of one message reaches one
+///     listener — a FIFO queue, a <c>GlobalPartitioning</c> listener, or a single listening node — and
+///     best-effort otherwise, which is why <c>FragmentOversizedMessages()</c> documents those three
+///     shapes.
+///     </para>
+///     <para>
+///     <b>Fragments are not deleted from SQS until the whole set arrives.</b> A node that holds two of
+///     three fragments and then crashes has told SQS nothing, so all three become visible again after
+///     the visibility timeout and can be reassembled by whoever picks them up. Deleting eagerly would
+///     turn a crash into permanent message loss.
+///     </para>
+/// </remarks>
+internal class SqsFragmentReassembler
+{
+    private readonly TimeSpan _timeout;
+    private readonly ILogger _logger;
+    private readonly Dictionary<Guid, PartialMessage> _partials = new();
+    private readonly object _locker = new();
+
+    public SqsFragmentReassembler(TimeSpan timeout, ILogger logger)
+    {
+        _timeout = timeout;
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Take one received fragment. Returns true and yields the reassembled body plus every message
+    ///     in the set once the last fragment lands; returns false while the set is still incomplete.
+    /// </summary>
+    public bool TryAccept(Message message, SqsFragmentHeader header, out string body, out Message[] messages)
+    {
+        body = string.Empty;
+        messages = [];
+
+        lock (_locker)
+        {
+            expireStale();
+
+            if (!_partials.TryGetValue(header.FragmentId, out var partial))
+            {
+                partial = new PartialMessage(header.Count, DateTimeOffset.UtcNow);
+                _partials[header.FragmentId] = partial;
+            }
+
+            // A redelivery of a fragment already held is not an error - SQS standard queues are
+            // at-least-once, so the same fragment arriving twice is expected rather than exceptional.
+            partial.Bodies[header.Index] = message.Body;
+            partial.Messages[header.Index] = message;
+
+            if (partial.Bodies.Any(x => x is null))
+            {
+                return false;
+            }
+
+            _partials.Remove(header.FragmentId);
+
+            body = string.Concat(partial.Bodies);
+            messages = partial.Messages!;
+            return true;
+        }
+    }
+
+    /// <summary>
+    ///     Drop fragment sets that have waited past the timeout without completing.
+    /// </summary>
+    /// <remarks>
+    ///     Dropping means forgetting them here, NOT deleting them from SQS — they were never deleted, so
+    ///     they simply become visible again and another attempt can be made. Without this the buffer
+    ///     would grow without bound on a queue where fragments genuinely never converge.
+    ///     </para>
+    ///     <para>
+    ///     Swept when the next fragment arrives rather than on a timer. A listener that has stopped
+    ///     receiving fragments altogether holds its last partial set until one does, which is bounded by
+    ///     <see cref="SqsMessageFragments.MaximumFragments" /> bodies and not worth a timer to reclaim.
+    /// </remarks>
+    private void expireStale()
+    {
+        if (_partials.Count == 0) return;
+
+        var cutoff = DateTimeOffset.UtcNow.Subtract(_timeout);
+        var stale = _partials.Where(x => x.Value.StartedAt < cutoff).Select(x => x.Key).ToArray();
+
+        foreach (var id in stale)
+        {
+            var partial = _partials[id];
+            _partials.Remove(id);
+
+            _logger.LogWarning(
+                "Abandoning an incomplete SQS message fragment set {FragmentId} after {Timeout} - held {Held} of {Count} fragments. " +
+                "The fragments were never deleted from SQS, so they will become visible again. This usually means several nodes are " +
+                "listening to one standard queue and no single one receives the whole set; see FragmentOversizedMessages().",
+                id, _timeout, partial.Bodies.Count(x => x is not null), partial.Count);
+        }
+    }
+
+    internal int PartialCount
+    {
+        get
+        {
+            lock (_locker)
+            {
+                return _partials.Count;
+            }
+        }
+    }
+
+    private class PartialMessage
+    {
+        public PartialMessage(int count, DateTimeOffset startedAt)
+        {
+            Count = count;
+            StartedAt = startedAt;
+            Bodies = new string?[count];
+            Messages = new Message[count];
+        }
+
+        public int Count { get; }
+        public DateTimeOffset StartedAt { get; }
+        public string?[] Bodies { get; }
+        public Message[] Messages { get; }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -28,6 +28,12 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     private readonly Block<Message[]>? _deleteBlock;
     private readonly RetryBlock<Message> _singleDeleteBlock;
 
+    // GH-3926: reassembles messages that the sender had to split across several SQS messages.
+    // Deliberately unconditional rather than gated on FragmentOversizedMessages -- the fragment
+    // framing is unambiguous, so a listener reads it whether or not this same endpoint would send
+    // that way, and an asymmetrically configured pair still works.
+    private readonly SqsFragmentReassembler _reassembler;
+
     public SqsListener(IWolverineRuntime runtime, AmazonSqsQueue queue, AmazonSqsTransport transport,
         IReceiver receiver)
     {
@@ -50,21 +56,32 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         {
             NativeDeadLetterQueueEnabled = true;
             _deadLetterQueue = _transport.Queues[_queue.DeadLetterQueueName];
+
+            // GH-3926: a listener that accepts fragmented messages has to be able to dead letter one too.
+            // The dead letter queue is Wolverine's own, so there is no interop reason to make this a
+            // second opt-in, and without it an oversized message could be reassembled and handled but
+            // never moved to errors.
+            if (_queue.FragmentOversizedMessages)
+            {
+                _deadLetterQueue.FragmentOversizedMessages = true;
+            }
         }
 
         _requeueBlock = new RetryBlock<AmazonSqsEnvelope>(async (env, _) =>
         {
             if (!env.WasDeleted)
             {
-                await CompleteAsync(env.SqsMessage);
+                await CompleteAsync(env.SqsMessages);
             }
 
-            await _queue.SendMessageAsync(env, logger);
+            await sendOrDiscardAsync(_queue, env, "requeue");
         }, runtime.LoggerFactory.CreateLogger<SqsListener>(), runtime.Cancellation);
 
         _deadLetterBlock =
-            new RetryBlock<Envelope>(async (e, _) => { await _deadLetterQueue!.SendMessageAsync(e, logger); }, logger,
-                runtime.Cancellation);
+            new RetryBlock<Envelope>(async (e, _) => { await sendOrDiscardAsync(_deadLetterQueue!, e, "dead letter"); },
+                logger, runtime.Cancellation);
+
+        _reassembler = new SqsFragmentReassembler(queue.FragmentReassemblyTimeout, logger);
 
         _singleDeleteBlock = new RetryBlock<Message>(
             (message, token) => _transport.Client!.DeleteMessageAsync(_queue.QueueUrl, message.ReceiptHandle, token),
@@ -85,6 +102,28 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         _loop.Start();
     }
 
+    /// <summary>
+    /// Send one envelope, giving up rather than retrying when it is simply too big for the queue.
+    /// </summary>
+    /// <remarks>
+    /// Both callers are <see cref="RetryBlock{T}" />s, which retry until they succeed. An oversized
+    /// message can never succeed -- SQS rejects it with a permanent SenderFault -- so letting that
+    /// exception through would spin the block forever on a send that is impossible, which is the very
+    /// failure GH-3926 exists to remove.
+    /// </remarks>
+    private async Task sendOrDiscardAsync(AmazonSqsQueue queue, Envelope envelope, string operation)
+    {
+        try
+        {
+            await queue.SendMessageAsync(envelope, _logger);
+        }
+        catch (SqsMessageTooLargeException e)
+        {
+            _logger.LogError(e, "Discarding envelope {Id} on {Operation} to {Queue} - it is too large for SQS and no retry can change that",
+                envelope.Id, operation, queue.Uri);
+        }
+    }
+
     private async Task<bool> pollOnceAsync(CancellationToken token)
     {
         var request = new ReceiveMessageRequest(_queue.QueueUrl);
@@ -103,6 +142,20 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         {
             try
             {
+                // GH-3926: a fragmented message is N SQS messages carrying Wolverine's own framing.
+                // Nothing is acked until the whole set is in hand -- the reassembler holds the partial
+                // and never deletes from SQS, so a crash halfway through just makes the fragments
+                // visible again rather than losing the message.
+                if (SqsMessageFragments.TryReadHeader(message, out var header))
+                {
+                    if (_reassembler.TryAccept(message, header, out var body, out var fragments))
+                    {
+                        envelopes.Add(buildEnvelope(fragments, body));
+                    }
+
+                    continue;
+                }
+
                 envelopes.Add(buildEnvelope(message));
             }
             catch (Exception e)
@@ -144,7 +197,7 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     {
         if (envelope is AmazonSqsEnvelope e)
         {
-            return new ValueTask(CompleteAsync(e.SqsMessage));
+            return new ValueTask(CompleteAsync(e.SqsMessages));
         }
 
         return ValueTask.CompletedTask;
@@ -234,14 +287,23 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
 
     private AmazonSqsEnvelope buildEnvelope(Message message)
     {
-        var envelope = new AmazonSqsEnvelope(message);
+        return buildEnvelope([message], message.Body);
+    }
+
+    /// <summary>
+    /// Build one envelope from the message(s) that carried it. A fragmented message hands over every
+    /// SQS message in the set plus the reassembled body; everything else is a set of one.
+    /// </summary>
+    private AmazonSqsEnvelope buildEnvelope(Message[] messages, string body)
+    {
+        var envelope = new AmazonSqsEnvelope(messages);
 
         // SQS only returns MessageAttributes when they were explicitly requested, and
         // brokers/SDKs may hand back a null collection when a message carries none (as is
         // the case for MassTransit/NServiceBus messages that keep their metadata in the body).
         // Guarantee a non-null dictionary so ISqsEnvelopeMapper implementations can read freely.
-        var attributes = message.MessageAttributes ?? new Dictionary<string, MessageAttributeValue>();
-        _mapper.ReadEnvelopeData(envelope, message.Body, attributes);
+        var attributes = messages[0].MessageAttributes ?? new Dictionary<string, MessageAttributeValue>();
+        _mapper.ReadEnvelopeData(envelope, body, attributes);
 
         // CritterWatch#942 — the Body string (base64, UTF-16, ~2.7× the wire payload size) is fully
         // mapped into the envelope now, and every later use of SqsMessage — single delete, batched
@@ -249,9 +311,27 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         // its whole time in flight (which, for buffered endpoints feeding a batching pipeline, can
         // be a long, deep queue), so release the one big thing on it. The mapping-failure path above
         // (raw forward to the dead-letter queue) still has Body because it never reaches here.
-        message.Body = null;
+        foreach (var message in messages)
+        {
+            message.Body = null;
+        }
 
         return envelope;
+    }
+
+    /// <summary>
+    /// Complete every SQS message that carried one envelope. A fragmented message is only really
+    /// handled once all of its fragments are deleted; deleting some of them would leave the rest to
+    /// reappear at the visibility timeout as an incomplete set that can never be reassembled.
+    /// </summary>
+    public Task CompleteAsync(Message[] sqsMessages)
+    {
+        if (sqsMessages.Length == 1)
+        {
+            return CompleteAsync(sqsMessages[0]);
+        }
+
+        return Task.WhenAll(sqsMessages.Select(CompleteAsync));
     }
 
     public Task CompleteAsync(Message sqsMessage)

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsMessageFragments.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsMessageFragments.cs
@@ -1,0 +1,148 @@
+using Amazon.SQS.Model;
+using Wolverine.Runtime;
+
+namespace Wolverine.AmazonSqs.Internal;
+
+/// <summary>
+///     Splits an outgoing message body that would exceed SQS's hard size limit into several SQS
+///     messages, and puts them back together on the receiving side.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <b>Wolverine to Wolverine only.</b> The fragments are Wolverine's own framing, carried in SQS
+///     message attributes; a non-Wolverine consumer reading this queue sees N unintelligible messages
+///     rather than one. That is why it is opt-in per endpoint rather than automatic.
+///     </para>
+///     <para>
+///     <b>Reassembly is per listener, in memory.</b> SQS is a competing-consumer queue: with several
+///     nodes on one standard queue, fragments of a single message can be delivered to different nodes
+///     and no one of them ever holds the full set. The endpoint configuration documents the three
+///     shapes where that cannot happen — a FIFO queue (a message group is delivered to one consumer at
+///     a time), a <c>GlobalPartitioning</c> listener (the group id's owner gets every fragment), or a
+///     single listening node.
+///     </para>
+/// </remarks>
+internal static class SqsMessageFragments
+{
+    /// <summary>
+    ///     SQS rejects any message whose body plus attributes exceeds 256KB, and the rejection is a
+    ///     <c>SenderFault</c> — permanent, not worth retrying.
+    /// </summary>
+    internal const int MaximumMessageBytes = 262_144;
+
+    /// <summary>
+    ///     The largest body Wolverine will hand SQS as a single message. Under
+    ///     <see cref="MaximumMessageBytes" /> by an allowance for the message attributes, which count
+    ///     against the same budget.
+    /// </summary>
+    /// <remarks>
+    ///     This, and not <see cref="FragmentBodyBytes" />, is what decides whether a message needs
+    ///     splitting at all. A body between the two is perfectly legal for SQS and must keep going out as
+    ///     one message exactly as it always has.
+    /// </remarks>
+    internal const int MaximumBodyBytes = MaximumMessageBytes - 4096;
+
+    /// <summary>
+    ///     Bytes of one fragment's body. Deliberately well under <see cref="MaximumBodyBytes" />: the
+    ///     fragment attributes and the SQS entry scaffolding all ride along, and under-estimating bounces
+    ///     the send rather than costing an extra message.
+    /// </summary>
+    internal const int FragmentBodyBytes = 200 * 1024;
+
+    /// <summary>
+    ///     Refuse to shard past this. A message needing more fragments than this is a claim-check
+    ///     problem, not a framing problem, and turning one 50MB message into 250 SQS messages would be
+    ///     an expensive way to find that out.
+    /// </summary>
+    internal const int MaximumFragments = 10;
+
+    internal const string FragmentIdAttribute = "wolverine-fragment-id";
+    internal const string FragmentIndexAttribute = "wolverine-fragment-index";
+    internal const string FragmentCountAttribute = "wolverine-fragment-count";
+
+    /// <summary>
+    ///     SQS returns only the message attributes a <c>ReceiveMessage</c> explicitly names, so a listener
+    ///     has to ask for these or a fragmented message arrives looking like N unrelated whole messages,
+    ///     each of which fails to deserialize.
+    /// </summary>
+    internal static readonly string[] AttributeNames =
+        [FragmentIdAttribute, FragmentIndexAttribute, FragmentCountAttribute];
+
+    /// <summary>
+    ///     Is this body too big for SQS to accept as one message?
+    /// </summary>
+    internal static bool ExceedsLimit(string body) => body.Length > MaximumBodyBytes;
+
+    /// <summary>
+    ///     Split a message body into fragments. Splits on the ALREADY-ENCODED body rather than on the
+    ///     envelope's bytes, so that whatever the endpoint's <see cref="ISqsEnvelopeMapper" /> produced
+    ///     is what gets reassembled — the mapper is not asked to know anything about fragmenting.
+    /// </summary>
+    internal static string[] Split(string body)
+    {
+        var count = (body.Length + FragmentBodyBytes - 1) / FragmentBodyBytes;
+
+        var fragments = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            var start = i * FragmentBodyBytes;
+            var length = Math.Min(FragmentBodyBytes, body.Length - start);
+            fragments[i] = body.Substring(start, length);
+        }
+
+        return fragments;
+    }
+
+    internal static Dictionary<string, MessageAttributeValue> AttributesFor(Guid fragmentId, int index, int count)
+    {
+        return new Dictionary<string, MessageAttributeValue>
+        {
+            [FragmentIdAttribute] = new() { StringValue = fragmentId.ToString(), DataType = "String" },
+            [FragmentIndexAttribute] = new() { StringValue = index.ToString(), DataType = "Number" },
+            [FragmentCountAttribute] = new() { StringValue = count.ToString(), DataType = "Number" }
+        };
+    }
+
+    /// <summary>
+    ///     Read the fragment framing off a received message, if it has any.
+    /// </summary>
+    internal static bool TryReadHeader(Message message, out SqsFragmentHeader header)
+    {
+        header = default;
+
+        if (message.MessageAttributes == null) return false;
+
+        if (!message.MessageAttributes.TryGetValue(FragmentIdAttribute, out var id)) return false;
+        if (!message.MessageAttributes.TryGetValue(FragmentIndexAttribute, out var index)) return false;
+        if (!message.MessageAttributes.TryGetValue(FragmentCountAttribute, out var count)) return false;
+
+        if (!Guid.TryParse(id.StringValue, out var fragmentId)) return false;
+        if (!int.TryParse(index.StringValue, out var i)) return false;
+        if (!int.TryParse(count.StringValue, out var n)) return false;
+
+        if (n <= 0 || i < 0 || i >= n) return false;
+
+        header = new SqsFragmentHeader(fragmentId, i, n);
+        return true;
+    }
+
+    /// <summary>
+    ///     The group id every fragment of one message must share, so that a FIFO queue keeps them on one
+    ///     consumer and a <c>GlobalPartitioning</c> listener routes them all to the node that owns the
+    ///     group.
+    /// </summary>
+    /// <remarks>
+    ///     The envelope's own <see cref="Envelope.GroupId" /> wins when it has one — the caller has
+    ///     already said which partition this message belongs to, and overriding it would send the
+    ///     fragments somewhere other than where the whole message was meant to go. Only when there is no
+    ///     group id at all does the fragment id stand in, which at least keeps the set together.
+    /// </remarks>
+    internal static string GroupIdFor(Envelope envelope, Guid fragmentId)
+    {
+        return string.IsNullOrEmpty(envelope.GroupId)
+            ? "wolverine-fragments-" + fragmentId
+            : envelope.GroupId;
+    }
+}
+
+internal readonly record struct SqsFragmentHeader(Guid FragmentId, int Index, int Count);

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSenderProtocol.cs
@@ -48,10 +48,42 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
     {
         await _queue.InitializeAsync(_logger);
 
-        var chunks = ChunkMessages(batch.Messages);
+        // GH-3926: turn each envelope into the SQS entries it actually needs - one normally, or N when
+        // the endpoint opted into fragmenting and the body is over SQS's limit. Done BEFORE chunking so
+        // that the 10-entry and 256KB-per-request limits are applied to what is really being sent.
+        var units = new List<SqsSendUnit>(batch.Messages.Count);
+        var unsendable = new List<Envelope>();
 
-        var successes = new List<Envelope>();
-        var failures = new List<Envelope>();
+        foreach (var envelope in batch.Messages)
+        {
+            if (TryBuildUnits(envelope, out var built))
+            {
+                units.AddRange(built);
+            }
+            else
+            {
+                unsendable.Add(envelope);
+            }
+        }
+
+        if (unsendable.Count != 0)
+        {
+            // Permanently unsendable, not a transient failure: SQS answers an oversized message with a
+            // SenderFault, and retrying it produces the same SenderFault forever. That infinite retry is
+            // how this presents in production - a flood of identical errors rather than one. Route it to
+            // the serialization-failure path, which logs and drops rather than re-queueing.
+            await callback.MarkSerializationFailureAsync(
+                new OutgoingMessageBatch(batch.Destination, unsendable));
+        }
+
+        if (units.Count == 0) return;
+
+        var chunks = ChunkUnits(units);
+
+        // An envelope is only successful when EVERY unit it produced was accepted, and its fragments can
+        // land in different requests, so failure is tracked by envelope across the whole send rather than
+        // accumulated per chunk. Half a message in SQS is not a delivery.
+        var failed = new HashSet<Envelope>();
 
         for (var i = 0; i < chunks.Length; i++)
         {
@@ -61,39 +93,120 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
             try
             {
                 var response = await _sqs.SendMessageBatchAsync(sqsBatch.Request);
-                sortChunkResults(sqsBatch, chunk, response, successes, failures);
+                sortChunkResults(sqsBatch, response, failed);
             }
             catch (Exception e)
             {
                 // This chunk (and any chunk after it) never made it to SQS, but earlier
                 // chunks may already have been accepted, so only fail what actually failed
-                var unsent = chunks.Skip(i).SelectMany(x => x);
-
-                if (successes.Count != 0)
+                foreach (var envelope in chunks.Skip(i).SelectMany(x => x).Select(x => x.Envelope))
                 {
-                    await callback.MarkSuccessfulAsync(new OutgoingMessageBatch(batch.Destination, successes));
+                    failed.Add(envelope);
                 }
 
-                await callback.MarkProcessingFailureAsync(
-                    new OutgoingMessageBatch(batch.Destination, failures.Concat(unsent).ToList()), e);
-
+                await reportAsync(callback, batch, units, unsendable, failed, e);
                 return;
             }
         }
 
-        if (failures.Count == 0)
+        await reportAsync(callback, batch, units, unsendable, failed, null);
+    }
+
+    private static async Task reportAsync(ISenderCallback callback, OutgoingMessageBatch batch,
+        List<SqsSendUnit> units, List<Envelope> unsendable, HashSet<Envelope> failed, Exception? exception)
+    {
+        if (failed.Count == 0 && unsendable.Count == 0)
         {
             await callback.MarkSuccessfulAsync(batch);
+            return;
+        }
+
+        var successes = units.Select(x => x.Envelope).Distinct().Where(x => !failed.Contains(x)).ToList();
+
+        if (successes.Count != 0)
+        {
+            await callback.MarkSuccessfulAsync(new OutgoingMessageBatch(batch.Destination, successes));
+        }
+
+        if (failed.Count == 0) return;
+
+        var failures = new OutgoingMessageBatch(batch.Destination, failed.ToList());
+
+        if (exception == null)
+        {
+            await callback.MarkProcessingFailureAsync(failures);
         }
         else
         {
-            if (successes.Count != 0)
-            {
-                await callback.MarkSuccessfulAsync(new OutgoingMessageBatch(batch.Destination, successes));
-            }
-
-            await callback.MarkProcessingFailureAsync(new OutgoingMessageBatch(batch.Destination, failures));
+            await callback.MarkProcessingFailureAsync(failures, exception);
         }
+    }
+
+    /// <summary>
+    ///     Turn one envelope into the SQS messages it needs: one normally, or N fragments when the
+    ///     endpoint opted into <see cref="AmazonSqsQueue.FragmentOversizedMessages" /> and the body is
+    ///     over SQS's limit. Returns <c>false</c> when this envelope can never be sent to this queue,
+    ///     which the caller turns into a drop rather than a retry.
+    /// </summary>
+    internal bool TryBuildUnits(Envelope envelope, out SqsSendUnit[] units)
+    {
+        units = [];
+
+        string body;
+        try
+        {
+            body = _queue.Mapper!.BuildMessageBody(envelope);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while mapping envelope {Envelope} to an SQS message body for {Uri}",
+                envelope, _queue.Uri);
+            return false;
+        }
+
+        if (!SqsMessageFragments.ExceedsLimit(body))
+        {
+            units = [new SqsSendUnit(envelope, body, envelope.Id.ToString(), null)];
+            return true;
+        }
+
+        // Below here the message is over SQS's limit, which SQS answers with a permanent SenderFault
+        // rather than anything a retry could clear.
+
+        if (!_queue.FragmentOversizedMessages)
+        {
+            _logger.LogError(
+                "Envelope {Id} of message type {MessageType} produced a {Size} byte body for {Uri}, over the {Maximum} bytes Wolverine will send in one SQS message. " +
+                "SQS rejects an oversized message with a permanent SenderFault, so retrying it would fail identically forever - it is being discarded instead. " +
+                "Use a claim check (WolverineFx.ClaimCheck.AmazonS3), or opt this endpoint into FragmentOversizedMessages().",
+                envelope.Id, envelope.MessageType, body.Length, _queue.Uri, SqsMessageFragments.MaximumBodyBytes);
+            return false;
+        }
+
+        var bodies = SqsMessageFragments.Split(body);
+
+        if (bodies.Length > SqsMessageFragments.MaximumFragments)
+        {
+            _logger.LogError(
+                "Envelope {Id} of message type {MessageType} produced a {Size} byte body for {Uri}, which would need {Needed} fragments against a maximum of {Maximum}. " +
+                "A message this large is a claim check problem rather than a framing one; see WolverineFx.ClaimCheck.AmazonS3. The message is being discarded.",
+                envelope.Id, envelope.MessageType, body.Length, _queue.Uri, bodies.Length,
+                SqsMessageFragments.MaximumFragments);
+            return false;
+        }
+
+        units = new SqsSendUnit[bodies.Length];
+        for (var i = 0; i < bodies.Length; i++)
+        {
+            // The fragment id is the envelope id rather than a fresh Guid, deliberately. A batch send is
+            // not atomic, so a retry can re-send fragments that SQS already accepted; with a stable id the
+            // stragglers are just redeliveries of the same set and the receiver folds them together,
+            // where a fresh id per attempt would orphan them.
+            var header = new SqsFragmentHeader(envelope.Id, i, bodies.Length);
+            units[i] = new SqsSendUnit(envelope, bodies[i], $"{envelope.Id}-{i}", header);
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -132,6 +245,40 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
     }
 
     /// <summary>
+    ///     <see cref="ChunkMessages" /> over the units actually being sent. Same two SQS limits, but
+    ///     measured against the encoded body rather than estimated from the envelope, since by this
+    ///     point the body has really been built.
+    /// </summary>
+    internal static SqsSendUnit[][] ChunkUnits(IEnumerable<SqsSendUnit> units)
+    {
+        var chunks = new List<SqsSendUnit[]>();
+        var current = new List<SqsSendUnit>(10);
+        var currentSize = 0;
+
+        foreach (var unit in units)
+        {
+            var size = EstimateEntrySize(unit);
+
+            if (current.Count > 0 && (current.Count == 10 || currentSize + size > MaximumBatchPayloadBytes))
+            {
+                chunks.Add(current.ToArray());
+                current.Clear();
+                currentSize = 0;
+            }
+
+            current.Add(unit);
+            currentSize += size;
+        }
+
+        if (current.Count > 0)
+        {
+            chunks.Add(current.ToArray());
+        }
+
+        return chunks.ToArray();
+    }
+
+    /// <summary>
     ///     Estimated wire size of one batch entry. The default mapper serializes the whole envelope
     ///     -- headers included -- and base64 encodes it, which inflates by 4/3.
     /// </summary>
@@ -141,19 +288,31 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
         return (raw + 2) / 3 * 4;
     }
 
+    /// <summary>
+    ///     Wire size of one batch entry whose body is already built. No base64 allowance here -- the
+    ///     mapper has already applied whatever encoding it uses.
+    /// </summary>
+    internal static int EstimateEntrySize(SqsSendUnit unit)
+    {
+        return unit.Body.Length + EntryOverheadBytes;
+    }
+
     // SendMessageBatchAsync is not transactional -- SQS can accept some entries and reject
     // others (throttling, oversized message, etc.) in the very same 200 response, so every
     // entry in response.Failed has to be routed back through the sender callback for retry
-    private void sortChunkResults(OutgoingSqsBatch sqsBatch, Envelope[] chunk, SendMessageBatchResponse response,
-        List<Envelope> successes, List<Envelope> failures)
+    private void sortChunkResults(OutgoingSqsBatch sqsBatch, SendMessageBatchResponse response,
+        HashSet<Envelope> failed)
     {
+        foreach (var envelope in sqsBatch.Dropped)
+        {
+            failed.Add(envelope);
+        }
+
         if (response.Failed == null || response.Failed.Count == 0)
         {
-            successes.AddRange(chunk);
             return;
         }
 
-        var failed = new HashSet<Envelope>();
         foreach (var entry in response.Failed)
         {
             if (sqsBatch.TryGetEnvelope(entry.Id, out var envelope))
@@ -161,6 +320,9 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
                 _logger.LogError(
                     "SQS batch send to {Uri} failed for message {Id}: {Code} - {Message} (SenderFault: {SenderFault}). The message will be retried",
                     _queue.Uri, entry.Id, entry.Code, entry.Message, entry.SenderFault);
+
+                // One rejected fragment means the receiver can never rebuild the message, so the whole
+                // envelope is a failure and every fragment of it is re-sent.
                 failed.Add(envelope);
             }
             else
@@ -170,18 +332,21 @@ internal class SqsSenderProtocol : ISenderProtocolWithNativeScheduling, IConditi
                     _queue.Uri, entry.Id, entry.Code, entry.Message);
             }
         }
+    }
+}
 
-        foreach (var envelope in chunk)
-        {
-            if (failed.Contains(envelope))
-            {
-                failures.Add(envelope);
-            }
-            else
-            {
-                successes.Add(envelope);
-            }
-        }
+/// <summary>
+///     One SQS message on its way out. Normally one per envelope; a fragmented envelope produces one
+///     per fragment, all carrying the same <see cref="Envelope" />.
+/// </summary>
+internal record SqsSendUnit(Envelope Envelope, string Body, string EntryId, SqsFragmentHeader? Fragment)
+{
+    /// <summary>
+    ///     One envelope that fits in one SQS message, which is the overwhelmingly common case.
+    /// </summary>
+    public static SqsSendUnit Whole(AmazonSqsQueue queue, Envelope envelope)
+    {
+        return new SqsSendUnit(envelope, queue.Mapper!.BuildMessageBody(envelope), envelope.Id.ToString(), null);
     }
 }
 
@@ -189,42 +354,60 @@ internal class OutgoingSqsBatch
 {
     private readonly Dictionary<string, Envelope> _envelopes = new();
 
-    public OutgoingSqsBatch(AmazonSqsQueue queue, ILogger logger, IEnumerable<Envelope> envelopes)
+    public OutgoingSqsBatch(AmazonSqsQueue queue, ILogger logger, IEnumerable<SqsSendUnit> units)
     {
         var entries = new List<SendMessageBatchRequestEntry>();
-        foreach (var envelope in envelopes)
+        foreach (var unit in units)
         {
+            var envelope = unit.Envelope;
+
             try
             {
-                var entry = new SendMessageBatchRequestEntry(envelope.Id.ToString(), queue.Mapper!.BuildMessageBody(envelope));
+                var entry = new SendMessageBatchRequestEntry(unit.EntryId, unit.Body);
+
                 if (queue.IsFifoQueue)
                 {
-                    var groupId = queue.Mapper.DetermineGroupId(envelope);
+                    var groupId = groupIdFor(queue, unit);
                     if (groupId.IsNotEmpty())
                     {
                         entry.MessageGroupId = groupId;
                     }
+
                     var deduplicationId = AmazonSqsQueue.DetermineDeduplicationId(envelope);
                     if (deduplicationId.IsNotEmpty())
                     {
-                        entry.MessageDeduplicationId = deduplicationId;
+                        // Every fragment of one envelope would otherwise carry the identical
+                        // deduplication id, and a FIFO queue would keep exactly one of them.
+                        entry.MessageDeduplicationId = unit.Fragment is { } fragment
+                            ? $"{deduplicationId}-{fragment.Index}"
+                            : deduplicationId;
                     }
                 }
                 else if (queue.EnableFairQueueMessageGroups)
                 {
                     // SQS fair queues: a MessageGroupId on a standard queue improves tenant fairness.
                     // No deduplication semantics apply to standard queues. See GH-2886.
-                    var groupId = queue.Mapper.DetermineGroupId(envelope);
+                    var groupId = groupIdFor(queue, unit);
                     if (groupId.IsNotEmpty())
                     {
                         entry.MessageGroupId = groupId;
                     }
                 }
 
-                foreach (var attribute in queue.Mapper.ToAttributes(envelope))
+                foreach (var attribute in queue.Mapper!.ToAttributes(envelope))
                 {
                     entry.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
                     entry.MessageAttributes.Add(attribute.Key, attribute.Value);
+                }
+
+                if (unit.Fragment is { } header)
+                {
+                    entry.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
+                    foreach (var pair in SqsMessageFragments.AttributesFor(header.FragmentId, header.Index,
+                                 header.Count))
+                    {
+                        entry.MessageAttributes[pair.Key] = pair.Value;
+                    }
                 }
 
                 var delaySeconds = queue.NativeDelaySecondsFor(envelope, DateTimeOffset.UtcNow, logger);
@@ -234,22 +417,44 @@ internal class OutgoingSqsBatch
                 }
 
                 entries.Add(entry);
-                _envelopes.Add(entry.Id, envelope);
+                _envelopes[entry.Id] = envelope;
             }
             catch (Exception e)
             {
                 logger.LogError(e, "Error while mapping envelope {Envelope} to an SQS SendMessageBatchRequestEntry",
                     envelope);
+
+                Dropped.Add(envelope);
             }
         }
 
         Request = new SendMessageBatchRequest(queue.QueueUrl, entries);
     }
 
+    /// <summary>
+    ///     Envelopes that could not be turned into an SQS entry at all. They are not in the request, so
+    ///     they cannot succeed, and leaving them out of both outcomes would silently lose them.
+    /// </summary>
+    public List<Envelope> Dropped { get; } = [];
+
     public SendMessageBatchRequest Request { get; }
 
     public bool TryGetEnvelope(string id, out Envelope envelope)
     {
         return _envelopes.TryGetValue(id, out envelope!);
+    }
+
+    /// <summary>
+    ///     Fragments of one message must share a group id, so that a FIFO queue keeps the whole set on a
+    ///     single consumer and in order. Returns null when there is no group id to set, which leaves
+    ///     <c>MessageGroupId</c> unset exactly as before.
+    /// </summary>
+    private static string? groupIdFor(AmazonSqsQueue queue, SqsSendUnit unit)
+    {
+        var groupId = unit.Fragment is { } fragment
+            ? SqsMessageFragments.GroupIdFor(unit.Envelope, fragment.FragmentId)
+            : queue.Mapper!.DetermineGroupId(unit.Envelope);
+
+        return groupId.IsNotEmpty() ? groupId : null;
     }
 }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/WolverineSqsTransportException.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/WolverineSqsTransportException.cs
@@ -6,3 +6,17 @@ public class WolverineSqsTransportException : Exception
     {
     }
 }
+
+/// <summary>
+///     An envelope that is simply too big for the queue it is bound for, and that the endpoint has not
+///     opted into fragmenting. SQS answers an oversized message with a permanent <c>SenderFault</c>, so
+///     this is never worth a retry -- which is exactly why it is its own type. The retrying paths
+///     (requeue, dead letter forwarding) catch it and give up rather than looping on a send that cannot
+///     ever succeed. See GH-3926.
+/// </summary>
+public class SqsMessageTooLargeException : WolverineSqsTransportException
+{
+    public SqsMessageTooLargeException(string? message) : base(message, null)
+    {
+    }
+}

--- a/src/Wolverine/Persistence/Durability/DurableSendingAgent.cs
+++ b/src/Wolverine/Persistence/Durability/DurableSendingAgent.cs
@@ -187,6 +187,18 @@ internal class DurableSendingAgent : SendingAgent
         return _deleteOutgoingMany.PostAsync(outgoing.Messages.ToArray());
     }
 
+    /// <summary>
+    ///     GH-3926: an envelope the transport has judged permanently unsendable has to leave the outgoing
+    ///     table as well as the in-memory queue. Logging it and stopping there leaves the row behind, and
+    ///     the durability agent re-reads and re-sends it on every recovery sweep -- which is precisely the
+    ///     endless retry this path exists to break.
+    /// </summary>
+    public override async Task MarkSerializationFailureAsync(OutgoingMessageBatch outgoing)
+    {
+        await base.MarkSerializationFailureAsync(outgoing);
+        await _deleteOutgoingMany.PostAsync(outgoing.Messages.ToArray());
+    }
+
     public override Task MarkSuccessfulAsync(Envelope outgoing)
     {
         return _deleteOutgoingOne.PostAsync(outgoing);

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -76,10 +76,15 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
         return markFailedAsync(outgoing);
     }
 
-    Task ISenderCallback.MarkSerializationFailureAsync(OutgoingMessageBatch outgoing)
+    /// <summary>
+    ///     The envelopes in this batch can never be sent to this destination -- the transport has already
+    ///     decided that retrying would fail identically forever. Log them and let them go. A buffered
+    ///     agent is done at that point; a durable one also has to clear them out of the outgoing table,
+    ///     which is why this is virtual.
+    /// </summary>
+    public virtual Task MarkSerializationFailureAsync(OutgoingMessageBatch outgoing)
     {
         _logger.OutgoingBatchFailed(outgoing);
-        // Can't really happen now, but what the heck.
         var exception = new Exception("Serialization failure with outgoing envelopes " +
                                       outgoing.Messages.Select(x => x.ToString()).Join(", "));
         _logger.LogError(exception, "Serialization failure");


### PR DESCRIPTION
Closes #3926.

A user publishing to a standard SQS queue from a buffered endpoint hit SQS's hard 256KB limit:

```
InvalidParameterValue - Message must be shorter than 262144 bytes. (SenderFault: true)
```

`SenderFault: true` means the request itself is wrong, so the identical request fails identically forever — but Wolverine treated it as a transient send failure and re-queued it. That is why this presented as a *flood* of identical errors rather than one.

## Stop retrying what can never succeed

`SqsSenderProtocol` now measures the body before the send and routes an oversized envelope to the permanent-failure path, so it is logged once and dropped.

That exposed a second route to the same loop: `SendingAgent.MarkSerializationFailureAsync` only logged, so on a **durable** endpoint the envelope stayed in the outgoing table and the durability agent re-read and re-sent it on every recovery sweep. It is now `virtual`, and `DurableSendingAgent` deletes the rows.

The one-at-a-time path (inline senders, requeues, dead-letter forwarding) throws `SqsMessageTooLargeException`. Both retrying callers catch it and give up, because a `RetryBlock` around an impossible send is the same bug wearing a different hat.

## Opt-in message fragmentation

For people who want the message to actually get through without adding S3, an endpoint can split an oversized body across several SQS messages and reassemble it on the other side:

```csharp
opts.PublishMessage<BigDocumentReceived>().ToSqsQueue("documents").FragmentOversizedMessages();
opts.ListenToSqsQueue("documents").FragmentOversizedMessages();
```

Design points worth review:

- **Claim checks stay the recommended answer.** The new docs page leads with `WolverineFx.ClaimCheck.AmazonS3` and only then describes fragmentation.
- **Fragmenting lives in `SqsSenderProtocol`**, the layer both buffered and durable go through, so buffered endpoints are covered.
- **The fragment id is the envelope id, not a fresh Guid.** A batch send is not atomic, so a retry re-sends fragments SQS already accepted; with a stable id those stragglers are redeliveries of the same set that the receiver folds together, where a fresh id per attempt would orphan them forever.
- **An envelope succeeds only if every one of its fragments does.** Half a message in SQS is not a delivery, so failure is tracked per envelope across the whole send rather than per chunk.
- **Reassembly is in-memory, per listener, and never acks early.** Fragments are not deleted from SQS until the whole set is in hand, so a node that crashes holding two of three loses nothing. Completing a reassembled envelope deletes all N.
- **Reassembly is unconditional on the listening side.** The framing is self-describing, so an asymmetrically configured pair still works; the flag governs sending, requeues and the timeout.
- **On a FIFO queue** every fragment shares a group id (the envelope's `GroupId` wins when it has one) and gets a distinct `MessageDeduplicationId`, since a shared one would have SQS keep exactly one fragment.

The competing-consumer constraint is documented rather than engineered around: fragmentation is only safe on a FIFO queue, behind a globally partitioned listener, or with a single listening node.

## Things found along the way

- **SQS returns only the message attributes a receive explicitly names.** `MessageAttributeNames` defaulted to null, so the fragment framing was invisible and every fragment arrived looking like a whole message that failed to deserialize. `ConfigureRequest` now always appends the framing attribute names.
- **The size check has to be SQS's limit, not the fragment size.** An earlier draft gated on the 200KB fragment size, which would have discarded a perfectly legal 220KB message. Now gated on `MaximumBodyBytes` (256KB less an attribute allowance), with tests pinning that band.
- **`BuildTenantSibling` had to carry the new settings**, or a per-tenant SQS queue silently loses them.

## Tests

- `sqs_message_fragmentation_3926` — split/reassemble round trip, header read-back and rejection of nonsense headers, group-id precedence, size-band boundaries, reassembler completion, out-of-order arrival, redelivery, isolation between sets, timeout abandonment.
- `sqs_sender_fragmentation_3926` — discard when not opted in, the rest of a batch still going out around it, fragmenting when opted in, per-request payload limits, the too-large-to-fragment ceiling, one rejected fragment failing the whole envelope, FIFO group and deduplication ids.
- `send_and_receive_oversized_messages_3926` — end to end over LocalStack: a 400KB message round trips intact, an ordinary message is unaffected, two oversized messages in flight do not cross-contaminate, and every fragment is deleted once handled.

Note the e2e class uses a shared `IClassFixture`: `AutoPurgeOnStartup` per test method calls SQS `PurgeQueue`, which is allowed only once every 60 seconds and swallows messages sent inside that window.
