### PR TITLE
Update to Fisher 0.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[5.12.0,6.0.0)" />
-    <PackageVersion Include="Fisher" Version="[0.6.0,1.0.0)" />
+    <PackageVersion Include="Fisher" Version="[0.7.0,1.0.0)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.23.0" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.23.0" />

--- a/src/Persistence/FisherTests/FisherTests.csproj
+++ b/src/Persistence/FisherTests/FisherTests.csproj
@@ -38,4 +38,18 @@
         <ProjectReference Include="..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
     </ItemGroup>
 
+  <!-- Fisher 0.7.0 started bundling JasperFx.Events.SourceGenerator inside its own nupkg
+       (analyzers/dotnet/cs/), exactly as Polecat already does. With the explicit reference above it
+       loads as two analyzer instances, each emitting every aggregate's .Evolver dispatcher into this
+       assembly, and the compile fails with CS0433 ("type exists in both FisherTests and
+       FisherTests"). The generator dedupes within one instance but cannot coordinate across two.
+       Drop Fisher's bundled copy and keep the explicit one — same store-agnostic generator, and it
+       still emits dispatchers for every aggregate in the compilation. See PolecatTests.csproj for
+       the twin. -->
+  <Target Name="DropDuplicateBundledEventSourceGenerator" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Filename)' == 'JasperFx.Events.SourceGenerator' and $([System.String]::Copy('%(Identity)').Replace('\', '/').Contains('/fisher/'))" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Moves the `Fisher` pin from `[0.6.0,1.0.0)` to `[0.7.0,1.0.0)`. NuGet resolves a range to its lowest match, so the floor is the version actually in use — the range alone did not pick 0.7.0 up.

## The one thing that needed fixing

Fisher 0.7.0 now bundles `JasperFx.Events.SourceGenerator` inside its own nupkg under `analyzers/dotnet/cs/`. `FisherTests` also references that generator explicitly, and has to: the aggregate evolvers for its test aggregates are generated with no runtime fallback. With both present the generator loads as **two analyzer instances**, each emitting every aggregate's `.Evolver` dispatcher into the same assembly:

```
error CS0433: The type 'AccountEvolver' exists in both 'FisherTests' and 'FisherTests'
```

It dedupes within one instance but cannot coordinate across two. `FisherTests.csproj` now drops Fisher's bundled copy and keeps the explicit one — the same store-agnostic generator, still emitting dispatchers for every aggregate in the compilation.

This is not a new problem so much as a newly-inherited one: Polecat already bundles the generator, and `PolecatTests.csproj` and `PolecatIncidentService.csproj` each carry the identical target. Fisher has simply caught up to its sibling, so it gets the same treatment.

## Verification

Full `wolverine.slnx` builds clean at `-f net9.0`. FisherTests 22/22, SqliteTests 168/169 (1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)