### PR TITLE
GH-3929: [ReadModel] infers Required, and [WriteAggregate]/[ReadAggregate] keep their old default (6.27.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### WolverineFx (core) + event store integrations
+
+- **`[WriteAggregate]` keeps its original `Required` default — regression fix.**
+  ([#3929](https://github.com/JasperFx/wolverine/issues/3929)) `WriteAggregateAttribute` derives from
+  `WriteModelAttribute` and overrides neither `Modify` nor `Required`, so it inherited GH-3916's
+  nullability inference in 6.27.0. `[WriteAggregate]` shipped a year before that inference, so an
+  existing `[WriteAggregate] Account? account` handler silently lost its not-found guard and began
+  running against a model that was never loaded. `[WriteAggregate]` and `[ReadAggregate]` now pin the
+  unconditional `Required = true` they have always had, in Marten, Polecat and Fisher alike. Say
+  `Required = false` explicitly, or use `[WriteModel]` / `[ReadModel]`, to opt out.
+
+- **`[ReadModel]` now takes `Required` from the parameter's nullable annotation**, matching what
+  GH-3916 did for `[WriteModel]`: `Order order` is required, `Order? order` is not and is handed to
+  the method as `null`. An explicit `Required` at the call site still wins. `[Entity]`,
+  `[DeciderFunction]` and `[DcbModel]` are unchanged.
+
+  Note that in an assembly compiled with `<Nullable>disable</Nullable>` the annotation reads as
+  *unknown* rather than *nullable*, so `[WriteModel]` and `[ReadModel]` fall back to `Required = true`
+  there — the inference is a no-op for those projects rather than a silent behaviour change.
+
+
 ### WolverineFx.AmazonSqs
 
 - **An oversized message is no longer retried forever, and can optionally be fragmented.**

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.27.0</Version>
+        <Version>6.27.1</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -315,10 +315,20 @@ Missing-model behavior matches `[Entity]` as well: `Required`, `MissingMessage` 
 what they mean there, and both attributes honor the
 [global entity defaults](#global-entity-defaults) below.
 
-On `[WriteModel]`, `Required` **defaults to the opposite of the parameter's nullable annotation**
-<Badge type="tip" text="6.27" /> — `Order order` is required and gets a not-found guard, `Order? order`
-is not and is handed to your method as `null` so your own null branch runs. Setting `Required`
-explicitly overrides the annotation either way.
+On `[WriteModel]` <Badge type="tip" text="6.27" /> and `[ReadModel]` <Badge type="tip" text="6.27.1" />,
+`Required` **defaults to the opposite of the parameter's nullable annotation** — `Order order` is
+required and gets a not-found guard, `Order? order` is not and is handed to your method as `null` so
+your own null branch runs. Setting `Required` explicitly overrides the annotation either way.
+
+::: warning The store-specific spellings keep the old default
+`[WriteAggregate]`, `[ReadAggregate]` and `[Entity]` **do not** infer from the annotation. They all
+predate it, and quietly dropping a not-found guard from existing code is a change that only shows up
+at runtime — so they keep their unconditional `Required = true`. Say `Required = false` explicitly on
+those, or move to `[WriteModel]` / `[ReadModel]`.
+
+In a project compiled with `<Nullable>disable</Nullable>` the annotation cannot be read, so
+`[WriteModel]` and `[ReadModel]` also fall back to `Required = true`.
+:::
 
 ::: warning Every return value is an event
 Under `[WriteModel]` and `[DeciderFunction]` alike, anything the method returns that is not

--- a/src/Persistence/FisherTests/aggregate_attributes_pin_required_3929.cs
+++ b/src/Persistence/FisherTests/aggregate_attributes_pin_required_3929.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Shouldly;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Fisher;
+
+namespace FisherTests;
+
+// GH-3929. [WriteAggregate]/[ReadAggregate] predate the nullable-annotation inference that
+// [WriteModel]/[ReadModel] now use for the Required default, so they must keep their own unconditional
+// default rather than inheriting it. Reflection rather than behaviour because the mechanism IS the
+// override - a store added later that forgets it inherits a silent, runtime-only behaviour change.
+public class aggregate_attributes_pin_required_3929
+{
+    private static MethodInfo defaultRequiredOn(Type type)
+    {
+        return type.GetMethod("DefaultRequired", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    }
+
+    [Fact]
+    public void write_aggregate_overrides_the_required_default()
+    {
+        defaultRequiredOn(typeof(WriteAggregateAttribute))
+            .DeclaringType.ShouldBe(typeof(WriteAggregateAttribute));
+    }
+
+    [Fact]
+    public void read_aggregate_overrides_the_required_default()
+    {
+        defaultRequiredOn(typeof(ReadAggregateAttribute))
+            .DeclaringType.ShouldBe(typeof(ReadAggregateAttribute));
+    }
+
+    [Fact]
+    public void the_core_attributes_still_infer_from_nullability()
+    {
+        defaultRequiredOn(typeof(WriteModelAttribute)).DeclaringType.ShouldBe(typeof(WriteModelAttribute));
+        defaultRequiredOn(typeof(ReadModelAttribute)).DeclaringType.ShouldBe(typeof(ReadModelAttribute));
+    }
+}

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/read_model_required_3929.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/read_model_required_3929.cs
@@ -1,0 +1,199 @@
+using IntegrationTests;
+using JasperFx;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Tracking;
+
+namespace MartenTests.AggregateHandlerWorkflow;
+
+// GH-3929. GH-3916 gave [WriteModel] a Required default taken from the parameter's nullable annotation
+// and left [ReadModel] on an unconditional true, so the write side inferred and the read side did not.
+//
+// The part that needs pinning rather than fixing: [WriteAggregate] and [ReadAggregate] derive from the
+// core attributes and predate the inference by a year. Inheriting it would silently drop the not-found
+// guard from existing `[WriteAggregate] Account? account` handlers, which would then run against a model
+// that was never loaded. Both keep their original unconditional default; the tests below are what say so.
+public class read_model_required_3929 : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(NullableReadModelHandler))
+                    .IncludeType(typeof(ExplicitlyRequiredNullableReadModelHandler))
+                    .IncludeType(typeof(NonNullableReadModelHandler))
+                    .IncludeType(typeof(PinnedReadAggregateUsage))
+                    .IncludeType(typeof(PinnedWriteAggregateUsage));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "read_model_required_3929";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task<Guid> givenBalance(decimal opening)
+    {
+        var streamId = Guid.NewGuid();
+        await using var session = theHost.DocumentStore().LightweightSession();
+        session.Events.StartStream<Account>(streamId, new AmountDeposited(opening));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task nullable_read_model_is_not_required_by_default()
+    {
+        NullableReadModelHandler.Reset();
+
+        // Nothing has ever been written to this stream, so the model is null
+        await theHost.InvokeAsync(new ReadMaybeMissingAccount(Guid.NewGuid()));
+
+        NullableReadModelHandler.WasCalled.ShouldBeTrue();
+        NullableReadModelHandler.SawNull.ShouldBeTrue();
+    }
+
+    // The annotation is a default, not an override.
+    [Fact]
+    public async Task explicit_required_still_wins_over_the_nullable_annotation()
+    {
+        ExplicitlyRequiredNullableReadModelHandler.Reset();
+
+        await theHost.InvokeAsync(new ReadRequiredAccount(Guid.NewGuid()));
+
+        ExplicitlyRequiredNullableReadModelHandler.WasCalled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task non_nullable_read_model_is_still_required()
+    {
+        NonNullableReadModelHandler.Reset();
+
+        await theHost.InvokeAsync(new ReadNonNullableAccount(Guid.NewGuid()));
+        NonNullableReadModelHandler.WasCalled.ShouldBeFalse();
+
+        await theHost.InvokeAsync(new ReadNonNullableAccount(await givenBalance(10m)));
+        NonNullableReadModelHandler.WasCalled.ShouldBeTrue();
+    }
+
+    // REGRESSION GUARD. [ReadAggregate] must NOT inherit the inference - it shipped 2025-02-28 with an
+    // unconditional Required, and quietly dropping the guard is a runtime-only behaviour change.
+    [Fact]
+    public async Task read_aggregate_keeps_its_unconditional_required_default()
+    {
+        PinnedReadAggregateUsage.Reset();
+
+        await theHost.InvokeAsync(new ReadMaybeMissingViaAggregate(Guid.NewGuid()));
+
+        PinnedReadAggregateUsage.WasCalled.ShouldBeFalse();
+    }
+
+    // REGRESSION GUARD, and the one that actually broke: [WriteAggregate] inherited GH-3916's inference
+    // in 6.27.0 even though it shipped 2025-07-28. Nothing covered the implicit case, so CI was green.
+    [Fact]
+    public async Task write_aggregate_keeps_its_unconditional_required_default()
+    {
+        PinnedWriteAggregateUsage.Reset();
+
+        await theHost.InvokeAsync(new WriteMaybeMissingViaAggregate(Guid.NewGuid(), 5m));
+
+        PinnedWriteAggregateUsage.WasCalled.ShouldBeFalse();
+    }
+}
+
+public record ReadMaybeMissingAccount(Guid AccountId);
+
+public record ReadRequiredAccount(Guid AccountId);
+
+public record ReadNonNullableAccount(Guid AccountId);
+
+public record ReadMaybeMissingViaAggregate(Guid AccountId);
+
+public record WriteMaybeMissingViaAggregate(Guid AccountId, decimal Amount);
+
+public static class NullableReadModelHandler
+{
+    public static bool WasCalled { get; private set; }
+    public static bool SawNull { get; private set; }
+
+    public static void Reset()
+    {
+        WasCalled = false;
+        SawNull = false;
+    }
+
+    public static void Handle(ReadMaybeMissingAccount command, [ReadModel] Account? account)
+    {
+        WasCalled = true;
+        SawNull = account == null;
+    }
+}
+
+public static class ExplicitlyRequiredNullableReadModelHandler
+{
+    public static bool WasCalled { get; private set; }
+
+    public static void Reset() => WasCalled = false;
+
+    public static void Handle(ReadRequiredAccount command, [ReadModel(Required = true)] Account? account)
+    {
+        WasCalled = true;
+    }
+}
+
+public static class NonNullableReadModelHandler
+{
+    public static bool WasCalled { get; private set; }
+
+    public static void Reset() => WasCalled = false;
+
+    public static void Handle(ReadNonNullableAccount command, [ReadModel] Account account)
+    {
+        WasCalled = true;
+    }
+}
+
+public static class PinnedReadAggregateUsage
+{
+    public static bool WasCalled { get; private set; }
+
+    public static void Reset() => WasCalled = false;
+
+    public static void Handle(ReadMaybeMissingViaAggregate command, [ReadAggregate] Account? account)
+    {
+        WasCalled = true;
+    }
+}
+
+public static class PinnedWriteAggregateUsage
+{
+    public static bool WasCalled { get; private set; }
+
+    public static void Reset() => WasCalled = false;
+
+    public static AmountDeposited Handle(WriteMaybeMissingViaAggregate command,
+        [WriteAggregate] Account? account)
+    {
+        WasCalled = true;
+
+        return new AmountDeposited(command.Amount);
+    }
+}

--- a/src/Persistence/PolecatTests/AggregateHandlerWorkflow/aggregate_attributes_pin_required_3929.cs
+++ b/src/Persistence/PolecatTests/AggregateHandlerWorkflow/aggregate_attributes_pin_required_3929.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Shouldly;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Polecat;
+
+namespace PolecatTests.AggregateHandlerWorkflow;
+
+// GH-3929. [WriteAggregate]/[ReadAggregate] predate the nullable-annotation inference that
+// [WriteModel]/[ReadModel] now use for the Required default, so they must keep their own unconditional
+// default rather than inheriting it. Reflection rather than behaviour because the mechanism IS the
+// override - a store added later that forgets it inherits a silent, runtime-only behaviour change.
+public class aggregate_attributes_pin_required_3929
+{
+    private static MethodInfo defaultRequiredOn(Type type)
+    {
+        return type.GetMethod("DefaultRequired", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    }
+
+    [Fact]
+    public void write_aggregate_overrides_the_required_default()
+    {
+        defaultRequiredOn(typeof(WriteAggregateAttribute))
+            .DeclaringType.ShouldBe(typeof(WriteAggregateAttribute));
+    }
+
+    [Fact]
+    public void read_aggregate_overrides_the_required_default()
+    {
+        defaultRequiredOn(typeof(ReadAggregateAttribute))
+            .DeclaringType.ShouldBe(typeof(ReadAggregateAttribute));
+    }
+
+    [Fact]
+    public void the_core_attributes_still_infer_from_nullability()
+    {
+        defaultRequiredOn(typeof(WriteModelAttribute)).DeclaringType.ShouldBe(typeof(WriteModelAttribute));
+        defaultRequiredOn(typeof(ReadModelAttribute)).DeclaringType.ShouldBe(typeof(ReadModelAttribute));
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/ReadAggregateAttribute.cs
+++ b/src/Persistence/Wolverine.Fisher/ReadAggregateAttribute.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Fisher.Persistence.Sagas;
@@ -22,6 +23,15 @@ public class ReadAggregateAttribute : ReadModelAttribute
     public ReadAggregateAttribute(string argumentName) : base(argumentName)
     {
     }
+
+    /// <summary>
+    ///     GH-3929: <c>[ReadAggregate]</c> shipped long before the nullability inference this release added
+    ///     to <see cref="ReadModelAttribute" />, so it keeps its original unconditional default. Inheriting
+    ///     the inference would silently drop the not-found guard from existing
+    ///     <c>[ReadAggregate] Thing? thing</c> handlers. Say <c>Required = false</c> explicitly, or use
+    ///     <c>[ReadModel]</c>, to opt out.
+    /// </summary>
+    protected override bool DefaultRequired(ParameterInfo parameter) => true;
 
     // GH-3907: name the store rather than resolving one. AddMarten/AddFisher without
     // IntegrateWithWolverine() registers no persistence strategy, and this attribute has always

--- a/src/Persistence/Wolverine.Fisher/WriteAggregateAttribute.cs
+++ b/src/Persistence/Wolverine.Fisher/WriteAggregateAttribute.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Fisher.Persistence.Sagas;
@@ -40,6 +41,15 @@ public class WriteAggregateAttribute : WriteModelAttribute
         get => (ConcurrencyStyle)(int)base.LoadStyle;
         set => base.LoadStyle = (ModelConcurrencyStyle)(int)value;
     }
+
+    /// <summary>
+    ///     GH-3929: <c>[WriteAggregate]</c> shipped long before the nullability inference GH-3916 added to
+    ///     <see cref="WriteModelAttribute" />, so it keeps its original unconditional default. Inheriting
+    ///     the inference would silently drop the not-found guard from existing
+    ///     <c>[WriteAggregate] Thing? thing</c> handlers, which then run against a model that was never
+    ///     loaded. Say <c>Required = false</c> explicitly, or use <c>[WriteModel]</c>, to opt out.
+    /// </summary>
+    protected override bool DefaultRequired(ParameterInfo parameter) => true;
 
     // GH-3907: name the store rather than resolving one. AddMarten/AddFisher without
     // IntegrateWithWolverine() registers no persistence strategy, and this attribute has always

--- a/src/Persistence/Wolverine.Marten/ReadAggregateAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/ReadAggregateAttribute.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Marten.Persistence.Sagas;
@@ -22,6 +23,15 @@ public class ReadAggregateAttribute : ReadModelAttribute
     public ReadAggregateAttribute(string argumentName) : base(argumentName)
     {
     }
+
+    /// <summary>
+    ///     GH-3929: <c>[ReadAggregate]</c> shipped long before the nullability inference this release added
+    ///     to <see cref="ReadModelAttribute" />, so it keeps its original unconditional default. Inheriting
+    ///     the inference would silently drop the not-found guard from existing
+    ///     <c>[ReadAggregate] Thing? thing</c> handlers. Say <c>Required = false</c> explicitly, or use
+    ///     <c>[ReadModel]</c>, to opt out.
+    /// </summary>
+    protected override bool DefaultRequired(ParameterInfo parameter) => true;
 
     // GH-3907: name the store rather than resolving one. AddMarten/AddPolecat without
     // IntegrateWithWolverine() registers no persistence strategy, and this attribute has always

--- a/src/Persistence/Wolverine.Marten/WriteAggregateAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/WriteAggregateAttribute.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Marten.Persistence.Sagas;
@@ -40,6 +41,15 @@ public class WriteAggregateAttribute : WriteModelAttribute
         get => (ConcurrencyStyle)(int)base.LoadStyle;
         set => base.LoadStyle = (ModelConcurrencyStyle)(int)value;
     }
+
+    /// <summary>
+    ///     GH-3929: <c>[WriteAggregate]</c> shipped long before the nullability inference GH-3916 added to
+    ///     <see cref="WriteModelAttribute" />, so it keeps its original unconditional default. Inheriting
+    ///     the inference would silently drop the not-found guard from existing
+    ///     <c>[WriteAggregate] Thing? thing</c> handlers, which then run against a model that was never
+    ///     loaded. Say <c>Required = false</c> explicitly, or use <c>[WriteModel]</c>, to opt out.
+    /// </summary>
+    protected override bool DefaultRequired(ParameterInfo parameter) => true;
 
     // GH-3907: name the store rather than resolving one. AddMarten/AddPolecat without
     // IntegrateWithWolverine() registers no persistence strategy, and this attribute has always

--- a/src/Persistence/Wolverine.Polecat/ReadAggregateAttribute.cs
+++ b/src/Persistence/Wolverine.Polecat/ReadAggregateAttribute.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Polecat.Persistence.Sagas;
@@ -22,6 +23,15 @@ public class ReadAggregateAttribute : ReadModelAttribute
     public ReadAggregateAttribute(string argumentName) : base(argumentName)
     {
     }
+
+    /// <summary>
+    ///     GH-3929: <c>[ReadAggregate]</c> shipped long before the nullability inference this release added
+    ///     to <see cref="ReadModelAttribute" />, so it keeps its original unconditional default. Inheriting
+    ///     the inference would silently drop the not-found guard from existing
+    ///     <c>[ReadAggregate] Thing? thing</c> handlers. Say <c>Required = false</c> explicitly, or use
+    ///     <c>[ReadModel]</c>, to opt out.
+    /// </summary>
+    protected override bool DefaultRequired(ParameterInfo parameter) => true;
 
     // GH-3907: name the store rather than resolving one. AddMarten/AddPolecat without
     // IntegrateWithWolverine() registers no persistence strategy, and this attribute has always

--- a/src/Persistence/Wolverine.Polecat/WriteAggregateAttribute.cs
+++ b/src/Persistence/Wolverine.Polecat/WriteAggregateAttribute.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using Wolverine.Polecat.Persistence.Sagas;
@@ -40,6 +41,15 @@ public class WriteAggregateAttribute : WriteModelAttribute
         get => (ConcurrencyStyle)(int)base.LoadStyle;
         set => base.LoadStyle = (ModelConcurrencyStyle)(int)value;
     }
+
+    /// <summary>
+    ///     GH-3929: <c>[WriteAggregate]</c> shipped long before the nullability inference GH-3916 added to
+    ///     <see cref="WriteModelAttribute" />, so it keeps its original unconditional default. Inheriting
+    ///     the inference would silently drop the not-found guard from existing
+    ///     <c>[WriteAggregate] Thing? thing</c> handlers, which then run against a model that was never
+    ///     loaded. Say <c>Required = false</c> explicitly, or use <c>[WriteModel]</c>, to opt out.
+    /// </summary>
+    protected override bool DefaultRequired(ParameterInfo parameter) => true;
 
     // GH-3907: name the store rather than resolving one. AddMarten/AddPolecat without
     // IntegrateWithWolverine() registers no persistence strategy, and this attribute has always

--- a/src/Wolverine/Persistence/EventSourcing/ReadModelAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/ReadModelAttribute.cs
@@ -31,6 +31,7 @@ namespace Wolverine.Persistence.EventSourcing;
 public class ReadModelAttribute : WolverineParameterAttribute, IDataRequirement, IRefersToAggregate
 {
     private OnMissing? _onMissing;
+    private bool? _required;
 
     public ReadModelAttribute()
     {
@@ -43,10 +44,39 @@ public class ReadModelAttribute : WolverineParameterAttribute, IDataRequirement,
     }
 
     /// <summary>
-    /// Is the existence of this aggregate required for the rest of the handler action or HTTP endpoint
-    /// execution to continue? Default is true.
+    ///     Should Wolverine stop the handler when the model cannot be found? Defaults to <b>the opposite of
+    ///     the parameter's nullable annotation</b>: <c>Order order</c> is required, <c>Order? order</c> is not.
     /// </summary>
-    public bool Required { get; set; } = true;
+    /// <remarks>
+    ///     GH-3929, matching what GH-3916 did for <see cref="WriteModelAttribute" />. Before this the
+    ///     default was an unconditional <c>true</c>, so a parameter annotated nullable — the author saying
+    ///     "I will handle absence" — still generated an <c>EntityIsNotNullGuard</c> and a
+    ///     <c>HandlerContinuation.Stop</c>, making the handler's own null branch dead code. An explicit
+    ///     <c>Required</c> at the call site still wins over the annotation.
+    ///     <para>
+    ///     <c>[ReadAggregate]</c> keeps the old unconditional default — see <see cref="DefaultRequired" />.
+    ///     </para>
+    /// </remarks>
+    public bool Required
+    {
+        get => _required ?? true;
+        set => _required = value;
+    }
+
+    /// <summary>
+    ///     The value <see cref="Required" /> takes when the call site did not set it. Defaults to the
+    ///     opposite of the parameter's nullable annotation.
+    /// </summary>
+    /// <remarks>
+    ///     GH-3929: virtual so that a store's own spelling of this workflow can keep the default it
+    ///     shipped with. <c>[ReadAggregate]</c> predates the nullability inference and overrides this to
+    ///     an unconditional <c>true</c>, because changing the default under existing code is a silent
+    ///     behaviour change that only shows up at runtime.
+    /// </remarks>
+    protected virtual bool DefaultRequired(ParameterInfo parameter)
+    {
+        return !ParameterNullability.IsNullableAnnotated(parameter);
+    }
 
     public string MissingMessage { get; set; } = null!;
 
@@ -60,6 +90,10 @@ public class ReadModelAttribute : WolverineParameterAttribute, IDataRequirement,
         GenerationRules rules)
     {
         _onMissing ??= container.GetInstance<WolverineOptions>().EntityDefaults.OnMissing;
+
+        // GH-3929: only when the call site said nothing. An explicit [ReadModel(Required = true)] on a
+        // nullable parameter still gets its guard - loudly wrong beats silently overridden.
+        _required ??= DefaultRequired(parameter);
 
         var provider = ResolveEventSourcingProvider(rules, container, parameter.ParameterType);
 

--- a/src/Wolverine/Persistence/EventSourcing/WriteModelAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/WriteModelAttribute.cs
@@ -105,7 +105,7 @@ public class WriteModelAttribute : WolverineParameterAttribute, IDataRequirement
 
         // GH-3916: only when the call site said nothing. An explicit [WriteModel(Required = true)] on a
         // nullable parameter still gets its guard - loudly wrong beats silently overridden.
-        _required ??= !isNullableAnnotated(parameter);
+        _required ??= DefaultRequired(parameter);
 
         var aggregateType = parameter.ParameterType;
         if (aggregateType.IsNullable())
@@ -227,17 +227,19 @@ public class WriteModelAttribute : WolverineParameterAttribute, IDataRequirement
         return null;
     }
 
-    // A parameter is nullable when it's a Nullable<T> value type or a reference type whose nullable
-    // annotation context marks it nullable. A fresh NullabilityInfoContext per call keeps this
-    // thread-safe across concurrent chain compilation.
-    private static bool isNullableAnnotated(ParameterInfo parameter)
+    /// <summary>
+    ///     The value <see cref="Required" /> takes when the call site did not set it. Defaults to the
+    ///     opposite of the parameter's nullable annotation (GH-3916).
+    /// </summary>
+    /// <remarks>
+    ///     GH-3929: virtual so that a store's own spelling of this workflow can keep the default it
+    ///     shipped with. <c>[WriteAggregate]</c> predates the nullability inference and overrides this to
+    ///     an unconditional <c>true</c>, because changing the default under existing code is a silent
+    ///     behaviour change that only shows up at runtime.
+    /// </remarks>
+    protected virtual bool DefaultRequired(ParameterInfo parameter)
     {
-        if (parameter.ParameterType.IsValueType)
-        {
-            return parameter.ParameterType.IsNullable();
-        }
-
-        return new NullabilityInfoContext().Create(parameter).WriteState == NullabilityState.Nullable;
+        return !ParameterNullability.IsNullableAnnotated(parameter);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2075",

--- a/src/Wolverine/Persistence/ParameterNullability.cs
+++ b/src/Wolverine/Persistence/ParameterNullability.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+///     Reads a parameter's nullable annotation, which several persistence attributes use as the default
+///     for <see cref="IDataRequirement.Required" />.
+/// </summary>
+/// <remarks>
+///     GH-3916 introduced this on <c>WriteModelAttribute</c>; GH-3929 gave <c>ReadModelAttribute</c> the
+///     same behaviour, so it lives here rather than being copied a second time.
+/// </remarks>
+internal static class ParameterNullability
+{
+    /// <summary>
+    ///     A parameter is nullable when it is a <c>Nullable&lt;T&gt;</c> value type, or a reference type
+    ///     whose nullable annotation context marks it nullable.
+    /// </summary>
+    /// <remarks>
+    ///     In an assembly compiled with <c>&lt;Nullable&gt;disable&lt;/Nullable&gt;</c> a reference type
+    ///     parameter reads as <see cref="NullabilityState.Unknown" /> rather than
+    ///     <see cref="NullabilityState.Nullable" />, so this returns <c>false</c> and callers keep their
+    ///     historical "required" default. Nullability inference is therefore a no-op for those codebases
+    ///     rather than a silent behaviour change.
+    ///     <para>
+    ///     A fresh <see cref="NullabilityInfoContext" /> per call keeps this thread-safe across concurrent
+    ///     chain compilation.
+    ///     </para>
+    /// </remarks>
+    internal static bool IsNullableAnnotated(ParameterInfo parameter)
+    {
+        if (parameter.ParameterType.IsValueType)
+        {
+            return parameter.ParameterType.IsNullable();
+        }
+
+        return new NullabilityInfoContext().Create(parameter).WriteState == NullabilityState.Nullable;
+    }
+}


### PR DESCRIPTION
Closes #3929. Includes the 6.27.1 version bump so the regression below spends one CI cycle rather than two.

## The regression, which is the urgent half

`WriteAggregateAttribute` derives from `WriteModelAttribute` and overrides neither `Modify` nor `Required`, so it inherited GH-3916's nullability inference wholesale in **6.27.0**. But it is not a new attribute:

| attribute | first commit |
|---|---|
| `[ReadAggregate]` (Marten) | `119df455d` 2025-02-28 |
| `[WriteAggregate]` (Marten) | `942007beb` 2025-07-28 |
| `ReadModelAttribute` (core) | `41e6c9f44` 2026-08-12 |

So an existing `[WriteAggregate] Account? account` handler silently lost its not-found guard in 6.27.0 and now runs against a model that was never loaded — for a *write* model that means appending events against a stream that wasn't fetched.

**Why nothing caught it:** the only `[WriteAggregate]` + nullable usage in the tree (`tenant_partitioned_aggregate_matrix.cs:231`) already sets `Required = false` explicitly, so no test exercised the implicit case. CI was green, and the 6.27.0 release notes attribute the change to `[WriteModel]` alone.

## The fix

A virtual `DefaultRequired(ParameterInfo)` hook on both core attributes. `[WriteAggregate]` and `[ReadAggregate]` override it to an unconditional `true` in Marten, Polecat and Fisher, restoring pre-6.27.0 behaviour exactly.

## GH-3929 proper

`[ReadModel]` now infers `Required` from the parameter's nullable annotation, matching `[WriteModel]`, with an explicit `Required` at the call site still winning. That closes the write/read asymmetry #3914 exists to remove — without changing `[ReadAggregate]`, which is the point of the hook.

## What is deliberately *not* changed

- **`[Entity]`** — the oldest and most widely used of the three, heavily in HTTP endpoints where `Required = true` + `OnMissing.Simple404` is the documented 404 behaviour. Loosening it would turn a clean 404 into a runtime NRE in an endpoint body.
- **`[DeciderFunction]` and `[DcbModel]`** — both already default `Required` to `false`, and correctly so: their model is folded out of an event stream or boundary and is always materialized, so absence is not the normal case. Seeding these from nullability would *tighten* `false → true` and could stop messages that process fine today.

## Two things worth knowing

- `isNullableAnnotated` moves to a shared `ParameterNullability` helper rather than being copied into `[ReadModel]`. (`Wolverine.Http/CodeGen/AsParametersBindingFrame.cs` still carries its own copy plus a property variant — left alone to keep this release tight.)
- In an assembly compiled with `<Nullable>disable</Nullable>` a reference-type parameter reads `NullabilityState.Unknown`, not `Nullable`. Verified empirically. So `Required` stays `true` and the inference is a no-op for those projects rather than a silent behaviour change — now documented.

## Tests

`read_model_required_3929` (Marten, behavioural): inference, explicit-wins, non-nullable, plus **regression guards** for `[ReadAggregate]` and `[WriteAggregate]`. Removing the pin fails exactly those two and nothing else — verified.

`aggregate_attributes_pin_required_3929` (Polecat, Fisher): reflection guards asserting the override exists, so a store added later cannot silently inherit the inference.

The absence of exactly this coverage is why the 6.27.0 regression shipped green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC
