### PR TITLE
GH-3955: stop the idle reaper from permanently latching durable endpoints

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3955_idle_reaper_and_durable_endpoints.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Bugs/Bug_3955_idle_reaper_and_durable_endpoints.cs
@@ -1,0 +1,135 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Postgresql;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Bugs;
+
+// Regression test for GH-3955. Reported by @wieslawo.
+//
+// A durable RabbitMQ queue used ONLY through IMessageBus.EndpointFor(uri) -- no message-type
+// subscriptions, not part of a sharded topology -- went permanently silent after one
+// SendingAgentIdleTimeout window. Envelopes kept landing in wolverine_outgoing_envelopes and were
+// never sent again until the process restarted.
+//
+// Two independent defects, both of which had to close:
+//
+// 1. executeIdleSendingAgentCleanup skipped only local queues and AutoStartSendingAgent()
+//    endpoints. AutoStartSendingAgent() is UsedInShardedTopology || Subscriptions.Any(), so an
+//    endpoint declared with opts.Publish(p => p.ToRabbitQueue(name).UseDurableOutbox()) and no
+//    .Message<T>() looked exactly as disposable as the ephemeral control/reply queues GH-1908
+//    was actually written for -- even though its sending agent owns the outbox drain for that
+//    destination.
+//
+// 2. Being reaped left the endpoint unusable rather than merely cold. RabbitMqEndpoint cached the
+//    sender forever (_sender ??= ...), so the next EndpointFor(uri) built a fresh
+//    DurableSendingAgent around the DISPOSED RabbitMqSender. RabbitMqChannelAgent.EnsureInitiated
+//    returns immediately once _disposed is set, so SendAsync threw "Channel has not been started
+//    for this sender" until the agent latched, and the circuit breaker's PingAsync went through
+//    the same no-op and could never heal it. EndpointCollection.RemoveSendingAgentAsync also left
+//    Endpoint.Agent pointing at the disposed agent, which DestinationEndpoint and MessageRoute
+//    both read.
+//
+// The second test does not depend on the reaper at all: it reaps by hand, which is both
+// deterministic and the honest way to pin defect 2 now that defect 1 keeps the reaper away from
+// durable endpoints.
+public class Bug_3955_idle_reaper_and_durable_endpoints : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _queueName = null!;
+    private Uri _uri = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _queueName = "bug3955_" + Guid.NewGuid().ToString("N")[..8];
+        _uri = new Uri("rabbitmq://queue/" + _queueName);
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Short enough to reap within a test, long enough not to race the sends themselves
+                opts.Durability.SendingAgentIdleTimeout = 1.Seconds();
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "bug3955");
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                // Deliberately NO .Message<T>() -- this endpoint is addressed only by Uri, so it has
+                // no subscriptions and AutoStartSendingAgent() is false. That is the whole setup.
+                opts.Publish(p => p.ToRabbitQueue(_queueName).UseDurableOutbox());
+
+                opts.ListenToRabbitQueue(_queueName);
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private Task sendAndWaitAsync(string name) =>
+        _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync(c => c.EndpointFor(_uri).SendAsync(new Bug3955Message(name)).AsTask());
+
+    [Fact]
+    public async Task durable_endpoint_still_sends_after_an_idle_window()
+    {
+        await sendAndWaitAsync("first");
+
+        // Two full reaper ticks. Before the fix the second tick removed the sending agent for a
+        // DURABLE endpoint and the send below never reached the broker.
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+
+        var runtime = _host.GetRuntime();
+        runtime.Endpoints.ActiveSendingAgents().Select(x => x.Destination)
+            .ShouldContain(_uri, "A durable endpoint's sending agent owns the outbox drain for its destination and must not be reaped as idle.");
+
+        await sendAndWaitAsync("second");
+    }
+
+    [Fact]
+    public async Task a_reaped_endpoint_comes_back_healthy_on_next_use()
+    {
+        await sendAndWaitAsync("before");
+
+        var runtime = _host.GetRuntime();
+        var endpoint = (RabbitMqEndpoint)runtime.Endpoints.EndpointFor(_uri)!;
+        var firstSender = endpoint.ResolveSender(runtime);
+
+        // Exactly what the idle cleanup does, minus the waiting
+        await ((EndpointCollection)runtime.Endpoints).RemoveSendingAgentAsync(_uri);
+
+        endpoint.Agent.ShouldBeNull("A removed sending agent must not stay reachable through Endpoint.Agent, which DestinationEndpoint and MessageRoute both read.");
+
+        var secondSender = endpoint.ResolveSender(runtime);
+        secondSender.ShouldNotBeSameAs(firstSender);
+        ((RabbitMqChannelAgent)secondSender).IsDisposed.ShouldBeFalse();
+
+        // ... and the endpoint genuinely works again rather than latching on a dead channel
+        await sendAndWaitAsync("after");
+    }
+}
+
+public record Bug3955Message(string Name);
+
+public static class Bug3955MessageHandler
+{
+    public static void Handle(Bug3955Message message)
+    {
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEndpoint.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEndpoint.cs
@@ -60,6 +60,18 @@ public abstract partial class RabbitMqEndpoint : Endpoint<IRabbitMqEnvelopeMappe
 
     internal ISender ResolveSender(IWolverineRuntime runtime)
     {
+        // The endpoint outlives its sending agent. When the idle cleanup reaps an agent it disposes the
+        // sender underneath, but this cache kept handing that dead sender to the next EndpointFor(uri)
+        // call, so the freshly built DurableSendingAgent wrapped a disposed channel agent:
+        // EnsureInitiated() returns immediately once _disposed is set, SendAsync then threw "Channel has
+        // not been started for this sender" until the agent latched, and the circuit breaker's PingAsync
+        // goes through the same no-op so it could never heal. Only a restart recovered the outbox.
+        // See https://github.com/JasperFx/wolverine/issues/3955.
+        if (_sender is RabbitMqChannelAgent { IsDisposed: true })
+        {
+            _sender = null;
+        }
+
         _sender ??= _parent.BuildSender(this, RoutingType, runtime);
         return _sender;
     }

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -581,6 +581,14 @@ public class EndpointCollection : IEndpointCollection
             _senders = _senders.Remove(destination);
         }
 
+        // Endpoint.Agent is a second, independent handle on the agent we are about to dispose, and
+        // DestinationEndpoint and MessageRoute both read it. Leaving it set handed callers a disposed
+        // agent long after this collection had forgotten it. See GH-3955.
+        if (ReferenceEquals(agent.Endpoint.Agent, agent))
+        {
+            agent.Endpoint.Agent = null;
+        }
+
         if (agent is IAsyncDisposable ad)
         {
             await ad.DisposeAsync();

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -616,6 +616,15 @@ public partial class WolverineRuntime
                 {
                     if (agent.Endpoint is LocalQueue) continue;
                     if (agent.Endpoint.AutoStartSendingAgent()) continue;
+
+                    // GH-1908 was aimed at ephemeral control and reply queues, and those are never
+                    // durable. A durable endpoint's sending agent owns the outbox drain for its
+                    // destination, so reaping it strands every envelope staged for that destination
+                    // until something rebuilds the agent -- and an endpoint reached only through
+                    // EndpointFor(uri) has no subscriptions, so nothing here recognized it as
+                    // load bearing. See https://github.com/JasperFx/wolverine/issues/3955.
+                    if (agent.Endpoint.Mode == EndpointMode.Durable) continue;
+
                     if (agent.LastMessageSentAt > cutoff) continue;
 
                     Logger.LogInformation("Removing idle sending agent for {Destination}", agent.Destination);


### PR DESCRIPTION
Fixes #3955.

@wieslawo's report was accurate at every link, and the source confirms all of it. Two independent defects, both fixed here.

## 1. The reaper treats a durable endpoint as ephemeral

`executeIdleSendingAgentCleanup` skips only local queues and endpoints where `AutoStartSendingAgent()` is true — and that is `UsedInShardedTopology || Subscriptions.Any()` (`Endpoint.cs:608`). An endpoint declared with

```csharp
opts.Publish(p => p.ToRabbitQueue("q1").UseDurableOutbox());  // no .Message<T>()
```

and addressed only by `EndpointFor(uri)` has no subscriptions, so it looked exactly as disposable as the ephemeral control/reply queues #1908 was actually written for — even though its sending agent owns the outbox drain for that destination.

Durable endpoints are now left alone. Deliberately **not** done by widening `AutoStartSendingAgent()`, which is also what decides who gets a sending agent eagerly at startup — that would open a Rabbit channel for every durable endpoint at boot.

## 2. A reaped endpoint came back dead, not cold

`RabbitMqEndpoint.ResolveSender` was `_sender ??= ...` — a permanent cache. The endpoint outlives its sending agent, so the next `EndpointFor(uri)` built a fresh `DurableSendingAgent` around the **disposed** `RabbitMqSender`. `RabbitMqChannelAgent.EnsureInitiated` returns immediately once `_disposed` is set, so `SendAsync` threw `"Channel has not been started for this sender"` until the agent latched after three failures — and the circuit watcher's `PingAsync` goes through the same no-op, so it could never heal. Only a restart recovered the outbox.

`ResolveSender` now rebuilds past a disposed channel agent, using the `IsDisposed` flag #3842 already added for exactly this "returned without a channel" ambiguity.

Separately, `EndpointCollection.RemoveSendingAgentAsync` left `Endpoint.Agent` pointing at the agent it had just disposed. That's a second, independent handle that `DestinationEndpoint.cs:22,39` and `MessageRoute.cs:61` both read, so a route built before the reap kept dispatching into a disposed agent. Now cleared. This half is transport-agnostic.

On 6.11.0 the same scenario surfaced as `ObjectDisposedException: SemaphoreSlim` before #3132 changed the `Locker` disposal — same root cause, different symptom, as the report notes.

## Testing

`SendingAgentIdleTimeout` had **no test coverage at all** before this. Two added, both verified red on unmodified `main` first:

- `durable_endpoint_still_sends_after_an_idle_window` — the reported scenario, with the timeout dialed to 1s.
- `a_reaped_endpoint_comes_back_healthy_on_next_use` — reaps by hand rather than waiting. Deterministic, and the honest way to pin the latch now that fix 1 keeps the reaper away from durable endpoints.

| Suite | Result |
|---|---|
| New `Bug_3955` tests | 2/2 (red first) |
| CoreTests | 2397/2399 (2 skipped) |
| Wolverine.RabbitMQ.Tests | 498/499 — see below |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

The one Rabbit failure, `multi_tenancy_through_virtual_hosts.send_message_to_a_specific_tenant`, is a **pre-existing tracking race unrelated to this diff**. Its session waits only for `MultiTenantMessage` to be received at node "two" and then asserts on `MultiTenantResponse` arriving back at main; the trace shows the response `Sent` in the same millisecond the completion condition was satisfied. That class passes 21/21 across three isolated runs, and the reaper logged exactly once in the entire suite — for an unrelated `dbcontrol://` endpoint, ~14,000 log lines after the failure. Worth its own one-line fix (`.WaitForMessageToBeReceivedAt<MultiTenantResponse>(Main)`), kept out of here on scope grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC