### PR TITLE
GH-3956: recognise the JasperFx.Events.Documents contracts in all three stores

### DIFF
--- a/src/Persistence/FisherTests/all_queryable_and_event_store_operations.cs
+++ b/src/Persistence/FisherTests/all_queryable_and_event_store_operations.cs
@@ -1,5 +1,12 @@
 using JasperFx;
 using JasperFx.Events;
+// NB: importing the JasperFx.Events.Documents NAMESPACE here would make ToListAsync() ambiguous
+// between DocumentQueryableExtensions and Fisher's own queryable extensions (CS0121), so alias
+// just the contracts under test.
+using IDocumentSessionOperations = JasperFx.Events.Documents.IDocumentSessionOperations;
+using IDocumentWriteOperations = JasperFx.Events.Documents.IDocumentWriteOperations;
+using IDocumentReadOperations = JasperFx.Events.Documents.IDocumentReadOperations;
+using IDocumentSessionFactory = JasperFx.Events.Documents.IDocumentSessionFactory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Fisher;
@@ -108,8 +115,52 @@ public class all_queryable_and_event_store_operations : IAsyncLifetime
         events.Count.ShouldBe(1);
         events[0].Data.ShouldBeOfType<FiLedgerEntryRecorded>().Note.ShouldBe("opening");
     }
-}
 
+    /// <summary>
+    ///     GH-3956. The store-agnostic JasperFx.Events.Documents contracts bind AND commit. Before this,
+    ///     a handler declaring one failed codegen outright on a stock host; once bound by the variable
+    ///     source alone, its writes were queued into the session's unit of work and silently discarded.
+    /// </summary>
+    [Fact]
+    public async Task document_session_operations_parameter_is_committed()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StoreFiNote(id, "session-ops"));
+
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        var note = await session.LoadAsync<FiNote>(id, TestContext.Current.CancellationToken);
+
+        note.ShouldNotBeNull();
+        note.Text.ShouldBe("session-ops");
+    }
+
+    /// <summary>
+    ///     The read and write contracts must be satisfied by the same session variable, or a handler that
+    ///     writes and then reads would silently be reading from a different unit of work.
+    /// </summary>
+    [Fact]
+    public async Task read_and_write_operations_resolve_to_one_session()
+    {
+        var result = await _host.MessageBus()
+            .InvokeAsync<FiSessionsCompared>(new CompareFiSessions(), TestContext.Current.CancellationToken);
+
+        result.SameInstance.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     Fisher registers IDocumentStore, never the lifted factory contract it already implements.
+    /// </summary>
+    [Fact]
+    public void document_session_factory_contracts_are_registered()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        _host.Services.GetRequiredService<IDocumentSessionFactory>().ShouldBeSameAs(store);
+        _host.Services
+            .GetRequiredService<JasperFx.Events.Documents.IDocumentSessionFactory<IDocumentSession, IQuerySession>>()
+            .ShouldBeSameAs(store);
+    }
+}
 public class FiWidget
 {
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -123,6 +174,17 @@ public record FiWidgetsCounted(int Count);
 public record PopularFiWidgetsFound(string[] Names);
 public record FiLedgerEntryRecorded(string Note);
 public record RecordFiLedgerEntry(Guid Id, string Note);
+
+[WolverineIgnore]
+public class FiNote
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+
+public record StoreFiNote(Guid Id, string Text);
+public record CompareFiSessions;
+public record FiSessionsCompared(bool SameInstance);
 
 [WolverineIgnore]
 public static class FiCatalogHandler
@@ -147,4 +209,12 @@ public static class FiCatalogHandler
 
     public static void Handle(FiWidgetsCounted msg) { }
     public static void Handle(PopularFiWidgetsFound msg) { }
+
+    // Only JasperFx.Events.Documents types named here -- nothing Fisher-specific
+    public static void Handle(StoreFiNote command, IDocumentSessionOperations session)
+        => session.Store(new FiNote { Id = command.Id, Text = command.Text });
+
+    public static FiSessionsCompared Handle(CompareFiSessions command,
+        IDocumentWriteOperations writes, IDocumentReadOperations reads)
+        => new(ReferenceEquals(writes, reads));
 }

--- a/src/Persistence/MartenTests/store_agnostic_document_session_parameters.cs
+++ b/src/Persistence/MartenTests/store_agnostic_document_session_parameters.cs
@@ -1,0 +1,179 @@
+using IntegrationTests;
+using JasperFx.Events.Documents;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+/// <summary>
+///     GH-3956. A handler can take the store-agnostic <c>JasperFx.Events.Documents</c> document contracts
+///     straight as parameters and stay valid on Marten, Polecat and Fisher alike — the document-side
+///     counterpart to <see cref="event_store_operations_parameter" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The parameters always bound: Marten's <c>IDocumentSession</c> implements all three, so a handler
+///         declaring one compiled, resolved and ran. What it did not get was a <b>commit</b> — the chain was
+///         never recognised as transactional, so the store queued into the session's unit of work and then
+///         vanished with no exception. Every assertion here is therefore about the document being readable
+///         from a <i>separate</i> session afterwards, never about the parameter being non-null.
+///     </para>
+/// </remarks>
+public class store_agnostic_document_session_parameters : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(SharedDocumentHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "shared_doc_ops_param";
+                }).IntegrateWithWolverine().UseLightweightSessions();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task session_operations_parameter_is_committed()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StoreViaSessionOperations(id, "session-ops"));
+
+        await using var session = _host.DocumentStore().LightweightSession();
+        var note = await session.LoadAsync<SharedNote>(id, TestContext.Current.CancellationToken);
+
+        note.ShouldNotBeNull();
+        note.Text.ShouldBe("session-ops");
+    }
+
+    [Fact]
+    public async Task write_operations_parameter_is_committed()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StoreViaWriteOperations(id, "write-ops"));
+
+        await using var session = _host.DocumentStore().LightweightSession();
+        var note = await session.LoadAsync<SharedNote>(id, TestContext.Current.CancellationToken);
+
+        note.ShouldNotBeNull();
+        note.Text.ShouldBe("write-ops");
+    }
+
+    /// <summary>
+    ///     The read and write contracts must be satisfied by the <b>same</b> session variable. If the read side
+    ///     resolved to its own query session instead, a handler that writes and then reads would silently be
+    ///     reading from a different unit of work.
+    /// </summary>
+    [Fact]
+    public async Task read_and_write_operations_resolve_to_one_session()
+    {
+        var result = await _host.MessageBus()
+            .InvokeAsync<DocumentSessionsCompared>(new CompareDocumentSessions(),
+                TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.SameInstance.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     A read-only parameter is not evidence that the chain writes anything, so it must NOT drag the chain
+    ///     into a transaction — but it still has to bind and read.
+    /// </summary>
+    [Fact]
+    public async Task read_operations_parameter_can_load_a_document()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var seed = _host.DocumentStore().LightweightSession())
+        {
+            seed.Store(new SharedNote { Id = id, Text = "seeded" });
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var result = await _host.MessageBus()
+            .InvokeAsync<SharedNoteFound>(new ReadSharedNote(id), TestContext.Current.CancellationToken);
+
+        result.Text.ShouldBe("seeded");
+    }
+
+    /// <summary>
+    ///     Marten registers <c>IDocumentStore</c>, never the lifted factory contract it already implements, so
+    ///     this failed to resolve on a stock host before GH-3956.
+    /// </summary>
+    [Fact]
+    public void document_session_factory_contracts_are_registered()
+    {
+        var factory = _host.Services.GetRequiredService<IDocumentSessionFactory>();
+        factory.ShouldBeSameAs(_host.Services.GetRequiredService<IDocumentStore>());
+
+        _host.Services.GetRequiredService<IDocumentSessionFactory<IDocumentSession, IQuerySession>>()
+            .ShouldBeSameAs(_host.Services.GetRequiredService<IDocumentStore>());
+    }
+}
+
+public class SharedNote
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+
+public record StoreViaSessionOperations(Guid Id, string Text);
+
+public record StoreViaWriteOperations(Guid Id, string Text);
+
+public record CompareDocumentSessions;
+
+public record DocumentSessionsCompared(bool SameInstance);
+
+public record ReadSharedNote(Guid Id);
+
+public record SharedNoteFound(string Text);
+
+[WolverineIgnore]
+public static class SharedDocumentHandler
+{
+    // Every signature below names only JasperFx.Events.Documents types -- nothing Marten-specific --
+    // which is the entire point of the issue
+    public static void Handle(StoreViaSessionOperations command, IDocumentSessionOperations session)
+    {
+        session.Store(new SharedNote { Id = command.Id, Text = command.Text });
+    }
+
+    public static void Handle(StoreViaWriteOperations command, IDocumentWriteOperations writes)
+    {
+        writes.Store(new SharedNote { Id = command.Id, Text = command.Text });
+    }
+
+    public static DocumentSessionsCompared Handle(CompareDocumentSessions command,
+        IDocumentWriteOperations writes, IDocumentReadOperations reads)
+    {
+        return new DocumentSessionsCompared(ReferenceEquals(writes, reads));
+    }
+
+    public static async Task<SharedNoteFound> Handle(ReadSharedNote command, IDocumentReadOperations reads)
+    {
+        var note = await reads.LoadAsync<SharedNote>(command.Id);
+        return new SharedNoteFound(note!.Text);
+    }
+}

--- a/src/Persistence/PolecatTests/all_queryable_and_event_store_operations.cs
+++ b/src/Persistence/PolecatTests/all_queryable_and_event_store_operations.cs
@@ -1,5 +1,12 @@
 using IntegrationTests;
 using JasperFx.Events;
+// NB: importing the JasperFx.Events.Documents NAMESPACE here would make ToListAsync() ambiguous
+// between DocumentQueryableExtensions and Polecat's own queryable extensions (CS0121), so alias
+// just the contracts under test.
+using IDocumentSessionOperations = JasperFx.Events.Documents.IDocumentSessionOperations;
+using IDocumentWriteOperations = JasperFx.Events.Documents.IDocumentWriteOperations;
+using IDocumentReadOperations = JasperFx.Events.Documents.IDocumentReadOperations;
+using IDocumentSessionFactory = JasperFx.Events.Documents.IDocumentSessionFactory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Polecat;
@@ -92,8 +99,52 @@ public class all_queryable_and_event_store_operations : IAsyncLifetime
         events.Count.ShouldBe(1);
         events[0].Data.ShouldBeOfType<PcLedgerEntryRecorded>().Note.ShouldBe("opening");
     }
-}
 
+    /// <summary>
+    ///     GH-3956. The store-agnostic JasperFx.Events.Documents contracts bind AND commit. Before this,
+    ///     a handler declaring one failed codegen outright on a stock host; once bound by the variable
+    ///     source alone, its writes were queued into the session's unit of work and silently discarded.
+    /// </summary>
+    [Fact]
+    public async Task document_session_operations_parameter_is_committed()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StorePcNote(id, "session-ops"));
+
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        var note = await session.LoadAsync<PcNote>(id, TestContext.Current.CancellationToken);
+
+        note.ShouldNotBeNull();
+        note.Text.ShouldBe("session-ops");
+    }
+
+    /// <summary>
+    ///     The read and write contracts must be satisfied by the same session variable, or a handler that
+    ///     writes and then reads would silently be reading from a different unit of work.
+    /// </summary>
+    [Fact]
+    public async Task read_and_write_operations_resolve_to_one_session()
+    {
+        var result = await _host.MessageBus()
+            .InvokeAsync<PcSessionsCompared>(new ComparePcSessions(), TestContext.Current.CancellationToken);
+
+        result.SameInstance.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     Polecat registers IDocumentStore, never the lifted factory contract it already implements.
+    /// </summary>
+    [Fact]
+    public void document_session_factory_contracts_are_registered()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        _host.Services.GetRequiredService<IDocumentSessionFactory>().ShouldBeSameAs(store);
+        _host.Services
+            .GetRequiredService<JasperFx.Events.Documents.IDocumentSessionFactory<IDocumentSession, IQuerySession>>()
+            .ShouldBeSameAs(store);
+    }
+}
 public class PcWidget
 {
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -107,6 +158,17 @@ public record PcWidgetsCounted(int Count);
 public record PopularPcWidgetsFound(string[] Names);
 public record PcLedgerEntryRecorded(string Note);
 public record RecordPcLedgerEntry(Guid Id, string Note);
+
+[WolverineIgnore]
+public class PcNote
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+
+public record StorePcNote(Guid Id, string Text);
+public record ComparePcSessions;
+public record PcSessionsCompared(bool SameInstance);
 
 [WolverineIgnore]
 public static class PcCatalogHandler
@@ -131,4 +193,12 @@ public static class PcCatalogHandler
 
     public static void Handle(PcWidgetsCounted msg) { }
     public static void Handle(PopularPcWidgetsFound msg) { }
+
+    // Only JasperFx.Events.Documents types named here -- nothing Polecat-specific
+    public static void Handle(StorePcNote command, IDocumentSessionOperations session)
+        => session.Store(new PcNote { Id = command.Id, Text = command.Text });
+
+    public static PcSessionsCompared Handle(ComparePcSessions command,
+        IDocumentWriteOperations writes, IDocumentReadOperations reads)
+        => new(ReferenceEquals(writes, reads));
 }

--- a/src/Persistence/Wolverine.Fisher/Codegen/SessionVariableSource.cs
+++ b/src/Persistence/Wolverine.Fisher/Codegen/SessionVariableSource.cs
@@ -1,6 +1,7 @@
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using Fisher;
 using Fisher.Events;
@@ -186,6 +187,67 @@ internal class SharedEventStoreOperationsFrame : SyncFrame
     {
         writer.Write(
             $"{typeof(JasperFx.Events.IEventStoreOperations)} {Variable.Usage} = {_session.Usage}.{nameof(IDocumentSession.Events)};");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+///     GH-3956. Supplies the store-agnostic <c>JasperFx.Events.Documents</c> document contracts — the
+///     document-side counterparts to <see cref="SharedEventOperationsSource"/> — so that a handler or HTTP
+///     endpoint written against the abstraction stays valid on Marten, Polecat and Fisher alike.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Fisher's own <c>IDocumentSession</c> already implements all three, so a handler declaring one of
+///         these bound and ran before this existed. What it did not get was a commit: codegen matches a
+///         variable by its exact type, so nothing satisfied the parameter from the session the chain had
+///         created, and <c>CanApply</c> did not recognise the abstraction either.
+///     </para>
+///     <para>
+///         All three — including the read-only contract — deliberately resolve from the chain's single
+///         <c>IDocumentSession</c> rather than opening a <c>IQuerySession</c> for the read side. A handler
+///         that takes <c>IDocumentReadOperations</c> alongside <c>IDocumentWriteOperations</c> would
+///         otherwise get two different sessions, and its reads would not see its own pending writes.
+///     </para>
+/// </remarks>
+internal class SharedDocumentOperationsSource : IVariableSource
+{
+    public bool Matches(Type type)
+    {
+        return type == typeof(JasperFx.Events.Documents.IDocumentSessionOperations)
+               || type == typeof(JasperFx.Events.Documents.IDocumentWriteOperations)
+               || type == typeof(JasperFx.Events.Documents.IDocumentReadOperations);
+    }
+
+    public Variable Create(Type type)
+    {
+        return new SharedDocumentOperationsFrame(type).Variable;
+    }
+}
+
+internal class SharedDocumentOperationsFrame : SyncFrame
+{
+    private readonly Type _contractType;
+    private Variable _session = null!;
+
+    public SharedDocumentOperationsFrame(Type contractType)
+    {
+        _contractType = contractType;
+        Variable = new Variable(contractType, this);
+    }
+
+    public Variable Variable { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // A plain assignment -- IDocumentSession derives from every one of these contracts, so no cast.
+        writer.Write($"{_contractType.FullNameInCode()} {Variable.Usage} = {_session.Usage};");
         Next?.GenerateCode(method, writer);
     }
 }

--- a/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
@@ -52,6 +52,7 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new EventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventStoreOperationsSource());
+        options.CodeGeneration.Sources.Add(new SharedDocumentOperationsSource());
 
         options.Policies.Add<FisherAggregateHandlerStrategy>();
 

--- a/src/Persistence/Wolverine.Fisher/Persistence/Sagas/FisherPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Fisher/Persistence/Sagas/FisherPersistenceFrameProvider.cs
@@ -82,18 +82,24 @@ internal partial class FisherPersistenceFrameProvider : IPersistenceFrameProvide
         if (ChainHasFisherSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain
-            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Fisher.Events.EventOperations) }).ToArray();
+            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Fisher.Events.EventOperations), typeof(global::JasperFx.Events.Documents.IDocumentSessionOperations), typeof(global::JasperFx.Events.Documents.IDocumentWriteOperations), typeof(global::JasperFx.Events.Documents.IDocumentReadOperations) }).ToArray();
                 // A handler that takes the event operations straight as a parameter -- the shared
         // JasperFx.Events.IEventOperations / IEventStoreOperations, or Fisher's own EventOperations -- is
         // unambiguously using this store, but none of those types appeared here, so
         // AutoApplyTransactions skipped the chain and nothing was ever committed. Appending
         // through the parameter queued into the session's unit of work and then silently
         // vanished, with no exception.
+        //
+        // GH-3956: same hole on the DOCUMENT side. See MartenPersistenceFrameProvider.CanApply.
+        // IDocumentReadOperations is probed but NOT matched, exactly as IQuerySession has always been --
+        // a read-only parameter is not evidence that the chain writes anything.
         return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations)
                                             || x.Closes(typeof(IEventStream<>))
                                             || x == typeof(global::JasperFx.Events.IEventOperations)
                                             || x == typeof(global::JasperFx.Events.IEventStoreOperations)
-                                            || x == typeof(global::Fisher.Events.EventOperations));
+                                            || x == typeof(global::Fisher.Events.EventOperations)
+                                            || x == typeof(global::JasperFx.Events.Documents.IDocumentSessionOperations)
+                                            || x == typeof(global::JasperFx.Events.Documents.IDocumentWriteOperations));
     }
 
     private static bool ChainHasFisherSessionAttributes(IChain chain)

--- a/src/Persistence/Wolverine.Fisher/WolverineOptionsFisherExtensions.cs
+++ b/src/Persistence/Wolverine.Fisher/WolverineOptionsFisherExtensions.cs
@@ -6,6 +6,7 @@ using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using Fisher;
 using Microsoft.Extensions.DependencyInjection;
+using JasperFx.Events.Documents;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Wolverine.Fisher.Publishing;
@@ -55,6 +56,21 @@ public static class WolverineOptionsFisherExtensions
         expression.Services.AddSingleton<IWolverineExtension, MapEventTypeMessages>();
 
         expression.Services.AddScoped<IFisherOutbox, FisherOutbox>();
+
+        // GH-3956: Fisher registers its own interfaces, never the store-agnostic
+        // JasperFx.Events.Documents contracts its session types already implement, so a service depending
+        // on one of those could not be resolved at all on a stock host. Handler PARAMETERS are satisfied by
+        // codegen (SharedDocumentOperationsSource); these registrations cover everything codegen does not
+        // see -- a service-located contract, or one injected into a class that a handler depends on.
+        expression.Services.TryAddScoped<IDocumentSessionOperations>(s => s.GetRequiredService<IDocumentSession>());
+        expression.Services.TryAddScoped<IDocumentWriteOperations>(s => s.GetRequiredService<IDocumentSession>());
+        expression.Services.TryAddScoped<IDocumentReadOperations>(s => s.GetRequiredService<IQuerySession>());
+
+        // IDocumentStore implements both of these, and it is a singleton, so this is a straight alias.
+        expression.Services.TryAddSingleton<IDocumentSessionFactory>(s => s.GetRequiredService<IDocumentStore>());
+        expression.Services
+            .TryAddSingleton<IDocumentSessionFactory<IDocumentSession, IQuerySession>>(s =>
+                (IDocumentSessionFactory<IDocumentSession, IQuerySession>)s.GetRequiredService<IDocumentStore>());
 
         expression.Services.AddSingleton<DatabaseSettings>(s =>
         {

--- a/src/Persistence/Wolverine.Marten/Codegen/SessionVariableSource.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/SessionVariableSource.cs
@@ -1,6 +1,7 @@
 ﻿using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
 using Marten;
 using Marten.Events;
 // JasperFx.Events deliberately excluded — IEventStoreOperations is ambiguous
@@ -190,6 +191,69 @@ internal class SharedEventStoreOperationsFrame : SyncFrame
     {
         writer.Write(
             $"{typeof(JasperFx.Events.IEventStoreOperations)} {Variable.Usage} = {_session.Usage}.{nameof(IDocumentSession.Events)};");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+///     GH-3956. Supplies the store-agnostic <c>JasperFx.Events.Documents</c> document contracts — the
+///     document-side counterparts to <see cref="SharedEventOperationsSource"/> — so that a handler or HTTP
+///     endpoint written against the abstraction stays valid on Marten, Polecat and Fisher alike.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Marten's own <c>IDocumentSession</c> already implements all three, so a handler declaring one of
+///         these bound and ran before this existed. What it did not get was a commit: codegen matches a
+///         variable by its exact type, so nothing satisfied the parameter from the session the chain had
+///         created, and <c>CanApply</c> did not recognise the abstraction either.
+///     </para>
+///     <para>
+///         All three — including the read-only contract — deliberately resolve from the chain's single
+///         <c>IDocumentSession</c> rather than opening a <c>IQuerySession</c> for the read side. A handler
+///         that takes <c>IDocumentReadOperations</c> alongside <c>IDocumentWriteOperations</c> would
+///         otherwise get two different sessions, and its reads would not see its own pending writes.
+///         Going through the session (not a store) also means an ancillary store's <c>[Storage]</c> frame
+///         has already swapped which session this resolves, and these follow it for free.
+///     </para>
+/// </remarks>
+internal class SharedDocumentOperationsSource : IVariableSource
+{
+    public bool Matches(Type type)
+    {
+        return type == typeof(JasperFx.Events.Documents.IDocumentSessionOperations)
+               || type == typeof(JasperFx.Events.Documents.IDocumentWriteOperations)
+               || type == typeof(JasperFx.Events.Documents.IDocumentReadOperations);
+    }
+
+    public Variable Create(Type type)
+    {
+        return new SharedDocumentOperationsFrame(type).Variable;
+    }
+}
+
+internal class SharedDocumentOperationsFrame : SyncFrame
+{
+    private readonly Type _contractType;
+    private Variable _session = null!;
+
+    public SharedDocumentOperationsFrame(Type contractType)
+    {
+        _contractType = contractType;
+        Variable = new Variable(contractType, this);
+    }
+
+    public Variable Variable { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // A plain assignment -- IDocumentSession derives from every one of these contracts, so no cast.
+        writer.Write($"{_contractType.FullNameInCode()} {Variable.Usage} = {_session.Usage};");
         Next?.GenerateCode(method, writer);
     }
 }

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -75,6 +75,7 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new EventStoreOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventStoreOperationsSource());
+        options.CodeGeneration.Sources.Add(new SharedDocumentOperationsSource());
 
         options.Policies.Add<MartenAggregateHandlerStrategy>();
 

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenPersistenceFrameProvider.cs
@@ -108,18 +108,26 @@ internal partial class MartenPersistenceFrameProvider : IPersistenceFrameProvide
         if (ChainHasMartenSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain
-            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Marten.Events.IEventStoreOperations) }).ToArray();
+            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Marten.Events.IEventStoreOperations), typeof(global::JasperFx.Events.Documents.IDocumentSessionOperations), typeof(global::JasperFx.Events.Documents.IDocumentWriteOperations), typeof(global::JasperFx.Events.Documents.IDocumentReadOperations) }).ToArray();
                 // A handler that takes the event operations straight as a parameter -- the shared
         // JasperFx.Events.IEventOperations / IEventStoreOperations, or Marten's own IEventStoreOperations -- is
         // unambiguously using this store, but none of those types appeared here, so
         // AutoApplyTransactions skipped the chain and nothing was ever committed. Appending
         // through the parameter queued into the session's unit of work and then silently
         // vanished, with no exception.
+        //
+        // GH-3956: the same hole existed on the DOCUMENT side. JasperFx.Events.Documents lifts the
+        // store-agnostic document contracts, and Marten's IDocumentSession implements all three, so a
+        // handler could already declare one and have it bind -- it just never got a commit.
+        // IDocumentReadOperations is deliberately probed but NOT matched here, exactly as IQuerySession
+        // has always been: a read-only parameter is not evidence that the chain writes anything.
         return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations)
                                             || x.Closes(typeof(IEventStream<>))
                                             || x == typeof(global::JasperFx.Events.IEventOperations)
                                             || x == typeof(global::JasperFx.Events.IEventStoreOperations)
-                                            || x == typeof(global::Marten.Events.IEventStoreOperations));
+                                            || x == typeof(global::Marten.Events.IEventStoreOperations)
+                                            || x == typeof(global::JasperFx.Events.Documents.IDocumentSessionOperations)
+                                            || x == typeof(global::JasperFx.Events.Documents.IDocumentWriteOperations));
     }
 
     private static bool ChainHasMartenSessionAttributes(IChain chain)

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -4,6 +4,7 @@ using JasperFx.Core.IoC;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using JasperFx.Events;
+using JasperFx.Events.Documents;
 using JasperFx.Events.Subscriptions;
 using Marten;
 using Marten.Events.Daemon.Coordination;
@@ -100,6 +101,26 @@ public static class WolverineOptionsMartenExtensions
         expression.Services.AddScoped<ScopedDocumentSessionHolder>();
         preferScopedSession<IDocumentSession>(expression.Services);
         preferScopedSession<IQuerySession>(expression.Services);
+
+        // GH-3956: Marten registers its own interfaces, never the store-agnostic JasperFx.Events.Documents
+        // contracts its session types already implement, so a service depending on one of those could not
+        // be resolved at all on a stock host. Handler PARAMETERS are satisfied by codegen
+        // (SharedDocumentOperationsSource); these registrations cover everything codegen does not see --
+        // a service-located contract, or one injected into a class that a handler depends on.
+        //
+        // Deliberately delegating to IDocumentSession / IQuerySession rather than to a fresh session, so
+        // the preferScopedSession decoration above applies: inside a handler scope these resolve to the
+        // handler's outbox-enrolled session, not a separate un-enrolled one.
+        expression.Services.TryAddScoped<IDocumentSessionOperations>(s => s.GetRequiredService<IDocumentSession>());
+        expression.Services.TryAddScoped<IDocumentWriteOperations>(s => s.GetRequiredService<IDocumentSession>());
+        expression.Services.TryAddScoped<IDocumentReadOperations>(s => s.GetRequiredService<IQuerySession>());
+
+        // IDocumentStore implements both of these, and it is a singleton, so this is a straight alias.
+        // Same move jasperfx#430 made for IProjectionCoordinator (see line ~149 below).
+        expression.Services.TryAddSingleton<IDocumentSessionFactory>(s => s.GetRequiredService<IDocumentStore>());
+        expression.Services
+            .TryAddSingleton<IDocumentSessionFactory<IDocumentSession, IQuerySession>>(s =>
+                (IDocumentSessionFactory<IDocumentSession, IQuerySession>)s.GetRequiredService<IDocumentStore>());
 
         // Gotta have at least a placeholder just in case a user also has
         // EF Core

--- a/src/Persistence/Wolverine.Polecat/Codegen/SessionVariableSource.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/SessionVariableSource.cs
@@ -1,6 +1,7 @@
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using Polecat;
 using Polecat.Events;
@@ -186,6 +187,67 @@ internal class SharedEventStoreOperationsFrame : SyncFrame
     {
         writer.Write(
             $"{typeof(JasperFx.Events.IEventStoreOperations)} {Variable.Usage} = {_session.Usage}.{nameof(IDocumentSession.Events)};");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+///     GH-3956. Supplies the store-agnostic <c>JasperFx.Events.Documents</c> document contracts — the
+///     document-side counterparts to <see cref="SharedEventOperationsSource"/> — so that a handler or HTTP
+///     endpoint written against the abstraction stays valid on Marten, Polecat and Fisher alike.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Polecat's own <c>IDocumentSession</c> already implements all three, so a handler declaring one of
+///         these bound and ran before this existed. What it did not get was a commit: codegen matches a
+///         variable by its exact type, so nothing satisfied the parameter from the session the chain had
+///         created, and <c>CanApply</c> did not recognise the abstraction either.
+///     </para>
+///     <para>
+///         All three — including the read-only contract — deliberately resolve from the chain's single
+///         <c>IDocumentSession</c> rather than opening a <c>IQuerySession</c> for the read side. A handler
+///         that takes <c>IDocumentReadOperations</c> alongside <c>IDocumentWriteOperations</c> would
+///         otherwise get two different sessions, and its reads would not see its own pending writes.
+///     </para>
+/// </remarks>
+internal class SharedDocumentOperationsSource : IVariableSource
+{
+    public bool Matches(Type type)
+    {
+        return type == typeof(JasperFx.Events.Documents.IDocumentSessionOperations)
+               || type == typeof(JasperFx.Events.Documents.IDocumentWriteOperations)
+               || type == typeof(JasperFx.Events.Documents.IDocumentReadOperations);
+    }
+
+    public Variable Create(Type type)
+    {
+        return new SharedDocumentOperationsFrame(type).Variable;
+    }
+}
+
+internal class SharedDocumentOperationsFrame : SyncFrame
+{
+    private readonly Type _contractType;
+    private Variable _session = null!;
+
+    public SharedDocumentOperationsFrame(Type contractType)
+    {
+        _contractType = contractType;
+        Variable = new Variable(contractType, this);
+    }
+
+    public Variable Variable { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // A plain assignment -- IDocumentSession derives from every one of these contracts, so no cast.
+        writer.Write($"{_contractType.FullNameInCode()} {Variable.Usage} = {_session.Usage};");
         Next?.GenerateCode(method, writer);
     }
 }

--- a/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatPersistenceFrameProvider.cs
@@ -90,18 +90,24 @@ internal partial class PolecatPersistenceFrameProvider : IPersistenceFrameProvid
         if (ChainHasPolecatSessionAttributes(chain)) return true;
 
         var serviceDependencies = chain
-            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Polecat.Events.IEventOperations) }).ToArray();
+            .ServiceDependencies(container, new[] { typeof(IDocumentSession), typeof(IQuerySession), typeof(IDocumentOperations), typeof(global::JasperFx.Events.IEventOperations), typeof(global::JasperFx.Events.IEventStoreOperations), typeof(global::Polecat.Events.IEventOperations), typeof(global::JasperFx.Events.Documents.IDocumentSessionOperations), typeof(global::JasperFx.Events.Documents.IDocumentWriteOperations), typeof(global::JasperFx.Events.Documents.IDocumentReadOperations) }).ToArray();
                 // A handler that takes the event operations straight as a parameter -- the shared
         // JasperFx.Events.IEventOperations / IEventStoreOperations, or Polecat's own IEventOperations -- is
         // unambiguously using this store, but none of those types appeared here, so
         // AutoApplyTransactions skipped the chain and nothing was ever committed. Appending
         // through the parameter queued into the session's unit of work and then silently
         // vanished, with no exception.
+        //
+        // GH-3956: same hole on the DOCUMENT side. See MartenPersistenceFrameProvider.CanApply.
+        // IDocumentReadOperations is probed but NOT matched, exactly as IQuerySession has always been --
+        // a read-only parameter is not evidence that the chain writes anything.
         return serviceDependencies.Any(x => x == typeof(IDocumentSession) || x == typeof(IDocumentOperations)
                                             || x.Closes(typeof(IEventStream<>))
                                             || x == typeof(global::JasperFx.Events.IEventOperations)
                                             || x == typeof(global::JasperFx.Events.IEventStoreOperations)
-                                            || x == typeof(global::Polecat.Events.IEventOperations));
+                                            || x == typeof(global::Polecat.Events.IEventOperations)
+                                            || x == typeof(global::JasperFx.Events.Documents.IDocumentSessionOperations)
+                                            || x == typeof(global::JasperFx.Events.Documents.IDocumentWriteOperations));
     }
 
     private static bool ChainHasPolecatSessionAttributes(IChain chain)

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -57,6 +57,7 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
         options.CodeGeneration.Sources.Add(new EventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventOperationsSource());
         options.CodeGeneration.Sources.Add(new SharedEventStoreOperationsSource());
+        options.CodeGeneration.Sources.Add(new SharedDocumentOperationsSource());
 
         options.Policies.Add<PolecatAggregateHandlerStrategy>();
 

--- a/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
+++ b/src/Persistence/Wolverine.Polecat/WolverineOptionsPolecatExtensions.cs
@@ -6,6 +6,7 @@ using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using Polecat;
 using Microsoft.Extensions.DependencyInjection;
+using JasperFx.Events.Documents;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Wolverine.Polecat.Distribution;
@@ -57,6 +58,21 @@ public static class WolverineOptionsPolecatExtensions
         expression.Services.AddSingleton<IWolverineExtension, MapEventTypeMessages>();
 
         expression.Services.AddScoped<IPolecatOutbox, PolecatOutbox>();
+
+        // GH-3956: Polecat registers its own interfaces, never the store-agnostic
+        // JasperFx.Events.Documents contracts its session types already implement, so a service depending
+        // on one of those could not be resolved at all on a stock host. Handler PARAMETERS are satisfied by
+        // codegen (SharedDocumentOperationsSource); these registrations cover everything codegen does not
+        // see -- a service-located contract, or one injected into a class that a handler depends on.
+        expression.Services.TryAddScoped<IDocumentSessionOperations>(s => s.GetRequiredService<IDocumentSession>());
+        expression.Services.TryAddScoped<IDocumentWriteOperations>(s => s.GetRequiredService<IDocumentSession>());
+        expression.Services.TryAddScoped<IDocumentReadOperations>(s => s.GetRequiredService<IQuerySession>());
+
+        // IDocumentStore implements both of these, and it is a singleton, so this is a straight alias.
+        expression.Services.TryAddSingleton<IDocumentSessionFactory>(s => s.GetRequiredService<IDocumentStore>());
+        expression.Services
+            .TryAddSingleton<IDocumentSessionFactory<IDocumentSession, IQuerySession>>(s =>
+                (IDocumentSessionFactory<IDocumentSession, IQuerySession>)s.GetRequiredService<IDocumentStore>());
 
         expression.Services.AddSingleton<DatabaseSettings>(s =>
         {


### PR DESCRIPTION
Closes #3956.

A handler could not take `JasperFx.Events.Documents.IDocumentSessionOperations`, `IDocumentWriteOperations` or `IDocumentReadOperations` as a parameter — which is the whole point of those contracts existing, since store-agnostic source has no other way to take a session without naming a concrete store type.

## Two independent gaps, both of which had to close

1. **Variable matching.** Codegen matches a variable by its *exact* type, so nothing satisfied the parameter from the `IDocumentSession` the chain had already created. Added a `SharedDocumentOperationsSource` per store, alongside the existing `SharedEventOperationsSource` — the document-side counterparts to the event ones.
2. **`CanApply`.** The fixed probe list/predicate named none of them, so `AutoApplyTransactions` skipped the chain and no `SaveChangesAsync` postprocessor was attached.

## Measured, not assumed

The issue describes a silent write loss. On a **stock** host it's actually harder than that — the handler fails codegen outright with `UnResolvableVariableException`, because the stores don't register the abstractions in DI either.

The silent-loss half is real and was confirmed directly: with the variable source in place but the predicate reverted, the handler binds, runs, and the write is queued into the session's unit of work and discarded with no exception — two of the new tests go red while the other three stay green. Both halves are load-bearing.

## Design notes

- **All three contracts resolve from the chain's single `IDocumentSession`, including the read-only one.** Resolving reads from a separate `IQuerySession` would hand a handler that takes read and write contracts together two different sessions, and its reads would not see its own pending writes. There's a test pinning that they're the same instance.
- **`IDocumentReadOperations` is probed but deliberately NOT matched in the predicate**, exactly as `IQuerySession` has always been: a read-only parameter is not evidence that the chain writes anything.
- **DI registration** delegates to `IDocumentSession`/`IQuerySession` rather than opening a fresh session, so Marten's GH-3001 scope priming still applies and a service-located contract gets the handler's outbox-enrolled session. `IDocumentStore` already implements `IDocumentSessionFactory`, so that one is a straight singleton alias — the same move jasperfx#430 made for `IProjectionCoordinator`.

## No package bump needed

The handoff notes assumed this would need `JasperFx.Events` 2.48.0. It doesn't — 2.47.0 already carries every type, and Marten 9.23.0 / Polecat 5.12.0 / Fisher 0.7.0 all implement them. Verified by reflecting on the pinned assemblies.

## One thing worth flagging for adopters

Importing the `JasperFx.Events.Documents` **namespace** makes `ToListAsync()` ambiguous between `DocumentQueryableExtensions` and each store's own queryable extensions (`CS0121`). The tests alias the individual contracts instead of importing the namespace. That's upstream in JasperFx.Events, not something this PR can fix, but it will bite anyone converting a file to the store-agnostic contracts.

## Verification

- New `store_agnostic_document_session_parameters` (Marten): 5/5, confirmed red first
- Polecat + Fisher document contract tests added to the existing `all_queryable_and_event_store_operations` class (that suite balances CI shards by test-*class* count): 7/7 each
- Full `FisherTests`: 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC