### PR TITLE
Stop Bug_189's chaos injection from taking down the Rabbit connection (GH-3950)

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_189_fails_if_there_are_many_messages_in_queue_on_startup.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_189_fails_if_there_are_many_messages_in_queue_on_startup.cs
@@ -126,13 +126,15 @@ public class Bug_189_fails_if_there_are_many_messages_in_queue_on_startup
 
         public static void Handle(Bug189 bug, Envelope envelope)
         {
-            if (envelope is RabbitMqEnvelope rabbit)
-            {
-                if (new Random().Next(0, 100) < 5)
-                {
-                    rabbit.OverrideDeliveryTag(1);
-                }
-            }
+            // The delivery-tag poisoning that used to live here has moved to
+            // stale_delivery_tag_settling, which exercises the same unknown-tag path at a message
+            // count low enough not to take the connection down with it. See GH-3950: every bad ack
+            // makes the broker close that channel, and closing a channel with deliveries still in
+            // flight races RabbitMQ.Client's receive loop into a library-initiated connection close
+            // (code=541) that Wolverine cannot catch. At a thousand messages that fired on 4 of 5
+            // local runs from a single poisoned tag, which is what made this test a chronic CI
+            // failure. This test is about starting up against a full queue — that is the regression
+            // it was written for, and it does not need chaos to prove it.
 
             // Five inline listeners run this concurrently. `_count++` on a volatile int is a
             // read-modify-write, so increments were being lost outright, and two threads could both

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/stale_delivery_tag_settling.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/stale_delivery_tag_settling.cs
@@ -1,0 +1,165 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+/// <summary>
+/// Settling a delivery tag the broker no longer recognises must not lose the message.
+/// <see cref="RabbitMqChannelCallback"/> swallows the resulting
+/// <c>PRECONDITION_FAILED - unknown delivery tag</c> rather than burning its retry budget, and the
+/// broker redelivers whatever was never settled.
+/// </summary>
+/// <remarks>
+/// This coverage used to live inside
+/// <c>Bug_189_fails_if_there_are_many_messages_in_queue_on_startup</c>, which poisoned ~5% of a
+/// thousand deliveries. That made it a chronic CI failure rather than a regression test: the broker
+/// closes a channel on every bad ack, and closing a channel that still has deliveries in flight
+/// races RabbitMQ.Client's own receive loop —
+/// <c>Connection.ProcessFrameAsync</c> → <c>SessionManager.Lookup</c> throws
+/// <c>KeyNotFoundException</c> for the channel number it just removed, and the client escalates that
+/// to a library-initiated connection close (code=541). Nothing in Wolverine can catch it; it is
+/// raised on the client's own <c>MainLoop</c> thread. See GH-3950.
+///
+/// <para>
+/// So the poisoning lives here instead, at a message count low enough that the closing channel has
+/// nothing in flight to race. Measured over repeated local runs this provokes the unknown-tag path
+/// without provoking the connection kill, where the thousand-message version provoked it on 4 of 5
+/// runs from a *single* poisoned tag.
+/// </para>
+/// </remarks>
+public class stale_delivery_tag_settling
+{
+    [Fact]
+    public async Task a_stale_delivery_tag_does_not_lose_the_message()
+    {
+        var queueName = RabbitTesting.NextQueueName();
+
+        StaleTagHandler.Reset(poisonAt: 2);
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+                opts.PublishAllMessages().ToRabbitQueue(queueName).SendInline();
+                opts.ListenToRabbitQueue(queueName).ProcessInline();
+            })
+            .StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var ids = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+
+        var bus = host.MessageBus();
+        foreach (var id in ids)
+        {
+            await bus.PublishAsync(new StaleTagMessage(id));
+        }
+
+        // The poisoned delivery is never settled, so the broker redelivers it — which is the whole
+        // point. Assert on distinct ids rather than a raw count for exactly that reason.
+        await StaleTagHandler.WaitForAll(ids.Length, TimeSpan.FromSeconds(60));
+
+        StaleTagHandler.HandledIds.ShouldBe(ids, ignoreOrder: true);
+        StaleTagHandler.PoisonedCount.ShouldBe(1);
+
+        // The load-bearing assertion. Poisoning the tag means the real delivery is never settled, so
+        // the broker has to redeliver it — and a redelivery is the only externally visible proof that
+        // the unknown-tag path was actually taken. Without this the test would still pass if
+        // OverrideDeliveryTag quietly became a no-op, which is exactly how a chaos test rots.
+        //
+        // It has to be waited for, not read: the rejection, the channel teardown and the requeue all
+        // happen after the fifth message has already been handled.
+        await StaleTagHandler.WaitForRedelivery(ids.Length, TimeSpan.FromSeconds(30));
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}
+
+public record StaleTagMessage(Guid Id);
+
+public static class StaleTagHandler
+{
+    private static TaskCompletionSource<bool> _source = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static readonly ConcurrentDictionary<Guid, byte> _ids = new();
+    private static int _delivered;
+    private static int _poisoned;
+    private static int _poisonAt;
+    private static int _expected;
+
+    public static IReadOnlyCollection<Guid> HandledIds => _ids.Keys.ToArray();
+    public static int PoisonedCount => Volatile.Read(ref _poisoned);
+    public static int DeliveryCount => Volatile.Read(ref _delivered);
+
+    /// <summary>
+    /// Statics on a static handler survive for the life of the worker process, and the supervisor
+    /// retries a failed test inside that same process — so a stale, already-completed source would
+    /// let a retry "pass" without receiving anything. Same trap documented in Bug_189.
+    /// </summary>
+    public static void Reset(int poisonAt)
+    {
+        _ids.Clear();
+        Interlocked.Exchange(ref _delivered, 0);
+        Interlocked.Exchange(ref _poisoned, 0);
+        _poisonAt = poisonAt;
+        _source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static async Task WaitForAll(int expected, TimeSpan timeout)
+    {
+        _expected = expected;
+
+        if (_ids.Count >= expected) return;
+
+        var completed = await Task.WhenAny(_source.Task, Task.Delay(timeout));
+        if (!ReferenceEquals(completed, _source.Task))
+        {
+            throw new TimeoutException(
+                $"Only {_ids.Count} of {expected} distinct messages were handled within {timeout}. " +
+                $"{Volatile.Read(ref _poisoned)} delivery tag(s) were poisoned.");
+        }
+    }
+
+    /// <summary>
+    /// Waits for the broker to redeliver whatever the poisoned settle failed to acknowledge.
+    /// </summary>
+    public static async Task WaitForRedelivery(int firstPassCount, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (Volatile.Read(ref _delivered) > firstPassCount) return;
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException(
+            $"The poisoned delivery was never redelivered within {timeout}: still {Volatile.Read(ref _delivered)} " +
+            $"deliveries for {firstPassCount} messages. Either the override no longer produces an unknown " +
+            $"delivery tag, or the settle path silently succeeded — in both cases this test is no longer " +
+            $"covering what it claims to.");
+    }
+
+    public static void Handle(StaleTagMessage message, Envelope envelope)
+    {
+        // Poison exactly one delivery. The counter only reaches _poisonAt once, so a redelivery of
+        // the poisoned message is not poisoned again and the test cannot loop.
+        //
+        // ulong.MaxValue, not 1. Tag 1 is a *real* tag: overriding to it early in a run just acks the
+        // first message ahead of schedule, which the broker accepts, and nothing is ever rejected —
+        // the assertion below caught exactly that and this test passed vacuously until it did. A tag
+        // that was never delivered is rejected outright with
+        // "PRECONDITION_FAILED - unknown delivery tag", which is the path under test.
+        if (envelope is RabbitMqEnvelope rabbit && Interlocked.Increment(ref _delivered) == _poisonAt)
+        {
+            Interlocked.Increment(ref _poisoned);
+            rabbit.OverrideDeliveryTag(ulong.MaxValue);
+        }
+
+        _ids.TryAdd(message.Id, 0);
+
+        if (_ids.Count >= _expected)
+        {
+            _source.TrySetResult(true);
+        }
+    }
+}


### PR DESCRIPTION
Isolated fix for the chronic `CIRabbitMQ` failure that has been blocking #3946. Related: #3950, which records the underlying client defect.

## What was actually wrong

`Bug_189_fails_if_there_are_many_messages_in_queue_on_startup` poisoned ~5% of a thousand delivery tags via the `OverrideDeliveryTag` chaos hook. That wasn't testing Wolverine harder — it was reliably provoking a defect in RabbitMQ.Client 7.1.2.

Every rejected ack makes the broker close that channel. Closing a channel that still has deliveries in flight races the client's own receive loop:

```
Dictionary`2.get_Item(TKey key)
RabbitMQ.Client.Impl.SessionManager.Lookup(Int32 number)
RabbitMQ.Client.Framing.Connection.ProcessFrameAsync(...)
RabbitMQ.Client.Framing.Connection.ReceiveLoopAsync(...)
RabbitMQ.Client.Framing.Connection.MainLoop()
---- KeyNotFoundException : The given key '4' was not present in the dictionary.
```

`Lookup` does an indexer read on a channel number it just removed, and the client escalates that into a **library-initiated close of the whole connection** (`code=541`). Wolverine cannot catch it — it is raised on the client's `MainLoop` thread, after the ack has gone out. Wolverine's settle paths are already hardened for the tag rejection itself (`RabbitMqChannelCallback.Complete`, `RabbitMqInteropFriendlyCallback`); it makes no difference to this.

## Measurements

Local, `docker compose` broker, client 7.1.2, 3–5 runs each:

| Scenario | `KeyNotFoundException` | `code=541` |
|---|---|---|
| Bug_189 as written (~5% of 1000) | every run | every run |
| Bug_189, poisoning removed | 0 | 0 |
| Bug_189, exactly **one** poisoned tag | 5/5 | **4/5** |
| 5 messages, one poisoned tag | 0/5 | 0/5 |

Row 3 is the finding: a single rejected ack suffices. It is the in-flight traffic, not the number of bad acks, that decides whether the connection dies. Same signature has failed CI on a PR (run 31894510951, twice) and on `main` (run 31741860971).

## What changed

Bug_189 is about **starting up against a full queue**. That regression needs no chaos, so the poisoning moves out to a focused `stale_delivery_tag_settling` at five messages, where the closing channel has nothing in flight to race.

The new test earned its keep the hard way, and both mistakes are worth recording because they're how chaos tests rot:

1. **Poisoning with tag `1` proves nothing.** Tag 1 is a *real* tag — overriding to it early just acks the first message ahead of schedule, which the broker accepts. Nothing is ever rejected. It now poisons with `ulong.MaxValue`, never delivered, which is rejected outright.
2. **The proof has to be waited for, not read.** It asserts the poisoned message is *redelivered* — the only externally visible evidence the unknown-tag path was taken — and the rejection, teardown and requeue all happen after the last message is handled. Reading it immediately reported "5 of 5" and passed vacuously.

Without that redelivery assertion the test would still pass if `OverrideDeliveryTag` quietly became a no-op.

## Verification

- Bug_189: 5/5 runs, zero `KeyNotFoundException`, zero `code=541`
- `stale_delivery_tag_settling`: 5/5 runs, zero `code=541`, redelivery observed every run
- Full `Wolverine.RabbitMQ.Tests`: **496/497, zero `code=541` across the entire suite**

The one failure is `multi_tenancy_through_virtual_hosts.send_message_to_a_specific_tenant` — a pre-existing tracked-session timing flake (the response *was* sent at 67ms; the session closed first). It was already `[FLAKY]` in both CI runs examined, and passes 7/7 in isolation here. Untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)