### PR TITLE
Support the `DateTimeOffset now` convention in Wolverine.HTTP

### DIFF
--- a/docs/guide/handlers/index.md
+++ b/docs/guide/handlers/index.md
@@ -238,7 +238,7 @@ The first argument always has to be the message type, but after that, you can ac
 * `Envelope` from Wolverine to interrogate metadata about the current message
 * `IMessageContext` or `IMessageBus` from Wolverine scoped to the current message being handled
 * `CancellationToken` for the current message execution to check for timeouts or system shut down
-* `DateTime now` or `DateTimeOffset now` for the current time. Don't laugh, I like doing this for testability's sake.
+* `DateTime now` or `DateTimeOffset now` for the current time. Don't laugh, I like doing this for testability's sake. Wolverine.HTTP endpoints [support this same convention](/guide/http/endpoints#the-current-time) as of 6.28.
 
 Some add ons or middleware add other possibilities as well.
 

--- a/docs/guide/http/endpoints.md
+++ b/docs/guide/http/endpoints.md
@@ -72,6 +72,7 @@ to determine how to source that parameter at runtime:
 | `IMessageBus`                              | Creates a new Wolverine message bus object                                                                              |
 | `HttpContext` or its members               | See the section below on accessing the HttpContext                                                                      |
 | Parameter name matches a route parameter   | See the [routing page](/guide/http/routing) for more information                                                        |
+| `DateTime now` or `DateTimeOffset now`     | The current UTC time. See [the current time](#the-current-time) below                                                   |
 | Decorated with `[FromHeader]`              | See [working with headers](/guide/http/headers) for more information                                                    |
 | `string`, `int`, `Guid`, etc.              | All other "simple" .NET types are assumed to be [query string values](/guide/http/querystring) |
 | The first concrete, "not simple" parameter | Deserializes the HTTP request body as JSON to this type                                                                 |
@@ -237,6 +238,33 @@ they are simply not described in the OpenAPI 3.1 output. First-class OpenAPI doc
 the underlying OpenAPI stack emits 3.2.
 :::
 
+## The Current Time <Badge type="tip" text="6.28" />
+
+A parameter named `now` of type `DateTime` or `DateTimeOffset` is filled with the current UTC time rather
+than being bound from the request. This is the same convention
+[message handlers have always had](/guide/handlers/#message-handler-parameters), and it exists for
+testability's sake — the endpoint stays a pure function of its inputs instead of reaching for a static clock:
+
+```cs
+[WolverineGet("/api/orders/{id}/age")]
+public static TimeSpan GetAge([Entity] Order order, DateTimeOffset now)
+    => now - order.PlacedAt;
+```
+
+The value comes from whatever `IVariableSource` is registered for the type in
+`WolverineOptions.CodeGeneration.Sources`, so HTTP endpoints and message handlers cannot drift, and a custom
+clock registered as a variable source is honored by both.
+
+::: warning
+The convention is keyed on the parameter being **named** `now`, not on its type alone. That is deliberate: in
+an HTTP endpoint a `DateTimeOffset` is otherwise an ordinary [query string value](/guide/http/querystring),
+and `DateTimeOffset from` / `DateTimeOffset to` are far too common to hijack. Only `now` is special.
+
+An explicit route argument still wins — `[WolverineGet("/report/{now}")]` binds `now` from the route, because
+a parameter the author spelled out in the route is not a request for the clock. So do `[FromRoute]`,
+`[FromQuery]`, and `[FromHeader]`, which are all resolved before this convention.
+:::
+
 ## JSON Handling
 
 See [JSON serialization for more information](/guide/http/json)
@@ -395,6 +423,13 @@ public static string GetNow(DateTimeOffset now) // using the custom parameter st
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/CustomParameterEndpoint.cs#L7-L14' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_http_endpoint_receiving_now' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+::: info
+As of 6.28 a `now` parameter is [handled by Wolverine out of the box](#the-current-time), so this particular
+strategy is no longer necessary — it is kept here purely because it is a small, complete illustration of the
+plugin interface. It still works: strategies registered through `AddParameterHandlingStrategy()` are placed
+ahead of every built-in strategy, which is also how you would override built-in behavior deliberately.
+:::
 
 ## Http Endpoint / Message Handler Combo
 

--- a/src/Http/Wolverine.Http.Tests/now_parameter_convention.cs
+++ b/src/Http/Wolverine.Http.Tests/now_parameter_convention.cs
@@ -1,0 +1,146 @@
+using Alba;
+using IntegrationTests;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests;
+
+// See NowConventionEndpoints. Message handlers have always supplied DateTimeOffset.UtcNow for a parameter
+// named `now` through JasperFx's NowTimeVariableSource; these prove the same convention now reaches HTTP
+// endpoints, and -- just as importantly -- that it did not eat ordinary date query string parameters on
+// the way in.
+public class now_parameter_convention : IAsyncLifetime
+{
+    private IAlbaHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        // Marten is here only because assembly wide endpoint discovery also picks up the [WriteAggregate] /
+        // [Entity] endpoints that live alongside these, and those need a document store to codegen against.
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(Servers.PostgresConnectionString);
+            opts.DatabaseSchemaName = "now_convention";
+        }).IntegrateWithWolverine().UseLightweightSessions();
+
+        builder.Host.UseWolverine(opts => opts.Discovery.IncludeAssembly(GetType().Assembly));
+        builder.Services.AddWolverineHttp();
+
+        theHost = await AlbaHost.For(builder, app =>
+        {
+            app.UseDeveloperExceptionPage();
+            app.MapWolverineEndpoints();
+        });
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (theHost != null)
+        {
+            await theHost.StopAsync();
+            theHost.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task datetimeoffset_now_is_supplied_as_utc_now()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/now/offset");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var now = DateTimeOffset.Parse(await result.ReadAsTextAsync());
+
+        now.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-5));
+        now.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow.AddSeconds(5));
+        now.Offset.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task datetime_now_is_supplied_too()
+    {
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/now/datetime");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // RoundtripKind so the trailing Z is preserved as Kind.Utc rather than being converted to local time,
+        // which would make the comparison against DateTime.UtcNow below wrong by the machine's offset.
+        var now = DateTime.Parse(await result.ReadAsTextAsync(), null,
+            System.Globalization.DateTimeStyles.RoundtripKind);
+
+        now.Kind.ShouldBe(DateTimeKind.Utc);
+        now.ShouldBeGreaterThan(DateTime.UtcNow.AddMinutes(-5));
+        now.ShouldBeLessThanOrEqualTo(DateTime.UtcNow.AddMinutes(5));
+    }
+
+    [Fact]
+    public async Task the_name_match_is_case_insensitive()
+    {
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/now/capitalized");
+            x.StatusCodeShouldBeOk();
+        });
+
+        (await result.ReadAsTextAsync()).ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_ordinary_date_query_parameter_still_binds_from_the_query_string()
+    {
+        // The regression this convention could easily have caused. IVariableSource matches on TYPE alone,
+        // so applying it without the name gate would have handed this endpoint UtcNow and silently ignored
+        // what the caller actually asked for.
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/now/range?from=2020-01-01T00:00:00Z&to=2020-12-31T00:00:00Z");
+            x.StatusCodeShouldBeOk();
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("2020-01-01 to 2020-12-31");
+    }
+
+    [Fact]
+    public async Task an_explicit_now_route_argument_still_wins()
+    {
+        // RouteParameterStrategy runs before this one on purpose -- a route argument the author spelled out
+        // is not a request for the clock.
+        var result = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/now/route/2020-06-01T00:00:00Z");
+            x.StatusCodeShouldBeOk();
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("2020-06-01");
+    }
+}
+
+public class NowConventionEndpoints
+{
+    [WolverineGet("/now/offset")]
+    public static string GetOffset(DateTimeOffset now) => now.ToString("O");
+
+    [WolverineGet("/now/datetime")]
+    public static string GetDateTime(DateTime now) => now.ToString("O");
+
+    [WolverineGet("/now/capitalized")]
+    public static string GetCapitalized(DateTimeOffset Now) => Now.ToString("O");
+
+    [WolverineGet("/now/range")]
+    public static string GetRange(DateTimeOffset from, DateTimeOffset to)
+        => $"{from:yyyy-MM-dd} to {to:yyyy-MM-dd}";
+
+    [WolverineGet("/now/route/{now}")]
+    public static string GetFromRoute(DateTimeOffset now) => now.ToString("yyyy-MM-dd");
+}

--- a/src/Http/Wolverine.Http/CodeGen/CurrentTimeParameterStrategy.cs
+++ b/src/Http/Wolverine.Http/CodeGen/CurrentTimeParameterStrategy.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+
+namespace Wolverine.Http.CodeGen;
+
+/// <summary>
+///     Supplies the current UTC time for an endpoint parameter named <c>now</c>, matching the long standing
+///     message handler convention documented at <c>/guide/handlers/#the-current-time</c>. The value itself comes
+///     from whatever <see cref="IVariableSource" /> is registered for the parameter's type -- normally JasperFx's
+///     <c>NowTimeVariableSource</c>, added to <c>WolverineOptions.CodeGeneration.Sources</c> at bootstrapping --
+///     so HTTP and message handlers cannot drift, and a custom clock registered as a variable source is honored
+///     by both.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Gated on the parameter <b>name</b> on purpose. <see cref="IVariableSource.Matches" /> takes only a
+///         <see cref="Type" />, and in an HTTP endpoint a bare <c>DateTimeOffset</c> is an entirely ordinary query
+///         string parameter -- <c>DateTimeOffset from</c>, <c>DateTimeOffset to</c>, <c>DateTimeOffset asOf</c>.
+///         Applying the variable source by type alone would silently hand those endpoints <c>UtcNow</c> instead of
+///         the caller's value, with nothing to notice at compile time or run time. A message handler has no such
+///         competition, which is why the type-only match is safe there and not here.
+///     </para>
+///     <para>
+///         Registered directly after <see cref="RouteParameterStrategy" /> so that an explicit <c>{now}</c> route
+///         argument still wins, as do the explicit <c>[FromRoute]</c> / <c>[FromQuery]</c> / <c>[FromHeader]</c>
+///         attribute strategies, which run earlier still.
+///     </para>
+/// </remarks>
+internal class CurrentTimeParameterStrategy : IParameterStrategy
+{
+    private readonly GenerationRules _rules;
+
+    public CurrentTimeParameterStrategy(GenerationRules rules)
+    {
+        _rules = rules;
+    }
+
+    public bool TryMatch(HttpChain chain, IServiceContainer container, ParameterInfo parameter,
+        out Variable? variable)
+    {
+        if (!string.Equals(parameter.Name, "now", StringComparison.OrdinalIgnoreCase))
+        {
+            variable = null;
+            return false;
+        }
+
+        foreach (var source in _rules.Sources)
+        {
+            if (source.Matches(parameter.ParameterType))
+            {
+                variable = source.Create(parameter.ParameterType);
+                return true;
+            }
+        }
+
+        variable = null;
+        return false;
+    }
+}

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -41,6 +41,12 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         _options = options;
         Container = container;
         Rules = _options.CodeGeneration;
+
+        // Added here rather than in the _strategies initializer because it needs Rules, which is only assigned
+        // above. Positioned relative to RouteParameterStrategy instead of at a fixed index so that inserting
+        // anything else into the list later cannot silently change which strategy wins for a `now` parameter.
+        var afterRouteArguments = _strategies.FindIndex(x => x is RouteParameterStrategy) + 1;
+        _strategies.Insert(afterRouteArguments, new CurrentTimeParameterStrategy(Rules));
     }
 
     internal IServiceContainer Container { get; }


### PR DESCRIPTION
Message handlers have long supplied `DateTimeOffset.UtcNow` for a parameter named `now` — documented at `/guide/handlers/#message-handler-parameters` as *"`DateTime now` or `DateTimeOffset now` for the current time. Don't laugh, I like doing this for testability's sake."* Wolverine.HTTP did not, so the same parameter on an endpoint silently did something else entirely.

```csharp
[WolverineGet("/api/orders/{id}/age")]
public static TimeSpan GetAge([Entity] Order order, DateTimeOffset now)
    => now - order.PlacedAt;   // now was bound from the query string, not the clock
```

## Why it didn't work

`NowTimeVariableSource` is already registered into `WolverineOptions.CodeGeneration.Sources` (`WolverineOptions.cs:256`), and `HttpGraph.Rules` **is** that same `GenerationRules` object — so the variable source was always reachable from HTTP. Nothing ever asked it.

`HttpGraph.ApplyParameterMatching` resolves endpoint parameters by walking an ordered `IParameterStrategy` list (`HttpGraph.ParameterMatching.cs:13`) and stopping at the first match. `QueryStringParameterStrategy` claims `DateTimeOffset` because it is parseable, so `now` bound from the query string and the walk never reached anything else. No error, no warning — the endpoint just got `default` on every request that didn't pass `?now=`.

## The fix

A new `CurrentTimeParameterStrategy` that consults the registered `IVariableSource`s and returns whatever one of them supplies for the parameter's type. The value still comes from `NowTimeVariableSource`, so HTTP and message handlers cannot drift, and a custom clock registered as a variable source is honored by both.

It is inserted **directly after `RouteParameterStrategy`**, positioned by `FindIndex` rather than a literal index so a future insertion into that list cannot silently change which strategy wins. That placement means an explicit `{now}` route argument still wins, as do `[FromRoute]` / `[FromQuery]` / `[FromHeader]`, which are resolved earlier still.

## The one judgment call: gated on the parameter *name*

`IVariableSource.Matches` takes only a `Type`. Applying it to HTTP on type alone — the literal reading of "apply the variable source to HTTP" — would have matched **every** `DateTimeOffset` parameter on every endpoint, including the extremely common `DateTimeOffset from` / `to` / `asOf` query parameters. Those endpoints would have silently started receiving `UtcNow` instead of what the caller asked for, with nothing failing at compile time or run time to reveal it.

So the HTTP side additionally requires the parameter to be named `now` (case-insensitive), which is exactly how the convention is already documented. A message handler has no such competition for a bare `DateTimeOffset`, which is why the type-only match remains correct there. `an_ordinary_date_query_parameter_still_binds_from_the_query_string` in the test suite pins this.

## Note on the existing `NowParameterStrategy` sample

`WolverineWebApi/Samples/CustomParameter.cs` contains a public `NowParameterStrategy` that the `IParameterStrategy` docs use as their worked example — its whole premise was "HTTP doesn't support `now`, here's how you'd add it."

- The new built-in is named `CurrentTimeParameterStrategy` so there are not two same-named strategies in the tree.
- The sample still wins where it is registered: `AddParameterHandlingStrategy()` routes to `InsertParameterStrategy`, which inserts at index 0, ahead of every built-in. No behavior change for anyone already using it.
- The docs section now carries a note that the convention is built in as of 6.28 and the sample is kept because it remains a small, complete illustration of the plugin interface — and of how to deliberately override built-in behavior.

## Testing

Five new tests in `now_parameter_convention.cs`:

- `DateTimeOffset now` is supplied as UTC now, with a zero offset
- `DateTime now` too, asserting `Kind == Utc` on the round trip
- the name match is case-insensitive
- **an ordinary `from`/`to` date query parameter still binds from the query string** — the regression this could easily have caused
- an explicit `{now}` route argument still wins

Full `Wolverine.Http.Tests` suite green, and `dotnet build wolverine.slnx -c Release -f net9.0` clean.

## Docs

- `docs/guide/http/endpoints.md` — a new "The Current Time" section, a row in the *Legal Endpoint Signatures* precedence table (placed where it actually sits in the order, between route arguments and `[FromHeader]`), and the note on the now-redundant sample.
- `docs/guide/handlers/index.md` — the existing bullet now points at the HTTP equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC
