### PR TITLE
Add [All] and [Queryable] parameter attributes, and fix event operations transactions

### DIFF
--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -20,6 +20,9 @@ These all speak one vocabulary, and none of it names your database:
 | An event sourced model spanning several streams, matched by tag | `[DcbModel]` |
 | To write a document back | `Storage.Store` / `Insert` / `Update` / `Delete` / `Nothing<T>` |
 | To append events to a stream | [`Storage.AppendEvents` / `Storage.StartStream`](/guide/handlers/side-effects#event-side-effects) |
+| Every document of a type | [`[All]`](#reading-every-document-of-a-type) |
+| The store's raw `IQueryable<T>` | [`[Queryable]`](#the-raw-iqueryable-escape-hatch) |
+| The event store's write API | [`IEventStoreOperations`](#injecting-the-event-store-operations) |
 
 ## Automatically Loading Entities to Method Parameters <Badge type="tip" text="3.6" />
 
@@ -257,6 +260,99 @@ runtime. Load the value explicitly in a `Before` method instead.
 On Fisher, a document table is created lazily on first write, and querying a type that has never been
 written throws rather than returning nothing. That applies to any Fisher query, not just this attribute,
 but it is worth knowing if a brand new deployment hits a `[FirstOrDefault]` before anything is stored.
+:::
+
+## Reading Every Document of a Type <Badge type="tip" text="6.28" />
+
+Where [`[FirstOrDefault]`](#reading-the-first-of-a-type) gives you one, `[All]` gives you all of them —
+the equivalent of `await session.Query<T>().ToListAsync()`, resolved through whichever provider owns the
+type:
+
+```cs
+[WolverineGet("/api/alerts/config/services")]
+public static IReadOnlyList<ServiceAlertOverrides> GetAll([All] IReadOnlyList<ServiceAlertOverrides> overrides)
+    => overrides;
+```
+
+* The parameter **must** be declared as `IReadOnlyList<T>`. Anything else fails with a message naming the
+  parameter and what to change it to. That is the shape Marten and RavenDb return from `ToListAsync()`
+  natively, and EF Core's `List<T>` converts to it implicitly, so every provider assigns straight across
+  with no copying.
+* An empty table yields an empty list, never `null` — so there is no "missing" case and no `OnMissing`.
+* The query is unfiltered. This is aimed at **small reference and configuration collections**; reading an
+  entire table into memory is a decision, not a default.
+* Supported by Marten, Polecat, Fisher, RavenDb and EF Core. **CosmosDb is not supported**, for the same
+  reason `[FirstOrDefault]` is not — see that section's warning.
+
+## The Raw `IQueryable` Escape Hatch <Badge type="tip" text="6.28" />
+
+`[Queryable]` injects the persistence mechanism's own `IQueryable<T>` — Marten's `session.Query<T>()`,
+EF Core's `dbContext.Set<T>()`, and so on — into a message handler, HTTP endpoint, or middleware method:
+
+```cs
+[WolverineGet("/api/alerts/recent")]
+public static async Task<IReadOnlyList<Alert>> GetRecent(
+    [Queryable] IQueryable<Alert> alerts, CancellationToken token)
+{
+    return await alerts
+        .Where(x => x.Level == "high")
+        .OrderByDescending(x => x.RaisedAt)
+        .Take(20)
+        .ToListAsync(token);
+}
+```
+
+::: danger Read this before using `[Queryable]`
+This is the escape hatch, and it is a sharp one. Every other attribute on this page describes *what* you
+want and leaves the store to satisfy it. This one hands you a provider-specific LINQ implementation.
+
+**It is not portable in practice, even though the type is.** Marten, EF Core, RavenDb and CosmosDb LINQ
+providers support very different subsets of LINQ. A query that compiles and runs correctly on one can
+throw at *runtime* on another. The concrete example that will catch you: **Marten 9 refuses synchronous
+LINQ execution outright**, so
+
+```cs
+var names = alerts.Where(x => x.Level == "high").ToArray();   // compiles everywhere
+```
+
+works on EF Core and throws `NotSupportedException: As of Marten 9.0, only asynchronous data access is
+supported` on Marten. **Always use the async LINQ operators** — `ToListAsync()`, `FirstOrDefaultAsync()`,
+`CountAsync()` — and pass the `CancellationToken`.
+
+**It reintroduces the coupling everything else here exists to remove**, and makes the method meaningfully
+harder to unit test — you can no longer hand it a list.
+
+**An unbounded query is easy to write by accident.** There is no paging, no limit, and no guard.
+
+**On CosmosDb especially:** Wolverine stores every user document in one shared container with no per-type
+discriminator, so an unfiltered queryable can surface documents of entirely other types deserialized as
+`T`. Filter on a discriminator of your own.
+:::
+
+Prefer `[All]` for a whole small collection, `[Entity]` for a single entity by identity, or a compiled
+query / `[FromQuerySpecification]` for anything filtered that you want to stay testable and portable.
+
+## Injecting the Event Store Operations <Badge type="tip" text="6.28" />
+
+A handler, HTTP endpoint, or middleware method can take `JasperFx.Events.IEventStoreOperations` (or the
+narrower write-only `IEventOperations`) directly as a parameter, and it resolves to the current session's
+`Events` on Marten, Polecat and Fisher alike:
+
+```cs
+public static void Handle(RecordLedgerEntry command, IEventStoreOperations events)
+{
+    events.StartStream(command.Id, new LedgerEntryRecorded(command.Note));
+}
+```
+
+Because it is the *current session's* operations, the appended events commit with the rest of the
+handler's work through the outbox — no `[Transactional]` needed. A handler marked
+`[Storage(typeof(IMyStore))]` gets that ancillary store's session instead.
+
+::: tip
+Returning [`Storage.AppendEvents()` / `Storage.StartStream()`](/guide/handlers/side-effects#event-side-effects)
+is the lower ceremony option and keeps the handler a pure function. Reach for the injected operations when
+you need something those two do not express.
 :::
 
 ## Event Sourced Models <Badge type="tip" text="6.26" />

--- a/src/Http/Wolverine.Http.Tests/event_store_operations_endpoint_parameter.cs
+++ b/src/Http/Wolverine.Http.Tests/event_store_operations_endpoint_parameter.cs
@@ -1,0 +1,86 @@
+using Alba;
+using IntegrationTests;
+using JasperFx.Events;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Marten;
+
+namespace Wolverine.Http.Tests;
+
+// The handler side of this is covered in MartenTests/event_store_operations_parameter. This is the HTTP
+// half, because HTTP chains reach AutoApplyTransactions through HttpGraph applying the shared
+// IChainPolicy list -- the same CanApply, but worth proving rather than reasoning about, since the whole
+// bug being fixed here is that CanApply did not recognize the event operations types and the append then
+// vanished with no error.
+public class event_store_operations_endpoint_parameter : IAsyncLifetime
+{
+    private IAlbaHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(Servers.PostgresConnectionString);
+            opts.DatabaseSchemaName = "event_store_ops_endpoint";
+        }).IntegrateWithWolverine().UseLightweightSessions();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(GetType().Assembly);
+            opts.Policies.AutoApplyTransactions();
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        theHost = await AlbaHost.For(builder, app =>
+        {
+            app.UseDeveloperExceptionPage();
+            app.MapWolverineEndpoints();
+        });
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (theHost != null)
+        {
+            await theHost.StopAsync();
+            theHost.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task the_endpoint_parameter_is_the_current_sessions_events()
+    {
+        var id = Guid.NewGuid();
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Url($"/api/ledger/{id}/opened");
+            x.StatusCodeShouldBe(204);
+        });
+
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession();
+        var events = await session.Events.FetchStreamAsync(id, token: TestContext.Current.CancellationToken);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<EndpointLedgerOpened>().Note.ShouldBe("opened");
+    }
+}
+
+public record EndpointLedgerOpened(string Note);
+
+public static class LedgerEndpoint
+{
+    // Takes the shared JasperFx contract directly -- valid on Marten, Polecat and Fisher alike
+    [WolverinePost("/api/ledger/{id}/opened"), EmptyResponse]
+    public static void Open(Guid id, IEventStoreOperations events)
+    {
+        events.StartStream(id, new EndpointLedgerOpened("opened"));
+    }
+}

--- a/src/Persistence/CosmosDbTests/queryable_attribute.cs
+++ b/src/Persistence/CosmosDbTests/queryable_attribute.cs
@@ -1,0 +1,117 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.CosmosDb;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+
+namespace CosmosDbTests;
+
+/// <summary>
+///     CosmosDb supports <c>[Queryable]</c> but deliberately NOT <c>[All]</c> or <c>[FirstOrDefault]</c>.
+/// </summary>
+/// <remarks>
+///     Wolverine's CosmosDb integration writes every user document into one shared <c>wolverine</c> container
+///     alongside its own envelopes and node records, with no per-type discriminator on user documents. So
+///     "every document of type T" cannot be asked for safely, which is why <c>[All]</c> refuses the provider
+///     outright. <c>[Queryable]</c> hands you the container's own queryable and leaves the filtering to you —
+///     which is exactly why the query below filters on a discriminating property of its own rather than
+///     trusting the container to hold only <c>CosmosWidget</c> documents.
+///
+///     This suite only runs on CI.
+/// </remarks>
+[Collection("cosmosdb")]
+public class queryable_attribute : IAsyncLifetime
+{
+    private readonly AppFixture _fixture;
+    private IHost _host = null!;
+
+    public queryable_attribute(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _fixture.ClearAll();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CosmosWidgetHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.UseCosmosDbPersistence(AppFixture.DatabaseName);
+                opts.Services.AddSingleton(_fixture.Client);
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task queryable_can_be_composed_against()
+    {
+        var container = _host.Services.GetRequiredService<Container>();
+        foreach (var (name, hits) in new[] { ("red", 5), ("green", 12), ("blue", 3) })
+        {
+            await container.UpsertItemAsync(new CosmosWidget
+            {
+                id = Guid.NewGuid().ToString(), docType = "widget", Name = name, Hits = hits
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new FindPopularCosmosWidgets(4));
+
+        tracked.Sent.SingleMessage<PopularCosmosWidgetsFound>().Names.ShouldBe(["green", "red"]);
+    }
+}
+
+public class CosmosWidget
+{
+    public string id { get; set; } = null!;
+
+    // The shared container holds Wolverine's own documents too, so user documents that intend to be queried
+    // as a set need a discriminator of their own. See the class remarks.
+    public string docType { get; set; } = null!;
+
+    public string Name { get; set; } = null!;
+    public int Hits { get; set; }
+}
+
+public record FindPopularCosmosWidgets(int Minimum);
+
+public record PopularCosmosWidgetsFound(string[] Names);
+
+[WolverineIgnore]
+public static class CosmosWidgetHandler
+{
+    public static async Task<PopularCosmosWidgetsFound> Handle(FindPopularCosmosWidgets command,
+        [Queryable] IQueryable<CosmosWidget> widgets, CancellationToken token)
+    {
+        // docType filter is NOT optional on Cosmos -- the container is shared
+        using var iterator = widgets
+            .Where(x => x.docType == "widget" && x.Hits >= command.Minimum)
+            .OrderByDescending(x => x.Hits)
+            .ToFeedIterator();
+
+        var names = new List<string>();
+        while (iterator.HasMoreResults)
+        {
+            foreach (var widget in await iterator.ReadNextAsync(token))
+            {
+                names.Add(widget.Name);
+            }
+        }
+
+        return new PopularCosmosWidgetsFound(names.ToArray());
+    }
+
+    public static void Handle(PopularCosmosWidgetsFound msg) { }
+}

--- a/src/Persistence/EfCoreTests/all_and_queryable_attributes.cs
+++ b/src/Persistence/EfCoreTests/all_and_queryable_attributes.cs
@@ -1,0 +1,144 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Persistence;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace EfCoreTests;
+
+// The EF Core proof for [All] and [Queryable]. No IEventStoreOperations coverage here -- EF Core is not an
+// event store, and its provider deliberately does not implement that seam.
+[Collection("sqlserver")]
+public class all_and_queryable_attributes : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(EfWidgetHandler));
+
+                opts.Services.AddDbContextWithWolverineIntegration<EfWidgetCatalogDbContext>(o =>
+                {
+                    o.UseSqlServer(Servers.SqlServerConnectionString);
+                });
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "all_queryable");
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EfWidgetCatalogDbContext>();
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        db.Widgets.RemoveRange(db.Widgets);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task seed()
+    {
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EfWidgetCatalogDbContext>();
+        await db.Widgets.AddRangeAsync(
+        [
+            new EfWidget { Id = Guid.NewGuid(), Name = "red", Hits = 5 },
+            new EfWidget { Id = Guid.NewGuid(), Name = "green", Hits = 12 },
+            new EfWidget { Id = Guid.NewGuid(), Name = "blue", Hits = 3 }
+        ], TestContext.Current.CancellationToken);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task all_gives_an_empty_list_when_nothing_is_stored()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountEfWidgets());
+        tracked.Sent.SingleMessage<EfWidgetsCounted>().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task all_supplies_every_row()
+    {
+        await seed();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountEfWidgets());
+        tracked.Sent.SingleMessage<EfWidgetsCounted>().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task queryable_can_be_composed_against()
+    {
+        await seed();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new FindPopularEfWidgets(4));
+        tracked.Sent.SingleMessage<PopularEfWidgetsFound>().Names.ShouldBe(["green", "red"]);
+    }
+}
+
+public class EfWidget
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public int Hits { get; set; }
+}
+
+public class EfWidgetCatalogDbContext : DbContext
+{
+    public EfWidgetCatalogDbContext(DbContextOptions<EfWidgetCatalogDbContext> options) : base(options) { }
+
+    public DbSet<EfWidget> Widgets { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.MapWolverineEnvelopeStorage();
+        modelBuilder.Entity<EfWidget>(map =>
+        {
+            map.ToTable("ef_widgets");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+            map.Property(x => x.Hits);
+        });
+    }
+}
+
+public record CountEfWidgets;
+public record FindPopularEfWidgets(int Minimum);
+public record EfWidgetsCounted(int Count);
+public record PopularEfWidgetsFound(string[] Names);
+
+[WolverineIgnore]
+public static class EfWidgetHandler
+{
+    public static EfWidgetsCounted Handle(CountEfWidgets command, [All] IReadOnlyList<EfWidget> widgets)
+        => new(widgets.Count);
+
+    // Async LINQ only, per the [Queryable] guidance -- EF Core would tolerate the sync form, Marten would not
+    public static async Task<PopularEfWidgetsFound> Handle(FindPopularEfWidgets command,
+        [Queryable] IQueryable<EfWidget> widgets, CancellationToken token)
+    {
+        var names = await widgets.Where(x => x.Hits >= command.Minimum)
+            .OrderByDescending(x => x.Hits)
+            .Select(x => x.Name)
+            .ToListAsync(token);
+
+        return new PopularEfWidgetsFound(names.ToArray());
+    }
+
+    public static void Handle(EfWidgetsCounted msg) { }
+    public static void Handle(PopularEfWidgetsFound msg) { }
+}

--- a/src/Persistence/FisherTests/all_queryable_and_event_store_operations.cs
+++ b/src/Persistence/FisherTests/all_queryable_and_event_store_operations.cs
@@ -1,0 +1,150 @@
+using JasperFx;
+using JasperFx.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Fisher;
+using Fisher.Linq;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Persistence;
+using Wolverine.Fisher;
+using Wolverine.Tracking;
+
+namespace FisherTests;
+
+// The Fisher proof for [All], [Queryable] and the IEventStoreOperations parameter. Deliberately one test
+// class rather than three: the Fisher suite are balanced by test-CLASS count because the per-class
+// Wolverine + Fisher + SQLite fixture cost dominates, so three classes here would cost three bootstraps
+// to assert what one can.
+public class all_queryable_and_event_store_operations : IAsyncLifetime
+{
+    private FisherTestDatabase theDatabase = null!;
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theDatabase = Servers.CreateDatabase("all_queryable");
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(FiCatalogHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddFisher(m =>
+                    {
+                        m.Connection(theDatabase.ConnectionString);
+                        m.AutoCreateSchemaObjects = AutoCreate.All;
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .IntegrateWithWolverine();
+            }).StartAsync();
+
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        theDatabase.Dispose();
+    }
+
+    private async Task seed()
+    {
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        session.Store(new FiWidget { Name = "red", Hits = 5 });
+        session.Store(new FiWidget { Name = "green", Hits = 12 });
+        session.Store(new FiWidget { Name = "blue", Hits = 3 });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task all_gives_an_empty_list_when_nothing_is_stored()
+    {
+        // Fisher creates a document table lazily on first write, and querying a type that has never been
+        // written throws "no such table" rather than returning nothing. That is a general Fisher trait, not
+        // something [All] introduces -- so establish the table then empty it, which is the state an
+        // application is actually in once it has used the type at all.
+        await using (var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            var seed = new FiWidget { Name = "temp", Hits = 1 };
+            session.Store(seed);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+            session.Delete(seed);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountFiWidgets());
+        tracked.Sent.SingleMessage<FiWidgetsCounted>().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task all_supplies_every_document()
+    {
+        await seed();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountFiWidgets());
+        tracked.Sent.SingleMessage<FiWidgetsCounted>().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task queryable_can_be_composed_against()
+    {
+        await seed();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new FindPopularFiWidgets(4));
+        tracked.Sent.SingleMessage<PopularFiWidgetsFound>().Names.ShouldBe(["green", "red"]);
+    }
+
+    [Fact]
+    public async Task event_store_operations_parameter_is_the_current_sessions_events()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new RecordFiLedgerEntry(id, "opening"));
+
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        var events = await session.Events.FetchStreamAsync(id, token: TestContext.Current.CancellationToken);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<FiLedgerEntryRecorded>().Note.ShouldBe("opening");
+    }
+}
+
+public class FiWidget
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+    public int Hits { get; set; }
+}
+
+public record CountFiWidgets;
+public record FindPopularFiWidgets(int Minimum);
+public record FiWidgetsCounted(int Count);
+public record PopularFiWidgetsFound(string[] Names);
+public record FiLedgerEntryRecorded(string Note);
+public record RecordFiLedgerEntry(Guid Id, string Note);
+
+[WolverineIgnore]
+public static class FiCatalogHandler
+{
+    public static FiWidgetsCounted Handle(CountFiWidgets command, [All] IReadOnlyList<FiWidget> widgets)
+        => new(widgets.Count);
+
+    // Async LINQ only -- see the [Queryable] warnings
+    public static async Task<PopularFiWidgetsFound> Handle(FindPopularFiWidgets command,
+        [Queryable] IQueryable<FiWidget> widgets, CancellationToken token)
+    {
+        var names = await widgets.Where(x => x.Hits >= command.Minimum)
+            .OrderByDescending(x => x.Hits)
+            .Select(x => x.Name)
+            .ToListAsync(token);
+
+        return new PopularFiWidgetsFound(names.ToArray());
+    }
+
+    public static void Handle(RecordFiLedgerEntry command, IEventStoreOperations events)
+        => events.StartStream(command.Id, new FiLedgerEntryRecorded(command.Note));
+
+    public static void Handle(FiWidgetsCounted msg) { }
+    public static void Handle(PopularFiWidgetsFound msg) { }
+}

--- a/src/Persistence/MartenTests/all_and_queryable_attributes.cs
+++ b/src/Persistence/MartenTests/all_and_queryable_attributes.cs
@@ -1,0 +1,122 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+// [All] and [Queryable] are storage agnostic in the same way [FirstOrDefault] is -- the handlers below are
+// what the Polecat, Fisher and EF Core suites run too.
+public class all_and_queryable_attributes : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(ColorHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "all_and_queryable";
+                }).IntegrateWithWolverine().UseLightweightSessions();
+            }).StartAsync();
+
+        await _host.DocumentStore().Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Color));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private Task seed() => _host.DocumentStore().BulkInsertDocumentsAsync(
+    [
+        new Color { Name = "red", Hits = 5 },
+        new Color { Name = "green", Hits = 12 },
+        new Color { Name = "blue", Hits = 3 }
+    ], cancellation: TestContext.Current.CancellationToken);
+
+    [Fact]
+    public async Task all_gives_an_empty_list_rather_than_null_when_nothing_is_stored()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountColors());
+
+        tracked.Sent.SingleMessage<ColorsCounted>().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task all_supplies_every_document()
+    {
+        await seed();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountColors());
+
+        tracked.Sent.SingleMessage<ColorsCounted>().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task queryable_can_be_composed_against()
+    {
+        await seed();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new FindPopularColors(4));
+
+        tracked.Sent.SingleMessage<PopularColorsFound>()
+            .Names.ShouldBe(["green", "red"]);
+    }
+}
+
+public class Color
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+    public int Hits { get; set; }
+}
+
+public record CountColors;
+
+public record FindPopularColors(int Minimum);
+
+public record ColorsCounted(int Count);
+
+public record PopularColorsFound(string[] Names);
+
+// [WolverineIgnore] so conventional discovery in other hosts in this assembly never picks these up
+[WolverineIgnore]
+public static class ColorHandler
+{
+    public static ColorsCounted Handle(CountColors command, [All] IReadOnlyList<Color> colors)
+        => new(colors.Count);
+
+    // The escape hatch: composing directly against the store's own LINQ provider.
+    //
+    // Note the Marten.ToListAsync() -- this handler is deliberately NOT portable, and that is the point of
+    // the warnings on [Queryable]. Marten 9 refuses synchronous LINQ execution outright ("only asynchronous
+    // data access is supported"), so the obvious .ToArray() that compiles fine and works on EF Core throws
+    // at RUNTIME here.
+    public static async Task<PopularColorsFound> Handle(FindPopularColors command,
+        [Queryable] IQueryable<Color> colors, CancellationToken token)
+    {
+        var names = await colors.Where(x => x.Hits >= command.Minimum)
+            .OrderByDescending(x => x.Hits)
+            .Select(x => x.Name)
+            .ToListAsync(token);
+
+        return new PopularColorsFound(names.ToArray());
+    }
+
+    public static void Handle(ColorsCounted msg) { }
+
+    public static void Handle(PopularColorsFound msg) { }
+}

--- a/src/Persistence/MartenTests/event_store_operations_parameter.cs
+++ b/src/Persistence/MartenTests/event_store_operations_parameter.cs
@@ -1,0 +1,81 @@
+using IntegrationTests;
+using JasperFx.Events;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+/// <summary>
+///     A handler or HTTP endpoint can take the shared <see cref="IEventStoreOperations" /> straight as a
+///     parameter, on Marten, Polecat and Fisher alike. In every case it resolves to
+///     <c>IDocumentSession.Events</c>.
+/// </summary>
+/// <remarks>
+///     The assertion that matters is not "the parameter was non-null" — it is that appending through the
+///     parameter lands in the database when the handler's transaction commits. That can only be true if the
+///     parameter is the <b>current session's</b> Events rather than some other session's, which is what makes
+///     this a real check on the variable source rather than a smoke test.
+/// </remarks>
+public class event_store_operations_parameter : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(LedgerHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "event_store_ops_param";
+                }).IntegrateWithWolverine().UseLightweightSessions();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_parameter_is_the_current_sessions_events()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new RecordLedgerEntry(id, "opening"));
+
+        // Committed by the handler's own transaction, which only happens if the parameter was this
+        // session's Events rather than a detached one
+        await using var session = _host.DocumentStore().LightweightSession();
+        var events = await session.Events.FetchStreamAsync(id, token: TestContext.Current.CancellationToken);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<LedgerEntryRecorded>().Note.ShouldBe("opening");
+    }
+}
+
+public record LedgerEntryRecorded(string Note);
+
+public record RecordLedgerEntry(Guid Id, string Note);
+
+[WolverineIgnore]
+public static class LedgerHandler
+{
+    // The shared JasperFx contract, not Marten's own derived IEventStoreOperations -- the same signature
+    // compiles and runs against Polecat and Fisher
+    public static void Handle(RecordLedgerEntry command, IEventStoreOperations events)
+    {
+        events.StartStream(command.Id, new LedgerEntryRecorded(command.Note));
+    }
+}

--- a/src/Persistence/PolecatTests/all_queryable_and_event_store_operations.cs
+++ b/src/Persistence/PolecatTests/all_queryable_and_event_store_operations.cs
@@ -1,0 +1,134 @@
+using IntegrationTests;
+using JasperFx.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Polecat.Linq;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Persistence;
+using Wolverine.Polecat;
+using Wolverine.Tracking;
+
+namespace PolecatTests;
+
+// The Polecat proof for [All], [Queryable] and the IEventStoreOperations parameter. Deliberately one test
+// class rather than three: the Polecat CI shards are balanced by test-CLASS count because the per-class
+// Wolverine + Polecat + SqlServer fixture cost dominates, so three classes here would cost three bootstraps
+// to assert what one can.
+public class all_queryable_and_event_store_operations : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(PcCatalogHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "pc_all_queryable";
+                }).IntegrateWithWolverine();
+            }).StartAsync();
+
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Advanced.Clean.DeleteAllDocumentsAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task seed()
+    {
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        session.Store(new PcWidget { Name = "red", Hits = 5 });
+        session.Store(new PcWidget { Name = "green", Hits = 12 });
+        session.Store(new PcWidget { Name = "blue", Hits = 3 });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task all_gives_an_empty_list_when_nothing_is_stored()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountPcWidgets());
+        tracked.Sent.SingleMessage<PcWidgetsCounted>().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task all_supplies_every_document()
+    {
+        await seed();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountPcWidgets());
+        tracked.Sent.SingleMessage<PcWidgetsCounted>().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task queryable_can_be_composed_against()
+    {
+        await seed();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new FindPopularPcWidgets(4));
+        tracked.Sent.SingleMessage<PopularPcWidgetsFound>().Names.ShouldBe(["green", "red"]);
+    }
+
+    [Fact]
+    public async Task event_store_operations_parameter_is_the_current_sessions_events()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new RecordPcLedgerEntry(id, "opening"));
+
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        var events = await session.Events.FetchStreamAsync(id, token: TestContext.Current.CancellationToken);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<PcLedgerEntryRecorded>().Note.ShouldBe("opening");
+    }
+}
+
+public class PcWidget
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+    public int Hits { get; set; }
+}
+
+public record CountPcWidgets;
+public record FindPopularPcWidgets(int Minimum);
+public record PcWidgetsCounted(int Count);
+public record PopularPcWidgetsFound(string[] Names);
+public record PcLedgerEntryRecorded(string Note);
+public record RecordPcLedgerEntry(Guid Id, string Note);
+
+[WolverineIgnore]
+public static class PcCatalogHandler
+{
+    public static PcWidgetsCounted Handle(CountPcWidgets command, [All] IReadOnlyList<PcWidget> widgets)
+        => new(widgets.Count);
+
+    // Async LINQ only -- see the [Queryable] warnings
+    public static async Task<PopularPcWidgetsFound> Handle(FindPopularPcWidgets command,
+        [Queryable] IQueryable<PcWidget> widgets, CancellationToken token)
+    {
+        var names = await widgets.Where(x => x.Hits >= command.Minimum)
+            .OrderByDescending(x => x.Hits)
+            .Select(x => x.Name)
+            .ToListAsync(token);
+
+        return new PopularPcWidgetsFound(names.ToArray());
+    }
+
+    public static void Handle(RecordPcLedgerEntry command, IEventStoreOperations events)
+        => events.StartStream(command.Id, new PcLedgerEntryRecorded(command.Note));
+
+    public static void Handle(PcWidgetsCounted msg) { }
+    public static void Handle(PopularPcWidgetsFound msg) { }
+}

--- a/src/Persistence/RavenDbTests/all_and_queryable_attributes.cs
+++ b/src/Persistence/RavenDbTests/all_and_queryable_attributes.cs
@@ -1,0 +1,127 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Persistence;
+using Wolverine.RavenDb;
+using Wolverine.Tracking;
+
+namespace RavenDbTests;
+
+// The RavenDb proof for [All] and [Queryable]. RavenDb has no event store integration in Wolverine, so
+// there is no IEventStoreOperations coverage here. This suite only runs on CI.
+[Collection("raven")]
+public class all_and_queryable_attributes : IAsyncLifetime
+{
+    private readonly DatabaseFixture _fixture;
+    private IDocumentStore _store = null!;
+    private IHost _host = null!;
+
+    public all_and_queryable_attributes(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = _fixture.StartRavenStore();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(RvWidgetHandler));
+                opts.Services.AddSingleton<IDocumentStore>(_store);
+                opts.UseRavenDbPersistence();
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task seedAndWait()
+    {
+        using (var session = _store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new RvWidget { Name = "red", Hits = 5 }, TestContext.Current.CancellationToken);
+            await session.StoreAsync(new RvWidget { Name = "green", Hits = 12 }, TestContext.Current.CancellationToken);
+            await session.StoreAsync(new RvWidget { Name = "blue", Hits = 3 }, TestContext.Current.CancellationToken);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // RavenDb indexes asynchronously, so wait for the writes to be queryable rather than racing them
+        for (var i = 0; i < 20; i++)
+        {
+            using var session = _store.OpenAsyncSession();
+            var count = await session.Query<RvWidget>()
+                .Customize(x => x.WaitForNonStaleResults())
+                .CountAsync(TestContext.Current.CancellationToken);
+            if (count == 3) return;
+            await Task.Delay(100.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task all_gives_an_empty_list_when_nothing_is_stored()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountRvWidgets());
+        tracked.Sent.SingleMessage<RvWidgetsCounted>().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task all_supplies_every_document()
+    {
+        await seedAndWait();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountRvWidgets());
+        tracked.Sent.SingleMessage<RvWidgetsCounted>().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task queryable_can_be_composed_against()
+    {
+        await seedAndWait();
+        var tracked = await _host.InvokeMessageAndWaitAsync(new FindPopularRvWidgets(4));
+        tracked.Sent.SingleMessage<PopularRvWidgetsFound>().Names.ShouldBe(["green", "red"]);
+    }
+}
+
+public class RvWidget
+{
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public int Hits { get; set; }
+}
+
+public record CountRvWidgets;
+public record FindPopularRvWidgets(int Minimum);
+public record RvWidgetsCounted(int Count);
+public record PopularRvWidgetsFound(string[] Names);
+
+[WolverineIgnore]
+public static class RvWidgetHandler
+{
+    public static RvWidgetsCounted Handle(CountRvWidgets command, [All] IReadOnlyList<RvWidget> widgets)
+        => new(widgets.Count);
+
+    // Async LINQ only, per the [Queryable] guidance
+    public static async Task<PopularRvWidgetsFound> Handle(FindPopularRvWidgets command,
+        [Queryable] IQueryable<RvWidget> widgets, CancellationToken token)
+    {
+        var names = await widgets.Where(x => x.Hits >= command.Minimum)
+            .OrderByDescending(x => x.Hits)
+            .Select(x => x.Name)
+            .ToListAsync(token);
+
+        return new PopularRvWidgetsFound(names.ToArray());
+    }
+
+    public static void Handle(RvWidgetsCounted msg) { }
+    public static void Handle(PopularRvWidgetsFound msg) { }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbPersistenceFrameProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
@@ -63,6 +64,16 @@ public class CosmosDbPersistenceFrameProvider : IPersistenceFrameProvider
     public Type DetermineSagaIdType(Type sagaType, IServiceContainer container)
     {
         return typeof(string);
+    }
+
+    public bool TryBuildQueryableFrame(Type elementType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var queryable = new QueryableFrame(elementType);
+        frame = queryable;
+        result = queryable.Result;
+        return true;
     }
 
     public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId)

--- a/src/Persistence/Wolverine.CosmosDb/Internals/QueryableFrame.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/QueryableFrame.cs
@@ -1,0 +1,53 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
+
+namespace Wolverine.CosmosDb.Internals;
+
+/// <summary>
+///     Exposes CosmosDb's raw <c>IQueryable&lt;T&gt;</c> for a
+///     <see cref="Wolverine.Persistence.QueryableAttribute" /> parameter.
+/// </summary>
+/// <remarks>
+///     <b>Read the caveat.</b> Wolverine's CosmosDb integration writes every user document into a single
+///     shared <c>wolverine</c> container -- the same one holding its own envelopes, node records and locks --
+///     with no per-type discriminator on user documents. A queryable obtained here is therefore scoped to that
+///     container, not to <c>T</c>, and an unfiltered query can deserialize documents of entirely other types
+///     as <c>T</c>. This is the same limitation that makes <c>[FirstOrDefault]</c> and <c>[All]</c> refuse to
+///     support CosmosDb at all; <c>[Queryable]</c> supports it because the whole point of the attribute is to
+///     hand you the store's own API, but you own the filtering.
+/// </remarks>
+internal class QueryableFrame : SyncFrame
+{
+    private readonly Type _elementType;
+    private Variable? _container;
+
+    public QueryableFrame(Type elementType)
+    {
+        _elementType = elementType;
+        Result = new Variable(typeof(IQueryable<>).MakeGenericType(elementType), $"queryable_{elementType.Name}",
+            this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"The raw CosmosDb IQueryable for {_elementType.NameInCode()}");
+        writer.WriteComment(
+            "NOTE: this container is shared across every document type; filter accordingly");
+        writer.Write(
+            $"{Result.VariableType.FullNameInCode()} {Result.Usage} = {_container!.Usage}.{nameof(Container.GetItemLinqQueryable)}<{_elementType.FullNameInCode()}>();");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _container = chain.FindVariable(typeof(Container));
+        yield return _container;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/AllFrame.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore.Codegen;
+
+/// <summary>
+///     Emits <c>await dbContext.Set&lt;T&gt;().ToListAsync(token)</c> for a
+///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
+/// </summary>
+/// <remarks>
+///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
+///     strings so that a rename in EF Core breaks this build instead of shipping a codegen failure that only
+///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+/// </remarks>
+internal class AllFrame : AsyncFrame
+{
+    private readonly Type _dbContextType;
+    private readonly Type _entityType;
+    private Variable? _context;
+    private Variable? _cancellation;
+
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType closes IReadOnlyList<>/IQueryable<> over the element type at CODEGEN time only. AOT consumers run pre-generated code in TypeLoadMode.Static, so this never fires in a published app. See the AOT guide.")]
+    public AllFrame(Type dbContextType, Type entityType)
+    {
+        _dbContextType = dbContextType;
+        _entityType = entityType;
+        Result = new Variable(typeof(IReadOnlyList<>).MakeGenericType(entityType), $"all_{entityType.Name}", this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+        writer.Write($"var {Result.Usage} = await {typeof(EntityFrameworkQueryableExtensions).FullNameInCode()}.{nameof(EntityFrameworkQueryableExtensions.ToListAsync)}({_context!.Usage}.{nameof(DbContext.Set)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _context = chain.FindVariable(_dbContextType);
+        yield return _context;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -128,6 +128,16 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
                    $"No known primary key for {sagaType.FullNameInCode()} in DbContext {context}");
     }
 
+    public bool TryBuildAllFrame(Type entityType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var all = new AllFrame(DetermineDbContextType(entityType, container), entityType);
+        frame = all;
+        result = all.Result;
+        return true;
+    }
+
     public bool TryBuildFirstOrDefaultFrame(Type entityType, IServiceContainer container,
         [NotNullWhen(true)] out Frame? frame,
         [NotNullWhen(true)] out Variable? result)
@@ -136,6 +146,16 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         var first = new FirstOrDefaultFrame(dbContextType, entityType);
         frame = first;
         result = first.Result;
+        return true;
+    }
+
+    public bool TryBuildQueryableFrame(Type elementType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var queryable = new QueryableFrame(DetermineDbContextType(elementType, container), elementType);
+        frame = queryable;
+        result = queryable.Result;
         return true;
     }
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/QueryableFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/QueryableFrame.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore.Codegen;
+
+/// <summary>
+///     Exposes EF Core's raw <c>IQueryable&lt;T&gt;</c> -- the <c>DbSet&lt;T&gt;</c> -- for a
+///     <see cref="Wolverine.Persistence.QueryableAttribute" /> parameter.
+/// </summary>
+internal class QueryableFrame : SyncFrame
+{
+    private readonly Type _dbContextType;
+    private readonly Type _elementType;
+    private Variable? _context;
+
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType closes IReadOnlyList<>/IQueryable<> over the element type at CODEGEN time only. AOT consumers run pre-generated code in TypeLoadMode.Static, so this never fires in a published app. See the AOT guide.")]
+    public QueryableFrame(Type dbContextType, Type elementType)
+    {
+        _dbContextType = dbContextType;
+        _elementType = elementType;
+        Result = new Variable(typeof(IQueryable<>).MakeGenericType(elementType), $"queryable_{elementType.Name}",
+            this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"The raw EF Core IQueryable for {_elementType.NameInCode()}");
+        writer.Write(
+            $"{Result.VariableType.FullNameInCode()} {Result.Usage} = {_context!.Usage}.{nameof(DbContext.Set)}<{_elementType.FullNameInCode()}>();");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _context = chain.FindVariable(_dbContextType);
+        yield return _context;
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.Fisher/Codegen/AllFrame.cs
@@ -1,0 +1,49 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Fisher;
+using Fisher.Linq;
+
+namespace Wolverine.Fisher.Codegen;
+
+/// <summary>
+///     Emits <c>await session.Query&lt;T&gt;().ToListAsync(token)</c> for a
+///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
+/// </summary>
+/// <remarks>
+///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
+///     strings so that a rename in Fisher breaks this build instead of shipping a codegen failure that only
+///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+/// </remarks>
+internal class AllFrame : AsyncFrame
+{
+    private readonly Type _entityType;
+    private Variable? _session;
+    private Variable? _cancellation;
+
+    public AllFrame(Type entityType)
+    {
+        _entityType = entityType;
+        Result = new Variable(typeof(IReadOnlyList<>).MakeGenericType(entityType), $"all_{entityType.Name}", this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+        writer.Write($"var {Result.Usage} = await {typeof(QueryableExtensions).FullNameInCode()}.{nameof(QueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/Codegen/QueryableFrame.cs
+++ b/src/Persistence/Wolverine.Fisher/Codegen/QueryableFrame.cs
@@ -1,0 +1,41 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Fisher;
+
+namespace Wolverine.Fisher.Codegen;
+
+/// <summary>
+///     Exposes Fisher's raw <c>IQueryable&lt;T&gt;</c> for a
+///     <see cref="Wolverine.Persistence.QueryableAttribute" /> parameter.
+/// </summary>
+internal class QueryableFrame : SyncFrame
+{
+    private readonly Type _elementType;
+    private Variable? _source;
+
+    public QueryableFrame(Type elementType)
+    {
+        _elementType = elementType;
+        Result = new Variable(typeof(IQueryable<>).MakeGenericType(elementType), $"queryable_{elementType.Name}",
+            this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"The raw Fisher IQueryable for {_elementType.NameInCode()}");
+        writer.Write(
+            $"{Result.VariableType.FullNameInCode()} {Result.Usage} = {_source!.Usage}.{nameof(IQuerySession.Query)}<{_elementType.FullNameInCode()}>();");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _source = chain.FindVariable(typeof(IDocumentSession));
+        yield return _source;
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/Codegen/SessionVariableSource.cs
+++ b/src/Persistence/Wolverine.Fisher/Codegen/SessionVariableSource.cs
@@ -140,3 +140,52 @@ internal class SharedEventOperationsFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 }
+
+/// <summary>
+///     Supplies the <b>shared</b> <see cref="JasperFx.Events.IEventStoreOperations"/> contract — the full
+///     read + write session-level event API — rather than Fisher's own derived spelling, so a message handler
+///     or HTTP endpoint can take it as a parameter and stay valid on Marten, Polecat and Fisher alike.
+/// </summary>
+/// <remarks>
+///     Sibling of <see cref="SharedEventOperationsSource"/>, which supplies the narrower write-only
+///     <c>IEventOperations</c>. Both resolve to exactly the same thing — <c>session.Events</c> — and both go
+///     through <c>IDocumentSession</c> rather than a store, so an ancillary store's <c>[Storage]</c> frame has
+///     already swapped the session and these follow it.
+/// </remarks>
+internal class SharedEventStoreOperationsSource : IVariableSource
+{
+    public bool Matches(Type type)
+    {
+        return type == typeof(JasperFx.Events.IEventStoreOperations);
+    }
+
+    public Variable Create(Type type)
+    {
+        return new SharedEventStoreOperationsFrame().Variable;
+    }
+}
+
+internal class SharedEventStoreOperationsFrame : SyncFrame
+{
+    private Variable _session = null!;
+
+    public SharedEventStoreOperationsFrame()
+    {
+        Variable = new Variable(typeof(JasperFx.Events.IEventStoreOperations), this);
+    }
+
+    public Variable Variable { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(JasperFx.Events.IEventStoreOperations)} {Variable.Usage} = {_session.Usage}.{nameof(IDocumentSession.Events)};");
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
@@ -51,6 +51,7 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new DocumentOperationsSource());
         options.CodeGeneration.Sources.Add(new EventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventOperationsSource());
+        options.CodeGeneration.Sources.Add(new SharedEventStoreOperationsSource());
 
         options.Policies.Add<FisherAggregateHandlerStrategy>();
 

--- a/src/Persistence/Wolverine.Fisher/Persistence/Sagas/FisherPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Fisher/Persistence/Sagas/FisherPersistenceFrameProvider.cs
@@ -82,8 +82,18 @@ internal partial class FisherPersistenceFrameProvider : IPersistenceFrameProvide
         if (ChainHasFisherSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain
-            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations) }).ToArray();
-        return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations) || x.Closes(typeof(IEventStream<>)));
+            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Fisher.Events.EventOperations) }).ToArray();
+                // A handler that takes the event operations straight as a parameter -- the shared
+        // JasperFx.Events.IEventOperations / IEventStoreOperations, or Fisher's own EventOperations -- is
+        // unambiguously using this store, but none of those types appeared here, so
+        // AutoApplyTransactions skipped the chain and nothing was ever committed. Appending
+        // through the parameter queued into the session's unit of work and then silently
+        // vanished, with no exception.
+        return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations)
+                                            || x.Closes(typeof(IEventStream<>))
+                                            || x == typeof(global::JasperFx.Events.IEventOperations)
+                                            || x == typeof(global::JasperFx.Events.IEventStoreOperations)
+                                            || x == typeof(global::Fisher.Events.EventOperations));
     }
 
     private static bool ChainHasFisherSessionAttributes(IChain chain)
@@ -119,6 +129,16 @@ internal partial class FisherPersistenceFrameProvider : IPersistenceFrameProvide
         return def == typeof(DocumentExistsAttribute<>) || def == typeof(DocumentDoesNotExistAttribute<>);
     }
 
+    public bool TryBuildAllFrame(Type entityType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var all = new AllFrame(entityType);
+        frame = all;
+        result = all.Result;
+        return true;
+    }
+
     public bool TryBuildFirstOrDefaultFrame(Type entityType, IServiceContainer container,
         [NotNullWhen(true)] out Frame? frame,
         [NotNullWhen(true)] out Variable? result)
@@ -126,6 +146,16 @@ internal partial class FisherPersistenceFrameProvider : IPersistenceFrameProvide
         var first = new FirstOrDefaultFrame(entityType);
         frame = first;
         result = first.Result;
+        return true;
+    }
+
+    public bool TryBuildQueryableFrame(Type elementType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var queryable = new QueryableFrame(elementType);
+        frame = queryable;
+        result = queryable.Result;
         return true;
     }
 

--- a/src/Persistence/Wolverine.Marten/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/AllFrame.cs
@@ -1,0 +1,48 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten;
+
+namespace Wolverine.Marten.Codegen;
+
+/// <summary>
+///     Emits <c>await session.Query&lt;T&gt;().ToListAsync(token)</c> for a
+///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
+/// </summary>
+/// <remarks>
+///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
+///     strings so that a rename in Marten breaks this build instead of shipping a codegen failure that only
+///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+/// </remarks>
+internal class AllFrame : AsyncFrame
+{
+    private readonly Type _entityType;
+    private Variable? _session;
+    private Variable? _cancellation;
+
+    public AllFrame(Type entityType)
+    {
+        _entityType = entityType;
+        Result = new Variable(typeof(IReadOnlyList<>).MakeGenericType(entityType), $"all_{entityType.Name}", this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+        writer.Write($"var {Result.Usage} = await {typeof(QueryableExtensions).FullNameInCode()}.{nameof(QueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IQuerySession));
+        yield return _session;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/QueryableFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/QueryableFrame.cs
@@ -1,0 +1,41 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten;
+
+namespace Wolverine.Marten.Codegen;
+
+/// <summary>
+///     Exposes Marten's raw <c>IQueryable&lt;T&gt;</c> for a
+///     <see cref="Wolverine.Persistence.QueryableAttribute" /> parameter.
+/// </summary>
+internal class QueryableFrame : SyncFrame
+{
+    private readonly Type _elementType;
+    private Variable? _source;
+
+    public QueryableFrame(Type elementType)
+    {
+        _elementType = elementType;
+        Result = new Variable(typeof(IQueryable<>).MakeGenericType(elementType), $"queryable_{elementType.Name}",
+            this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"The raw Marten IQueryable for {_elementType.NameInCode()}");
+        writer.Write(
+            $"{Result.VariableType.FullNameInCode()} {Result.Usage} = {_source!.Usage}.{nameof(IQuerySession.Query)}<{_elementType.FullNameInCode()}>();");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _source = chain.FindVariable(typeof(IQuerySession));
+        yield return _source;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Codegen/SessionVariableSource.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/SessionVariableSource.cs
@@ -144,3 +144,52 @@ internal class SharedEventOperationsFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 }
+
+/// <summary>
+///     Supplies the <b>shared</b> <see cref="JasperFx.Events.IEventStoreOperations"/> contract — the full
+///     read + write session-level event API — rather than Marten's own derived spelling, so a message handler
+///     or HTTP endpoint can take it as a parameter and stay valid on Marten, Polecat and Fisher alike.
+/// </summary>
+/// <remarks>
+///     Sibling of <see cref="SharedEventOperationsSource"/>, which supplies the narrower write-only
+///     <c>IEventOperations</c>. Both resolve to exactly the same thing — <c>session.Events</c> — and both go
+///     through <c>IDocumentSession</c> rather than a store, so an ancillary store's <c>[Storage]</c> frame has
+///     already swapped the session and these follow it.
+/// </remarks>
+internal class SharedEventStoreOperationsSource : IVariableSource
+{
+    public bool Matches(Type type)
+    {
+        return type == typeof(JasperFx.Events.IEventStoreOperations);
+    }
+
+    public Variable Create(Type type)
+    {
+        return new SharedEventStoreOperationsFrame().Variable;
+    }
+}
+
+internal class SharedEventStoreOperationsFrame : SyncFrame
+{
+    private Variable _session = null!;
+
+    public SharedEventStoreOperationsFrame()
+    {
+        Variable = new Variable(typeof(JasperFx.Events.IEventStoreOperations), this);
+    }
+
+    public Variable Variable { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(JasperFx.Events.IEventStoreOperations)} {Variable.Usage} = {_session.Usage}.{nameof(IDocumentSession.Events)};");
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -74,6 +74,7 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new DocumentOperationsSource());
         options.CodeGeneration.Sources.Add(new EventStoreOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventOperationsSource());
+        options.CodeGeneration.Sources.Add(new SharedEventStoreOperationsSource());
 
         options.Policies.Add<MartenAggregateHandlerStrategy>();
 

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
@@ -108,8 +108,18 @@ internal partial class MartenPersistenceFrameProvider : IPersistenceFrameProvide
         if (ChainHasMartenSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain
-            .ServiceDependencies(container, new []{typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations)}).ToArray();
-        return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations) || x.Closes(typeof(IEventStream<>)));
+            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Marten.Events.IEventStoreOperations) }).ToArray();
+                // A handler that takes the event operations straight as a parameter -- the shared
+        // JasperFx.Events.IEventOperations / IEventStoreOperations, or Marten's own IEventStoreOperations -- is
+        // unambiguously using this store, but none of those types appeared here, so
+        // AutoApplyTransactions skipped the chain and nothing was ever committed. Appending
+        // through the parameter queued into the session's unit of work and then silently
+        // vanished, with no exception.
+        return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations)
+                                            || x.Closes(typeof(IEventStream<>))
+                                            || x == typeof(global::JasperFx.Events.IEventOperations)
+                                            || x == typeof(global::JasperFx.Events.IEventStoreOperations)
+                                            || x == typeof(global::Marten.Events.IEventStoreOperations));
     }
 
     private static bool ChainHasMartenSessionAttributes(IChain chain)
@@ -145,6 +155,16 @@ internal partial class MartenPersistenceFrameProvider : IPersistenceFrameProvide
         if (!type.IsGenericType) return false;
         var def = type.GetGenericTypeDefinition();
         return def == typeof(DocumentExistsAttribute<>) || def == typeof(DocumentDoesNotExistAttribute<>);
+    }
+
+    public bool TryBuildQueryableFrame(Type elementType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var queryable = new QueryableFrame(elementType);
+        frame = queryable;
+        result = queryable.Result;
+        return true;
     }
 
     public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId)
@@ -201,6 +221,16 @@ internal partial class MartenPersistenceFrameProvider : IPersistenceFrameProvide
     public Frame[] DetermineFrameToNullOutMaybeSoftDeleted(Variable entity)
     {
         return [new SetVariableToNullIfSoftDeletedFrame(entity)];
+    }
+
+    public bool TryBuildAllFrame(Type entityType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var all = new AllFrame(entityType);
+        frame = all;
+        result = all.Result;
+        return true;
     }
 
     public bool TryBuildFirstOrDefaultFrame(Type entityType, IServiceContainer container,

--- a/src/Persistence/Wolverine.Polecat/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/AllFrame.cs
@@ -1,0 +1,49 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Polecat;
+using Polecat.Linq;
+
+namespace Wolverine.Polecat.Codegen;
+
+/// <summary>
+///     Emits <c>await session.Query&lt;T&gt;().ToListAsync(token)</c> for a
+///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
+/// </summary>
+/// <remarks>
+///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
+///     strings so that a rename in Polecat breaks this build instead of shipping a codegen failure that only
+///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+/// </remarks>
+internal class AllFrame : AsyncFrame
+{
+    private readonly Type _entityType;
+    private Variable? _session;
+    private Variable? _cancellation;
+
+    public AllFrame(Type entityType)
+    {
+        _entityType = entityType;
+        Result = new Variable(typeof(IReadOnlyList<>).MakeGenericType(entityType), $"all_{entityType.Name}", this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+        writer.Write($"var {Result.Usage} = await {typeof(PolecatQueryableExtensions).FullNameInCode()}.{nameof(PolecatQueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/Codegen/QueryableFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/QueryableFrame.cs
@@ -1,0 +1,41 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Polecat;
+
+namespace Wolverine.Polecat.Codegen;
+
+/// <summary>
+///     Exposes Polecat's raw <c>IQueryable&lt;T&gt;</c> for a
+///     <see cref="Wolverine.Persistence.QueryableAttribute" /> parameter.
+/// </summary>
+internal class QueryableFrame : SyncFrame
+{
+    private readonly Type _elementType;
+    private Variable? _source;
+
+    public QueryableFrame(Type elementType)
+    {
+        _elementType = elementType;
+        Result = new Variable(typeof(IQueryable<>).MakeGenericType(elementType), $"queryable_{elementType.Name}",
+            this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"The raw Polecat IQueryable for {_elementType.NameInCode()}");
+        writer.Write(
+            $"{Result.VariableType.FullNameInCode()} {Result.Usage} = {_source!.Usage}.{nameof(IQuerySession.Query)}<{_elementType.FullNameInCode()}>();");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _source = chain.FindVariable(typeof(IDocumentSession));
+        yield return _source;
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/Codegen/SessionVariableSource.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/SessionVariableSource.cs
@@ -140,3 +140,52 @@ internal class SharedEventOperationsFrame : SyncFrame
         Next?.GenerateCode(method, writer);
     }
 }
+
+/// <summary>
+///     Supplies the <b>shared</b> <see cref="JasperFx.Events.IEventStoreOperations"/> contract — the full
+///     read + write session-level event API — rather than Polecat's own derived spelling, so a message handler
+///     or HTTP endpoint can take it as a parameter and stay valid on Marten, Polecat and Fisher alike.
+/// </summary>
+/// <remarks>
+///     Sibling of <see cref="SharedEventOperationsSource"/>, which supplies the narrower write-only
+///     <c>IEventOperations</c>. Both resolve to exactly the same thing — <c>session.Events</c> — and both go
+///     through <c>IDocumentSession</c> rather than a store, so an ancillary store's <c>[Storage]</c> frame has
+///     already swapped the session and these follow it.
+/// </remarks>
+internal class SharedEventStoreOperationsSource : IVariableSource
+{
+    public bool Matches(Type type)
+    {
+        return type == typeof(JasperFx.Events.IEventStoreOperations);
+    }
+
+    public Variable Create(Type type)
+    {
+        return new SharedEventStoreOperationsFrame().Variable;
+    }
+}
+
+internal class SharedEventStoreOperationsFrame : SyncFrame
+{
+    private Variable _session = null!;
+
+    public SharedEventStoreOperationsFrame()
+    {
+        Variable = new Variable(typeof(JasperFx.Events.IEventStoreOperations), this);
+    }
+
+    public Variable Variable { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(JasperFx.Events.IEventStoreOperations)} {Variable.Usage} = {_session.Usage}.{nameof(IDocumentSession.Events)};");
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
@@ -81,8 +81,18 @@ internal partial class PolecatPersistenceFrameProvider : IPersistenceFrameProvid
         if (ChainHasPolecatSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain
-            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations) }).ToArray();
-        return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations) || x.Closes(typeof(IEventStream<>)));
+            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Polecat.Events.IEventOperations) }).ToArray();
+                // A handler that takes the event operations straight as a parameter -- the shared
+        // JasperFx.Events.IEventOperations / IEventStoreOperations, or Polecat's own IEventOperations -- is
+        // unambiguously using this store, but none of those types appeared here, so
+        // AutoApplyTransactions skipped the chain and nothing was ever committed. Appending
+        // through the parameter queued into the session's unit of work and then silently
+        // vanished, with no exception.
+        return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations)
+                                            || x.Closes(typeof(IEventStream<>))
+                                            || x == typeof(global::JasperFx.Events.IEventOperations)
+                                            || x == typeof(global::JasperFx.Events.IEventStoreOperations)
+                                            || x == typeof(global::Polecat.Events.IEventOperations));
     }
 
     private static bool ChainHasPolecatSessionAttributes(IChain chain)
@@ -118,6 +128,16 @@ internal partial class PolecatPersistenceFrameProvider : IPersistenceFrameProvid
         return def == typeof(DocumentExistsAttribute<>) || def == typeof(DocumentDoesNotExistAttribute<>);
     }
 
+    public bool TryBuildAllFrame(Type entityType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var all = new AllFrame(entityType);
+        frame = all;
+        result = all.Result;
+        return true;
+    }
+
     public bool TryBuildFirstOrDefaultFrame(Type entityType, IServiceContainer container,
         [NotNullWhen(true)] out Frame? frame,
         [NotNullWhen(true)] out Variable? result)
@@ -125,6 +145,16 @@ internal partial class PolecatPersistenceFrameProvider : IPersistenceFrameProvid
         var first = new FirstOrDefaultFrame(entityType);
         frame = first;
         result = first.Result;
+        return true;
+    }
+
+    public bool TryBuildQueryableFrame(Type elementType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var queryable = new QueryableFrame(elementType);
+        frame = queryable;
+        result = queryable.Result;
         return true;
     }
 

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -56,6 +56,7 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new DocumentOperationsSource());
         options.CodeGeneration.Sources.Add(new EventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventOperationsSource());
+        options.CodeGeneration.Sources.Add(new SharedEventStoreOperationsSource());
 
         options.Policies.Add<PolecatAggregateHandlerStrategy>();
 

--- a/src/Persistence/Wolverine.RavenDb/Internals/AllFrame.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/AllFrame.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace Wolverine.RavenDb.Internals;
+
+/// <summary>
+///     Emits <c>await session.Query&lt;T&gt;().ToListAsync(token)</c> for a
+///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
+/// </summary>
+/// <remarks>
+///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
+///     strings so that a rename in the RavenDb client breaks this build instead of shipping a codegen failure that
+///     only surfaces the first time an endpoint using the attribute is compiled at runtime. That matters more here
+///     than for the other providers, since the RavenDb suite only runs on CI.
+/// </remarks>
+internal class AllFrame : AsyncFrame
+{
+    private readonly Type _entityType;
+    private Variable? _session;
+    private Variable? _cancellation;
+
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType closes IReadOnlyList<>/IQueryable<> over the element type at CODEGEN time only. AOT consumers run pre-generated code in TypeLoadMode.Static, so this never fires in a published app. See the AOT guide.")]
+    public AllFrame(Type entityType)
+    {
+        _entityType = entityType;
+        Result = new Variable(typeof(IReadOnlyList<>).MakeGenericType(entityType), $"all_{entityType.Name}", this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+        writer.Write($"var {Result.Usage} = await {typeof(LinqExtensions).FullNameInCode()}.{nameof(LinqExtensions.ToListAsync)}({_session!.Usage}.Query<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IAsyncDocumentSession));
+        yield return _session;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}

--- a/src/Persistence/Wolverine.RavenDb/Internals/QueryableFrame.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/QueryableFrame.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace Wolverine.RavenDb.Internals;
+
+/// <summary>
+///     Exposes RavenDb's raw <c>IQueryable&lt;T&gt;</c> for a
+///     <see cref="Wolverine.Persistence.QueryableAttribute" /> parameter.
+/// </summary>
+internal class QueryableFrame : SyncFrame
+{
+    private readonly Type _elementType;
+    private Variable? _source;
+
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MakeGenericType closes IReadOnlyList<>/IQueryable<> over the element type at CODEGEN time only. AOT consumers run pre-generated code in TypeLoadMode.Static, so this never fires in a published app. See the AOT guide.")]
+    public QueryableFrame(Type elementType)
+    {
+        _elementType = elementType;
+        Result = new Variable(typeof(IQueryable<>).MakeGenericType(elementType), $"queryable_{elementType.Name}",
+            this);
+    }
+
+    public Variable Result { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"The raw RavenDb IQueryable for {_elementType.NameInCode()}");
+        writer.Write(
+            $"{Result.VariableType.FullNameInCode()} {Result.Usage} = {_source!.Usage}.Query<{_elementType.FullNameInCode()}>();");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _source = chain.FindVariable(typeof(IAsyncDocumentSession));
+        yield return _source;
+    }
+}

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbPersistenceFrameProvider.cs
@@ -69,6 +69,16 @@ public class RavenDbPersistenceFrameProvider : IPersistenceFrameProvider
         return typeof(string);
     }
 
+    public bool TryBuildAllFrame(Type entityType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var all = new AllFrame(entityType);
+        frame = all;
+        result = all.Result;
+        return true;
+    }
+
     public bool TryBuildFirstOrDefaultFrame(Type entityType, IServiceContainer container,
         [NotNullWhen(true)] out Frame? frame,
         [NotNullWhen(true)] out Variable? result)
@@ -76,6 +86,16 @@ public class RavenDbPersistenceFrameProvider : IPersistenceFrameProvider
         var first = new FirstOrDefaultFrame(entityType);
         frame = first;
         result = first.Result;
+        return true;
+    }
+
+    public bool TryBuildQueryableFrame(Type elementType, IServiceContainer container,
+        [NotNullWhen(true)] out Frame? frame,
+        [NotNullWhen(true)] out Variable? result)
+    {
+        var queryable = new QueryableFrame(elementType);
+        frame = queryable;
+        result = queryable.Result;
         return true;
     }
 

--- a/src/Testing/CoreTests/Persistence/all_and_queryable_validation.cs
+++ b/src/Testing/CoreTests/Persistence/all_and_queryable_validation.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Attributes;
+using Wolverine;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// [All] and [Queryable] are strict about the parameter type they will accept. The point of these is that the
+// message says what was wrong and what to write instead, rather than failing somewhere in codegen.
+public class all_and_queryable_validation
+{
+    // The type check lives in the parameter attribute's Modify(), which runs during code generation for
+    // the chain rather than at host startup -- the same timing [Entity]'s own errors have. So the message
+    // surfaces on first invocation, which is what these assert.
+    private static async Task<InvalidOperationException> shouldFail(Type handlerType)
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType))
+            .StartAsync();
+
+        return await Should.ThrowAsync<InvalidOperationException>(
+            () => host.InvokeAsync(new CountValidationColors()));
+    }
+
+    [Fact]
+    public async Task all_rejects_a_bare_ienumerable()
+    {
+        var ex = await shouldFail(typeof(AllOnEnumerableHandler));
+
+        ex.Message.ShouldContain("[All] attribute can only be applied to a parameter of type IReadOnlyList<T>");
+        ex.Message.ShouldContain("colors");                 // names the parameter
+        ex.Message.ShouldContain(nameof(AllOnEnumerableHandler)); // names the declaring method
+        ex.Message.ShouldContain("IReadOnlyList<ValidationColor>"); // suggests the concrete fix
+    }
+
+    [Fact]
+    public async Task all_rejects_a_single_entity()
+    {
+        var ex = await shouldFail(typeof(AllOnSingleHandler));
+
+        ex.Message.ShouldContain("IReadOnlyList<T>");
+    }
+
+    [Fact]
+    public async Task queryable_rejects_a_non_queryable_parameter()
+    {
+        var ex = await shouldFail(typeof(QueryableOnListHandler));
+
+        ex.Message.ShouldContain("[Queryable] attribute can only be applied to a parameter of type IQueryable<T>");
+        ex.Message.ShouldContain("colors");
+        ex.Message.ShouldContain("IQueryable<ValidationColor>");
+    }
+}
+
+public class ValidationColor
+{
+    public Guid Id { get; set; }
+}
+
+public record CountValidationColors;
+
+// [WolverineIgnore] -- these are deliberately invalid and would break every other host in this assembly
+[WolverineIgnore]
+public static class AllOnEnumerableHandler
+{
+    public static void Handle(CountValidationColors command, [All] IEnumerable<ValidationColor> colors) { }
+}
+
+[WolverineIgnore]
+public static class AllOnSingleHandler
+{
+    public static void Handle(CountValidationColors command, [All] ValidationColor colors) { }
+}
+
+[WolverineIgnore]
+public static class QueryableOnListHandler
+{
+    public static void Handle(CountValidationColors command, [Queryable] IReadOnlyList<ValidationColor> colors) { }
+}

--- a/src/Wolverine/Persistence/AllAttribute.cs
+++ b/src/Wolverine/Persistence/AllAttribute.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Sagas;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Marks a message handler or HTTP endpoint parameter as <b>every</b> document of its element type in the
+/// configured persistence — the equivalent of <c>await session.Query&lt;T&gt;().ToListAsync()</c>, resolved
+/// through whichever persistence provider owns the type. Like <see cref="FirstOrDefaultAttribute"/>, the point
+/// is storage agnostic code: the same handler is valid whether the store behind it is Marten, Polecat, Fisher,
+/// RavenDb, or EF Core.
+/// </summary>
+/// <example>
+/// <code>
+/// [WolverineGet("/api/alerts/config/services")]
+/// public static IReadOnlyList&lt;ServiceAlertOverrides&gt; GetAll([All] IReadOnlyList&lt;ServiceAlertOverrides&gt; overrides)
+///     => overrides;
+/// </code>
+/// </example>
+/// <remarks>
+/// <para>
+/// The parameter must be declared as <c>IReadOnlyList&lt;T&gt;</c>. Anything else throws with a message naming
+/// the parameter and what it should have been.
+/// </para>
+/// <para>
+/// An empty table yields an empty list, never null, so there is no "missing" case to configure and no
+/// <c>Required</c> / <c>OnMissing</c> here.
+/// </para>
+/// <para>
+/// The query is unfiltered on purpose. If you need a predicate, that is what a <c>Before</c> method, a compiled
+/// query, or <see cref="FromQuerySpecificationAttribute"/> are for. Reading an entire table into memory is also
+/// something to do deliberately — this is aimed at small reference and configuration collections.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class AllAttribute : WolverineParameterAttribute
+{
+    public AllAttribute()
+    {
+        ValueSource = ValueSource.Anything;
+    }
+
+    public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
+        GenerationRules rules)
+    {
+        var elementType = DetermineElementType(parameter);
+
+        if (!rules.TryFindPersistenceFrameProvider(container, elementType, out var provider))
+        {
+            throw new InvalidOperationException(
+                $"Could not determine a matching persistence service for [All] parameter '{parameter.Name}' of " +
+                $"element type {elementType.FullNameInCode()}. Check that the persistence integration for this " +
+                "type has been registered, i.e. IntegrateWithWolverine() for Marten.");
+        }
+
+        if (!provider.TryBuildAllFrame(elementType, container, out var frame, out var result))
+        {
+            throw new InvalidOperationException(
+                $"The {provider.GetType().FullNameInCode()} persistence provider does not support [All], so " +
+                $"parameter '{parameter.Name}' of element type {elementType.FullNameInCode()} cannot be " +
+                "resolved. Load the values explicitly in a Before method instead.");
+        }
+
+        chain.Middleware.Add(frame);
+        result.OverrideName(parameter.Name!);
+
+        // Keeps the value reachable from Before/After middleware methods added later, the same way
+        // [Entity] and [FirstOrDefault] do.
+        EntityAttribute.StoreDeferredMiddlewareVariable(chain, parameter.Name!, result);
+
+        return result;
+    }
+
+    /// <summary>
+    ///     The element type behind an <c>IReadOnlyList&lt;T&gt;</c> parameter.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately one accepted shape rather than any <c>IEnumerable&lt;T&gt;</c>. <c>IReadOnlyList&lt;T&gt;</c>
+    ///     is what Marten and RavenDb hand back from <c>ToListAsync()</c> natively, and EF Core's
+    ///     <c>List&lt;T&gt;</c> converts to it implicitly, so every provider assigns straight across with no
+    ///     copying. A lazy <c>IEnumerable&lt;T&gt;</c> would also leave the reader guessing whether the query had
+    ///     already run.
+    /// </remarks>
+    internal static Type DetermineElementType(ParameterInfo parameter)
+    {
+        var type = parameter.ParameterType;
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        throw new InvalidOperationException(
+            $"The [All] attribute can only be applied to a parameter of type IReadOnlyList<T>, but " +
+            $"'{parameter.Name}' on {describeMember(parameter)} is declared as " +
+            $"{type.FullNameInCode()}. Change it to IReadOnlyList<{elementNameHint(type)}>.");
+    }
+
+    private static string describeMember(ParameterInfo parameter)
+    {
+        var method = parameter.Member;
+        return $"{method.DeclaringType?.FullNameInCode()}.{method.Name}";
+    }
+
+    // Best effort so the message can suggest the concrete fix rather than a bare "List<T>". Deliberately
+    // avoids walking the interface graph -- that needs a DynamicallyAccessedMembers annotation the caller
+    // cannot satisfy, and this is only a hint inside an exception message.
+    private static string elementNameHint(Type type)
+    {
+        if (type.IsArray)
+        {
+            return type.GetElementType()!.NameInCode();
+        }
+
+        if (type.IsGenericType && type.GetGenericArguments().Length == 1)
+        {
+            return type.GetGenericArguments()[0].NameInCode();
+        }
+
+        return type.NameInCode();
+    }
+}

--- a/src/Wolverine/Persistence/IPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/IPersistenceFrameProvider.cs
@@ -124,6 +124,58 @@ public interface IPersistenceFrameProvider
         result = null;
         return false;
     }
+
+    /// <summary>
+    /// Attempt to build a codegen <see cref="Frame"/> that executes the equivalent of
+    /// <c>session.Query&lt;T&gt;().ToListAsync()</c> for <paramref name="entityType"/> against this provider's
+    /// own session, producing a <c>List&lt;T&gt;</c> as a new variable for downstream frames.
+    ///
+    /// <para>
+    /// Return <c>true</c> if the provider can express an unfiltered "every row of this type" read. The
+    /// default implementation returns <c>false</c>, which <see cref="AllAttribute"/> turns into a
+    /// bootstrapping time error naming the provider rather than silently doing nothing.
+    /// </para>
+    /// </summary>
+    /// <param name="entityType">The element type to read every instance of.</param>
+    /// <param name="container">Active codegen service container.</param>
+    /// <param name="frame">The built frame, when the provider supports this.</param>
+    /// <param name="result">The <c>List&lt;T&gt;</c> variable produced by the frame, when built.</param>
+    bool TryBuildAllFrame(
+        Type entityType,
+        IServiceContainer container,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Frame? frame,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Variable? result)
+    {
+        frame = null;
+        result = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempt to build a codegen <see cref="Frame"/> that exposes this provider's raw
+    /// <c>IQueryable&lt;T&gt;</c> for <paramref name="elementType"/> — Marten's <c>session.Query&lt;T&gt;()</c>,
+    /// EF Core's <c>dbContext.Set&lt;T&gt;()</c>, and so on — as a new variable for the endpoint or handler to
+    /// compose a query against directly.
+    ///
+    /// <para>
+    /// Return <c>true</c> if the provider can hand out a queryable. The default returns <c>false</c>, which
+    /// <see cref="QueryableAttribute"/> turns into a bootstrapping time error naming the provider.
+    /// </para>
+    /// </summary>
+    /// <param name="elementType">The element type of the queryable.</param>
+    /// <param name="container">Active codegen service container.</param>
+    /// <param name="frame">The built frame, when the provider supports this.</param>
+    /// <param name="result">The <c>IQueryable&lt;T&gt;</c> variable produced by the frame, when built.</param>
+    bool TryBuildQueryableFrame(
+        Type elementType,
+        IServiceContainer container,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Frame? frame,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Variable? result)
+    {
+        frame = null;
+        result = null;
+        return false;
+    }
 }
 
 

--- a/src/Wolverine/Persistence/QueryableAttribute.cs
+++ b/src/Wolverine/Persistence/QueryableAttribute.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Sagas;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Injects the persistence mechanism's raw <see cref="IQueryable{T}" /> — Marten's
+/// <c>session.Query&lt;T&gt;()</c>, EF Core's <c>dbContext.Set&lt;T&gt;()</c>, and so on — into a message
+/// handler, HTTP endpoint, or middleware method parameter.
+/// </summary>
+/// <example>
+/// <code>
+/// [WolverineGet("/api/alerts/recent")]
+/// public static Task&lt;List&lt;Alert&gt;&gt; GetRecent([Queryable] IQueryable&lt;Alert&gt; alerts, CancellationToken token)
+///     => alerts.Where(x =&gt; x.Level == "high").OrderByDescending(x =&gt; x.RaisedAt).Take(20).ToListAsync(token);
+/// </code>
+/// </example>
+/// <remarks>
+/// <para>
+/// <b>This is the escape hatch, and it is a sharp one.</b> Unlike <see cref="EntityAttribute" />,
+/// <see cref="FirstOrDefaultAttribute" /> and <see cref="AllAttribute" />, which describe *what* you want and
+/// leave the store to satisfy it, this hands you a provider-specific LINQ implementation. Read the warnings in
+/// the documentation before reaching for it:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// It is <b>not portable in practice</b>. Marten, EF Core, RavenDb and CosmosDb LINQ providers support very
+/// different subsets of LINQ; a query that compiles and runs on one can throw at *runtime* on another. The
+/// type is storage agnostic, the query you write against it is not.
+/// </item>
+/// <item>
+/// It reintroduces exactly the persistence coupling the other attributes exist to remove, and makes the method
+/// meaningfully harder to unit test.
+/// </item>
+/// <item>
+/// An unbounded query is easy to write by accident. There is no paging, no limit, and no guard.
+/// </item>
+/// <item>
+/// On <b>CosmosDb</b> in particular, Wolverine stores every user document in one shared container with no
+/// per-type discriminator, so an unfiltered queryable can surface documents of other types entirely.
+/// </item>
+/// </list>
+/// <para>
+/// Prefer <see cref="AllAttribute" /> for a whole small collection, <see cref="EntityAttribute" /> for a single
+/// entity by identity, or <see cref="FromQuerySpecificationAttribute" /> / a compiled query for anything
+/// filtered that you want to stay testable and portable.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class QueryableAttribute : WolverineParameterAttribute
+{
+    public QueryableAttribute()
+    {
+        ValueSource = ValueSource.Anything;
+    }
+
+    public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
+        GenerationRules rules)
+    {
+        var elementType = DetermineElementType(parameter);
+
+        if (!rules.TryFindPersistenceFrameProvider(container, elementType, out var provider))
+        {
+            throw new InvalidOperationException(
+                $"Could not determine a matching persistence service for [Queryable] parameter " +
+                $"'{parameter.Name}' of element type {elementType.FullNameInCode()}. Check that the persistence " +
+                "integration for this type has been registered, i.e. IntegrateWithWolverine() for Marten.");
+        }
+
+        if (!provider.TryBuildQueryableFrame(elementType, container, out var frame, out var result))
+        {
+            throw new InvalidOperationException(
+                $"The {provider.GetType().FullNameInCode()} persistence provider does not support [Queryable], " +
+                $"so parameter '{parameter.Name}' of element type {elementType.FullNameInCode()} cannot be " +
+                "resolved.");
+        }
+
+        chain.Middleware.Add(frame);
+        result.OverrideName(parameter.Name!);
+
+        EntityAttribute.StoreDeferredMiddlewareVariable(chain, parameter.Name!, result);
+
+        return result;
+    }
+
+    /// <summary>
+    ///     The element type behind an <c>IQueryable&lt;T&gt;</c> parameter.
+    /// </summary>
+    internal static Type DetermineElementType(ParameterInfo parameter)
+    {
+        var type = parameter.ParameterType;
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IQueryable<>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        var member = parameter.Member;
+
+        throw new InvalidOperationException(
+            $"The [Queryable] attribute can only be applied to a parameter of type IQueryable<T>, but " +
+            $"'{parameter.Name}' on {member.DeclaringType?.FullNameInCode()}.{member.Name} is declared as " +
+            $"{type.FullNameInCode()}. Change it to IQueryable<{elementNameHint(type)}>.");
+    }
+
+    // Mirrors AllAttribute.elementNameHint -- deliberately avoids walking the interface graph, which would
+    // need a DynamicallyAccessedMembers annotation the caller cannot satisfy for an exception message hint.
+    private static string elementNameHint(Type type)
+    {
+        if (type.IsArray)
+        {
+            return type.GetElementType()!.NameInCode();
+        }
+
+        if (type.IsGenericType && type.GetGenericArguments().Length == 1)
+        {
+            return type.GetGenericArguments()[0].NameInCode();
+        }
+
+        return type.NameInCode();
+    }
+}


### PR DESCRIPTION
Two new parameter attributes in the `[Entity]` / `[FirstOrDefault]` family, plus two defects found while validating that `IEventStoreOperations` works as a parameter — **one of which predates this branch and silently loses data**.

## `[All]`

Every document of its element type, resolved through whichever provider owns it:

```csharp
[WolverineGet("/api/alerts/config/services")]
public static IReadOnlyList<ServiceAlertOverrides> GetAll([All] IReadOnlyList<ServiceAlertOverrides> overrides)
    => overrides;
```

The parameter must be `IReadOnlyList<T>`. That is deliberately the one accepted shape: it is what Marten and RavenDb hand back from `ToListAsync()` natively, and EF Core's `List<T>` converts to it implicitly, so **every provider assigns straight across with no copying**. (The first cut used `List<T>` and needed a cast-or-copy shim on Marten; this deletes it.)

Marten, Polecat, Fisher, RavenDb, EF Core. **CosmosDb unsupported** — same storage-model reason as `[FirstOrDefault]`: one shared container, no per-type discriminator, so "every document of type `T`" cannot be asked for safely.

## `[Queryable]` — the escape hatch

```csharp
public static async Task<IReadOnlyList<Alert>> GetRecent(
    [Queryable] IQueryable<Alert> alerts, CancellationToken token)
    => await alerts.Where(x => x.Level == "high").OrderByDescending(x => x.RaisedAt).Take(20).ToListAsync(token);
```

Requested with "plenty of warnings", and the docs carry a `::: danger` block rather than a token note. The most useful warning is one I hit for real while writing the tests:

> **Marten 9 refuses synchronous LINQ outright.** A plain `.ToArray()` compiles everywhere, works on EF Core, and throws `NotSupportedException: As of Marten 9.0, only asynchronous data access is supported` on Marten.

So: the *type* is storage agnostic, the *query you write against it* is not. Always the async operators, always pass the token. Also documented: it reintroduces the coupling the other attributes exist to remove, makes handlers meaningfully harder to unit test, and makes an unbounded query easy to write by accident.

All six providers, **including CosmosDb** — with a warning that its shared container can surface other document types deserialized as `T`, and a test whose query filters on a discriminator of its own to make the point.

Both attributes validate their parameter type and name the parameter, its declaring method, what it is declared as, and what to write instead.

## The two defects — worth the review time

Validating `IEventStoreOperations` as a parameter (message handlers *and* HTTP endpoints, Marten/Polecat/Fisher) turned up:

**1. No source matched the shared contract.** Each store registered a source for its *own* derived spelling only — `Marten.Events.IEventStoreOperations`, `Polecat.Events.IEventOperations`, `Fisher.Events.EventOperations`. A parameter typed as the shared `JasperFx.Events.IEventStoreOperations` resolved on none of them. Added `SharedEventStoreOperationsSource` to all three, sibling to the `SharedEventOperationsSource` from #3934. In every case it resolves to `IDocumentSession.Events`, and the compiler proves the cast — including Fisher, whose `.Events` is a concrete class rather than an interface.

**2. `CanApply` never knew about event operations, so nothing committed. This one is not new.**

`CanApply` checked service dependencies for `IDocumentSession`, `IQuerySession`, `IDocumentOperations` and `IEventStream<>` — no event-operations type appeared anywhere. So `AutoApplyTransactions` skipped the chain entirely, the append queued into the session's unit of work, and **vanished with no exception**. My first test failed with a stream of zero events and no error at all.

Because it also covers each store's *own* event-operations types — which have been resolvable as parameters far longer than this branch — `Handle(cmd, Marten.Events.IEventStoreOperations events)` has been silently not-committing for as long as that source has existed. `CanApply` now recognizes the shared JasperFx types and each store's own, on all three.

This is the same failure signature as the `ISideEffect` problem in #3934: queued into the unit of work, no commit, no exception. Third instance of "the transaction gate does not recognize a legitimate store usage."

## Testing

| Suite | Coverage |
|---|---|
| MartenTests | `[All]` (empty + populated), `[Queryable]`, `IEventStoreOperations` parameter — 4/4 |
| PolecatTests | all three, one class — 4/4 |
| FisherTests | all three, one class — 4/4 |
| EfCoreTests | `[All]` + `[Queryable]` — 3/3 |
| Wolverine.Http.Tests | `IEventStoreOperations` on an **HTTP endpoint** — 1/1 |
| CoreTests | parameter-type validation messages — 3/3 |
| RavenDbTests | `[All]` + `[Queryable]` — compiles, first run on CI |
| CosmosDbTests | `[Queryable]` — compiles, first run on CI |

The `IEventStoreOperations` tests assert the append **lands in the database when the handler's transaction commits**, not merely that the parameter was non-null — that is the only assertion that actually proves it is the current session's `Events`, and it is what failed before the `CanApply` fix.

Polecat and Fisher are combined into one test class each on purpose: their CI shards are balanced by test-*class* count because the per-class fixture bootstrap dominates, so three classes would cost three bootstraps to assert what one can.

`dotnet build wolverine.slnx -c Release -f net9.0` clean. Note the EF Core and RavenDb projects run stricter AOT analysis than the others — `MakeGenericType` in four frames needed the standard codegen-time suppression.

## Not included

gRPC. No parameter attribute works there at all — `CodeFirstGrpcServiceChain.HandlerCalls()` returns `[]` and `ApplyParameterMatching` is an empty override, by design, since RPC signatures are proto-defined and the work forwards to a message handler where these attributes already work. Filed as #3935 rather than inflating this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC
