### PR TITLE
Batch [All] queries, and stop test hosts leaking config file watchers

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,4 +21,30 @@
         <PackageReference Include="Microsoft.OpenApi" />
     </ItemGroup>
 
+    <!--
+      Every test process builds hundreds of hosts, and Host.CreateDefaultBuilder() attaches a
+      FileSystemWatcher to the content root for each one. See src/DisableConfigReloadInTests.cs for
+      the mechanics and the numbers. Linked in from here rather than per-project so a new test
+      project cannot silently reintroduce the leak.
+
+      Keyed on IsTestProject, which Microsoft.NET.Test.Sdk sets for us, rather than on the project
+      name: eight suites here do not end in "Tests" (the six *.LeaderElection projects,
+      EfCoreTests.MultiTenancy, ChaosTesting) and a name test quietly skips every one of them.
+      It also excludes Wolverine.ComplianceTests, which ships as WolverineFx.ComplianceTests — a
+      module initializer that mutates process environment variables has no business inside a
+      published package.
+
+      This lives in Directory.Build.targets and not .props because .props is imported before the
+      project body and before the NuGet-generated props, so IsTestProject is not set yet there.
+
+      Do NOT reach for '$(PackageId)' == '' as the package guard: PackageId defaults to the assembly
+      name, so that condition is false for every project and silently compiles nothing — while the
+      build still reports success.
+    -->
+    <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+        <Compile Include="$(MSBuildThisFileDirectory)src/DisableConfigReloadInTests.cs">
+            <Link>DisableConfigReloadInTests.cs</Link>
+        </Compile>
+    </ItemGroup>
+
 </Project>

--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -284,6 +284,32 @@ public static IReadOnlyList<ServiceAlertOverrides> GetAll([All] IReadOnlyList<Se
 * Supported by Marten, Polecat, Fisher, RavenDb and EF Core. **CosmosDb is not supported**, for the same
   reason `[FirstOrDefault]` is not — see that section's warning.
 
+### Batched Reads <Badge type="tip" text="6.28" />
+
+On Marten, Polecat and Fisher, **two or more** batchable reads in the same handler or endpoint are resolved
+in a *single database round trip* rather than one query each. Nothing to turn on — write the parameters and
+Wolverine batches them:
+
+```cs
+public static InventoryCounted Handle(
+    CountInventory command,
+    [All] IReadOnlyList<Part> parts,
+    [All] IReadOnlyList<Supplier> suppliers)
+    => new(parts.Count, suppliers.Count);
+```
+
+That generates one `CreateBatchQuery()`, enlists both reads, executes once, and then resolves each result —
+instead of two separate round trips. `[All]` batches alongside the other batchable operations too, so an
+`[All]` next to an `[Entity]` load or a query specification joins the same batch.
+
+A **single** read is deliberately left alone: the batch machinery buys nothing for one query, so a lone
+`[All]` still emits the plain `Query<T>().ToListAsync()`.
+
+::: tip
+This is why `[All]` is worth preferring over [`[Queryable]`](#the-raw-iqueryable-escape-hatch) when you
+genuinely want the whole collection — a queryable you compose yourself cannot participate in the batch.
+:::
+
 ## The Raw `IQueryable` Escape Hatch <Badge type="tip" text="6.28" />
 
 `[Queryable]` injects the persistence mechanism's own `IQueryable<T>` — Marten's `session.Query<T>()`,

--- a/src/DisableConfigReloadInTests.cs
+++ b/src/DisableConfigReloadInTests.cs
@@ -1,0 +1,46 @@
+using System.Runtime.CompilerServices;
+
+namespace IntegrationTests;
+
+/// <summary>
+///     Turns off the host builder's configuration file watching for the whole test process.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>Host.CreateDefaultBuilder()</c> registers <c>appsettings.json</c> with <c>reloadOnChange: true</c>,
+///         and that stands up a <c>PhysicalFileProvider</c> and a <c>FileSystemWatcher</c> over the content root
+///         <b>whether or not the file exists</b>. A test assembly builds hundreds of hosts, and the watchers
+///         outlive them: a full MartenTests run was holding <b>1028</b> kqueue handles by test ~594, against
+///         <b>4</b> with this switch on.
+///     </para>
+///     <para>
+///         Nothing in this repository reloads configuration mid-test, so those watchers are pure overhead —
+///         and on macOS the failure mode is ugly. Once the watcher can no longer start, its change token fires
+///         immediately, re-registers, and fires again, recursing until the stack overflows and the process dies
+///         on SIGABRT (exit 134) partway through a run.
+///     </para>
+///     <para>
+///         <c>hostBuilder:reloadConfigOnChange</c> is the framework's own opt-out. It is read out of <i>host</i>
+///         configuration, which includes <c>DOTNET_</c>-prefixed environment variables, so setting it here
+///         reaches every <c>CreateDefaultBuilder</c>, <c>CreateApplicationBuilder</c> and
+///         <c>WebApplication.CreateBuilder</c> the process goes on to build. The environment variable provider
+///         translates <c>__</c> to <c>:</c>, which is the portable spelling of the key.
+///     </para>
+/// </remarks>
+internal static class DisableConfigReloadInTests
+{
+    private const string Key = "DOTNET_hostBuilder__reloadConfigOnChange";
+
+    /// <summary>
+    ///     Runs before the test assembly's entry point, and so before any host is built.
+    /// </summary>
+    [ModuleInitializer]
+    internal static void Disable()
+    {
+        // Deliberately does not overwrite: a job that wants the watchers back can export its own value.
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Key)))
+        {
+            Environment.SetEnvironmentVariable(Key, "false");
+        }
+    }
+}

--- a/src/Persistence/FisherTests/batched_all_queries.cs
+++ b/src/Persistence/FisherTests/batched_all_queries.cs
@@ -1,0 +1,126 @@
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Fisher;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Persistence;
+using Wolverine.Fisher;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace FisherTests;
+
+// Two or more batchable reads in one handler share a single Fisher IBatchedQuery. Asserts on the GENERATED
+// SOURCE as well as the results, because both forms return identical data -- a results-only test would pass
+// just as happily if batching silently never engaged.
+public class batched_all_queries : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private FisherTestDatabase theDatabase = null!;
+    private IHost _host = null!;
+
+    public batched_all_queries(ITestOutputHelper output) => _output = output;
+
+    public async ValueTask InitializeAsync()
+    {
+        theDatabase = Servers.CreateDatabase("batched_all");
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(FiInventoryHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddFisher(m =>
+                    {
+                        m.Connection(theDatabase.ConnectionString);
+                        m.AutoCreateSchemaObjects = AutoCreate.All;
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .IntegrateWithWolverine();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        session.Store(new FiPart { Name = "bolt" });
+        session.Store(new FiPart { Name = "nut" });
+        session.Store(new FiSupplier { Name = "acme" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        theDatabase.Dispose();
+    }
+
+    private string sourceFor<T>()
+    {
+        _host.GetRuntime().Handlers.HandlerFor<T>();
+        var chain = _host.GetRuntime().Handlers.ChainFor<T>();
+        chain.ShouldNotBeNull();
+        chain.SourceCode.ShouldNotBeNull();
+        _output.WriteLine(chain.SourceCode);
+        return chain.SourceCode;
+    }
+
+    [Fact]
+    public async Task two_all_parameters_share_one_batched_query()
+    {
+        var code = sourceFor<CountFiInventory>();
+
+        code.ShouldContain("CreateBatchQuery()");
+        code.ShouldContain("_BatchItem");
+        code.Split("CreateBatchQuery()").Length.ShouldBe(2);
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountFiInventory());
+        var counted = tracked.Sent.SingleMessage<FiInventoryCounted>();
+        counted.Parts.ShouldBe(2);
+        counted.Suppliers.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_lone_all_parameter_is_left_standalone()
+    {
+        var code = sourceFor<CountFiParts>();
+
+        code.ShouldNotContain("CreateBatchQuery()");
+        code.ShouldContain("ToListAsync");
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountFiParts());
+        tracked.Sent.SingleMessage<FiPartsCounted>().Parts.ShouldBe(2);
+    }
+}
+
+public class FiPart
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+}
+
+public class FiSupplier
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+}
+
+public record CountFiInventory;
+public record CountFiParts;
+public record FiInventoryCounted(int Parts, int Suppliers);
+public record FiPartsCounted(int Parts);
+
+[WolverineIgnore]
+public static class FiInventoryHandler
+{
+    public static FiInventoryCounted Handle(CountFiInventory command,
+        [All] IReadOnlyList<FiPart> parts, [All] IReadOnlyList<FiSupplier> suppliers)
+        => new(parts.Count, suppliers.Count);
+
+    public static FiPartsCounted Handle(CountFiParts command, [All] IReadOnlyList<FiPart> parts)
+        => new(parts.Count);
+
+    public static void Handle(FiInventoryCounted msg) { }
+    public static void Handle(FiPartsCounted msg) { }
+}

--- a/src/Persistence/MartenTests/batched_all_queries.cs
+++ b/src/Persistence/MartenTests/batched_all_queries.cs
@@ -1,0 +1,139 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Persistence;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests;
+
+/// <summary>
+///     Two or more batchable reads in one handler resolve in a single round trip through Marten's
+///     <c>IBatchedQuery</c> rather than one query each. A lone read stays standalone.
+/// </summary>
+/// <remarks>
+///     These assert on the GENERATED SOURCE as well as the results, because that is the only way to prove the
+///     optimization actually happened -- both the batched and the unbatched forms return identical data, so a
+///     results-only test would pass just as happily if batching silently never engaged.
+/// </remarks>
+public class batched_all_queries : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
+
+    public batched_all_queries(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(InventoryHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "batched_all";
+                }).IntegrateWithWolverine().UseLightweightSessions();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var store = _host.DocumentStore();
+        await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Part));
+        await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Supplier));
+
+        await store.BulkInsertDocumentsAsync(
+            [new Part { Name = "bolt" }, new Part { Name = "nut" }],
+            cancellation: TestContext.Current.CancellationToken);
+        await store.BulkInsertDocumentsAsync(
+            [new Supplier { Name = "acme" }],
+            cancellation: TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private string sourceFor<T>()
+    {
+        _host.GetRuntime().Handlers.HandlerFor<T>();
+        var chain = _host.GetRuntime().Handlers.ChainFor<T>();
+        chain.ShouldNotBeNull();
+        chain.SourceCode.ShouldNotBeNull();
+        _output.WriteLine(chain.SourceCode);
+        return chain.SourceCode;
+    }
+
+    [Fact]
+    public async Task two_all_parameters_share_one_batched_query()
+    {
+        var code = sourceFor<CountInventory>();
+
+        code.ShouldContain("CreateBatchQuery()");
+        code.ShouldContain("_BatchItem");
+        code.ShouldContain(".Execute(");
+
+        // ...and one batch, not two
+        code.Split("CreateBatchQuery()").Length.ShouldBe(2);
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountInventory());
+        var counted = tracked.Sent.SingleMessage<InventoryCounted>();
+        counted.Parts.ShouldBe(2);
+        counted.Suppliers.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_lone_all_parameter_is_left_standalone()
+    {
+        // The batch-of-one is deliberately NOT taken: a single read gains nothing from the batch machinery,
+        // and Marten's batching policy short circuits on frames.Count <= 1.
+        var code = sourceFor<CountParts>();
+
+        code.ShouldNotContain("CreateBatchQuery()");
+        code.ShouldContain("ToListAsync");
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountParts());
+        tracked.Sent.SingleMessage<PartsCounted>().Parts.ShouldBe(2);
+    }
+}
+
+public class Part
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+}
+
+public class Supplier
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+}
+
+public record CountInventory;
+public record CountParts;
+public record InventoryCounted(int Parts, int Suppliers);
+public record PartsCounted(int Parts);
+
+[WolverineIgnore]
+public static class InventoryHandler
+{
+    public static InventoryCounted Handle(CountInventory command,
+        [All] IReadOnlyList<Part> parts, [All] IReadOnlyList<Supplier> suppliers)
+        => new(parts.Count, suppliers.Count);
+
+    public static PartsCounted Handle(CountParts command, [All] IReadOnlyList<Part> parts)
+        => new(parts.Count);
+
+    public static void Handle(InventoryCounted msg) { }
+    public static void Handle(PartsCounted msg) { }
+}

--- a/src/Persistence/PolecatTests/batched_all_queries.cs
+++ b/src/Persistence/PolecatTests/batched_all_queries.cs
@@ -1,0 +1,124 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Persistence;
+using Wolverine.Polecat;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PolecatTests;
+
+// Two or more batchable reads in one handler share a single Polecat IBatchedQuery. Asserts on the GENERATED
+// SOURCE as well as the results, because both forms return identical data -- a results-only test would pass
+// just as happily if batching silently never engaged.
+public class batched_all_queries : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
+
+    public batched_all_queries(ITestOutputHelper output) => _output = output;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(PcInventoryHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "pc_batched_all";
+                }).IntegrateWithWolverine();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Advanced.Clean.DeleteAllDocumentsAsync();
+
+        await using var session = store.LightweightSession();
+        session.Store(new PcPart { Name = "bolt" });
+        session.Store(new PcPart { Name = "nut" });
+        session.Store(new PcSupplier { Name = "acme" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private string sourceFor<T>()
+    {
+        _host.GetRuntime().Handlers.HandlerFor<T>();
+        var chain = _host.GetRuntime().Handlers.ChainFor<T>();
+        chain.ShouldNotBeNull();
+        chain.SourceCode.ShouldNotBeNull();
+        _output.WriteLine(chain.SourceCode);
+        return chain.SourceCode;
+    }
+
+    [Fact]
+    public async Task two_all_parameters_share_one_batched_query()
+    {
+        var code = sourceFor<CountPcInventory>();
+
+        code.ShouldContain("CreateBatchQuery()");
+        code.ShouldContain("_BatchItem");
+        code.Split("CreateBatchQuery()").Length.ShouldBe(2);
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountPcInventory());
+        var counted = tracked.Sent.SingleMessage<PcInventoryCounted>();
+        counted.Parts.ShouldBe(2);
+        counted.Suppliers.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_lone_all_parameter_is_left_standalone()
+    {
+        var code = sourceFor<CountPcParts>();
+
+        code.ShouldNotContain("CreateBatchQuery()");
+        code.ShouldContain("ToListAsync");
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new CountPcParts());
+        tracked.Sent.SingleMessage<PcPartsCounted>().Parts.ShouldBe(2);
+    }
+}
+
+public class PcPart
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+}
+
+public class PcSupplier
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+}
+
+public record CountPcInventory;
+public record CountPcParts;
+public record PcInventoryCounted(int Parts, int Suppliers);
+public record PcPartsCounted(int Parts);
+
+[WolverineIgnore]
+public static class PcInventoryHandler
+{
+    public static PcInventoryCounted Handle(CountPcInventory command,
+        [All] IReadOnlyList<PcPart> parts, [All] IReadOnlyList<PcSupplier> suppliers)
+        => new(parts.Count, suppliers.Count);
+
+    public static PcPartsCounted Handle(CountPcParts command, [All] IReadOnlyList<PcPart> parts)
+        => new(parts.Count);
+
+    public static void Handle(PcInventoryCounted msg) { }
+    public static void Handle(PcPartsCounted msg) { }
+}

--- a/src/Persistence/Wolverine.Fisher/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.Fisher/Codegen/AllFrame.cs
@@ -3,6 +3,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Fisher;
+using Fisher.Batching;
 using Fisher.Linq;
 
 namespace Wolverine.Fisher.Codegen;
@@ -12,15 +13,24 @@ namespace Wolverine.Fisher.Codegen;
 ///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
 /// </summary>
 /// <remarks>
-///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
-///     strings so that a rename in Fisher breaks this build instead of shipping a codegen failure that only
-///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+///     <para>
+///         The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as
+///         literal strings so that a rename in Fisher breaks this build instead of shipping a codegen failure
+///         that only surfaces the first time an endpoint using the attribute is compiled at runtime.
+///     </para>
+///     <para>
+///         Implements <see cref="IBatchableFrame" />, so a handler with more than one batchable read resolves
+///         them in a <b>single round trip</b> through Fisher's <see cref="IBatchedQuery" />.
+///         <see cref="FisherBatchingPolicy" /> owns that decision and deliberately leaves a lone read standalone.
+///     </para>
 /// </remarks>
-internal class AllFrame : AsyncFrame
+internal class AllFrame : AsyncFrame, IBatchableFrame
 {
     private readonly Type _entityType;
     private Variable? _session;
     private Variable? _cancellation;
+    private Variable? _batchQuery;
+    private Variable? _batchItem;
 
     public AllFrame(Type entityType)
     {
@@ -30,16 +40,47 @@ internal class AllFrame : AsyncFrame
 
     public Variable Result { get; }
 
+    public void EnlistInBatchQuery(Variable batchQuery)
+    {
+        _batchQuery = batchQuery;
+        _batchItem = new Variable(typeof(Task<>).MakeGenericType(Result.VariableType), $"{Result.Usage}_BatchItem",
+            this);
+    }
+
+    public void WriteCodeToEnlistInBatchQuery(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchItem == null || _batchQuery == null) return;
+
+        // Fisher's batched Query takes a Func<IQuerySession, IQueryable<T>> rather than being fluent off
+        // the batch, and returns Task<IReadOnlyList<T>> directly -- exactly this frame's result type.
+        writer.WriteLine(
+            $"var {_batchItem.Usage} = {_batchQuery.Usage}.{nameof(IBatchedQuery.Query)}<{_entityType.FullNameInCode()}>(q => q.Query<{_entityType.FullNameInCode()}>());");
+    }
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
-        writer.Write($"var {Result.Usage} = await {typeof(QueryableExtensions).FullNameInCode()}.{nameof(QueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+        if (_batchItem != null)
+        {
+            writer.WriteComment($"Every {_entityType.NameInCode()}, from the batched query");
+            writer.Write($"var {Result.Usage} = await {_batchItem.Usage}.ConfigureAwait(false);");
+        }
+        else
+        {
+            writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+            writer.Write($"var {Result.Usage} = await {typeof(QueryableExtensions).FullNameInCode()}.{nameof(QueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+        }
 
         Next?.GenerateCode(method, writer);
     }
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
+        if (_batchQuery != null)
+        {
+            yield return _batchQuery;
+            yield break;
+        }
+
         _session = chain.FindVariable(typeof(IDocumentSession));
         yield return _session;
 

--- a/src/Persistence/Wolverine.Marten/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/AllFrame.cs
@@ -3,6 +3,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Marten;
+using Marten.Services.BatchQuerying;
 
 namespace Wolverine.Marten.Codegen;
 
@@ -11,15 +12,26 @@ namespace Wolverine.Marten.Codegen;
 ///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
 /// </summary>
 /// <remarks>
-///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
-///     strings so that a rename in Marten breaks this build instead of shipping a codegen failure that only
-///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+///     <para>
+///         The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as
+///         literal strings so that a rename in Marten breaks this build instead of shipping a codegen failure
+///         that only surfaces the first time an endpoint using the attribute is compiled at runtime.
+///     </para>
+///     <para>
+///         Implements <see cref="IBatchableFrame" />, so a handler with more than one batchable read — two
+///         <c>[All]</c> parameters, or an <c>[All]</c> alongside an <c>[Entity]</c> or a query specification —
+///         resolves them in a <b>single round trip</b> through Marten's <see cref="IBatchedQuery" /> rather than
+///         one query each. <see cref="MartenBatchingPolicy" /> owns that decision and deliberately leaves a lone
+///         read standalone.
+///     </para>
 /// </remarks>
-internal class AllFrame : AsyncFrame
+internal class AllFrame : AsyncFrame, IBatchableFrame
 {
     private readonly Type _entityType;
     private Variable? _session;
     private Variable? _cancellation;
+    private Variable? _batchQuery;
+    private Variable? _batchItem;
 
     public AllFrame(Type entityType)
     {
@@ -29,16 +41,50 @@ internal class AllFrame : AsyncFrame
 
     public Variable Result { get; }
 
+    public void EnlistInBatchQuery(Variable batchQuery)
+    {
+        _batchQuery = batchQuery;
+        _batchItem = new Variable(typeof(Task<>).MakeGenericType(Result.VariableType), $"{Result.Usage}_BatchItem",
+            this);
+    }
+
+    public void WriteCodeToEnlistInBatchQuery(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchItem == null || _batchQuery == null) return;
+
+        // batch.Query<T>().ToList() hands back Task<IReadOnlyList<T>>, which is exactly this frame's
+        // result type -- no conversion, unlike the standalone path's ToListAsync().
+        writer.WriteLine(
+            $"var {_batchItem.Usage} = {_batchQuery.Usage}.{nameof(IBatchedQuery.Query)}<{_entityType.FullNameInCode()}>().ToList();");
+    }
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
-        writer.Write($"var {Result.Usage} = await {typeof(QueryableExtensions).FullNameInCode()}.{nameof(QueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+        if (_batchItem != null)
+        {
+            // Batched: the Query<T>().ToList() call was already emitted inside MartenBatchFrame, and the
+            // batch has executed by the time this runs. Resolve the pending task into the result variable.
+            writer.WriteComment($"Every {_entityType.NameInCode()}, from the batched query");
+            writer.Write($"var {Result.Usage} = await {_batchItem.Usage}.ConfigureAwait(false);");
+        }
+        else
+        {
+            writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+            writer.Write(
+                $"var {Result.Usage} = await {typeof(QueryableExtensions).FullNameInCode()}.{nameof(QueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+        }
 
         Next?.GenerateCode(method, writer);
     }
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
+        if (_batchQuery != null)
+        {
+            yield return _batchQuery;
+            yield break;
+        }
+
         _session = chain.FindVariable(typeof(IQuerySession));
         yield return _session;
 

--- a/src/Persistence/Wolverine.Polecat/Codegen/AllFrame.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/AllFrame.cs
@@ -3,6 +3,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Polecat;
+using Polecat.Batching;
 using Polecat.Linq;
 
 namespace Wolverine.Polecat.Codegen;
@@ -12,15 +13,24 @@ namespace Wolverine.Polecat.Codegen;
 ///     <see cref="Wolverine.Persistence.AllAttribute" /> parameter.
 /// </summary>
 /// <remarks>
-///     The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as literal
-///     strings so that a rename in Polecat breaks this build instead of shipping a codegen failure that only
-///     surfaces the first time an endpoint using the attribute is compiled at runtime.
+///     <para>
+///         The extension class and method are referenced through <c>typeof</c> / <c>nameof</c> rather than as
+///         literal strings so that a rename in Polecat breaks this build instead of shipping a codegen failure
+///         that only surfaces the first time an endpoint using the attribute is compiled at runtime.
+///     </para>
+///     <para>
+///         Implements <see cref="IBatchableFrame" />, so a handler with more than one batchable read resolves
+///         them in a <b>single round trip</b> through Polecat's <see cref="IBatchedQuery" />.
+///         <see cref="PolecatBatchingPolicy" /> owns that decision and deliberately leaves a lone read standalone.
+///     </para>
 /// </remarks>
-internal class AllFrame : AsyncFrame
+internal class AllFrame : AsyncFrame, IBatchableFrame
 {
     private readonly Type _entityType;
     private Variable? _session;
     private Variable? _cancellation;
+    private Variable? _batchQuery;
+    private Variable? _batchItem;
 
     public AllFrame(Type entityType)
     {
@@ -30,16 +40,46 @@ internal class AllFrame : AsyncFrame
 
     public Variable Result { get; }
 
+    public void EnlistInBatchQuery(Variable batchQuery)
+    {
+        _batchQuery = batchQuery;
+        _batchItem = new Variable(typeof(Task<>).MakeGenericType(Result.VariableType), $"{Result.Usage}_BatchItem",
+            this);
+    }
+
+    public void WriteCodeToEnlistInBatchQuery(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchItem == null || _batchQuery == null) return;
+
+        // batch.Query<T>().ToList() hands back Task<IReadOnlyList<T>>, exactly this frame's result type
+        writer.WriteLine(
+            $"var {_batchItem.Usage} = {_batchQuery.Usage}.{nameof(IBatchedQuery.Query)}<{_entityType.FullNameInCode()}>().ToList();");
+    }
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
-        writer.Write($"var {Result.Usage} = await {typeof(PolecatQueryableExtensions).FullNameInCode()}.{nameof(PolecatQueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+        if (_batchItem != null)
+        {
+            writer.WriteComment($"Every {_entityType.NameInCode()}, from the batched query");
+            writer.Write($"var {Result.Usage} = await {_batchItem.Usage}.ConfigureAwait(false);");
+        }
+        else
+        {
+            writer.WriteComment($"Read every {_entityType.NameInCode()} in the database");
+            writer.Write($"var {Result.Usage} = await {typeof(PolecatQueryableExtensions).FullNameInCode()}.{nameof(PolecatQueryableExtensions.ToListAsync)}({_session!.Usage}.{nameof(IQuerySession.Query)}<{_entityType.FullNameInCode()}>(), {_cancellation!.Usage}).ConfigureAwait(false);");
+        }
 
         Next?.GenerateCode(method, writer);
     }
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
+        if (_batchQuery != null)
+        {
+            yield return _batchQuery;
+            yield break;
+        }
+
         _session = chain.FindVariable(typeof(IDocumentSession));
         yield return _session;
 

--- a/src/Testing/SlowTests/SlowTests.csproj
+++ b/src/Testing/SlowTests/SlowTests.csproj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <!-- Never shipped: it is not in build/Build.cs's NugetProjects list. Declared explicitly
+             because every sibling test project declares it. -->
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -37,6 +37,7 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("Wolverine.Polecat")]
 [assembly: InternalsVisibleTo("Wolverine.Fisher")]
 [assembly: InternalsVisibleTo("PolecatTests")]
+[assembly: InternalsVisibleTo("FisherTests")]
 [assembly: InternalsVisibleTo("Wolverine.EntityFrameworkCore")]
 [assembly: InternalsVisibleTo("Wolverine.RavenDb")]
 [assembly: InternalsVisibleTo("Wolverine.Pulsar")]


### PR DESCRIPTION
## `[All]` query batching

Two or more batchable reads in one handler or endpoint now resolve in a **single round trip** on Marten, Polecat and Fisher. `AllFrame` implements each store's `IBatchableFrame`, so an `[All]` joins the same batch as an `[Entity]` load or a query specification.

```csharp
public static InventoryCounted Handle(
    CountInventory command,
    [All] IReadOnlyList<Part> parts,
    [All] IReadOnlyList<Supplier> suppliers)
    => new(parts.Count, suppliers.Count);
```

| Store | Create batch | Batched all-of-type |
|---|---|---|
| Marten | `session.CreateBatchQuery()` | `batch.Query<T>().ToList()` |
| Polecat | same | same |
| Fisher | `session.Events.CreateBatchQuery()` | `batch.Query<T>(q => q.Query<T>())` |

All three hand back `Task<IReadOnlyList<T>>`, matching `AllFrame`'s result type exactly — no conversion, unlike the standalone `ToListAsync()` path.

A **lone** read is deliberately left standalone. That needed no new code: every store's batching policy already opens with `if (frames.Count <= 1) return;`. `Bug_2387`, the load-bearing Marten batch-of-one, still passes.

The tests assert on the **generated source** as well as the results — both the batched and unbatched forms return identical data, so a results-only test would pass just as happily if batching silently never engaged. Two tests per store, proving both directions.

## Config file watcher leak in test hosts

Included here because it is what let the batching work be verified at all.

`Host.CreateDefaultBuilder()` registers `appsettings.json` with `reloadOnChange: true`, which stands up a `PhysicalFileProvider` + `FileSystemWatcher` over the content root **even when no `appsettings.json` exists**. A test assembly builds hundreds of hosts and the watchers accumulate — `MartenTests` was holding **1028 kqueue handles** by test ~594. Once a watcher can no longer start, its change token fires immediately, re-registers and fires again:

```
PhysicalFilesWatcher.TryEnableFileSystemWatcher
  → ChangeTokenRegistration.OnChangeTokenFired
  → CancellationTokenSource.Register → ... (100+ frames and growing)
```

That recursion overflows the stack, and a .NET stack overflow aborts the process with **SIGABRT / exit 134** — mid-run, while the runner still reports `Failed: 0` and exits `0`. It is nondeterministic; one run wedged for 21 minutes on a single test with every thread parked instead of aborting.

**It framed this branch.** Adding one more host-creating test class tipped an already-marginal suite, and the evidence read as 2/2 crashes with batching against 0/1 without:

| Run | Batching | Watchers | Result |
|---|---|---|---|
| 1 | yes | on | crash, 594 |
| 2 | yes | on | crash, 596 |
| baseline | no | on | clean, 595 |
| 3 | yes | on | wedged at 594, killed at 21m |
| 4 | yes | **off** (env var) | **597/597, exit 0, 11m01s** |
| 5 | yes | **off** (this fix) | **597/597, exit 0, 11m09s** |

597 is exactly the count predicted for a healthy batched run.

`DisableConfigReloadInTests` sets the framework's own opt-out, `DOTNET_hostBuilder__reloadConfigOnChange`, from a `[ModuleInitializer]` linked into every test project from `Directory.Build.targets`. Nothing in this repository reloads configuration mid-test.

Three things worth knowing about the wiring:

1. Keyed on **`IsTestProject`**, not the project name — eight suites here do not end in `Tests` (the six `*.LeaderElection` projects, `EfCoreTests.MultiTenancy`, `ChaosTesting`). *(Note: `Directory.Build.props`'s existing `UseMicrosoftTestingPlatformRunner` condition does use `EndsWith('Tests')`, so it misses those eight for Bobcat supervision — pre-existing, out of scope here.)*
2. It lives in `Directory.Build.**targets**`, not `.props`, because `.props` is imported before the project body and the NuGet-generated props, so `IsTestProject` is not set yet there.
3. **`'$(PackageId)' == ''` would be a broken guard** — `PackageId` defaults to the assembly name, so it matches no project, compiles nothing, and the build still reports success.

`Wolverine.ComplianceTests` is correctly excluded: it ships as `WolverineFx.ComplianceTests`, and a module initializer that mutates process environment variables has no business inside a published package. `SlowTests.csproj` now declares `<IsPackable>false</IsPackable>`, which every sibling test project already did.

## Incidental

`FisherTests` was missing from Wolverine's `InternalsVisibleTo` list that every sibling suite is on — `chain.SourceCode` needs it.

## Verification

- `MartenTests` **597/597**, twice, clean, exit 0.
- `Bug_2387` passes.
- `dotnet build wolverine.slnx -c Release -f net9.0` → **0 errors, 0 warnings**.

## Known, not addressed here

The runner reporting `Failed: 0` and exit code `0` while silently running fewer tests means `CIMarten` can go green on a partial run. That hazard is independent of this root cause and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC