### PR TITLE
GH-3953: let the persistence provider decide who owns a chain's transaction

### DIFF
--- a/docs/guide/durability/marten/ancillary-stores.md
+++ b/docs/guide/durability/marten/ancillary-stores.md
@@ -150,6 +150,16 @@ public static class PlayerMessageHandler
 To route a whole assembly of handlers to one ancillary store from an `IChainPolicy` without per-handler attributes,
 call `chain.UseMartenStore(storeType)` (or the provider-agnostic `chain.UseAncillaryStorage(storeType, container)`).
 
+::: tip
+The attribute (or `UseMartenStore()` / `UseAncillaryStorage()`) is the *only* thing that moves a handler's transaction
+and its inbox/dead letter bookkeeping to an ancillary store. Injecting an ancillary store interface — directly, or
+through another service that takes one — to run read-only queries changes nothing: the handler keeps committing
+through the main store's `IDocumentSession`, and its envelopes stay in the main store's inbox.
+
+This differs from [EF Core](/guide/durability/efcore/), where the enrolled `DbContext` a handler injects *is* the
+transaction owner, so it also decides which store holds the inbox row.
+:::
+
 So what's possible so far?
 
 * The transactional inbox support is available in all configured Marten stores

--- a/src/Persistence/MartenTests/AncillaryStores/Bug_3953_read_only_ancillary_dependency.cs
+++ b/src/Persistence/MartenTests/AncillaryStores/Bug_3953_read_only_ancillary_dependency.cs
@@ -1,0 +1,174 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.Tracking;
+using Wolverine.Util;
+
+namespace MartenTests.AncillaryStores;
+
+// Regression test for GH-3953. Reported by @kentcooper.
+//
+// A handler whose transaction is owned by the MAIN Marten store's IDocumentSession also depends -- for
+// read-only reference lookups -- on an ancillary Marten store, either directly or transitively through
+// another service. The recursive ServiceDependencies() inference added for GH-3870
+// (WolverineRuntime.HostService.inferAncillaryStoreType) saw the single ancillary marker anywhere in that
+// dependency graph and routed the handler's inbox / dead letter row into the ancillary store, even though
+// nothing in the handler ever commits there.
+//
+// That inference is only correct for a provider whose transaction owner IS a plain service dependency --
+// EF Core, where DetermineDbContextType picks the injected DbContext. For Marten (and Polecat / Fisher)
+// the ancillary store has to be named with [MartenStore] / [Storage], which populates
+// chain.AncillaryStoreType directly; merely injecting the store interface says nothing about who owns the
+// transaction.
+//
+// These assertions read the routing DECISION rather than pushing messages through a broker: it is exactly
+// the value DurableReceiver and DurableLocalQueue consult per envelope, and it isolates the inference from
+// everything downstream of it.
+public class Bug_3953_read_only_ancillary_dependency : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "bug3953_main";
+                    m.Events.DatabaseSchemaName = "bug3953_main";
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddMartenStore<IBug3953SystemStore>(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "bug3953_system";
+                    m.Events.DatabaseSchemaName = "bug3953_system";
+                }).IntegrateWithWolverine();
+
+                opts.Services.AddScoped<IBug3953Directory, Bug3953Directory>();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(Bug3953Handlers))
+                    .IncludeType(typeof(Bug3953SystemStoreHandler));
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private IMessageStore? ancillaryStoreFor<T>()
+    {
+        return theHost.GetRuntime().Stores
+            .TryFindAncillaryStoreForMessageType(null, typeof(T).ToMessageTypeName());
+    }
+
+    [Fact]
+    public void a_directly_injected_ancillary_store_does_not_claim_the_inbox()
+    {
+        ancillaryStoreFor<Bug3953DirectMessage>()
+            .ShouldBeNull(
+                "The handler's transaction is owned by the main store's IDocumentSession; the ancillary " +
+                "store is only queried.");
+    }
+
+    [Fact]
+    public void a_transitively_injected_ancillary_store_does_not_claim_the_inbox()
+    {
+        ancillaryStoreFor<Bug3953TransitiveMessage>()
+            .ShouldBeNull(
+                "Same as the direct case, but the ancillary store is reached through another service's " +
+                "constructor.");
+    }
+
+    [Fact]
+    public void an_explicitly_attributed_handler_still_claims_the_inbox()
+    {
+        // The control. Narrowing the GH-3870 inference must not weaken the attribute path that
+        // GH-2576 / GH-2944 / GH-3109 depend on.
+        var store = ancillaryStoreFor<Bug3953AttributedMessage>();
+        store.ShouldNotBeNull();
+        store.ShouldBeSameAs(theHost.GetRuntime().Stores.FindAncillaryStore(typeof(IBug3953SystemStore)));
+    }
+}
+
+public interface IBug3953SystemStore : IDocumentStore;
+
+public record Bug3953DirectMessage(Guid Id);
+
+public record Bug3953TransitiveMessage(Guid Id);
+
+public record Bug3953AttributedMessage(Guid Id);
+
+public class Bug3953Doc
+{
+    public Guid Id { get; set; }
+}
+
+public class Bug3953Reference
+{
+    public Guid Id { get; set; }
+}
+
+public interface IBug3953Directory
+{
+    Task<bool> ExistsAsync(Guid id, CancellationToken token);
+}
+
+// The ancillary store is QUERIED here and nothing more -- it never owns a transaction.
+public class Bug3953Directory : IBug3953Directory
+{
+    private readonly IBug3953SystemStore _systemStore;
+
+    public Bug3953Directory(IBug3953SystemStore systemStore) => _systemStore = systemStore;
+
+    public async Task<bool> ExistsAsync(Guid id, CancellationToken token)
+    {
+        await using var query = _systemStore.QuerySession();
+        return await query.Query<Bug3953Reference>().AnyAsync(x => x.Id == id, token);
+    }
+}
+
+public static class Bug3953Handlers
+{
+    public static async Task Handle(Bug3953DirectMessage message, IDocumentSession session,
+        IBug3953SystemStore systemStore, CancellationToken token)
+    {
+        await using var query = systemStore.QuerySession();
+        await query.Query<Bug3953Reference>().AnyAsync(x => x.Id == message.Id, token);
+
+        session.Store(new Bug3953Doc { Id = message.Id });
+    }
+
+    public static async Task Handle(Bug3953TransitiveMessage message, IDocumentSession session,
+        IBug3953Directory directory, CancellationToken token)
+    {
+        await directory.ExistsAsync(message.Id, token);
+
+        session.Store(new Bug3953Doc { Id = message.Id });
+    }
+}
+
+[MartenStore(typeof(IBug3953SystemStore))]
+public static class Bug3953SystemStoreHandler
+{
+    public static void Handle(Bug3953AttributedMessage message, IDocumentSession session)
+    {
+        session.Store(new Bug3953Reference { Id = message.Id });
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -496,6 +496,29 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         return serviceDependencies.Any(x => x.CanBeCastTo<DbContext>() || _abstractions.Contains(x));
     }
 
+    /// <summary>
+    /// EF Core is the one provider whose transaction owner is a plain service dependency, so it is the one
+    /// provider that can tell Wolverine which enrolled store a handler's durable inbox row belongs in
+    /// (GH-3870). Deliberately the same <see cref="DetermineDbContextType(IChain,IServiceContainer)" /> the
+    /// transactional middleware uses, so the inbox row and the SaveChanges land in the same database.
+    /// </summary>
+    public Type? TryDetermineTransactionOwnerType(IChain chain, IServiceContainer container)
+    {
+        if (!CanApply(chain, container)) return null;
+
+        try
+        {
+            return DetermineDbContextType(chain, container);
+        }
+        catch (Exception)
+        {
+            // Ambiguous or unresolvable - DetermineDbContextType throws a chain-specific message that
+            // codegen surfaces to the developer. This runs at startup while building the inbox routing
+            // map, where the safe answer is "no ancillary store", exactly as before GH-3870.
+            return null;
+        }
+    }
+
     internal Type? TryDetermineDbContextType(Type entityType, IServiceContainer container)
     {
         if (_dbContextTypes.TryFind(entityType, out var dbContextType))

--- a/src/Wolverine/Persistence/IPersistenceFrameProvider.cs
+++ b/src/Wolverine/Persistence/IPersistenceFrameProvider.cs
@@ -25,6 +25,25 @@ public interface IPersistenceFrameProvider
     bool CanApply(IChain chain, IServiceContainer container);
 
     /// <summary>
+    ///     The service type that owns this chain's transaction, when that owner is itself one of the
+    ///     chain's own service dependencies — EF Core's <c>DbContext</c>, chosen by
+    ///     <c>DetermineDbContextType</c>. Wolverine uses this to route a handler's durable inbox row to
+    ///     the ancillary message store enrolled for that owner, so the inbox update and the handler's
+    ///     writes share one transaction (GH-3870).
+    /// </summary>
+    /// <remarks>
+    ///     Returns null by default, which is the correct answer for every provider whose ancillary store
+    ///     must be named explicitly with <c>[Storage]</c> / <c>[MartenStore]</c> / <c>[PolecatStore]</c>
+    ///     (Marten, Polecat, Fisher). Those designations already populate
+    ///     <see cref="IChain.AncillaryStoreType" />, and a bare dependency on the store interface says
+    ///     nothing about who commits — a store injected only to run read-only queries would otherwise
+    ///     pull the inbox row away from the store the handler actually writes to (GH-3953).
+    ///     Implementations must not throw: an unresolvable or ambiguous owner is reported as null and
+    ///     left for codegen to diagnose.
+    /// </remarks>
+    Type? TryDetermineTransactionOwnerType(IChain chain, IServiceContainer container) => null;
+
+    /// <summary>
     ///     Use for Saga creation support as returned value
     /// </summary>
     /// <param name="entityType"></param>

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -9,6 +9,7 @@ using Wolverine.Attributes;
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.Batching;
 using Wolverine.Runtime.Handlers;
@@ -586,20 +587,42 @@ public partial class WolverineRuntime
     /// ancillary one, leaving the envelope permanently Incoming and outside the handler's
     /// transaction. See https://github.com/JasperFx/wolverine/issues/3870.
     ///
-    /// ServiceDependencies() is the same view of the chain that EF Core's DetermineDbContextType()
-    /// uses to pick the transactional DbContext, so this inference agrees with whichever DbContext
-    /// the transactional middleware chose. Ambiguity is not resolved by guessing: a chain that
-    /// depends on two ancillary markers has no single owning transaction, so it is left to the main
-    /// store exactly as before.
+    /// The chain's own persistence provider is the only thing that can say who owns its transaction,
+    /// so it gets the deciding vote through IPersistenceFrameProvider.TryDetermineTransactionOwnerType.
+    /// EF Core answers with the DbContext its transactional middleware picked, so the inbox row lands
+    /// in the same database as the SaveChanges. Every other provider answers null, because their
+    /// ancillary stores are named with [Storage]/[MartenStore]/[PolecatStore] -- which has already
+    /// populated AncillaryStoreType above -- and merely depending on a store interface says nothing
+    /// about who commits. Inferring from the dependency graph alone dragged the inbox, and with it
+    /// dead-lettering, away from a Marten handler that used an ancillary store purely for read-only
+    /// reference queries. See https://github.com/JasperFx/wolverine/issues/3953.
     /// </summary>
     private Type? inferAncillaryStoreType(HandlerChain chain, Type[] markerTypes)
     {
         if (markerTypes.Length == 0) return null;
 
+        // Cheap pre-filter: no marker anywhere in the dependency graph means there is nothing to infer,
+        // and the provider (which may build DbContexts to answer) never has to be consulted.
         var dependencies = chain.ServiceDependencies(_container, Type.EmptyTypes).ToArray();
-        var matches = markerTypes.Where(dependencies.Contains).ToArray();
+        if (!markerTypes.Any(dependencies.Contains)) return null;
 
-        return matches.Length == 1 ? matches[0] : null;
+        try
+        {
+            var owner = Options.CodeGeneration.GetPersistenceProviders(chain, _container)
+                .TryDetermineTransactionOwnerType(chain, _container);
+
+            return owner != null && markerTypes.Contains(owner) ? owner : null;
+        }
+        catch (Exception e)
+        {
+            // Inbox routing must never take the application down at startup. Whatever a provider cannot
+            // answer here it will answer -- or fail loudly and specifically about -- at codegen time.
+            Logger.LogDebug(e,
+                "Unable to determine the transaction owner of {Chain} while mapping handlers to ancillary message stores. Its inbox will use the main store.",
+                chain.Description);
+
+            return null;
+        }
     }
 
     private async Task executeIdleSendingAgentCleanup()


### PR DESCRIPTION
Fixes #3953.

## The defect

A handler whose transaction is owned by the **main** store's `IDocumentSession`, but which also depends on an ancillary Marten store for read-only reference queries, had its inbox and dead-letter rows routed into that ancillary store. @kentcooper's dead-letter diagnostic found 0 rows in the tenant store and 1 in the ancillary one; some retry paths left tenant envelopes `Incoming`.

`WolverineRuntime.HostService.inferAncillaryStoreType` — added by #3875 for #3870 — scanned `chain.ServiceDependencies()` for ancillary store marker types and mapped the chain on exactly one match. `ServiceDependencies` walks constructor graphs recursively, so **any** dependency that merely *holds* an ancillary store matched. A `ReadOnlyDirectory(ISystemStore)` two hops down counted the same as an injected `DbContext`. The scan has no notion of who commits.

The reporter's diagnosis was exactly right: that inference is only correct for **EF Core**, where the injected `DbContext` genuinely *is* the transaction owner that `DetermineDbContextType` picks. Marten, Polecat and Fisher require `[MartenStore]` / `[Storage]` / `[PolecatStore]` to target an ancillary store, and that designation has already populated `chain.AncillaryStoreType` by the time this runs — a bare dependency on the store interface says nothing at all.

## The fix

Give the chain's own provider the deciding vote, via a new default-null member on `IPersistenceFrameProvider`:

```csharp
Type? TryDetermineTransactionOwnerType(IChain chain, IServiceContainer container) => null;
```

Implemented only by `EFCorePersistenceFrameProvider`, which delegates to the same `DetermineDbContextType` the transactional middleware uses — so the inbox row and the `SaveChanges` land in one database, which is the whole point of #3870.

Two details worth reviewing:

- The cheap marker-in-dependencies scan **stays** as a pre-filter, so the provider (which may build `DbContext` instances to answer) is never consulted for a chain with no marker at all.
- The consultation is wrapped in `try`/`catch` + `LogDebug`, because this runs during `startMessagingTransportsAsync` and `DetermineDbContextType` *throws* on an ambiguous multi-`DbContext` chain. Codegen still surfaces that error with its chain-specific message; startup should not die over inbox routing.

Deliberate side effect: a chain depending on two enrolled `DbContext` types now follows its `[Transactional(typeof(X))]` / `[Storage(typeof(X))]` designation instead of falling back to "ambiguous, use the main store".

## Testing

`MartenTests/AncillaryStores/Bug_3953_read_only_ancillary_dependency.cs` asserts the routing **decision** (`Stores.TryFindAncillaryStoreForMessageType`) rather than pushing messages through a broker — that is exactly the value `DurableReceiver` and `DurableLocalQueue` consult per envelope, and it isolates the inference from everything downstream. Three cases: direct marker injection, transitive injection through another service's constructor, and an attributed control that must **still** claim the inbox. Verified red first, 2 of 3 failing with the literal `should be null but was wolverinedb://postgresql/localhost/postgres/bug3953_system`.

Local runs:

| Suite | Result |
|---|---|
| EfCoreTests (Bug_3870, Bug_3886, both sticky routing suites) | 203/203 |
| MartenTests | 600/600 |
| CoreTests | 2397/2399 (2 skipped) |
| PolecatTests | 283/285 (2 skipped) |
| PersistenceTests | 90/90 |
| Rabbit Bug_2155 / Bug_2944 / Bug_1684 | 3/3 |
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |

## Not addressed

The issue also asks for a supported way to explicitly pin a chain to the **main** store and suppress inference. Left out on purpose: with the false positive gone there is nothing to suppress on the Marten side, and EF Core already has `[Transactional(typeof(X))]` / `[Storage(typeof(X))]` for designating the owner. Happy to add an opt-out if a case turns up that this doesn't cover.

Docs: added a tip to `guide/durability/marten/ancillary-stores` stating that only the attribute (or `UseMartenStore()` / `UseAncillaryStorage()`) moves a handler's inbox, and calling out the EF Core difference explicitly — that distinction is what made this surprising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC