### PR TITLE
Make the SQLite schema name the table prefix it is documented to be (GH-3943)

### DIFF
--- a/docs/guide/durability/sqlite.md
+++ b/docs/guide/durability/sqlite.md
@@ -197,8 +197,31 @@ The SQLite persistence uses the following data type mappings:
 
 ### Schema Names
 
-SQLite only supports the `main` schema name at this time. Unlike PostgreSQL or SQL Server, SQLite does not have
-a traditional schema system for Wolverine queue and envelope tables.
+SQLite has no user-defined schemas. The only schema names a plain connection knows are `main`, `temp`, and
+whatever has been `ATTACH`ed, so there is nothing for a `schema.table` qualifier to point at.
+
+Wolverine therefore treats the schema name as a **table name prefix**. The default is `main`, which prefixes
+nothing — the tables are `wolverine_incoming_envelopes`, `wolverine_outgoing_envelopes` and so on:
+
+```csharp
+opts.PersistMessagesWithSqlite(connectionString, "reporting");
+// => reporting_wolverine_incoming_envelopes, reporting_wolverine_outgoing_envelopes, ...
+```
+
+That gives the setting a meaning SQLite can honour: several logically separate Wolverine table sets living in
+one database file without colliding. Saga tables take the same prefix. The advisory lock table
+(`wolverine_locks`) deliberately does not — lock ids are derived from the schema name, so prefixed table sets
+share one lock table and still take distinct rows out of it.
+
+::: warning
+Before Wolverine 6.28.1 the schema name was passed through as a real schema qualifier, which meant any value
+other than `main` produced SQL against a database that was never attached and failed at runtime with
+`SQLite Error 1: 'no such table: <name>.wolverine_incoming_envelopes'`. See
+[GH-3943](https://github.com/JasperFx/wolverine/issues/3943).
+:::
+
+The SQLite transport's queue tables are named `wolverine_queue_<name>` and take no prefix — they are named by
+the transport rather than by the message store.
 
 `UseSqlitePersistenceAndTransport()` is intentionally connection-string only:
 

--- a/src/Persistence/FisherTests/Bug_3943_message_storage_schema_name.cs
+++ b/src/Persistence/FisherTests/Bug_3943_message_storage_schema_name.cs
@@ -1,0 +1,118 @@
+using Fisher;
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Fisher;
+using Wolverine.RDBMS;
+using Wolverine.Tracking;
+
+namespace FisherTests;
+
+/// <summary>
+///     GH-3943: setting <see cref="FisherIntegration.MessageStorageSchemaName" /> used to kill the host
+///     at the first envelope write with
+///     <c>SqliteException: no such table: &lt;name&gt;.wolverine_incoming_envelopes</c>. The value was
+///     documented as a naming prefix but reached <c>SqliteMessageStore</c> as a schema qualifier, and
+///     SQLite has no user-defined schemas — <c>&lt;name&gt;</c> named a database nothing ever ATTACHed.
+/// </summary>
+/// <remarks>
+///     This is the reporter's shape: a monitoring console standing up a third store flavour, carrying
+///     over the same two configuration lines its Marten and Polecat flavours use. On SQLite the value
+///     now prefixes the durability table names, which is the meaning the property was documented to
+///     have and the one that lets Fisher's own <c>&lt;schema&gt;_fi_*</c> tables and Wolverine's
+///     durability tables coexist in the one file under a shared naming convention.
+/// </remarks>
+public class Bug_3943_message_storage_schema_name : IAsyncLifetime
+{
+    private const string SchemaName = "cw_chaingate_wolverine";
+
+    private FisherTestDatabase theDatabase = null!;
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theDatabase = Servers.CreateDatabase("bug_3943");
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(RecordReadingHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddFisher(m =>
+                    {
+                        m.Connection(theDatabase.ConnectionString);
+                        m.AutoCreateSchemaObjects = AutoCreate.All;
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .IntegrateWithWolverine(w =>
+                    {
+                        w.MessageStorageSchemaName = SchemaName;
+                        w.TransportSchemaName = SchemaName;
+                    });
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+        theDatabase.Dispose();
+    }
+
+    [Fact]
+    public async Task the_host_handles_a_message_through_the_outbox()
+    {
+        // Pre-fix this threw "no such table: cw_chaingate_wolverine.wolverine_incoming_envelopes".
+        await theHost.InvokeMessageAndWaitAsync(new RecordReading("kasey", 42));
+
+        await using var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        var reading = await session.LoadAsync<Reading>("kasey", TestContext.Current.CancellationToken);
+        reading.ShouldNotBeNull();
+        reading.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task the_durability_tables_carry_the_name_as_a_prefix()
+    {
+        await using var connection = new SqliteConnection(theDatabase.ConnectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        (await tableExistsAsync(connection, $"{SchemaName}_{DatabaseConstants.IncomingTable}")).ShouldBeTrue();
+        (await tableExistsAsync(connection, $"{SchemaName}_{DatabaseConstants.OutgoingTable}")).ShouldBeTrue();
+
+        // And not as a qualifier against a database that was never ATTACHed.
+        (await tableExistsAsync(connection, DatabaseConstants.IncomingTable)).ShouldBeFalse();
+    }
+
+    private static async Task<bool> tableExistsAsync(SqliteConnection connection, string table)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "select count(*) from sqlite_master where type = 'table' and name = $name";
+        command.Parameters.AddWithValue("$name", table);
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)) > 0;
+    }
+}
+
+public class Reading
+{
+    public string Id { get; set; } = null!;
+    public int Value { get; set; }
+}
+
+public record RecordReading(string Name, int Value);
+
+public static class RecordReadingHandler
+{
+    public static void Handle(RecordReading command, IDocumentSession session)
+    {
+        session.Store(new Reading { Id = command.Name, Value = command.Value });
+    }
+}

--- a/src/Persistence/PersistenceTests/table_naming_contract.cs
+++ b/src/Persistence/PersistenceTests/table_naming_contract.cs
@@ -1,3 +1,4 @@
+using NSubstitute;
 using Shouldly;
 using Wolverine.RDBMS;
 using Xunit;
@@ -51,6 +52,41 @@ public class table_naming_contract
         // A prefixed name is a single identifier, so there is nothing for the quoting to bracket.
         settings.QuotedTableNameFor(DatabaseConstants.IncomingTable)
             .ShouldBe("reporting_wolverine_incoming_envelopes");
+    }
+
+    [Fact]
+    public void renders_against_a_test_double_that_only_stubs_the_schema_name()
+    {
+        // Guards the reason TableNameFor / DbObjectNameFor are extension methods rather than default
+        // interface members. As default members a substitute intercepts them and hands back null, so
+        // every durability operation built against a mocked IMessageDatabase silently loses its table
+        // name — which is how GH-3943's first cut broke
+        // release_orphaned_ancillary_high_water_mark_3850. Extension methods cannot be intercepted.
+        var database = Substitute.For<IMessageDatabase>();
+        database.SchemaName.Returns("ancillary");
+
+        database.TableNameFor(DatabaseConstants.IncomingTable)
+            .ShouldBe("ancillary.wolverine_incoming_envelopes");
+
+        // Settings is null on a bare substitute, so the prefix check has to tolerate that.
+        database.DbObjectNameFor(DatabaseConstants.IncomingTable)
+            .QualifiedName.ShouldBe("ancillary.wolverine_incoming_envelopes");
+    }
+
+    [Fact]
+    public void a_prefixing_database_renders_a_resolvable_db_object_name()
+    {
+        var database = Substitute.For<IMessageDatabase>();
+        database.SchemaName.Returns("reporting");
+        database.Settings.Returns(new DatabaseSettings
+        {
+            SchemaName = "reporting", SchemaNameIsTablePrefix = true
+        });
+
+        // "main" is always attached on SQLite, so the qualified form still resolves to the prefixed
+        // table for the operations that need the two halves apart.
+        database.DbObjectNameFor(DatabaseConstants.IncomingTable)
+            .QualifiedName.ShouldBe("main.reporting_wolverine_incoming_envelopes");
     }
 
     [Theory]

--- a/src/Persistence/PersistenceTests/table_naming_contract.cs
+++ b/src/Persistence/PersistenceTests/table_naming_contract.cs
@@ -1,0 +1,67 @@
+using Shouldly;
+using Wolverine.RDBMS;
+using Xunit;
+
+namespace PersistenceTests;
+
+/// <summary>
+/// GH-3943 introduced a single qualification point — <see cref="DatabaseSettings.TableNameFor"/> and
+/// its <c>MessageDatabase&lt;T&gt;</c> twin — that every reference to a Wolverine table in generated
+/// SQL now routes through, so that SQLite can render a table name prefix where the engines that
+/// actually have schemas render a <c>schema.table</c> qualifier.
+///
+/// <para>
+/// These are the guard rails on that hook: the default rendering has to stay byte-identical to the
+/// interpolation it replaced, because Postgres, SQL Server, MySQL and Oracle all reach it.
+/// </para>
+/// </summary>
+public class table_naming_contract
+{
+    [Fact]
+    public void qualifies_with_the_schema_by_default()
+    {
+        var settings = new DatabaseSettings { SchemaName = "wolverine" };
+
+        settings.TableNameFor(DatabaseConstants.IncomingTable)
+            .ShouldBe("wolverine.wolverine_incoming_envelopes");
+        settings.QuotedTableNameFor(DatabaseConstants.IncomingTable)
+            .ShouldBe("\"wolverine\".wolverine_incoming_envelopes");
+    }
+
+    [Fact]
+    public void no_schema_name_means_no_qualifier()
+    {
+        // PersistNodeRecord guarded on this explicitly before GH-3943 and still depends on it.
+        var settings = new DatabaseSettings { SchemaName = null };
+
+        settings.TableNameFor(DatabaseConstants.NodeRecordTableName)
+            .ShouldBe(DatabaseConstants.NodeRecordTableName);
+        settings.QuotedTableNameFor(DatabaseConstants.NodeRecordTableName)
+            .ShouldBe(DatabaseConstants.NodeRecordTableName);
+    }
+
+    [Fact]
+    public void prefixes_rather_than_qualifies_when_the_engine_has_no_schemas()
+    {
+        var settings = new DatabaseSettings { SchemaName = "reporting", SchemaNameIsTablePrefix = true };
+
+        settings.TableNameFor(DatabaseConstants.IncomingTable)
+            .ShouldBe("reporting_wolverine_incoming_envelopes");
+
+        // A prefixed name is a single identifier, so there is nothing for the quoting to bracket.
+        settings.QuotedTableNameFor(DatabaseConstants.IncomingTable)
+            .ShouldBe("reporting_wolverine_incoming_envelopes");
+    }
+
+    [Theory]
+    [InlineData(null, "wolverine_incoming_envelopes")]
+    [InlineData("", "wolverine_incoming_envelopes")]
+    // "main" is Wolverine.Sqlite's default and the only schema a plain SQLite connection always
+    // knows. It has to prefix nothing, or every database provisioned before GH-3943 is orphaned.
+    [InlineData("main", "wolverine_incoming_envelopes")]
+    [InlineData("custom", "custom_wolverine_incoming_envelopes")]
+    public void prefixing_rules(string? schemaName, string expected)
+    {
+        TablePrefixing.Apply(schemaName, DatabaseConstants.IncomingTable).ShouldBe(expected);
+    }
+}

--- a/src/Persistence/SqliteTests/Bug_3943_schema_name_is_a_table_prefix.cs
+++ b/src/Persistence/SqliteTests/Bug_3943_schema_name_is_a_table_prefix.cs
@@ -1,0 +1,168 @@
+using JasperFx.Resources;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Weasel.Sqlite;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Sqlite;
+using Xunit;
+
+namespace SqliteTests;
+
+/// <summary>
+/// Regression for https://github.com/JasperFx/wolverine/issues/3943.
+///
+/// <para>
+/// A schema name — <c>PersistMessagesWithSqlite(connectionString, "custom")</c>, or
+/// <c>FisherIntegration.MessageStorageSchemaName</c> — used to reach
+/// <see cref="Wolverine.RDBMS.MessageDatabase{T}"/> as a <c>schema.table</c> qualifier, so the
+/// durability SQL named <c>custom.wolverine_incoming_envelopes</c>. SQLite has no user-defined
+/// schemas: the only ones a plain connection knows are <c>main</c>, <c>temp</c>, and whatever has
+/// been ATTACHed, so the host built fine and then died on the first envelope write with
+/// <c>SqliteException: no such table: custom.wolverine_incoming_envelopes</c>. Weasel's own
+/// <see cref="SqliteObjectName"/> drops the schema from <c>QualifiedName</c>, so the DDL had been
+/// creating a bare <c>wolverine_incoming_envelopes</c> the whole time — DDL and DML disagreed the
+/// moment anyone set the property.
+/// </para>
+///
+/// <para>
+/// The fix folds the schema name into the table names as a prefix, which is what the property was
+/// documented to do and what gives it a meaning SQLite can honour: separately nameable table sets
+/// inside one database file. The default (<c>main</c>) prefixes nothing, so databases provisioned
+/// before this change are untouched.
+/// </para>
+/// </summary>
+public class Bug_3943_schema_name_is_a_table_prefix : IAsyncLifetime
+{
+    private SqliteTestDatabase _database = null!;
+    private IHost? _host;
+
+    public ValueTask InitializeAsync()
+    {
+        _database = Servers.CreateDatabase(nameof(Bug_3943_schema_name_is_a_table_prefix));
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        _database.Dispose();
+    }
+
+    [Fact]
+    public async Task a_custom_schema_name_prefixes_the_durability_tables()
+    {
+        _host = await startHostAsync("custom");
+
+        var tables = await existingTableNamesAsync();
+
+        tables.ShouldContain($"custom_{DatabaseConstants.IncomingTable}");
+        tables.ShouldContain($"custom_{DatabaseConstants.OutgoingTable}");
+        tables.ShouldContain($"custom_{DatabaseConstants.DeadLetterTable}");
+        tables.ShouldContain($"custom_{DatabaseConstants.NodeTableName}");
+
+        // The unprefixed names belong to a *different* logical table set, so a prefixed host must
+        // not provision them. This is the half that makes two stores in one file worth having.
+        tables.ShouldNotContain(DatabaseConstants.IncomingTable);
+        tables.ShouldNotContain(DatabaseConstants.OutgoingTable);
+    }
+
+    [Fact]
+    public async Task the_default_schema_name_leaves_the_table_names_alone()
+    {
+        // Guards the upgrade path: "main" is Wolverine.Sqlite's default, and every database
+        // provisioned before GH-3943 has bare wolverine_* tables. Prefixing those would orphan them.
+        _host = await startHostAsync(null);
+
+        var tables = await existingTableNamesAsync();
+
+        tables.ShouldContain(DatabaseConstants.IncomingTable);
+        tables.ShouldContain(DatabaseConstants.OutgoingTable);
+        tables.ShouldContain(DatabaseConstants.DeadLetterTable);
+        tables.ShouldNotContain($"main_{DatabaseConstants.IncomingTable}");
+    }
+
+    [Fact]
+    public async Task envelopes_round_trip_through_a_prefixed_store()
+    {
+        // The reported failure verbatim: the host starts, and then the first envelope write throws
+        // "no such table: <name>.wolverine_incoming_envelopes". Everything here is inbox/outbox SQL
+        // inherited from MessageDatabase<T>, which is exactly where the bad qualifier came from.
+        _host = await startHostAsync("cw_chaingate_wolverine");
+
+        var store = _host.Services.GetRequiredService<IMessageStore>();
+
+        var incoming = ObjectMother.Envelope();
+        incoming.Status = EnvelopeStatus.Incoming;
+        await store.Inbox.StoreIncomingAsync(incoming);
+
+        var outgoing = ObjectMother.Envelope();
+        outgoing.Status = EnvelopeStatus.Outgoing;
+        await store.Outbox.StoreOutgoingAsync(outgoing, 0);
+
+        var counts = await store.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(1);
+        counts.Outgoing.ShouldBe(1);
+
+        await store.Inbox.MarkIncomingEnvelopeAsHandledAsync(incoming);
+
+        var afterHandled = await store.Admin.FetchCountsAsync();
+        afterHandled.Incoming.ShouldBe(0);
+        afterHandled.Handled.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task two_prefixed_table_sets_can_share_one_database_file()
+    {
+        // The point of the whole feature, and the shape the issue reports from: a monitoring console
+        // whose store and whose Wolverine durability tables live in the same SQLite file.
+        _host = await startHostAsync("alpha");
+
+        using var second = await startHostAsync("beta");
+
+        var tables = await existingTableNamesAsync();
+        tables.ShouldContain($"alpha_{DatabaseConstants.IncomingTable}");
+        tables.ShouldContain($"beta_{DatabaseConstants.IncomingTable}");
+
+        var alpha = _host.Services.GetRequiredService<IMessageStore>();
+        var beta = second.Services.GetRequiredService<IMessageStore>();
+
+        await alpha.Inbox.StoreIncomingAsync(ObjectMother.Envelope());
+
+        // Disjoint storage, not two views of one table.
+        (await alpha.Admin.FetchCountsAsync()).Incoming.ShouldBe(1);
+        (await beta.Admin.FetchCountsAsync()).Incoming.ShouldBe(0);
+
+        await second.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    private Task<IHost> startHostAsync(string? schemaName)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlite(_database.ConnectionString, schemaName);
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddResourceSetupOnStartup();
+            })
+            .StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private async Task<List<string>> existingTableNamesAsync()
+    {
+        await using var connection = new SqliteConnection(_database.ConnectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        var tables = await connection.ExistingTablesAsync(schemas: ["main"], ct: TestContext.Current.CancellationToken);
+        return tables.Select(x => x.Name).ToList();
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
@@ -66,9 +66,12 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
 
         // GH-3884's transport schema stamping has no Fisher equivalent, and deliberately so:
         // SQLite has no schemas. Wolverine.Sqlite's transport places its queue tables in the one
-        // database file, so there is nothing here for MessageStorageSchemaName / TransportSchemaName
-        // to align. Those properties still steer where the SqliteMessageStore's own tables go, which
-        // is a naming prefix rather than a schema.
+        // database file, so there is nothing here for TransportSchemaName to align — it is inert on
+        // Fisher and kept only for source parity with the Marten and Polecat integrations.
+        // MessageStorageSchemaName does steer where the SqliteMessageStore's tables go, and GH-3943
+        // made it the naming prefix this comment always claimed it was: it reached the store as a
+        // `schema.table` qualifier instead, so any value other than "main" named a database nothing
+        // had ATTACHed and the host died on the first envelope write with "no such table".
 
         options.Policies.Add<FisherOpPolicy>();
 
@@ -89,13 +92,16 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
     private string _transportSchemaName = "wolverine_queues";
 
     /// <summary>
-    /// The database schema to place SQLite-backed queues.
+    /// Present for source parity with the Marten and Polecat integrations. <b>It has no effect on a
+    /// Fisher host</b>: a Fisher store is a single SQLite file and SQLite has no schemas, so the
+    /// SQLite transport names its queue tables <c>wolverine_queue_&lt;name&gt;</c> in that one file
+    /// and there is no schema for this to steer. Nothing reads it.
     /// </summary>
     /// <remarks>
-    /// GH-3884: setting this is authoritative — it overwrites whatever the SQLite transport was
-    /// configured with, because this integration applies at host build. Leaving it alone leaves the
-    /// transport's own configuration (its default, or an explicit
-    /// <c>UseSqlServerPersistenceAndTransport(..., transportSchema: ...)</c>) untouched.
+    /// GH-3884 removed the equivalent setters from <c>SqlitePersistenceExpression</c> for the same
+    /// reason. See also GH-3943, where setting this alongside
+    /// <see cref="MessageStorageSchemaName"/> is how the reporter arrived at the message storage bug
+    /// — this half was simply inert.
     /// </remarks>
     public string TransportSchemaName
     {
@@ -109,9 +115,17 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
     private string? _messageStorageSchemaName;
 
     /// <summary>
-    /// The database schema to place the message store tables for Wolverine.
-    /// The default is "wolverine"
+    /// Names the Wolverine message store tables inside the Fisher database file. SQLite has no
+    /// schemas, so this is a <b>table name prefix</b>: <c>"reporting"</c> gives you
+    /// <c>reporting_wolverine_incoming_envelopes</c> and friends, which is what lets logically
+    /// separate Wolverine table sets share one file. The default is <c>main</c>, which prefixes
+    /// nothing and leaves the tables named exactly as they have always been.
     /// </summary>
+    /// <remarks>
+    /// GH-3943: this used to reach <c>SqliteMessageStore</c> as a <c>schema.table</c> qualifier, so
+    /// any value other than <c>main</c> emitted SQL against a database nothing had ATTACHed and the
+    /// host died on the first envelope write with <c>no such table</c>.
+    /// </remarks>
     public string? MessageStorageSchemaName
     {
         get => _messageStorageSchemaName;

--- a/src/Persistence/Wolverine.Fisher/WolverineOptionsFisherExtensions.cs
+++ b/src/Persistence/Wolverine.Fisher/WolverineOptionsFisherExtensions.cs
@@ -136,6 +136,10 @@ public static class WolverineOptionsFisherExtensions
         var settings = new DatabaseSettings
         {
             SchemaName = schemaName,
+            // GH-3943: SQLite has no schemas, so the name is a table name prefix. Without this the
+            // store emits `<name>.wolverine_incoming_envelopes` against a database nothing ATTACHed
+            // and the host dies on the first envelope write with "no such table".
+            SchemaNameIsTablePrefix = true,
             AutoCreate = AutoCreate.CreateOrUpdate,
             Role = MessageStoreRole.Main,
             ScheduledJobLockId = $"{schemaName}:scheduled-jobs".GetDeterministicHashCode(),

--- a/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
@@ -51,7 +51,7 @@ public static class DatabasePersistence
         var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
 
         builder.Append(
-            $"insert into {settings.SchemaName}.{DatabaseConstants.OutgoingTable} ({DatabaseConstants.OutgoingFields}) values ({parameterList});");
+            $"insert into {settings.TableNameFor(DatabaseConstants.OutgoingTable)} ({DatabaseConstants.OutgoingFields}) values ({parameterList});");
     }
 
     public static DbCommand BuildIncomingStorageCommand(IEnumerable<Envelope> envelopes,
@@ -86,7 +86,7 @@ public static class DatabasePersistence
         var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
 
         builder.Append(
-            $@"insert into {settings.SchemaName}.{DatabaseConstants.IncomingTable}({DatabaseConstants.IncomingFields}) values ({parameterList});");
+            $@"insert into {settings.TableNameFor(DatabaseConstants.IncomingTable)}({DatabaseConstants.IncomingFields}) values ({parameterList});");
     }
 
     public static async Task<Envelope> ReadIncomingAsync(DbDataReader reader, CancellationToken cancellation = default)
@@ -245,7 +245,7 @@ public static class DatabasePersistence
         var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
         
         builder.Append(
-            $"insert into {wolverineDatabase.SchemaName}.{DatabaseConstants.DeadLetterTable} ({deadLetterFields}) values ({parameterList});");
+            $"insert into {wolverineDatabase.TableNameFor(DatabaseConstants.DeadLetterTable)} ({deadLetterFields}) values ({parameterList});");
     }
 
     public static async Task<Envelope> ReadOutgoingAsync(DbDataReader reader, CancellationToken cancellation = default)

--- a/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
@@ -27,6 +27,40 @@ public class DatabaseSettings
             return $"\"{escaped}\"";
         }
     }
+
+    /// <summary>
+    /// True for engines that have no user-defined schemas at all — SQLite, where the only "schema"
+    /// names a connection knows are <c>main</c>, <c>temp</c>, and whatever has been ATTACHed. For
+    /// those, <see cref="SchemaName"/> is folded into the table names as a prefix instead of being
+    /// emitted as a <c>schema.table</c> qualifier, which is what lets several logically separate
+    /// Wolverine table sets share one database file. See GH-3943.
+    /// </summary>
+    public bool SchemaNameIsTablePrefix { get; set; }
+
+    /// <summary>
+    /// Renders the storage identifier for one of Wolverine's envelope storage tables, honoring
+    /// <see cref="SchemaNameIsTablePrefix"/>. Every reference to a Wolverine table in generated SQL
+    /// should go through this rather than interpolating <c>{SchemaName}.{table}</c> directly.
+    /// </summary>
+    public string TableNameFor(string tableName)
+    {
+        if (SchemaNameIsTablePrefix) return TablePrefixing.Apply(SchemaName, tableName);
+
+        // No schema configured at all means no qualifier — every dialect then resolves the table
+        // against the connection's default schema.
+        return string.IsNullOrEmpty(SchemaName) ? tableName : $"{SchemaName}.{tableName}";
+    }
+
+    /// <summary>
+    /// The <see cref="TableNameFor"/> rendering, but with the schema name quoted for engines that
+    /// need it. Prefixed names are single identifiers and are never quoted here.
+    /// </summary>
+    public string QuotedTableNameFor(string tableName)
+    {
+        if (SchemaNameIsTablePrefix) return TablePrefixing.Apply(SchemaName, tableName);
+
+        return string.IsNullOrEmpty(SchemaName) ? tableName : $"{QuotedSchemaName}.{tableName}";
+    }
     public AutoCreate AutoCreate { get; set; } = JasperFx.AutoCreate.CreateOrUpdate;
 
     /// <summary>

--- a/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableIncomingMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableIncomingMessagesOperation.cs
@@ -31,7 +31,7 @@ internal class CheckRecoverableIncomingMessagesOperation : IDatabaseOperation
     public void ConfigureCommand(DbCommandBuilder builder)
     {
         builder.Append(
-            $"select {DatabaseConstants.ReceivedAt}, count(*) from {_database.SchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.Status} = '{EnvelopeStatus.Incoming}' and {DatabaseConstants.OwnerId} = {TransportConstants.AnyNode} group by {DatabaseConstants.ReceivedAt};");
+            $"select {DatabaseConstants.ReceivedAt}, count(*) from {_database.TableNameFor(DatabaseConstants.IncomingTable)} where {DatabaseConstants.Status} = '{EnvelopeStatus.Incoming}' and {DatabaseConstants.OwnerId} = {TransportConstants.AnyNode} group by {DatabaseConstants.ReceivedAt};");
     }
 
     public async Task ReadResultsAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableOutgoingMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/CheckRecoverableOutgoingMessagesOperation.cs
@@ -31,7 +31,7 @@ internal class CheckRecoverableOutgoingMessagesOperation : IDatabaseOperation
     public void ConfigureCommand(DbCommandBuilder builder)
     {
         builder.Append(
-            $"select distinct destination from {_database.SchemaName}.{DatabaseConstants.OutgoingTable} where owner_id = 0;");
+            $"select distinct destination from {_database.TableNameFor(DatabaseConstants.OutgoingTable)} where owner_id = 0;");
     }
 
     public async Task ReadResultsAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredDeadLetterMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredDeadLetterMessagesOperation.cs
@@ -22,7 +22,7 @@ internal class DeleteExpiredDeadLetterMessagesOperation : IDatabaseOperation
     public string Description { get; } = "Delete any expired dead letter messages from storage";
     public void ConfigureCommand(DbCommandBuilder builder)
     {
-        builder.Append($"delete from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Expires} < ");
+        builder.Append($"delete from {_database.TableNameFor(DatabaseConstants.DeadLetterTable)} where {DatabaseConstants.Expires} < ");
         builder.AppendParameter(_utcNow);
         builder.Append(';');
     }

--- a/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredHandledEnvelopesCommand.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredHandledEnvelopesCommand.cs
@@ -35,7 +35,7 @@ internal class DeleteExpiredHandledEnvelopesCommand : IAgentCommand
         {
             // This provider can't bound the delete; fall back to a single unbounded delete, but
             // still on this dedicated timer and transaction, off the main recovery loop.
-            var incomingTable = new DbObjectName(_database.SchemaName, DatabaseConstants.IncomingTable);
+            var incomingTable = _database.DbObjectNameFor(DatabaseConstants.IncomingTable);
             var fallback = new DatabaseOperationBatch(_database,
                 [new DeleteExpiredEnvelopesOperation(incomingTable, now)]);
             return await fallback.ExecuteAsync(runtime, cancellationToken);

--- a/src/Persistence/Wolverine.RDBMS/Durability/DeleteOldNodeEventRecords.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/DeleteOldNodeEventRecords.cs
@@ -27,7 +27,7 @@ internal class DeleteOldNodeEventRecords : IDatabaseOperation, IDoNotReturnData
     {
         var cutoffTime = DateTimeOffset.UtcNow.Subtract(_settings.NodeEventRecordExpirationTime);
         
-        builder.Append($"delete from {_database.SchemaName}.{DatabaseConstants.NodeRecordTableName} where timestamp < ");
+        builder.Append($"delete from {_database.TableNameFor(DatabaseConstants.NodeRecordTableName)} where timestamp < ");
         builder.AppendParameter(cutoffTime);
         builder.Append(';');
     }

--- a/src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncomingOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/MoveReplayableErrorMessagesToIncomingOperation.cs
@@ -20,11 +20,11 @@ internal class MoveReplayableErrorMessagesToIncomingOperation : IDatabaseOperati
     public void ConfigureCommand(DbCommandBuilder builder)
     {
         builder.Append(
-            $"insert into {_database.SchemaName}.{DatabaseConstants.IncomingTable} ({DatabaseConstants.IncomingFields}) ");
+            $"insert into {_database.TableNameFor(DatabaseConstants.IncomingTable)} ({DatabaseConstants.IncomingFields}) ");
         builder.Append(
             $"select {DatabaseConstants.Body}, {DatabaseConstants.Id}, '{EnvelopeStatus.Incoming}', 0, null, 0, {DatabaseConstants.MessageType}, {DatabaseConstants.ReceivedAt}, null ");
         builder.Append(
-            $"from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = {builder.ParameterPrefix}replayable;");
+            $"from {_database.TableNameFor(DatabaseConstants.DeadLetterTable)} where {DatabaseConstants.Replayable} = {builder.ParameterPrefix}replayable;");
         builder.AddNamedParameter("replayable", true);
 
         // This operation writes two statements, so the boundary has to be explicit -- the trailing
@@ -32,7 +32,7 @@ internal class MoveReplayableErrorMessagesToIncomingOperation : IDatabaseOperati
         builder.StartNewCommand();
 
         builder.Append(
-            $"delete from {_database.SchemaName}.{DatabaseConstants.DeadLetterTable} where {DatabaseConstants.Replayable} = {builder.ParameterPrefix}replayable;");
+            $"delete from {_database.TableNameFor(DatabaseConstants.DeadLetterTable)} where {DatabaseConstants.Replayable} = {builder.ParameterPrefix}replayable;");
     }
 
     public Task ReadResultsAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
@@ -40,13 +40,9 @@ public class PersistNodeRecord : IDatabaseOperation, IDoNotReturnData
             // persistence failed with "SQL syntax error... near
             // '\"wolverine\".wolverine_node_records'". Unquoted matches what the rest of the
             // provider already does (and works for every dialect with a default schema name).
-            if (!string.IsNullOrEmpty(_settings.SchemaName))
-            {
-                builder.Append(_settings.SchemaName);
-                builder.Append('.');
-            }
-
-            builder.Append(DatabaseConstants.NodeRecordTableName);
+            // GH-3943: routed through DatabaseSettings.TableNameFor so SQLite, which has no schemas,
+            // gets the prefixed single identifier instead of a `schema.table` qualifier.
+            builder.Append(_settings.TableNameFor(DatabaseConstants.NodeRecordTableName));
             builder.Append(" (node_number, event_name, description) values (");
             builder.AppendParameter(@event.NodeNumber);
             builder.Append(", ");

--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesForAncillaryOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesForAncillaryOperation.cs
@@ -37,9 +37,8 @@ internal class ReleaseOrphanedMessagesForAncillaryOperation : IDatabaseOperation
     {
         if (_activeNodeNumbers.Count == 0) return;
 
-        var schemaName = _database.SchemaName;
-        var incomingTable = new DbObjectName(schemaName, DatabaseConstants.IncomingTable);
-        var outgoingTable = new DbObjectName(schemaName, DatabaseConstants.OutgoingTable);
+        var incomingTable = _database.DbObjectNameFor(DatabaseConstants.IncomingTable);
+        var outgoingTable = _database.DbObjectNameFor(DatabaseConstants.OutgoingTable);
         var nodeList = string.Join(", ", _activeNodeNumbers);
 
         // GH-3850. The list is cached per node for up to one polling interval, so it cannot describe

--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesOperation.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesOperation.cs
@@ -23,10 +23,9 @@ internal class ReleaseOrphanedMessagesOperation : IDatabaseOperation, IDoNotRetu
 
     public void ConfigureCommand(DbCommandBuilder builder)
     {
-        var schemaName = _database.SchemaName;
-        var incomingTable = new DbObjectName(schemaName, DatabaseConstants.IncomingTable);
-        var outgoingTable = new DbObjectName(schemaName, DatabaseConstants.OutgoingTable);
-        var nodesTable = new DbObjectName(schemaName, DatabaseConstants.NodeTableName);
+        var incomingTable = _database.DbObjectNameFor(DatabaseConstants.IncomingTable);
+        var outgoingTable = _database.DbObjectNameFor(DatabaseConstants.OutgoingTable);
+        var nodesTable = _database.DbObjectNameFor(DatabaseConstants.NodeTableName);
 
         builder.Append(
             $"update {incomingTable} set {DatabaseConstants.OwnerId} = 0 where {DatabaseConstants.OwnerId} != 0 and {DatabaseConstants.OwnerId} not in (select {DatabaseConstants.NodeNumber} from {nodesTable});");

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -251,7 +251,7 @@ internal class DurabilityAgent : IAgent
     internal IDatabaseOperation[] buildOperationBatch(IReadOnlyList<int>? activeNodeNumbers = null,
         int nodeNumberHighWaterMark = 0)
     {
-        var incomingTable = new DbObjectName(_database.SchemaName, DatabaseConstants.IncomingTable);
+        var incomingTable = _database.DbObjectNameFor(DatabaseConstants.IncomingTable);
         var now = DateTimeOffset.UtcNow;
         List<IDatabaseOperation> ops =
         [
@@ -281,7 +281,7 @@ internal class DurabilityAgent : IAgent
 
         if (_runtime.Options.Durability.OutboxStaleTime.HasValue)
         {
-            ops.Add(new BumpStaleOutgoingEnvelopesOperation(new DbObjectName(_database.SchemaName, DatabaseConstants.OutgoingTable), _runtime.Options.Durability, now));
+            ops.Add(new BumpStaleOutgoingEnvelopesOperation(_database.DbObjectNameFor(DatabaseConstants.OutgoingTable), _runtime.Options.Durability, now));
         }
 
         if (_runtime.Options.Durability.InboxStaleTime.HasValue)

--- a/src/Persistence/Wolverine.RDBMS/DynamicListeners/RdbmsListenerStore.cs
+++ b/src/Persistence/Wolverine.RDBMS/DynamicListeners/RdbmsListenerStore.cs
@@ -30,16 +30,20 @@ internal sealed class RdbmsListenerStore : IListenerStore
     private readonly string _deleteSql;
     private readonly string _selectAllSql;
 
+    /// <param name="table">
+    /// The fully rendered storage identifier for the listener registry table, as produced by
+    /// <see cref="MessageDatabase{T}.QuotedTableNameFor"/> — schema-qualified on engines that have
+    /// schemas, and a prefixed single identifier on SQLite (GH-3943).
+    /// </param>
     public RdbmsListenerStore(
         DbDataSource dataSource,
-        string quotedSchemaName,
+        string table,
         Func<Exception, bool> isUniqueConstraintViolation)
     {
         _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
         _isUniqueConstraintViolation = isUniqueConstraintViolation
                                        ?? throw new ArgumentNullException(nameof(isUniqueConstraintViolation));
 
-        var table = $"{quotedSchemaName}.{DatabaseConstants.ListenersTableName}";
         _insertSql = $"insert into {table} (uri) values (@uri)";
         _deleteSql = $"delete from {table} where uri = @uri";
         _selectAllSql = $"select uri from {table}";

--- a/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
@@ -57,6 +57,21 @@ public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDataba
 
     string SchemaName { get; set; }
 
+    /// <summary>
+    /// Renders the storage identifier for one of Wolverine's tables. Every reference to a Wolverine
+    /// table in generated SQL goes through this rather than interpolating <c>{SchemaName}.{table}</c>
+    /// directly, because engines without schemas (SQLite) fold the schema name into the table name as
+    /// a prefix instead. See GH-3943.
+    /// </summary>
+    string TableNameFor(string tableName) =>
+        string.IsNullOrEmpty(SchemaName) ? tableName : $"{SchemaName}.{tableName}";
+
+    /// <summary>
+    /// The <see cref="TableNameFor"/> rendering as a <see cref="DbObjectName"/>, for the operations
+    /// that need the schema and table halves separately.
+    /// </summary>
+    DbObjectName DbObjectNameFor(string tableName) => new(SchemaName, tableName);
+
     DbDataSource DataSource { get; }
     ILogger Logger { get; }
 
@@ -76,7 +91,7 @@ public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDataba
         DateTimeOffset keepUntil, CancellationToken cancellation)
     {
         var cmd = conn.CreateCommand(
-                $"update {SchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keep where id = @id")
+                $"update {TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keep where id = @id")
             .With("id", envelope.Id)
             .With("keep", keepUntil);
         cmd.Transaction = tx;

--- a/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
@@ -49,6 +49,43 @@ public static class MessageDatabaseExtensions
 
         return false;
     }
+
+    /// <summary>
+    /// Renders the storage identifier for one of Wolverine's tables. Every reference to a Wolverine
+    /// table in generated SQL goes through this rather than interpolating <c>{SchemaName}.{table}</c>
+    /// directly, because engines without schemas (SQLite) fold the schema name into the table name
+    /// as a prefix instead. See GH-3943.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately an extension method rather than a member on <see cref="IMessageDatabase"/>: a
+    /// default interface member would be intercepted by test doubles and silently return null, and
+    /// adding a required member would break every implementation outside this repository.
+    /// </remarks>
+    public static string TableNameFor(this IMessageDatabase database, string tableName)
+    {
+        if (database.Settings?.SchemaNameIsTablePrefix == true)
+        {
+            return TablePrefixing.Apply(database.SchemaName, tableName);
+        }
+
+        return string.IsNullOrEmpty(database.SchemaName)
+            ? tableName
+            : $"{database.SchemaName}.{tableName}";
+    }
+
+    /// <summary>
+    /// The <see cref="TableNameFor"/> rendering as a <see cref="DbObjectName"/>, for the operations
+    /// that need the schema and table halves separately. On a prefixing engine the schema half is
+    /// <c>main</c> — the one schema a SQLite connection always has — so the qualified name still
+    /// resolves to the prefixed table.
+    /// </summary>
+    public static DbObjectName DbObjectNameFor(this IMessageDatabase database, string tableName)
+    {
+        return database.Settings?.SchemaNameIsTablePrefix == true
+            ? new DbObjectName(TablePrefixing.DefaultSqliteSchemaName,
+                TablePrefixing.Apply(database.SchemaName, tableName))
+            : new DbObjectName(database.SchemaName, tableName);
+    }
 }
 
 public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDatabaseRegistry
@@ -56,21 +93,6 @@ public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDataba
     public DatabaseSettings Settings {get; }
 
     string SchemaName { get; set; }
-
-    /// <summary>
-    /// Renders the storage identifier for one of Wolverine's tables. Every reference to a Wolverine
-    /// table in generated SQL goes through this rather than interpolating <c>{SchemaName}.{table}</c>
-    /// directly, because engines without schemas (SQLite) fold the schema name into the table name as
-    /// a prefix instead. See GH-3943.
-    /// </summary>
-    string TableNameFor(string tableName) =>
-        string.IsNullOrEmpty(SchemaName) ? tableName : $"{SchemaName}.{tableName}";
-
-    /// <summary>
-    /// The <see cref="TableNameFor"/> rendering as a <see cref="DbObjectName"/>, for the operations
-    /// that need the schema and table halves separately.
-    /// </summary>
-    DbObjectName DbObjectNameFor(string tableName) => new(SchemaName, tableName);
 
     DbDataSource DataSource { get; }
     ILogger Logger { get; }
@@ -91,7 +113,7 @@ public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDataba
         DateTimeOffset keepUntil, CancellationToken cancellation)
     {
         var cmd = conn.CreateCommand(
-                $"update {TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keep where id = @id")
+                $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keep where id = @id")
             .With("id", envelope.Id)
             .With("keep", keepUntil);
         cmd.Transaction = tx;

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -158,28 +158,28 @@ public abstract partial class MessageDatabase<T>
     public async Task<IReadOnlyList<Envelope>> AllIncomingAsync()
     {
         return await CreateCommand(
-                $"select {DatabaseConstants.IncomingFields} from {QuotedSchemaName}.{DatabaseConstants.IncomingTable}")
+                $"select {DatabaseConstants.IncomingFields} from {QuotedTableNameFor(DatabaseConstants.IncomingTable)}")
             .FetchListAsync(r => DatabasePersistence.ReadIncomingAsync(r, _cancellation), _cancellation);
     }
 
     public Task<IReadOnlyList<Envelope>> AllOutgoingAsync()
     {
         return CreateCommand(
-                $"select {DatabaseConstants.OutgoingFields} from {QuotedSchemaName}.{DatabaseConstants.OutgoingTable}")
+                $"select {DatabaseConstants.OutgoingFields} from {QuotedTableNameFor(DatabaseConstants.OutgoingTable)}")
             .FetchListAsync(r => DatabasePersistence.ReadOutgoingAsync(r, _cancellation), _cancellation);
     }
 
     public Task ReleaseAllOwnershipAsync()
     {
         return CreateCommand(
-                $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set owner_id = 0;update {QuotedSchemaName}.{DatabaseConstants.OutgoingTable} set owner_id = 0")
+                $"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set owner_id = 0;update {QuotedTableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = 0")
             .ExecuteNonQueryAsync(_cancellation);
     }
 
     public Task ReleaseAllOwnershipAsync(int ownerId)
     {
         return CreateCommand(
-                $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set owner_id = 0 where owner_id = @id;update {QuotedSchemaName}.{DatabaseConstants.OutgoingTable} set owner_id = 0 where owner_id = @id")
+                $"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set owner_id = 0 where owner_id = @id;update {QuotedTableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = 0 where owner_id = @id")
             .With("id", ownerId)
             .ExecuteNonQueryAsync(_cancellation);
     }
@@ -239,19 +239,19 @@ public abstract partial class MessageDatabase<T>
         try
         {
             var tx = await conn.BeginTransactionAsync(_cancellation);
-            await tx.CreateCommand($"delete from {QuotedSchemaName}.{DatabaseConstants.OutgoingTable}")
+            await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.OutgoingTable)}")
                 .ExecuteNonQueryAsync(_cancellation);
-            await tx.CreateCommand($"delete from {QuotedSchemaName}.{DatabaseConstants.IncomingTable}")
+            await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.IncomingTable)}")
                 .ExecuteNonQueryAsync(_cancellation);
-            await tx.CreateCommand($"delete from {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable}")
+            await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)}")
                 .ExecuteNonQueryAsync(_cancellation);
 
             if (_settings.Role == MessageStoreRole.Main)
             {
-                await tx.CreateCommand($"delete from {QuotedSchemaName}.{DatabaseConstants.AgentRestrictionsTableName}")
+                await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.AgentRestrictionsTableName)}")
                     .ExecuteNonQueryAsync(_cancellation);
 
-                await tx.CreateCommand($"delete from {QuotedSchemaName}.{DatabaseConstants.NodeRecordTableName}")
+                await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.NodeRecordTableName)}")
                     .ExecuteNonQueryAsync(_cancellation);
 
                 // Clear the dynamic-listener registry too, so test hosts that call
@@ -260,7 +260,7 @@ public abstract partial class MessageDatabase<T>
                 // wolverine_listeners table doesn't exist.
                 if (Durability.EnableDynamicListeners)
                 {
-                    await tx.CreateCommand($"delete from {QuotedSchemaName}.{DatabaseConstants.ListenersTableName}")
+                    await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.ListenersTableName)}")
                         .ExecuteNonQueryAsync(_cancellation);
                 }
             }

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetterAdminService.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetterAdminService.cs
@@ -18,7 +18,7 @@ public abstract partial class MessageDatabase<T>
     {
         var builder = ToCommandBuilder();
         builder.Append($"select {DatabaseConstants.ReceivedAt}, {DatabaseConstants.MessageType}, {DatabaseConstants.ExceptionType}, count(*) as total");
-        builder.Append($" from {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable}");
+        builder.Append($" from {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)}");
         builder.Append(" where 1 = 1");
 
         if (range.From.HasValue)
@@ -82,7 +82,7 @@ public abstract partial class MessageDatabase<T>
 
         var topSelect = toTopClause(query);
         
-        builder.Append($"select{topSelect} {DatabaseConstants.DeadLetterFields}, count(*) OVER() as total_rows from {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable} where 1 = 1");
+        builder.Append($"select{topSelect} {DatabaseConstants.DeadLetterFields}, count(*) OVER() as total_rows from {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)} where 1 = 1");
 
         writeDeadLetterWhereClause(query, builder);
 
@@ -183,7 +183,7 @@ public abstract partial class MessageDatabase<T>
     {
         var builder = ToCommandBuilder();
         
-        builder.Append($"delete from {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable} where 1 = 1");
+        builder.Append($"delete from {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)} where 1 = 1");
 
         writeDeadLetterWhereClause(query, builder);
 
@@ -195,7 +195,7 @@ public abstract partial class MessageDatabase<T>
         var builder = ToCommandBuilder();
 
         builder.Append(
-            $"update {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable} set {DatabaseConstants.Replayable} = ");
+            $"update {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)} set {DatabaseConstants.Replayable} = ");
         builder.AppendParameter(true);
         builder.Append(" where 1 = 1");
         writeDeadLetterWhereClause(query, builder);
@@ -215,7 +215,7 @@ public abstract partial class MessageDatabase<T>
 
         var builder = ToCommandBuilder();
         builder.Append(
-            $"update {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable} set {DatabaseConstants.Body} = ");
+            $"update {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)} set {DatabaseConstants.Body} = ");
         builder.AppendParameter(serialized);
         builder.Append($", {DatabaseConstants.Replayable} = ");
         builder.AppendParameter(true);

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetters.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.DeadLetters.cs
@@ -9,7 +9,7 @@ public abstract partial class MessageDatabase<T>
     public async Task<DeadLetterEnvelope?> DeadLetterEnvelopeByIdAsync(Guid id, string? tenantId = null)
     {
         await using var reader = await CreateCommand(
-                $"select {DatabaseConstants.DeadLetterFields} from {QuotedSchemaName}.{DatabaseConstants.DeadLetterTable} where id = @id")
+                $"select {DatabaseConstants.DeadLetterFields} from {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)} where id = @id")
             .With("id", id)
             .ExecuteReaderAsync(_cancellation);
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
@@ -22,7 +22,7 @@ public abstract partial class MessageDatabase<T>
         var builder = ToCommandBuilder();
         foreach (var envelope in incoming)
         {
-            builder.Append($"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set owner_id = ");
+            builder.Append($"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set owner_id = ");
             builder.AppendParameter(ownerId);
             builder.Append($" where {DatabaseConstants.Id} = ");
             builder.AppendParameter(envelope.Id);
@@ -63,7 +63,7 @@ public abstract partial class MessageDatabase<T>
         try
         {
             var builder = ToCommandBuilder();
-            builder.Append($"delete from {QuotedSchemaName}.{DatabaseConstants.IncomingTable} WHERE id = ");
+            builder.Append($"delete from {QuotedTableNameFor(DatabaseConstants.IncomingTable)} WHERE id = ");
             builder.AppendParameter(envelope.Id);
             builder.Append($" and {DatabaseConstants.ReceivedAt} = ");
             builder.AppendParameter(envelope.Destination!.ToString());
@@ -101,7 +101,7 @@ public abstract partial class MessageDatabase<T>
 
         foreach (var envelope in envelopes)
         {
-            builder.Append($"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = ");
+            builder.Append($"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = ");
             builder.AppendParameter(envelope.Id);
             builder.Append(" and ");
             builder.Append(DatabaseConstants.ReceivedAt);

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
@@ -34,7 +34,7 @@ public abstract partial class MessageDatabase<T>
         if (HasDisposed) return Task.CompletedTask;
 
         return CreateCommand(
-                $"delete from {QuotedSchemaName}.{DatabaseConstants.OutgoingTable} where id = @id")
+                $"delete from {QuotedTableNameFor(DatabaseConstants.OutgoingTable)} where id = @id")
             .With("id", envelope.Id)
             .ExecuteNonQueryAsync(_cancellation);
     }

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Scheduled.cs
@@ -12,7 +12,7 @@ public abstract partial class MessageDatabase<T>
     {
         Logger.LogDebug("Persisting envelope {EnvelopeId} ({MessageType}) as Scheduled in database inbox at {Destination}", envelope.Id, envelope.MessageType, envelope.Destination);
         return CreateCommand(
-                $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set execution_time = @time, status = \'{EnvelopeStatus.Scheduled}\', attempts = @attempts, owner_id = {TransportConstants.AnyNode} where id = @id and {DatabaseConstants.ReceivedAt} = @uri;")
+                $"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set execution_time = @time, status = \'{EnvelopeStatus.Scheduled}\', attempts = @attempts, owner_id = {TransportConstants.AnyNode} where id = @id and {DatabaseConstants.ReceivedAt} = @uri;")
             .With("time", envelope.ScheduledTime!.Value)
             .With("attempts", envelope.Attempts)
             .With("id", envelope.Id)
@@ -35,7 +35,7 @@ public abstract partial class MessageDatabase<T>
         // (e.g. ProcessInline retry #1, or BufferedLocalQueue's scheduled-publish path),
         // UPDATE affects 0 rows and we fall back to StoreIncomingAsync.
         var rowsAffected = await CreateCommand(
-                $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set execution_time = @time, status = \'{EnvelopeStatus.Scheduled}\', attempts = @attempts, owner_id = {TransportConstants.AnyNode} where id = @id and {DatabaseConstants.ReceivedAt} = @uri;")
+                $"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set execution_time = @time, status = \'{EnvelopeStatus.Scheduled}\', attempts = @attempts, owner_id = {TransportConstants.AnyNode} where id = @id and {DatabaseConstants.ReceivedAt} = @uri;")
             .With("time", envelope.ScheduledTime!.Value)
             .With("attempts", envelope.Attempts)
             .With("id", envelope.Id)

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.ScheduledMessages.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.ScheduledMessages.cs
@@ -15,7 +15,7 @@ public abstract partial class MessageDatabase<T>
 
         // Columns: 0=id, 1=message_type, 2=execution_time, 3=received_at, 4=attempts, 5=total_rows
         builder.Append(
-            $"select{topSelect} {DatabaseConstants.Id}, {DatabaseConstants.MessageType}, {DatabaseConstants.ExecutionTime}, {DatabaseConstants.ReceivedAt}, {DatabaseConstants.Attempts}, count(*) OVER() as total_rows from {QuotedSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}'");
+            $"select{topSelect} {DatabaseConstants.Id}, {DatabaseConstants.MessageType}, {DatabaseConstants.ExecutionTime}, {DatabaseConstants.ReceivedAt}, {DatabaseConstants.Attempts}, count(*) OVER() as total_rows from {QuotedTableNameFor(DatabaseConstants.IncomingTable)} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}'");
 
         writeScheduledMessageWhereClause(query, builder);
 
@@ -77,7 +77,7 @@ public abstract partial class MessageDatabase<T>
         var builder = ToCommandBuilder();
 
         builder.Append(
-            $"delete from {QuotedSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}'");
+            $"delete from {QuotedTableNameFor(DatabaseConstants.IncomingTable)} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}'");
 
         writeScheduledMessageWhereClause(query, builder);
 
@@ -100,7 +100,7 @@ public abstract partial class MessageDatabase<T>
         var builder = ToCommandBuilder();
 
         builder.Append(
-            $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.ExecutionTime} = ");
+            $"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.ExecutionTime} = ");
         builder.AppendParameter(newExecutionTime.ToUniversalTime());
         builder.Append($" where {DatabaseConstants.Id} = ");
         builder.AppendParameter(envelopeId);
@@ -124,7 +124,7 @@ public abstract partial class MessageDatabase<T>
     {
         var builder = ToCommandBuilder();
         builder.Append(
-            $"select {DatabaseConstants.MessageType}, count(*) as total from {QuotedSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}' group by {DatabaseConstants.MessageType}");
+            $"select {DatabaseConstants.MessageType}, count(*) as total from {QuotedTableNameFor(DatabaseConstants.IncomingTable)} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}' group by {DatabaseConstants.MessageType}");
 
         await using var cmd = builder.Compile();
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Tenants.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Tenants.cs
@@ -27,9 +27,9 @@ public abstract partial class MessageDatabase<T>
         var builder = ToCommandBuilder();
         foreach (var assignment in assignments)
         {
-            builder.Append($"delete from  {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {StorageConstants.TenantIdColumn} = ");
+            builder.Append($"delete from  {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} where {StorageConstants.TenantIdColumn} = ");
             builder.AppendParameter(assignment.TenantId);
-            builder.Append($";insert into {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} ({StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn}) values (");
+            builder.Append($";insert into {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} ({StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn}) values (");
             builder.AppendParameter(assignment.TenantId);
             builder.Append(", ");
             builder.AppendParameter(assignment.Value);
@@ -66,7 +66,7 @@ public abstract partial class MessageDatabase<T>
         {
             await using var reader =
                 await conn.CreateCommand(
-                        $"select {StorageConstants.ConnectionStringColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {StorageConstants.TenantIdColumn} = @id")
+                        $"select {StorageConstants.ConnectionStringColumn} from {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} where {StorageConstants.TenantIdColumn} = @id")
                     .With("id", tenantId)
                     .ExecuteReaderAsync(_cancellation);
 
@@ -102,7 +102,7 @@ public abstract partial class MessageDatabase<T>
         {
             await using var reader =
                 await conn.CreateCommand(
-                        $"select {StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {DatabaseConstants.DisabledColumn} = @disabled")
+                        $"select {StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn} from {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} where {DatabaseConstants.DisabledColumn} = @disabled")
                     .With("disabled", false)
                     .ExecuteReaderAsync(_cancellation);
 
@@ -137,8 +137,8 @@ public abstract partial class MessageDatabase<T>
             // ON CONFLICT (which SqlServer rejects), and a bool parameter rather than a `false`
             // literal (SqlServer has no boolean literal — it parses `false` as a column name). GH-3023.
             await conn.CreateCommand(
-                    $"delete from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {StorageConstants.TenantIdColumn} = @id;" +
-                    $"insert into {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} ({StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn}, {DatabaseConstants.DisabledColumn}) values (@id, @connection, @disabled)")
+                    $"delete from {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} where {StorageConstants.TenantIdColumn} = @id;" +
+                    $"insert into {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} ({StorageConstants.TenantIdColumn}, {StorageConstants.ConnectionStringColumn}, {DatabaseConstants.DisabledColumn}) values (@id, @connection, @disabled)")
                 .With("id", tenantId)
                 .With("connection", connectionString)
                 .With("disabled", false)
@@ -157,7 +157,7 @@ public abstract partial class MessageDatabase<T>
         try
         {
             await conn.CreateCommand(
-                    $"update {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} set {DatabaseConstants.DisabledColumn} = @disabled where {StorageConstants.TenantIdColumn} = @id")
+                    $"update {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} set {DatabaseConstants.DisabledColumn} = @disabled where {StorageConstants.TenantIdColumn} = @id")
                 .With("id", tenantId)
                 .With("disabled", disabled)
                 .ExecuteNonQueryAsync(_cancellation);
@@ -175,7 +175,7 @@ public abstract partial class MessageDatabase<T>
         try
         {
             await conn.CreateCommand(
-                    $"delete from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {StorageConstants.TenantIdColumn} = @id")
+                    $"delete from {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} where {StorageConstants.TenantIdColumn} = @id")
                 .With("id", tenantId)
                 .ExecuteNonQueryAsync(_cancellation);
         }
@@ -193,7 +193,7 @@ public abstract partial class MessageDatabase<T>
         try
         {
             await using var reader = await conn.CreateCommand(
-                    $"select {StorageConstants.TenantIdColumn} from {Settings.SchemaName}.{DatabaseConstants.TenantsTableName} where {DatabaseConstants.DisabledColumn} = @disabled")
+                    $"select {StorageConstants.TenantIdColumn} from {Settings.TableNameFor(DatabaseConstants.TenantsTableName)} where {DatabaseConstants.DisabledColumn} = @disabled")
                 .With("disabled", true)
                 .ExecuteReaderAsync(_cancellation);
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -44,16 +44,16 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
         Logger = logger;
         _schemaName = databaseSettings.SchemaName ?? settings.MessageStorageSchemaName ?? provider.DefaultDatabaseSchemaName;
 
-        IncomingFullName = $"{SchemaName}.{DatabaseConstants.IncomingTable}";
-        OutgoingFullName = $"{SchemaName}.{DatabaseConstants.OutgoingTable}";
+        IncomingFullName = TableNameFor(DatabaseConstants.IncomingTable);
+        OutgoingFullName = TableNameFor(DatabaseConstants.OutgoingTable);
 
         Durability = settings;
         _cancellation = settings.Cancellation;
 
         _markEnvelopeAsHandledById =
-            $"update {SchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
+            $"update {TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
         _incrementIncomingEnvelopeAttempts =
-            $"update {SchemaName}.{DatabaseConstants.IncomingTable} set attempts = @attempts where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
+            $"update {TableNameFor(DatabaseConstants.IncomingTable)} set attempts = @attempts where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
 
         // ReSharper disable once VirtualMemberCallInConstructor
         _outgoingEnvelopeSql = determineOutgoingEnvelopeSql(settings);
@@ -107,7 +107,8 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     /// </summary>
     protected virtual IListenerStore BuildListenerStore()
     {
-        return new RdbmsListenerStore(_dataSource, QuotedSchemaName, IsUniqueConstraintViolation);
+        return new RdbmsListenerStore(_dataSource, QuotedTableNameFor(DatabaseConstants.ListenersTableName),
+            IsUniqueConstraintViolation);
     }
 
     public MessageStoreRole Role { get; private set; }
@@ -179,8 +180,8 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
         {
             _schemaName = value;
 
-            IncomingFullName = $"{QuotedSchemaName}.{DatabaseConstants.IncomingTable}";
-            OutgoingFullName = $"{QuotedSchemaName}.{DatabaseConstants.OutgoingTable}";
+            IncomingFullName = QuotedTableNameFor(DatabaseConstants.IncomingTable);
+            OutgoingFullName = QuotedTableNameFor(DatabaseConstants.OutgoingTable);
         }
     }
 
@@ -189,6 +190,40 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     /// Override in derived classes for database-specific quoting (e.g., double quotes for PostgreSQL, square brackets for SQL Server).
     /// </summary>
     protected virtual string QuotedSchemaName => SchemaName;
+
+    /// <summary>
+    /// True when this engine has no user-defined schemas and <see cref="SchemaName"/> is a table name
+    /// prefix rather than a qualifier. Driven by <see cref="DatabaseSettings.SchemaNameIsTablePrefix"/>;
+    /// only SQLite sets it. See GH-3943.
+    /// </summary>
+    protected bool SchemaNameIsTablePrefix => _settings.SchemaNameIsTablePrefix;
+
+    /// <inheritdoc />
+    public string TableNameFor(string tableName)
+    {
+        if (SchemaNameIsTablePrefix) return TablePrefixing.Apply(SchemaName, tableName);
+
+        return string.IsNullOrEmpty(SchemaName) ? tableName : $"{SchemaName}.{tableName}";
+    }
+
+    /// <summary>
+    /// The <see cref="TableNameFor"/> rendering, but with the schema name quoted per this provider's
+    /// rules. Prefixed names are single identifiers and are never quoted.
+    /// </summary>
+    protected string QuotedTableNameFor(string tableName)
+    {
+        if (SchemaNameIsTablePrefix) return TablePrefixing.Apply(SchemaName, tableName);
+
+        return string.IsNullOrEmpty(SchemaName) ? tableName : $"{QuotedSchemaName}.{tableName}";
+    }
+
+    /// <inheritdoc />
+    public virtual DbObjectName DbObjectNameFor(string tableName)
+    {
+        return SchemaNameIsTablePrefix
+            ? new DbObjectName(TablePrefixing.DefaultSqliteSchemaName, TablePrefixing.Apply(SchemaName, tableName))
+            : new DbObjectName(SchemaName, tableName);
+    }
 
     public Task EnqueueAsync(IDatabaseOperation operation)
     {
@@ -284,7 +319,7 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
 
         var impacted = await _dataSource
             .CreateCommand(
-                $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set owner_id = 0 where owner_id = @owner and {DatabaseConstants.ReceivedAt} = @uri")
+                $"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set owner_id = 0 where owner_id = @owner and {DatabaseConstants.ReceivedAt} = @uri")
             .With("owner", ownerId)
             .With("uri", receivedAt.ToString())
             .ExecuteNonQueryAsync(_cancellation);

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -44,16 +44,16 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
         Logger = logger;
         _schemaName = databaseSettings.SchemaName ?? settings.MessageStorageSchemaName ?? provider.DefaultDatabaseSchemaName;
 
-        IncomingFullName = TableNameFor(DatabaseConstants.IncomingTable);
-        OutgoingFullName = TableNameFor(DatabaseConstants.OutgoingTable);
+        IncomingFullName = this.TableNameFor(DatabaseConstants.IncomingTable);
+        OutgoingFullName = this.TableNameFor(DatabaseConstants.OutgoingTable);
 
         Durability = settings;
         _cancellation = settings.Cancellation;
 
         _markEnvelopeAsHandledById =
-            $"update {TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
+            $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
         _incrementIncomingEnvelopeAttempts =
-            $"update {TableNameFor(DatabaseConstants.IncomingTable)} set attempts = @attempts where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
+            $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set attempts = @attempts where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
 
         // ReSharper disable once VirtualMemberCallInConstructor
         _outgoingEnvelopeSql = determineOutgoingEnvelopeSql(settings);
@@ -198,31 +198,15 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     /// </summary>
     protected bool SchemaNameIsTablePrefix => _settings.SchemaNameIsTablePrefix;
 
-    /// <inheritdoc />
-    public string TableNameFor(string tableName)
-    {
-        if (SchemaNameIsTablePrefix) return TablePrefixing.Apply(SchemaName, tableName);
-
-        return string.IsNullOrEmpty(SchemaName) ? tableName : $"{SchemaName}.{tableName}";
-    }
-
     /// <summary>
-    /// The <see cref="TableNameFor"/> rendering, but with the schema name quoted per this provider's
-    /// rules. Prefixed names are single identifiers and are never quoted.
+    /// The <see cref="MessageDatabaseExtensions.TableNameFor"/> rendering, but with the schema name
+    /// quoted per this provider's rules. Prefixed names are single identifiers and are never quoted.
     /// </summary>
     protected string QuotedTableNameFor(string tableName)
     {
         if (SchemaNameIsTablePrefix) return TablePrefixing.Apply(SchemaName, tableName);
 
         return string.IsNullOrEmpty(SchemaName) ? tableName : $"{QuotedSchemaName}.{tableName}";
-    }
-
-    /// <inheritdoc />
-    public virtual DbObjectName DbObjectNameFor(string tableName)
-    {
-        return SchemaNameIsTablePrefix
-            ? new DbObjectName(TablePrefixing.DefaultSqliteSchemaName, TablePrefixing.Apply(SchemaName, tableName))
-            : new DbObjectName(SchemaName, tableName);
     }
 
     public Task EnqueueAsync(IDatabaseOperation operation)

--- a/src/Persistence/Wolverine.RDBMS/Sagas/DatabaseSagaStoreDiagnostics.cs
+++ b/src/Persistence/Wolverine.RDBMS/Sagas/DatabaseSagaStoreDiagnostics.cs
@@ -188,8 +188,7 @@ public sealed class DatabaseSagaStoreDiagnostics : ISagaStoreDiagnostics
 
     private string qualifyTableName(string tableName)
     {
-        var schema = _database.SchemaName;
-        return string.IsNullOrEmpty(schema) ? tableName : $"{schema}.{tableName}";
+        return string.IsNullOrEmpty(_database.SchemaName) ? tableName : _database.TableNameFor(tableName);
     }
 
     /// <summary>

--- a/src/Persistence/Wolverine.RDBMS/TablePrefixing.cs
+++ b/src/Persistence/Wolverine.RDBMS/TablePrefixing.cs
@@ -1,0 +1,27 @@
+namespace Wolverine.RDBMS;
+
+/// <summary>
+/// Folds a configured "schema name" into a table name for database engines that have no schemas.
+/// See <see cref="DatabaseSettings.SchemaNameIsTablePrefix"/> and GH-3943.
+/// </summary>
+public static class TablePrefixing
+{
+    /// <summary>
+    /// The one schema name a plain SQLite connection always knows. It is both Wolverine.Sqlite's
+    /// default and the "no prefix at all" value, so hosts that never set a schema name — and every
+    /// database they have already provisioned — keep the bare <c>wolverine_*</c> table names.
+    /// </summary>
+    public const string DefaultSqliteSchemaName = "main";
+
+    /// <summary>
+    /// Renders <paramref name="tableName"/> prefixed by <paramref name="schemaName"/>. An empty
+    /// schema name, or the default <c>main</c>, yields the table name unchanged.
+    /// </summary>
+    public static string Apply(string? schemaName, string tableName)
+    {
+        if (string.IsNullOrEmpty(schemaName)) return tableName;
+        if (schemaName == DefaultSqliteSchemaName) return tableName;
+
+        return $"{schemaName}_{tableName}";
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlTransport.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlTransport.cs
@@ -36,7 +36,7 @@ internal class DatabaseControlTransport : ITransport, IAsyncDisposable
 
         Options = options;
 
-        TableName = new DbObjectName(database.SchemaName, DatabaseConstants.ControlQueueTableName);
+        TableName = database.DbObjectNameFor(DatabaseConstants.ControlQueueTableName);
     }
     
     public bool TryBuildBrokerUsage(out BrokerDescription description)

--- a/src/Persistence/Wolverine.Sqlite/Sagas/DatabaseSagaSchema.cs
+++ b/src/Persistence/Wolverine.Sqlite/Sagas/DatabaseSagaSchema.cs
@@ -38,14 +38,19 @@ public class DatabaseSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : 
 
         var idColumn = typeof(TId) == typeof(Guid) || typeof(TId) == typeof(string) ? "TEXT" : "INTEGER";
 
-        _insertSql = $"insert into {definition.TableName} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.Version}) values (@id, @body, 1)";
+        // GH-3943: SQLite has no schemas, so a configured schema name prefixes the saga table just
+        // like it prefixes the envelope storage tables. That is what keeps two logically separate
+        // Wolverine table sets from colliding inside the one database file.
+        var tableName = TablePrefixing.Apply(settings.SchemaName, definition.TableName);
+
+        _insertSql = $"insert into {tableName} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.Version}) values (@id, @body, 1)";
         _updateSql =
-            $"update {definition.TableName} set {DatabaseConstants.Body} = @body, {DatabaseConstants.Version} = @version + 1, last_modified = datetime('now') where {DatabaseConstants.Id} = @id and {DatabaseConstants.Version} = @version";
-        _loadSql = $"select body, version from {definition.TableName} where {DatabaseConstants.Id} = @id";
+            $"update {tableName} set {DatabaseConstants.Body} = @body, {DatabaseConstants.Version} = @version + 1, last_modified = datetime('now') where {DatabaseConstants.Id} = @id and {DatabaseConstants.Version} = @version";
+        _loadSql = $"select body, version from {tableName} where {DatabaseConstants.Id} = @id";
 
-        _deleteSql = $"delete from {definition.TableName} where id = @id";
+        _deleteSql = $"delete from {tableName} where id = @id";
 
-        var table = new Table(new SqliteObjectName(definition.TableName));
+        var table = new Table(new SqliteObjectName(tableName));
         table.AddColumn("id", idColumn).AsPrimaryKey();
         table.AddColumn(DatabaseConstants.Body, "TEXT").NotNull();
         table.AddColumn(DatabaseConstants.Version, "INTEGER").DefaultValue(1).NotNull();

--- a/src/Persistence/Wolverine.Sqlite/Schema/DeadLettersTable.cs
+++ b/src/Persistence/Wolverine.Sqlite/Schema/DeadLettersTable.cs
@@ -8,8 +8,13 @@ namespace Wolverine.Sqlite.Schema;
 internal class DeadLettersTable : Table
 {
     public DeadLettersTable(DurabilitySettings durability, string schemaName) : base(
-        new SqliteObjectName(DatabaseConstants.DeadLetterTable))
+        new SqliteObjectName(TablePrefixing.Apply(schemaName, DatabaseConstants.DeadLetterTable)))
     {
+        // GH-3943: SQLite has no schemas, so the configured schema name is a table name prefix.
+        // Index names share the one namespace with tables here, so they take the prefix too —
+        // otherwise two prefixed table sets in the same file collide on the index name.
+        var tableName = TablePrefixing.Apply(schemaName, DatabaseConstants.DeadLetterTable);
+
         AddColumn(DatabaseConstants.Id, "TEXT").AsPrimaryKey();
         AddColumn(DatabaseConstants.ExecutionTime, "TEXT");
         AddColumn(DatabaseConstants.Body, "BLOB").NotNull();
@@ -25,7 +30,7 @@ internal class DeadLettersTable : Table
 
         // GH-3279: DLQ replay and cleanup both filter on `replayable`; a partial index scoped to the
         // handful of replayable rows keeps both off a full-table scan.
-        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.DeadLetterTable}_replayable")
+        Indexes.Add(new IndexDefinition($"idx_{tableName}_replayable")
         {
             Columns = [DatabaseConstants.Replayable],
             Predicate = $"{DatabaseConstants.Replayable} = 1"
@@ -46,7 +51,7 @@ internal class DeadLettersTable : Table
             AddColumn(DatabaseConstants.Expires, "TEXT");
 
             // Same story for the expiration sweep, which filters on `expires`.
-            Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.DeadLetterTable}_expires")
+            Indexes.Add(new IndexDefinition($"idx_{tableName}_expires")
             {
                 Columns = [DatabaseConstants.Expires],
                 Predicate = $"{DatabaseConstants.Expires} is not null"

--- a/src/Persistence/Wolverine.Sqlite/Schema/IncomingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.Sqlite/Schema/IncomingEnvelopeTable.cs
@@ -8,7 +8,7 @@ namespace Wolverine.Sqlite.Schema;
 internal class IncomingEnvelopeTable : Table
 {
     public IncomingEnvelopeTable(DurabilitySettings durability, string schemaName) : base(
-        new SqliteObjectName(DatabaseConstants.IncomingTable))
+        new SqliteObjectName(TablePrefixing.Apply(schemaName, DatabaseConstants.IncomingTable)))
     {
         AddColumn(DatabaseConstants.Id, "TEXT").AsPrimaryKey();
         AddColumn(DatabaseConstants.Status, "TEXT").NotNull();

--- a/src/Persistence/Wolverine.Sqlite/Schema/OutgoingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.Sqlite/Schema/OutgoingEnvelopeTable.cs
@@ -8,7 +8,7 @@ namespace Wolverine.Sqlite.Schema;
 internal class OutgoingEnvelopeTable : Table
 {
     public OutgoingEnvelopeTable(DurabilitySettings durability, string schemaName) : base(
-        new SqliteObjectName(DatabaseConstants.OutgoingTable))
+        new SqliteObjectName(TablePrefixing.Apply(schemaName, DatabaseConstants.OutgoingTable)))
     {
         AddColumn(DatabaseConstants.Id, "TEXT").AsPrimaryKey();
         AddColumn(DatabaseConstants.OwnerId, "INTEGER").NotNull();

--- a/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
@@ -51,8 +51,11 @@ public interface ISqliteBackedPersistence
     ISqliteBackedPersistence OverrideAutoCreateResources(AutoCreate autoCreate);
 
     /// <summary>
-    /// Override the database schema name for the envelope storage tables (the transactional inbox/outbox).
-    /// Default is "wolverine"
+    /// Names the envelope storage tables (the transactional inbox/outbox). SQLite has no schemas, so
+    /// this is a <b>table name prefix</b> rather than a qualifier: <c>"reporting"</c> gives you
+    /// <c>reporting_wolverine_incoming_envelopes</c> and friends, which is what lets logically
+    /// separate Wolverine table sets share one database file. The default is <c>main</c>, which
+    /// prefixes nothing. See GH-3943.
     /// </summary>
     /// <param name="schemaName"></param>
     /// <returns></returns>
@@ -223,6 +226,8 @@ internal class SqliteBackedPersistence : ISqliteBackedPersistence, IWolverineExt
             DataSource = DataSource,
             ScheduledJobLockId = ScheduledJobLockId,
             SchemaName = EnvelopeStorageSchemaName,
+            // GH-3943: SQLite has no schemas. The name is folded into the table names as a prefix.
+            SchemaNameIsTablePrefix = true,
             AddTenantLookupTable = UseMasterTableTenancy,
             TenantConnections = TenantConnections,
             // Propagate the AutoCreate override (see #2780).

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -52,19 +52,19 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
     [UnconditionalSuppressMessage("AOT", "IL3050",
         Justification = "DatabaseSagaSchema<,> closed over runtime saga / id types at startup; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide / #2769.")]
     public SqliteMessageStore(DatabaseSettings databaseSettings, DurabilitySettings settings, DbDataSource dataSource,
-        ILogger<SqliteMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes) : base(databaseSettings, dataSource,
+        ILogger<SqliteMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes) : base(asTablePrefixed(databaseSettings), dataSource,
         settings, logger, new SqliteMigrator(), SqliteProvider.Instance)
     {
         _reassignIncomingSql =
-            $"update {DatabaseConstants.IncomingTable} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where id IN (@ids)";
+            $"update {TableNameFor(DatabaseConstants.IncomingTable)} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where id IN (@ids)";
         _deleteOutgoingEnvelopesSql =
-            $"delete from {DatabaseConstants.OutgoingTable} WHERE id IN (@ids);";
+            $"delete from {TableNameFor(DatabaseConstants.OutgoingTable)} WHERE id IN (@ids);";
 
         _findAtLargeEnvelopesSql =
-            $"select {DatabaseConstants.IncomingFields} from {DatabaseConstants.IncomingTable} where owner_id = {TransportConstants.AnyNode} and status = '{EnvelopeStatus.Incoming}' and {DatabaseConstants.ReceivedAt} = @address limit @limit";
+            $"select {DatabaseConstants.IncomingFields} from {TableNameFor(DatabaseConstants.IncomingTable)} where owner_id = {TransportConstants.AnyNode} and status = '{EnvelopeStatus.Incoming}' and {DatabaseConstants.ReceivedAt} = @address limit @limit";
 
         _discardAndReassignOutgoingSql = _deleteOutgoingEnvelopesSql +
-                                         $";update {DatabaseConstants.OutgoingTable} set owner_id = @node where id IN (@rids)";
+                                         $";update {TableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = @node where id IN (@rids)";
 
         DataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
         _settings.DataSource ??= DataSource;
@@ -78,7 +78,30 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         }
     }
 
+    /// <summary>
+    /// GH-3943: SQLite has no user-defined schemas, so a schema name is only ever a table name
+    /// prefix here. Stamped on the way into the base constructor — which renders table names before
+    /// this class's own body runs — rather than left to each caller, because a store built without
+    /// it would emit prefixed DDL and schema-qualified DML and fail with "no such table". That split
+    /// is the bug this exists to make unrepresentable.
+    /// </summary>
+    private static DatabaseSettings asTablePrefixed(DatabaseSettings databaseSettings)
+    {
+        databaseSettings.SchemaNameIsTablePrefix = true;
+        return databaseSettings;
+    }
+
     public new DbDataSource DataSource { get; }
+
+    /// <summary>
+    /// GH-3943: a SQLite table is identified by its bare name — <see cref="SqliteObjectName"/>
+    /// deliberately drops the schema from <c>QualifiedName</c> — so the configured schema name has
+    /// to arrive baked into the name itself.
+    /// </summary>
+    public override DbObjectName DbObjectNameFor(string tableName)
+    {
+        return new SqliteObjectName(TableNameFor(tableName));
+    }
 
     public async Task<IReadOnlyList<DbObjectName>> SchemaTablesAsync(CancellationToken ct = default)
     {
@@ -235,7 +258,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
     {
         var counts = new PersistedCounts();
 
-        await using (var reader = await CreateCommand($"select status, count(*) from {DatabaseConstants.IncomingTable} group by status")
+        await using (var reader = await CreateCommand($"select status, count(*) from {TableNameFor(DatabaseConstants.IncomingTable)} group by status")
                          .ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
@@ -260,12 +283,12 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             await reader.CloseAsync();
         }
 
-        var longCount = await CreateCommand($"select count(*) from {DatabaseConstants.OutgoingTable}")
+        var longCount = await CreateCommand($"select count(*) from {TableNameFor(DatabaseConstants.OutgoingTable)}")
             .ExecuteScalarAsync();
 
         counts.Outgoing = Convert.ToInt32(longCount);
 
-        var deadLetterCount = await CreateCommand($"select count(*) from {DatabaseConstants.DeadLetterTable}")
+        var deadLetterCount = await CreateCommand($"select count(*) from {TableNameFor(DatabaseConstants.DeadLetterTable)}")
             .ExecuteScalarAsync();
 
         counts.DeadLetter = Convert.ToInt32(deadLetterCount);
@@ -279,8 +302,8 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         var reassignIds = string.Join(",", reassigned.Select(e => $"'{e.Id:D}'"));
 
         await using var cmd = CreateCommand(
-            $"delete from {DatabaseConstants.OutgoingTable} WHERE lower(id) IN ({discardIds});" +
-            $"update {DatabaseConstants.OutgoingTable} set owner_id = @node where lower(id) IN ({reassignIds})");
+            $"delete from {TableNameFor(DatabaseConstants.OutgoingTable)} WHERE lower(id) IN ({discardIds});" +
+            $"update {TableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = @node where lower(id) IN ({reassignIds})");
         cmd.Parameters.Add(new SqliteParameter("@node", nodeId));
 
         await cmd.ExecuteNonQueryAsync(_cancellation);
@@ -291,14 +314,14 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         if (HasDisposed) return;
 
         var ids = string.Join(",", envelopes.Select(e => $"'{e.Id:D}'"));
-        await CreateCommand($"delete from {DatabaseConstants.OutgoingTable} WHERE lower(id) IN ({ids})")
+        await CreateCommand($"delete from {TableNameFor(DatabaseConstants.OutgoingTable)} WHERE lower(id) IN ({ids})")
             .ExecuteNonQueryAsync(_cancellation);
     }
 
     protected override string determineOutgoingEnvelopeSql(DurabilitySettings settings)
     {
         return
-            $"select {DatabaseConstants.OutgoingFields} from {DatabaseConstants.OutgoingTable} where owner_id = {TransportConstants.AnyNode} and destination = @destination LIMIT {settings.RecoveryBatchSize}";
+            $"select {DatabaseConstants.OutgoingFields} from {TableNameFor(DatabaseConstants.OutgoingTable)} where owner_id = {TransportConstants.AnyNode} and destination = @destination LIMIT {settings.RecoveryBatchSize}";
     }
 
     public override async Task<IReadOnlyList<Envelope>> LoadPageOfGloballyOwnedIncomingAsync(Uri listenerAddress,
@@ -318,7 +341,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
     public override void WriteLoadScheduledEnvelopeSql(DbCommandBuilder builder, DateTimeOffset utcNow)
     {
         builder.Append(
-            $"select {DatabaseConstants.IncomingFields} from {DatabaseConstants.IncomingTable} where status = '{EnvelopeStatus.Scheduled}' and datetime(execution_time) <= datetime(");
+            $"select {DatabaseConstants.IncomingFields} from {TableNameFor(DatabaseConstants.IncomingTable)} where status = '{EnvelopeStatus.Scheduled}' and datetime(execution_time) <= datetime(");
 
         builder.AppendParameter(utcNow.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss"));
         builder.Append($") order by execution_time LIMIT {Durability.RecoveryBatchSize};");
@@ -354,7 +377,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             var ids = string.Join(",", envelopes.Select(e => $"'{e.Id:D}'"));
             await using var reassign = conn.CreateCommand(
-                $"update {DatabaseConstants.IncomingTable} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where lower(id) IN ({ids})");
+                $"update {TableNameFor(DatabaseConstants.IncomingTable)} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where lower(id) IN ({ids})");
             reassign.Transaction = tx;
             await reassign.With("owner", durabilitySettings.AssignedNodeNumber)
                 .ExecuteNonQueryAsync(_cancellation);
@@ -385,7 +408,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         if (Durability.MessageIdentity == MessageIdentity.IdOnly)
         {
             var count = await conn
-                .CreateCommand($"select count(id) from {DatabaseConstants.IncomingTable} where id = @id")
+                .CreateCommand($"select count(id) from {TableNameFor(DatabaseConstants.IncomingTable)} where id = @id")
                 .With("id", envelope.Id)
                 .ExecuteScalarAsync(cancellation);
 
@@ -394,7 +417,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         else
         {
             var count = await conn
-                .CreateCommand($"select count(id) from {DatabaseConstants.IncomingTable} where id = @id and {DatabaseConstants.ReceivedAt} = @destination")
+                .CreateCommand($"select count(id) from {TableNameFor(DatabaseConstants.IncomingTable)} where id = @id and {DatabaseConstants.ReceivedAt} = @destination")
                 .With("id", envelope.Id)
                 .With("destination", envelope.Destination!.ToString())
                 .ExecuteScalarAsync(cancellation);
@@ -464,7 +487,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
         if (Role == MessageStoreRole.Main)
         {
-            var nodeTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.NodeTableName));
+            var nodeTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.NodeTableName)));
             nodeTable.AddColumn("id", "TEXT").AsPrimaryKey();
             nodeTable.AddColumn("node_number", "INTEGER").NotNull();
             nodeTable.AddColumn("description", "TEXT").NotNull();
@@ -476,7 +499,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             yield return nodeTable;
 
-            var assignmentTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.NodeAssignmentsTableName));
+            var assignmentTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.NodeAssignmentsTableName)));
             assignmentTable.AddColumn("id", "TEXT").AsPrimaryKey();
             assignmentTable.AddColumn("node_id", "TEXT").NotNull();
             assignmentTable.AddColumn("started", "TEXT").NotNull().DefaultValueByExpression("(datetime('now'))");
@@ -485,7 +508,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             if (_settings.CommandQueuesEnabled)
             {
-                var queueTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.ControlQueueTableName));
+                var queueTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.ControlQueueTableName)));
                 queueTable.AddColumn("id", "TEXT").AsPrimaryKey();
                 queueTable.AddColumn("message_type", "TEXT").NotNull();
                 queueTable.AddColumn("node_id", "TEXT").NotNull();
@@ -498,14 +521,14 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             if (_settings.AddTenantLookupTable)
             {
-                var tenantTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.TenantsTableName));
+                var tenantTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.TenantsTableName)));
                 tenantTable.AddColumn(StorageConstants.TenantIdColumn, "TEXT").AsPrimaryKey();
                 tenantTable.AddColumn(StorageConstants.ConnectionStringColumn, "TEXT").NotNull();
                 tenantTable.AddColumn(DatabaseConstants.DisabledColumn, "INTEGER").DefaultValueByExpression("0").NotNull();
                 yield return tenantTable;
             }
 
-            var eventTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.NodeRecordTableName));
+            var eventTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.NodeRecordTableName)));
             eventTable.AddColumn("id", "INTEGER").AsPrimaryKey().AutoIncrement();
             eventTable.AddColumn("node_number", "INTEGER").NotNull();
             eventTable.AddColumn("event_name", "TEXT").NotNull();
@@ -514,14 +537,17 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             yield return eventTable;
 
             var restrictionTable =
-                new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.AgentRestrictionsTableName));
+                new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.AgentRestrictionsTableName)));
             restrictionTable.AddColumn("id", "TEXT").AsPrimaryKey();
             restrictionTable.AddColumn("uri", "TEXT").NotNull();
             restrictionTable.AddColumn("type", "TEXT").NotNull();
             restrictionTable.AddColumn("node", "INTEGER").NotNull().DefaultValue(0);
             yield return restrictionTable;
 
-            // Advisory lock table for SQLite
+            // Advisory lock table for SQLite. Deliberately NOT prefixed by the schema name the way
+            // the tables above are (GH-3943): lock ids are already derived from a hash of the schema
+            // name, so several prefixed table sets sharing one file take distinct rows out of one
+            // shared table. SqliteAdvisoryLock's SQL names it unqualified to match.
             var lockTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName("wolverine_locks"));
             lockTable.AddColumn("lock_id", "INTEGER").AsPrimaryKey();
             lockTable.AddColumn("acquired_at", "TEXT").NotNull();
@@ -532,7 +558,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             if (Durability.EnableDynamicListeners)
             {
                 var listenerTable =
-                    new Weasel.Sqlite.Tables.Table(new SqliteObjectName(DatabaseConstants.ListenersTableName));
+                    new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.ListenersTableName)));
                 listenerTable.AddColumn("uri", "TEXT").AsPrimaryKey();
                 yield return listenerTable;
             }
@@ -586,9 +612,9 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         var deleted = 1;
 
         var sql = $@"
-        DELETE FROM {DatabaseConstants.IncomingTable}
+        DELETE FROM {TableNameFor(DatabaseConstants.IncomingTable)}
         WHERE id IN (
-            SELECT id FROM {DatabaseConstants.IncomingTable}
+            SELECT id FROM {TableNameFor(DatabaseConstants.IncomingTable)}
             WHERE status = '{EnvelopeStatus.Handled}'
             LIMIT 10000
         );

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -56,15 +56,15 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         settings, logger, new SqliteMigrator(), SqliteProvider.Instance)
     {
         _reassignIncomingSql =
-            $"update {TableNameFor(DatabaseConstants.IncomingTable)} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where id IN (@ids)";
+            $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where id IN (@ids)";
         _deleteOutgoingEnvelopesSql =
-            $"delete from {TableNameFor(DatabaseConstants.OutgoingTable)} WHERE id IN (@ids);";
+            $"delete from {this.TableNameFor(DatabaseConstants.OutgoingTable)} WHERE id IN (@ids);";
 
         _findAtLargeEnvelopesSql =
-            $"select {DatabaseConstants.IncomingFields} from {TableNameFor(DatabaseConstants.IncomingTable)} where owner_id = {TransportConstants.AnyNode} and status = '{EnvelopeStatus.Incoming}' and {DatabaseConstants.ReceivedAt} = @address limit @limit";
+            $"select {DatabaseConstants.IncomingFields} from {this.TableNameFor(DatabaseConstants.IncomingTable)} where owner_id = {TransportConstants.AnyNode} and status = '{EnvelopeStatus.Incoming}' and {DatabaseConstants.ReceivedAt} = @address limit @limit";
 
         _discardAndReassignOutgoingSql = _deleteOutgoingEnvelopesSql +
-                                         $";update {TableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = @node where id IN (@rids)";
+                                         $";update {this.TableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = @node where id IN (@rids)";
 
         DataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
         _settings.DataSource ??= DataSource;
@@ -92,16 +92,6 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
     }
 
     public new DbDataSource DataSource { get; }
-
-    /// <summary>
-    /// GH-3943: a SQLite table is identified by its bare name — <see cref="SqliteObjectName"/>
-    /// deliberately drops the schema from <c>QualifiedName</c> — so the configured schema name has
-    /// to arrive baked into the name itself.
-    /// </summary>
-    public override DbObjectName DbObjectNameFor(string tableName)
-    {
-        return new SqliteObjectName(TableNameFor(tableName));
-    }
 
     public async Task<IReadOnlyList<DbObjectName>> SchemaTablesAsync(CancellationToken ct = default)
     {
@@ -258,7 +248,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
     {
         var counts = new PersistedCounts();
 
-        await using (var reader = await CreateCommand($"select status, count(*) from {TableNameFor(DatabaseConstants.IncomingTable)} group by status")
+        await using (var reader = await CreateCommand($"select status, count(*) from {this.TableNameFor(DatabaseConstants.IncomingTable)} group by status")
                          .ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
@@ -283,12 +273,12 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             await reader.CloseAsync();
         }
 
-        var longCount = await CreateCommand($"select count(*) from {TableNameFor(DatabaseConstants.OutgoingTable)}")
+        var longCount = await CreateCommand($"select count(*) from {this.TableNameFor(DatabaseConstants.OutgoingTable)}")
             .ExecuteScalarAsync();
 
         counts.Outgoing = Convert.ToInt32(longCount);
 
-        var deadLetterCount = await CreateCommand($"select count(*) from {TableNameFor(DatabaseConstants.DeadLetterTable)}")
+        var deadLetterCount = await CreateCommand($"select count(*) from {this.TableNameFor(DatabaseConstants.DeadLetterTable)}")
             .ExecuteScalarAsync();
 
         counts.DeadLetter = Convert.ToInt32(deadLetterCount);
@@ -302,8 +292,8 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         var reassignIds = string.Join(",", reassigned.Select(e => $"'{e.Id:D}'"));
 
         await using var cmd = CreateCommand(
-            $"delete from {TableNameFor(DatabaseConstants.OutgoingTable)} WHERE lower(id) IN ({discardIds});" +
-            $"update {TableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = @node where lower(id) IN ({reassignIds})");
+            $"delete from {this.TableNameFor(DatabaseConstants.OutgoingTable)} WHERE lower(id) IN ({discardIds});" +
+            $"update {this.TableNameFor(DatabaseConstants.OutgoingTable)} set owner_id = @node where lower(id) IN ({reassignIds})");
         cmd.Parameters.Add(new SqliteParameter("@node", nodeId));
 
         await cmd.ExecuteNonQueryAsync(_cancellation);
@@ -314,14 +304,14 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         if (HasDisposed) return;
 
         var ids = string.Join(",", envelopes.Select(e => $"'{e.Id:D}'"));
-        await CreateCommand($"delete from {TableNameFor(DatabaseConstants.OutgoingTable)} WHERE lower(id) IN ({ids})")
+        await CreateCommand($"delete from {this.TableNameFor(DatabaseConstants.OutgoingTable)} WHERE lower(id) IN ({ids})")
             .ExecuteNonQueryAsync(_cancellation);
     }
 
     protected override string determineOutgoingEnvelopeSql(DurabilitySettings settings)
     {
         return
-            $"select {DatabaseConstants.OutgoingFields} from {TableNameFor(DatabaseConstants.OutgoingTable)} where owner_id = {TransportConstants.AnyNode} and destination = @destination LIMIT {settings.RecoveryBatchSize}";
+            $"select {DatabaseConstants.OutgoingFields} from {this.TableNameFor(DatabaseConstants.OutgoingTable)} where owner_id = {TransportConstants.AnyNode} and destination = @destination LIMIT {settings.RecoveryBatchSize}";
     }
 
     public override async Task<IReadOnlyList<Envelope>> LoadPageOfGloballyOwnedIncomingAsync(Uri listenerAddress,
@@ -341,7 +331,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
     public override void WriteLoadScheduledEnvelopeSql(DbCommandBuilder builder, DateTimeOffset utcNow)
     {
         builder.Append(
-            $"select {DatabaseConstants.IncomingFields} from {TableNameFor(DatabaseConstants.IncomingTable)} where status = '{EnvelopeStatus.Scheduled}' and datetime(execution_time) <= datetime(");
+            $"select {DatabaseConstants.IncomingFields} from {this.TableNameFor(DatabaseConstants.IncomingTable)} where status = '{EnvelopeStatus.Scheduled}' and datetime(execution_time) <= datetime(");
 
         builder.AppendParameter(utcNow.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss"));
         builder.Append($") order by execution_time LIMIT {Durability.RecoveryBatchSize};");
@@ -377,7 +367,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             var ids = string.Join(",", envelopes.Select(e => $"'{e.Id:D}'"));
             await using var reassign = conn.CreateCommand(
-                $"update {TableNameFor(DatabaseConstants.IncomingTable)} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where lower(id) IN ({ids})");
+                $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where lower(id) IN ({ids})");
             reassign.Transaction = tx;
             await reassign.With("owner", durabilitySettings.AssignedNodeNumber)
                 .ExecuteNonQueryAsync(_cancellation);
@@ -408,7 +398,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         if (Durability.MessageIdentity == MessageIdentity.IdOnly)
         {
             var count = await conn
-                .CreateCommand($"select count(id) from {TableNameFor(DatabaseConstants.IncomingTable)} where id = @id")
+                .CreateCommand($"select count(id) from {this.TableNameFor(DatabaseConstants.IncomingTable)} where id = @id")
                 .With("id", envelope.Id)
                 .ExecuteScalarAsync(cancellation);
 
@@ -417,7 +407,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         else
         {
             var count = await conn
-                .CreateCommand($"select count(id) from {TableNameFor(DatabaseConstants.IncomingTable)} where id = @id and {DatabaseConstants.ReceivedAt} = @destination")
+                .CreateCommand($"select count(id) from {this.TableNameFor(DatabaseConstants.IncomingTable)} where id = @id and {DatabaseConstants.ReceivedAt} = @destination")
                 .With("id", envelope.Id)
                 .With("destination", envelope.Destination!.ToString())
                 .ExecuteScalarAsync(cancellation);
@@ -487,7 +477,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
         if (Role == MessageStoreRole.Main)
         {
-            var nodeTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.NodeTableName)));
+            var nodeTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.NodeTableName)));
             nodeTable.AddColumn("id", "TEXT").AsPrimaryKey();
             nodeTable.AddColumn("node_number", "INTEGER").NotNull();
             nodeTable.AddColumn("description", "TEXT").NotNull();
@@ -499,7 +489,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             yield return nodeTable;
 
-            var assignmentTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.NodeAssignmentsTableName)));
+            var assignmentTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.NodeAssignmentsTableName)));
             assignmentTable.AddColumn("id", "TEXT").AsPrimaryKey();
             assignmentTable.AddColumn("node_id", "TEXT").NotNull();
             assignmentTable.AddColumn("started", "TEXT").NotNull().DefaultValueByExpression("(datetime('now'))");
@@ -508,7 +498,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             if (_settings.CommandQueuesEnabled)
             {
-                var queueTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.ControlQueueTableName)));
+                var queueTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.ControlQueueTableName)));
                 queueTable.AddColumn("id", "TEXT").AsPrimaryKey();
                 queueTable.AddColumn("message_type", "TEXT").NotNull();
                 queueTable.AddColumn("node_id", "TEXT").NotNull();
@@ -521,14 +511,14 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 
             if (_settings.AddTenantLookupTable)
             {
-                var tenantTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.TenantsTableName)));
+                var tenantTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.TenantsTableName)));
                 tenantTable.AddColumn(StorageConstants.TenantIdColumn, "TEXT").AsPrimaryKey();
                 tenantTable.AddColumn(StorageConstants.ConnectionStringColumn, "TEXT").NotNull();
                 tenantTable.AddColumn(DatabaseConstants.DisabledColumn, "INTEGER").DefaultValueByExpression("0").NotNull();
                 yield return tenantTable;
             }
 
-            var eventTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.NodeRecordTableName)));
+            var eventTable = new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.NodeRecordTableName)));
             eventTable.AddColumn("id", "INTEGER").AsPrimaryKey().AutoIncrement();
             eventTable.AddColumn("node_number", "INTEGER").NotNull();
             eventTable.AddColumn("event_name", "TEXT").NotNull();
@@ -537,7 +527,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             yield return eventTable;
 
             var restrictionTable =
-                new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.AgentRestrictionsTableName)));
+                new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.AgentRestrictionsTableName)));
             restrictionTable.AddColumn("id", "TEXT").AsPrimaryKey();
             restrictionTable.AddColumn("uri", "TEXT").NotNull();
             restrictionTable.AddColumn("type", "TEXT").NotNull();
@@ -558,7 +548,7 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             if (Durability.EnableDynamicListeners)
             {
                 var listenerTable =
-                    new Weasel.Sqlite.Tables.Table(new SqliteObjectName(TableNameFor(DatabaseConstants.ListenersTableName)));
+                    new Weasel.Sqlite.Tables.Table(new SqliteObjectName(this.TableNameFor(DatabaseConstants.ListenersTableName)));
                 listenerTable.AddColumn("uri", "TEXT").AsPrimaryKey();
                 yield return listenerTable;
             }
@@ -612,9 +602,9 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         var deleted = 1;
 
         var sql = $@"
-        DELETE FROM {TableNameFor(DatabaseConstants.IncomingTable)}
+        DELETE FROM {this.TableNameFor(DatabaseConstants.IncomingTable)}
         WHERE id IN (
-            SELECT id FROM {TableNameFor(DatabaseConstants.IncomingTable)}
+            SELECT id FROM {this.TableNameFor(DatabaseConstants.IncomingTable)}
             WHERE status = '{EnvelopeStatus.Handled}'
             LIMIT 10000
         );

--- a/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
@@ -29,10 +29,14 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
         _settings = settings;
         _database = database;
         _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
-        var schemaName = settings.SchemaName ?? "main";
-        _nodeTable = new SqliteObjectName(NodeTableName);
-        _restrictionTable = new SqliteObjectName(DatabaseConstants.AgentRestrictionsTableName);
-        _assignmentTable = new SqliteObjectName(NodeAssignmentsTableName);
+        var schemaName = settings.SchemaName ?? TablePrefixing.DefaultSqliteSchemaName;
+
+        // GH-3943: SQLite has no schemas, so the configured name prefixes these table names rather
+        // than qualifying them. `main` — the default — leaves them exactly as they have always been.
+        _nodeTable = new SqliteObjectName(TablePrefixing.Apply(schemaName, NodeTableName));
+        _restrictionTable =
+            new SqliteObjectName(TablePrefixing.Apply(schemaName, DatabaseConstants.AgentRestrictionsTableName));
+        _assignmentTable = new SqliteObjectName(TablePrefixing.Apply(schemaName, NodeAssignmentsTableName));
 
         _lockId = schemaName.GetDeterministicHashCode();
     }

--- a/src/Persistence/Wolverine.Sqlite/SqliteTenantedMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteTenantedMessageStore.cs
@@ -114,7 +114,9 @@ internal class SqliteTenantedMessageStore : ITenantedMessageSource
             ConnectionString = connectionString,
             Role = MessageStoreRole.Tenant,
             ScheduledJobLockId = _persistence.ScheduledJobLockId,
-            SchemaName = _persistence.EnvelopeStorageSchemaName
+            SchemaName = _persistence.EnvelopeStorageSchemaName,
+            // GH-3943: SQLite has no schemas. The name is folded into the table names as a prefix.
+            SchemaNameIsTablePrefix = true
         };
 
         var store = new SqliteMessageStore(settings, _runtime.Options.Durability, dataSource,

--- a/src/Persistence/Wolverine.Sqlite/Transport/SqliteQueueSender.cs
+++ b/src/Persistence/Wolverine.Sqlite/Transport/SqliteQueueSender.cs
@@ -27,6 +27,7 @@ internal class SqliteQueueSender : ISqliteQueueSender
     private readonly string _deleteFromIncomingAndScheduleSql;
     private readonly string _writeDirectlyToQueueTableSql;
     private readonly string _writeDirectlyToTheScheduledTable;
+    private readonly string _outgoingTable;
 
     public SqliteQueueSender(SqliteQueue queue) : this(queue, queue.DataSource, null)
     {
@@ -40,22 +41,31 @@ internal class SqliteQueueSender : ISqliteQueueSender
 
         Destination = SqliteQueue.ToUri(queue.Name, databaseName);
 
+        // GH-3943: the durability tables this sender drains carry the message store's schema name as
+        // a prefix on SQLite. The queue tables themselves are named by the transport and take no
+        // prefix, which is why they come off the queue rather than through this. A null Store means
+        // no SQLite persistence is registered at all, in which case the unprefixed default is right.
+        _outgoingTable = queue.Parent.Store?.TableNameFor(DatabaseConstants.OutgoingTable)
+                            ?? DatabaseConstants.OutgoingTable;
+        var incomingTable = queue.Parent.Store?.TableNameFor(DatabaseConstants.IncomingTable)
+                            ?? DatabaseConstants.IncomingTable;
+
         _moveFromOutgoingToQueueSql = $@"
 INSERT into {queue.QueueTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil})
 SELECT {DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.DeliverBy}
 FROM
-    {DatabaseConstants.OutgoingTable}
+    {_outgoingTable}
 WHERE lower({DatabaseConstants.Id}) = lower(@id);
-DELETE FROM {DatabaseConstants.OutgoingTable} WHERE lower({DatabaseConstants.Id}) = lower(@id);
+DELETE FROM {_outgoingTable} WHERE lower({DatabaseConstants.Id}) = lower(@id);
 ";
 
         _moveFromOutgoingToScheduledSql = $@"
 INSERT into {queue.ScheduledTable.Identifier} ({DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.ExecutionTime})
 SELECT {DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, @time
 FROM
-    {DatabaseConstants.OutgoingTable}
+    {_outgoingTable}
 WHERE lower({DatabaseConstants.Id}) = lower(@id);
-DELETE FROM {DatabaseConstants.OutgoingTable} WHERE lower({DatabaseConstants.Id}) = lower(@id);
+DELETE FROM {_outgoingTable} WHERE lower({DatabaseConstants.Id}) = lower(@id);
 ";
 
         _writeDirectlyToQueueTableSql =
@@ -67,7 +77,7 @@ values (@id, @body, @type, @time)
 ".Trim();
 
         _deleteFromIncomingAndScheduleSql =
-            $"DELETE FROM {DatabaseConstants.IncomingTable} WHERE lower(id) = lower(@id);" + _writeDirectlyToTheScheduledTable;
+            $"DELETE FROM {incomingTable} WHERE lower(id) = lower(@id);" + _writeDirectlyToTheScheduledTable;
     }
 
     public bool SupportsNativeScheduledSend => true;
@@ -198,7 +208,7 @@ values (@id, @body, @type, @time)
         {
             if (e.Message.ContainsIgnoreCase("UNIQUE constraint failed"))
             {
-                await conn.CreateCommand($"DELETE FROM {DatabaseConstants.OutgoingTable} WHERE lower(id) = lower(@id)")
+                await conn.CreateCommand($"DELETE FROM {_outgoingTable} WHERE lower(id) = lower(@id)")
                     .With("id", $"{envelope.Id:D}")
                     .ExecuteNonQueryAsync(cancellationToken);
 


### PR DESCRIPTION
Closes #3943.

## What was wrong

`FisherIntegration.MessageStorageSchemaName` — and `PersistMessagesWithSqlite`'s own `schemaName` argument — reached `SqliteMessageStore` as a `schema.table` qualifier. SQLite has no user-defined schemas: the only names a plain connection knows are `main`, `temp`, and whatever has been `ATTACH`ed. So any value other than `main` emitted SQL against a database that never existed, and the host died on the first envelope write with:

```
SQLite Error 1: 'no such table: cw_chaingate_wolverine.wolverine_incoming_envelopes'
```

The two halves had disagreed all along. Weasel's `SqliteObjectName` drops the schema from `QualifiedName`, so the DDL had been creating a bare `wolverine_incoming_envelopes` the whole time, while the DML inherited from `MessageDatabase<T>` asked for a qualified one. The default `?? "main"` is what kept that invisible until someone set the property — and the property is exactly what a codebase carries over from a Postgres or SQL Server host.

## What changed

Suggestion 1 from the issue: make it the prefix the comment already claimed it was.

**`Wolverine.RDBMS`** — every reference to a Wolverine table in generated SQL now routes through one qualification point (`TableNameFor` / `QuotedTableNameFor` / `DbObjectNameFor`), backed by a new `DatabaseSettings.SchemaNameIsTablePrefix` flag. The default rendering is byte-identical to the interpolation it replaced, so **Postgres, SQL Server, MySQL and Oracle are untouched** — each of those keeps its own provider-specific SQL besides. `PersistNodeRecord`'s existing empty-schema guard is now folded into the helper.

**`Wolverine.Sqlite`** — sets the flag, and does so on the way *into* the base constructor rather than leaving it to callers, so a store cannot be constructed with prefixed DDL and qualified DML. The name prefixes the envelope, node, assignment, control-queue, tenant, listener and saga tables, plus the dead-letter index names (SQLite puts indexes in the same identifier namespace as tables, so two prefixed table sets would otherwise collide there). `wolverine_locks` stays unprefixed on purpose: lock ids are already derived from the schema name, so several table sets in one file take distinct rows out of one shared table.

`main` — the default — prefixes nothing, so **every database provisioned before this change is untouched** and there is no migration.

**`Wolverine.Fisher`** — passes the flag through, and `TransportSchemaName` is now documented as what it has always been on a Fisher host: inert. The SQLite transport names its queue tables `wolverine_queue_<name>` in the one file; there is no schema for it to steer, and nothing read the property. That is a wart worth a follow-up, not a silent no-op left undocumented.

```csharp
opts.PersistMessagesWithSqlite(connectionString, "reporting");
// => reporting_wolverine_incoming_envelopes, reporting_wolverine_outgoing_envelopes, ...
```

## Verification

Red baseline confirmed against `main`: 3 of the 4 new SQLite tests fail there with the issue's verbatim error (`no such table: custom.wolverine_incoming_envelopes`, `...alpha...`, `...cw_chaingate_wolverine...`). The fourth — "the default schema name leaves the table names alone" — passes on both sides, which is the point of having it.

New coverage:
- `SqliteTests/Bug_3943_schema_name_is_a_table_prefix` — table naming, the `main` upgrade path, an envelope round trip through a prefixed store, and two prefixed table sets sharing one file with disjoint storage.
- `FisherTests/Bug_3943_message_storage_schema_name` — the reporter's shape: `MessageStorageSchemaName` + `TransportSchemaName` on a Fisher host, message handled through the outbox.
- `PersistenceTests/table_naming_contract` — guard rails on the shared hook, including that the schema-qualified rendering is unchanged.

Local suites: SqliteTests 168/169 (1 skipped), FisherTests 22/22, PersistenceTests, PostgresqlTests 480/482 (1 skipped, 1 pre-existing RabbitMQ-not-running failure), SqlServerTests. Full `wolverine.slnx` builds clean at `-f net9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)