### PR TITLE
GH-3796 follow-up: make the prefetch drain safe for a non-terminal stop

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/drain_wait_for_prefetch_repeated_stop.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/drain_wait_for_prefetch_repeated_stop.cs
@@ -1,0 +1,119 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// Follow-up to GH-3796. DrainWaitForPrefetch completes the consumer's BatchingChannel inside
+// RabbitMqListener.StopAsync, but StopAsync is NOT always a terminal shutdown -- RequeueContinuation
+// stops the listener inline from the handler pipeline and the background PauseAsync then stops it a
+// second time before disposing it, so a durable listener genuinely sees StopAsync twice on one
+// consumer.
+//
+// A JasperFx BatchingChannel tolerates every post-completion call: TriggerBatch, Complete,
+// WaitForCompletionAsync and even PostAsync all quietly do nothing rather than throw. That makes the
+// second stop harmless but not free (it re-runs the cancel-ok wait against a drained channel), and it
+// makes the window between Complete and Dispose's latch actively dangerous: a delivery landing there
+// is posted into a completed channel and SILENTLY DISCARDED, never reaching the receiver -- exactly
+// the redelivery this feature exists to prevent. DrainBatchedDeliveriesAsync now latches before
+// completing, so such a delivery is rejected-with-requeue instead of vanishing.
+//
+// This test pins the sequence rather than the race: it is a regression guard, and it passes both
+// before and after the fix. The behavior it protects -- everything still drains when StopAsync runs
+// twice on one consumer -- is what a naive "guard the second Complete" fix would break.
+public class drain_wait_for_prefetch_repeated_stop : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private string _queueName = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _queueName = RabbitTesting.NextQueueName();
+        var schemaName = $"drain_repeat_{Guid.NewGuid():N}";
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.LocalRoutingConventionDisabled = true;
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = schemaName;
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine(x => x.MessageStorageSchemaName = schemaName);
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.PublishMessage<RepeatedStopMessage>().ToRabbitQueue(_queueName);
+
+                // Durable + MaximumMessagesToReceive > 1 is what creates the BatchingChannel, so this
+                // is the configuration where the double Complete() is reachable at all.
+                opts.ListenToRabbitQueue(_queueName)
+                    .UseDurableInbox()
+                    .DrainWaitForPrefetch()
+                    .PreFetchCount(100);
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        await _host.ResetResourceState();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task stopping_the_same_consumer_twice_still_drains_everything()
+    {
+        const int messageCount = 10;
+
+        var bus = _host.MessageBus();
+        for (var i = 0; i < messageCount; i++)
+        {
+            await bus.PublishAsync(new RepeatedStopMessage(Guid.NewGuid()));
+        }
+
+        var runtime = _host.GetRuntime();
+        var agent = runtime.Endpoints.ActiveListeners()
+            .Single(x => x.Uri == new Uri($"rabbitmq://queue/{_queueName}"));
+
+        // Give the broker a moment to push the batch onto the wire so there is something prefetched
+        // to drain rather than an empty stop.
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
+
+        // The RequeueContinuation shape: an inline stop from the pipeline...
+        await ((ListeningAgent)agent).Listener!.StopAsync();
+
+        // ... followed by the background PauseAsync, which stops the SAME consumer again and only
+        // then disposes it.
+        await agent.StopAndDrainAsync();
+
+        agent.Status.ShouldBe(ListeningStatus.Stopped);
+
+        var incoming = await runtime.Storage.Admin.AllIncomingAsync();
+        incoming.Count(x => x.MessageType == typeof(RepeatedStopMessage).ToMessageTypeName())
+            .ShouldBe(messageCount);
+    }
+}
+
+public record RepeatedStopMessage(Guid Id);
+
+public static class RepeatedStopMessageHandler
+{
+    public static void Handle(RepeatedStopMessage message)
+    {
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
@@ -193,6 +193,11 @@ public class multi_tenancy_through_virtual_hosts : IClassFixture<MultiTenantedRa
             .Timeout(15.Seconds())
             .AlsoTrack(_fixture.One, _fixture.Two, _fixture.Three)
             .WaitForMessageToBeReceivedAt<MultiTenantMessage>(_fixture.Two)
+            // The assertions below also require the RESPONSE to have made it back to main. Waiting
+            // only on the request meant the session could complete in the same millisecond the
+            // response was sent, leaving SingleRecord<MultiTenantResponse>() with nothing to find --
+            // a chronic full-suite flake that passed in isolation.
+            .WaitForMessageToBeReceivedAt<MultiTenantResponse>(_fixture.Main)
             .SendMessageAndWaitAsync(message, new DeliveryOptions{TenantId = "two"});
 
         var record = session.Received.SingleRecord<MultiTenantMessage>();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/multi_tenancy_through_virtual_hosts.cs
@@ -175,6 +175,20 @@ public class MultiTenantedRabbitFixture : IAsyncLifetime
 // multi_response, global_response and multi_incoming are fixed names in the shared default vhost -- but
 // it does not yet prove it. The full tracked-session table and the stack are in the per-run
 // test-ledger-CIRabbitMQ artifact; read one before theorising further.
+//
+// UPDATE 2026-08-16: one contributing cause IS now identified and fixed, but it is NOT the
+// interference above -- do not read this as the file being clean.
+//
+// send_message_to_a_specific_tenant asserted on MultiTenantResponse while its tracked session waited
+// only for MultiTenantMessage to reach node two. A local full-suite trace caught the session
+// completing in the SAME MILLISECOND the response was Sent by node two, so SingleRecord had nothing
+// to find. Note that contradicts the inference recorded above from run 30856898284: the response WAS
+// produced, the session just stopped before it landed. The condition now includes the response.
+//
+// Two local full-suite runs failed on this test before that change (501/502, 498/499) and the run
+// after was 502/502 -- one clean run, which is evidence and not proof. The fixed-queue-name
+// interference is untouched by this, and if it bites, the symptom is now a 15s timeout rather than
+// "no messages of type MultiTenantResponse". Keep reading the ledger artifact before theorising.
 public class multi_tenancy_through_virtual_hosts : IClassFixture<MultiTenantedRabbitFixture>
 {
     private readonly MultiTenantedRabbitFixture _fixture;
@@ -195,8 +209,9 @@ public class multi_tenancy_through_virtual_hosts : IClassFixture<MultiTenantedRa
             .WaitForMessageToBeReceivedAt<MultiTenantMessage>(_fixture.Two)
             // The assertions below also require the RESPONSE to have made it back to main. Waiting
             // only on the request meant the session could complete in the same millisecond the
-            // response was sent, leaving SingleRecord<MultiTenantResponse>() with nothing to find --
-            // a chronic full-suite flake that passed in isolation.
+            // response was sent, leaving SingleRecord<MultiTenantResponse>() with nothing to find.
+            // This removes one real race; see the class note above for the separate, still
+            // unidentified interference this does NOT address.
             .WaitForMessageToBeReceivedAt<MultiTenantResponse>(_fixture.Main)
             .SendMessageAndWaitAsync(message, new DeliveryOptions{TenantId = "two"});
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -15,6 +15,7 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     private readonly IRabbitMqEnvelopeMapper _mapper;
     private readonly IReceiver _workerQueue;
     private bool _latched;
+    private bool _batchDrained;
     private readonly SemaphoreSlim _cancelOks = new(0);
 
     // GH-3492: durable endpoints coalesce prefetched deliveries into Envelope[] batches so the
@@ -72,8 +73,16 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     public void Dispose()
     {
         _latched = true;
+
         // Push any accumulated-but-unflushed deliveries onward; anything genuinely in flight
         // is unacked and will be redelivered by the broker (and deduplicated by the inbox).
+        //
+        // Pointless once DrainBatchedDeliveriesAsync has completed the channel, which
+        // DrainWaitForPrefetch does strictly BEFORE this Dispose. A completed BatchingChannel does
+        // not throw here -- it quietly does nothing -- so skipping is about saying which call is
+        // load bearing rather than avoiding an exception. See GH-3796.
+        if (_batchDrained) return;
+
         _batching?.TriggerBatch();
     }
 
@@ -94,13 +103,30 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
     /// Flush any batched-but-undelivered envelopes to the receiver and await that flush. cancel-ok only
     /// guarantees deliveries reached the batching channel, so without this the receiver latches first and
     /// the batch is redelivered.
+    ///
+    /// <para>
+    /// Idempotent, because <see cref="RabbitMqListener.StopAsync"/> is not always a terminal shutdown:
+    /// <c>RequeueContinuation</c> stops the listener from inside the handler pipeline and the background
+    /// <c>PauseAsync</c> then stops it a second time before disposing it. The second stop has nothing
+    /// left to drain, and re-running the cancel-ok wait against an already completed channel only spends
+    /// shutdown budget. See GH-3796.
+    /// </para>
     /// </summary>
     internal async Task DrainBatchedDeliveriesAsync()
     {
-        if (_batching == null)
+        if (_batching == null || _batchDrained)
         {
             return;
         }
+
+        // A BatchingChannel accepts posts after Complete() and silently discards them -- it does not
+        // throw -- so a delivery landing between this Complete and Dispose's latch would vanish
+        // without ever reaching the receiver, which is precisely the redelivery DrainWaitForPrefetch
+        // exists to prevent. Latching first turns that window into an explicit reject-with-requeue.
+        // Safe here because this runs only after cancel-ok, and the broker sends no further deliveries
+        // on a cancelled consumer.
+        _latched = true;
+        _batchDrained = true;
 
         _batching.TriggerBatch();
         _batching.Complete();


### PR DESCRIPTION
Follow-up to #3796, as discussed on merge.

## The problem

`DrainWaitForPrefetch` completes the consumer's `BatchingChannel` inside `RabbitMqListener.StopAsync`. But **`StopAsync` is not always a terminal shutdown** — `RequeueContinuation.cs:47-49` stops the listener inline from the handler pipeline, and the background `PauseAsync` then stops the *same consumer* again before disposing it. So a durable listener genuinely sees two `StopAsync` calls against one channel.

I measured what a JasperFx `BatchingChannel` actually does after `Complete()` rather than assuming:

| call after `Complete()` | behavior |
|---|---|
| `TriggerBatch()` | no-op, no throw |
| `Complete()` | no-op, no throw |
| `WaitForCompletionAsync()` | no-op, no throw |
| **`PostAsync(item)`** | **accepted and silently discarded** |

Nothing throws — so the duplicate stop is harmless but not free. The real problem is the last row. A delivery landing between `Complete()` and `Dispose`'s latch is posted into a completed channel and **silently swallowed**: it never reaches the receiver and is never acked, so the broker redelivers it on channel close. That is precisely the redelivery `DrainWaitForPrefetch` exists to prevent, reached through a silent path.

## The fix

`DrainBatchedDeliveriesAsync` now latches **before** completing, so such a delivery is rejected-with-requeue through the guard already at the top of `HandleBasicDeliverAsync` instead of vanishing. Safe because the drain only runs after `cancel-ok`, and the broker sends no further deliveries on a cancelled consumer.

The drain is also idempotent now, so the second stop doesn't re-run the `cancel-ok` wait against an already-drained channel, and `Dispose` skips a `TriggerBatch` that would do nothing.

For reference, `SqsListener` sidesteps this ordering entirely — its `StopAsync` calls only `TriggerBatch`, with `Complete` reserved for the dispose-time `flushPendingDeletesAsync`, and a comment naming the paused-listener case. The Rabbit drain has to complete *earlier* than dispose in order to beat `LatchReceiver`, so it tracks the state instead.

## On the test

`drain_wait_for_prefetch_repeated_stop` pins the double-stop sequence end to end. Being straight about it: **it is a regression guard, not a red-first repro** — I verified it passes both with and without the fix, because the channel tolerates the duplicate calls. What it protects is that everything still drains when `StopAsync` runs twice, which a naive "just guard the second `Complete()`" fix would break. The silent-swallow window itself needs a delivery to land inside a sub-millisecond race, which I didn't think was worth building a flaky test around.

## Unrelated flake, partially addressed — folded in

`multi_tenancy_through_virtual_hosts.send_message_to_a_specific_tenant` waited only for the **request** to reach node two, then asserted on the **response** arriving back at main. A local full-suite trace caught the session completing in the same millisecond node two *Sent* the response, so `SingleRecord` had nothing to find. It now waits for the response too.

Two caveats, because this file carries a standing GH-3763 note I should have read before calling it fixed:

- That note records a prior inference from CI run 30856898284 that "the request never produced its response". My trace shows the opposite — the response **was** produced, the session just stopped before it landed. I've updated the note so the file doesn't argue with itself.
- The note's real subject — suspected interference from the fixture's fixed queue names (`Queue1`, `multi_response`, `global_response`, `multi_incoming`) in the shared default vhost — is **untouched** by this. If it bites, the symptom changes from "no messages of type MultiTenantResponse" to a 15s timeout.

So: one contributing race identified and removed, not a chronic flake eliminated.

| Run | Result |
|---|---|
| Rabbit suite, before | 501/502 and 498/499 — same test failing |
| Rabbit suite, after | 502/502 — one clean run, which is evidence, not proof |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

Included here rather than split out because it failed two consecutive full-suite runs and would otherwise redden this PR's own CI.

## Not addressed here

`RequeueContinuation`'s inline `StopAsync()` can now block a handler for up to `DurabilitySettings.DrainTimeout` (default **30s**) when the flag is on, waiting for `cancel-ok`. It is not a deadlock — the batch flush persists and enqueues rather than waiting on the handler pipeline — but it is latency on a path whose own comments explain it was carefully built not to wait. Worth a separate look at whether that call site should opt out of the drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC
