### PR TITLE
GH-3954: stop assigning durability agents to nodes that cannot run them

### DIFF
--- a/src/Persistence/PersistenceTests/Agents/durability_agent_capability_publication.cs
+++ b/src/Persistence/PersistenceTests/Agents/durability_agent_capability_publication.cs
@@ -1,0 +1,115 @@
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Persistence;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PersistenceTests.Agents;
+
+/// <summary>
+///     GH-3954. The end-to-end half of the capability gate: the leader now refuses to assign
+///     <c>wolverinedb://</c> agents to a node that has not published
+///     <see cref="MessageStoreCollection.DurabilityCapabilityUri" />, so the marker actually reaching
+///     <c>WolverineNode.Capabilities</c> at startup is load bearing for every durable Wolverine application.
+///     If it ever stops being published, durability agents stop being assigned everywhere — this is the test
+///     that says so directly rather than leaving it to an agent count somewhere else.
+/// </summary>
+public class durability_agent_capability_publication : PostgresqlContext, IAsyncDisposable
+{
+    private IHost? _host;
+
+    private async Task<WolverineRuntime> startAsync(Action<WolverineOptions>? configure = null)
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("durability_capability");
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "durability_capability");
+                opts.Services.AddResourceSetupOnStartup();
+                opts.Durability.Mode = DurabilityMode.Balanced;
+
+                configure?.Invoke(opts);
+            }).StartAsync();
+
+        return _host.GetRuntime();
+    }
+
+    private async Task<bool> waitForDurabilityAgent(TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (!cts.IsCancellationRequested)
+        {
+            if (_host!.RunningAgents().Any(x => x.Scheme == "wolverinedb"))
+            {
+                return true;
+            }
+
+            try
+            {
+                await Task.Delay(250.Milliseconds(), cts.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+        }
+
+        return _host!.RunningAgents().Any(x => x.Scheme == "wolverinedb");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_host != null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task a_durability_enabled_node_publishes_the_capability_and_gets_its_agent()
+    {
+        var runtime = await startAsync();
+
+        var node = await runtime.Storage.Nodes.LoadNodeAsync(runtime.Options.UniqueNodeId, CancellationToken.None);
+        node.ShouldNotBeNull();
+        node.Capabilities.ShouldContain(MessageStoreCollection.DurabilityCapabilityUri);
+
+        await _host!.WaitUntilAssumesLeadershipAsync(30.Seconds());
+
+        // The assignment the gate must NOT block. A regression in publishing the marker shows up here as
+        // an empty list rather than as a subtly wrong agent count somewhere else.
+        (await waitForDurabilityAgent(TimeSpan.FromSeconds(30)))
+            .ShouldBeTrue("the durability agent was never assigned to a node that IS capable of running it");
+    }
+
+    [Fact]
+    public async Task a_node_with_the_durability_agent_disabled_publishes_nothing_and_is_not_assigned()
+    {
+        var runtime = await startAsync(opts => opts.Durability.DurabilityAgentEnabled = false);
+
+        var node = await runtime.Storage.Nodes.LoadNodeAsync(runtime.Options.UniqueNodeId, CancellationToken.None);
+        node.ShouldNotBeNull();
+        node.Capabilities.ShouldNotContain(MessageStoreCollection.DurabilityCapabilityUri);
+
+        await _host!.WaitUntilAssumesLeadershipAsync(30.Seconds());
+
+        // Previously the leader assigned anyway, the node threw "Unrecognized agent scheme 'wolverinedb'",
+        // and it re-issued the identical assignment every five minutes indefinitely.
+        _host!.RunningAgents().ShouldNotContain(x => x.Scheme == "wolverinedb");
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/durability_agents_only_go_to_capable_nodes.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/durability_agents_only_go_to_capable_nodes.cs
@@ -1,0 +1,181 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Wolverine.Persistence;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+///     GH-3954. A node started with <c>Durability.DurabilityAgentEnabled = false</c> never registers the
+///     durability agent family, so it throws <c>ArgumentOutOfRangeException: Unrecognized agent scheme
+///     'wolverinedb'</c> the moment the leader hands it one. The leader then re-issued the identical
+///     assignment every five minutes forever, no durability agent ran anywhere for that store, and
+///     <c>owner_id = 0</c> outgoing envelopes were never recovered — silently, with every queue table
+///     reading zero.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The capability here is per-NODE, not per-agent. The blue/green and group-affinity paths gate on
+///         <see cref="AssignmentGrid.AllNodesHaveSameCapabilities(string)" />, which returns true trivially
+///         when there is one node AND when every node is equally incapable — precisely the two configurations
+///         in the report — so a fix modelled on those paths would have changed neither. The single-node case
+///         below is the reporter's own deterministic repro.
+///     </para>
+/// </remarks>
+public class durability_agents_only_go_to_capable_nodes
+{
+    private static Uri Durability(string db) => new($"wolverinedb://postgresql/localhost/{db}/wolverine");
+
+    private static AssignmentGrid.Node Capable(AssignmentGrid.Node node)
+    {
+        node.HasCapabilities([MessageStoreCollection.DurabilityCapabilityUri]);
+        return node;
+    }
+
+    private static void distribute(AssignmentGrid grid)
+    {
+        grid.DistributeEvenlyWithAffinity("wolverinedb", _ => null,
+            MessageStoreCollection.NodeCanRunDurabilityAgents);
+    }
+
+    [Fact]
+    public void a_lone_incapable_node_is_not_given_the_durability_agent()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithAgents(Durability("main"));
+
+        distribute(grid);
+
+        // Before this, the _nodes.Count == 1 fast path assigned unconditionally and the node threw
+        grid.AgentFor(Durability("main")).AssignedNode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_lone_capable_node_still_takes_everything()
+    {
+        var grid = new AssignmentGrid();
+        Capable(grid.WithNode(1, Guid.NewGuid()));
+        grid.WithAgents(Durability("main"));
+
+        distribute(grid);
+
+        grid.AgentFor(Durability("main")).AssignedNode.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void the_capable_node_is_chosen_even_when_it_is_the_leader()
+    {
+        var grid = new AssignmentGrid();
+        var leader = Capable(grid.WithNode(1, Guid.NewGuid()));
+        leader.IsLeader = true;
+        grid.WithNode(2, Guid.NewGuid()); // the producer -- DurabilityAgentEnabled = false
+        grid.WithAgents(Durability("main"));
+
+        distribute(grid);
+
+        // The remainder pass prefers !IsLeader, which in this two node cluster deterministically targeted
+        // the incapable producer -- the exact shape reported
+        grid.AgentFor(Durability("main")).AssignedNode.ShouldBe(leader);
+    }
+
+    [Fact]
+    public void an_agent_already_parked_on_an_incapable_node_is_moved_off()
+    {
+        var grid = new AssignmentGrid();
+        var capable = Capable(grid.WithNode(1, Guid.NewGuid()));
+        var incapable = grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(Durability("main"));
+
+        incapable.Assign(grid.AgentFor(Durability("main")));
+
+        distribute(grid);
+
+        grid.AgentFor(Durability("main")).AssignedNode.ShouldBe(capable);
+    }
+
+    [Fact]
+    public void nothing_is_assigned_when_no_node_is_capable()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(Durability("one"), Durability("two"));
+
+        distribute(grid);
+
+        grid.AgentFor(Durability("one")).AssignedNode.ShouldBeNull();
+        grid.AgentFor(Durability("two")).AssignedNode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void capable_nodes_still_get_an_even_spread()
+    {
+        var grid = new AssignmentGrid();
+        Capable(grid.WithNode(1, Guid.NewGuid()));
+        Capable(grid.WithNode(2, Guid.NewGuid()));
+        grid.WithAgents(Durability("one"), Durability("two"), Durability("three"), Durability("four"));
+
+        distribute(grid);
+
+        foreach (var node in grid.Nodes)
+        {
+            node.Agents.Count.ShouldBe(2);
+        }
+    }
+
+    /// <summary>
+    ///     The GH-3785 affinity preference follows another family's placements, and that family may be running
+    ///     on a node that cannot host durability agents. Co-location is an optimisation; capability is not.
+    /// </summary>
+    [Fact]
+    public void an_affinity_preference_for_an_incapable_node_is_discarded()
+    {
+        var grid = new AssignmentGrid();
+        var capable = Capable(grid.WithNode(1, Guid.NewGuid()));
+        var incapable = grid.WithNode(2, Guid.NewGuid());
+        grid.WithAgents(Durability("main"));
+
+        grid.DistributeEvenlyWithAffinity("wolverinedb", _ => incapable,
+            MessageStoreCollection.NodeCanRunDurabilityAgents);
+
+        grid.AgentFor(Durability("main")).AssignedNode.ShouldBe(capable);
+    }
+
+    [Fact]
+    public void warns_once_when_no_node_in_the_cluster_can_run_durability_agents()
+    {
+        var grid = new AssignmentGrid();
+        grid.WithNode(1, Guid.NewGuid());
+        grid.WithAgents(Durability("main"));
+
+        var logger = Substitute.For<ILogger>();
+        logger.IsEnabled(LogLevel.Warning).Returns(true);
+
+        var warned = false;
+        MessageStoreCollection.WarnIfNoCapableNode(grid, logger, ref warned);
+        warned.ShouldBeTrue();
+
+        MessageStoreCollection.WarnIfNoCapableNode(grid, logger, ref warned);
+
+        logger.ReceivedWithAnyArgs(1).Log(default, default, default!, default, default!);
+    }
+
+    [Fact]
+    public void does_not_warn_when_at_least_one_node_is_capable()
+    {
+        var grid = new AssignmentGrid();
+        Capable(grid.WithNode(1, Guid.NewGuid()));
+        grid.WithAgents(Durability("main"));
+
+        var logger = Substitute.For<ILogger>();
+        logger.IsEnabled(LogLevel.Warning).Returns(true);
+
+        var warned = false;
+        MessageStoreCollection.WarnIfNoCapableNode(grid, logger, ref warned);
+
+        warned.ShouldBeFalse();
+        logger.DidNotReceiveWithAnyArgs().Log(default, default, default!, default, default!);
+    }
+}

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageDatabase.Agents.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageDatabase.Agents.cs
@@ -49,14 +49,19 @@ public partial class MultiTenantedMessageStore : IAgentFamily
     {
         // GH-3785: same cross-family database affinity as MessageStoreCollection — see the note there.
         var preference = DurabilityProjectionAffinity.BuildPreference(assignments);
-        assignments.DistributeEvenlyWithAffinity(Scheme, preference.NodeFor);
+        assignments.DistributeEvenlyWithAffinity(Scheme, preference.NodeFor,
+            MessageStoreCollection.NodeCanRunDurabilityAgents);
 
         preference.ReportTo(_logger, ref _lastAffinityReport);
+
+        // GH-3954: same node-level capability gate as MessageStoreCollection — see the note there.
+        MessageStoreCollection.WarnIfNoCapableNode(assignments, _logger, ref _warnedAboutNoCapableNode);
 
         return ValueTask.CompletedTask;
     }
 
     private (int Known, int Considered, int Matched) _lastAffinityReport;
+    private bool _warnedAboutNoCapableNode;
 
     private class DummyAgent : IAgent
     {

--- a/src/Wolverine/Persistence/DurabilityAffinityPreference.cs
+++ b/src/Wolverine/Persistence/DurabilityAffinityPreference.cs
@@ -4,7 +4,7 @@ using Wolverine.Runtime.Agents;
 namespace Wolverine.Persistence;
 
 /// <summary>
-///     GH-3785: the preference function handed to <see cref="AssignmentGrid.DistributeEvenlyWithAffinity" />,
+///     GH-3785: the preference function handed to <see cref="AssignmentGrid.DistributeEvenlyWithAffinity(string, Func{Uri, AssignmentGrid.Node})" />,
 ///     plus a count of how much of it actually engaged.
 ///
 ///     <para>The affinity join is deliberately fail-silent — <see cref="DurabilityProjectionAffinity" /> falls

--- a/src/Wolverine/Persistence/DurabilityProjectionAffinity.cs
+++ b/src/Wolverine/Persistence/DurabilityProjectionAffinity.cs
@@ -35,7 +35,7 @@ internal static class DurabilityProjectionAffinity
     }
 
     /// <summary>
-    ///     Build the preference function for <see cref="AssignmentGrid.DistributeEvenlyWithAffinity" /> from
+    ///     Build the preference function for <see cref="AssignmentGrid.DistributeEvenlyWithAffinity(string, Func{Uri, AssignmentGrid.Node})" /> from
     ///     the event-subscription assignments already present in the grid. Returns the node hosting the most
     ///     of a database's event-subscription agents (during a blue/green split a database legitimately has
     ///     one owner per version; the durability agent follows the larger side, tie-broken by node id for

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -12,6 +12,27 @@ namespace Wolverine.Persistence;
 
 public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
 {
+    /// <summary>
+    ///     GH-3954. A node-level marker saying "this node can run durability agents at all", published into
+    ///     <see cref="Runtime.Agents.WolverineNode.Capabilities" /> at startup when the durability agent family
+    ///     is registered, and consulted by the leader when it distributes <c>wolverinedb://</c> agents.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A node-level marker rather than the per-agent capability matching the blue/green and
+    ///         group-affinity paths use, for two reasons. First, this family is an <see cref="IAgentFamily" />
+    ///         and NOT an <see cref="IStaticAgentFamily" />, and only static families contribute to
+    ///         <c>Capabilities</c> — so no <c>wolverinedb://</c> agent Uri has ever appeared there on any node,
+    ///         capable or not, and per-agent matching would find zero capable nodes everywhere. Second,
+    ///         <c>Capabilities</c> is a startup snapshot, while this family's agent list GROWS at runtime as
+    ///         tenant databases are added; matching per agent would strand every later-added tenant database's
+    ///         durability agent. Whether a node can run these agents is genuinely a per-node property —
+    ///         <c>Durability.DurabilityAgentEnabled</c> turns the whole family on or off — so that is what gets
+    ///         published.
+    ///     </para>
+    /// </remarks>
+    public static readonly Uri DurabilityCapabilityUri = new("wolverine://durability-agents-enabled");
+
     private readonly IWolverineRuntime _runtime;
     private readonly List<MultiTenantedMessageStore> _multiTenanted = new();
     private ImHashMap<Uri, IMessageStore> _services = ImHashMap<Uri, IMessageStore>.Empty;
@@ -322,18 +343,54 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         // NodeAgentController evaluating this family AFTER the event-subscription family. A database with
         // no projection agents in the grid falls back to the even spread.
         var preference = DurabilityProjectionAffinity.BuildPreference(assignments);
-        assignments.DistributeEvenlyWithAffinity(Scheme, preference.NodeFor);
+        assignments.DistributeEvenlyWithAffinity(Scheme, preference.NodeFor, NodeCanRunDurabilityAgents);
 
         // The fallback is silent by design, so say out loud how much of it engaged -- see
         // DurabilityAffinityPreference. Logged only when the numbers move.
         _affinityLogger ??= _runtime.LoggerFactory.CreateLogger<MessageStoreCollection>();
         preference.ReportTo(_affinityLogger, ref _lastAffinityReport);
 
+        WarnIfNoCapableNode(assignments, _affinityLogger, ref _warnedAboutNoCapableNode);
+
         return ValueTask.CompletedTask;
     }
 
     private ILogger? _affinityLogger;
     private (int Known, int Considered, int Matched) _lastAffinityReport;
+    private bool _warnedAboutNoCapableNode;
+
+    /// <summary>
+    ///     GH-3954. Whether a node has published <see cref="DurabilityCapabilityUri" /> — i.e. it started with
+    ///     <c>Durability.DurabilityAgentEnabled</c> on and registered this family.
+    /// </summary>
+    internal static bool NodeCanRunDurabilityAgents(AssignmentGrid.Node node)
+    {
+        return node.Capabilities.Contains(DurabilityCapabilityUri);
+    }
+
+    /// <summary>
+    ///     GH-3954. The reported failure was silent: every queue table read zero while a nine-day backlog of
+    ///     unrecovered envelopes sat in wolverine_outgoing_envelopes. Leaving the agents unassigned stops the
+    ///     five-minute reassignment churn but is just as quiet on its own, so name the condition and the
+    ///     setting that causes it. Latched so it is said once per transition, not every evaluation.
+    /// </summary>
+    internal static void WarnIfNoCapableNode(AssignmentGrid assignments, ILogger logger, ref bool alreadyWarned)
+    {
+        if (assignments.Nodes.Any(NodeCanRunDurabilityAgents))
+        {
+            alreadyWarned = false;
+            return;
+        }
+
+        if (alreadyWarned)
+        {
+            return;
+        }
+
+        alreadyWarned = true;
+        logger.LogWarning(
+            "No node in this Wolverine cluster can run durability agents, so none were assigned and no outgoing envelope recovery, scheduled message processing or node reassignment will happen for any message store. Every node in the cluster started with Durability.DurabilityAgentEnabled = false. Enable it on at least one node.");
+    }
 
     internal async Task<IAgent> StartScheduledJobProcessing(IWolverineRuntime runtime)
     {

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -361,6 +361,30 @@ public partial class AssignmentGrid
     /// </summary>
     public void DistributeEvenlyWithAffinity(string scheme, Func<Uri, Node?> preferredNodeFor)
     {
+        DistributeEvenlyWithAffinity(scheme, preferredNodeFor, _ => true);
+    }
+
+    /// <summary>
+    ///     Same as <see cref="DistributeEvenlyWithAffinity(string, Func{Uri, Node})" />, restricted to the nodes
+    ///     for which <paramref name="nodeIsCapable" /> is true. Agents are never placed on an incapable node,
+    ///     and any agent currently sitting on one is detached so it can move.
+    /// </summary>
+    /// <remarks>
+    ///     GH-3954. Note the capability question here is per-NODE, not per-agent as in
+    ///     <see cref="DistributeEvenlyWithBlueGreenSemantics(string)" /> — and deliberately NOT gated on
+    ///     <see cref="AllNodesHaveSameCapabilities(string)" />, which returns true trivially both when there is
+    ///     a single node (<c>_nodes.Skip(1)</c> is empty) and when every node is equally incapable. Those are
+    ///     exactly the two configurations that were reported, so a fix modelled on the blue/green path would
+    ///     not have changed either of them.
+    ///
+    ///     <para>When NO node is capable this assigns nothing and leaves the agents unassigned, rather than
+    ///     handing them to a node that will throw "Unrecognized agent scheme" and be re-assigned the same work
+    ///     five minutes later, forever. Callers should say so out loud — see
+    ///     <c>MessageStoreCollection.EvaluateAssignmentsAsync</c>.</para>
+    /// </remarks>
+    public void DistributeEvenlyWithAffinity(string scheme, Func<Uri, Node?> preferredNodeFor,
+        Func<Node, bool> nodeIsCapable)
+    {
         if (_nodes.Count == 0)
         {
             throw new InvalidOperationException("There are no active nodes");
@@ -372,9 +396,24 @@ public partial class AssignmentGrid
             return;
         }
 
-        if (_nodes.Count == 1)
+        var capableNodes = _nodes.Where(nodeIsCapable).ToList();
+
+        // Detach anything parked on a node that cannot run it, so the passes below can move it. This also
+        // covers the "nobody is capable" case: everything ends up detached rather than latched onto a node
+        // that will only throw.
+        foreach (var agent in agents.Where(x => x.AssignedNode != null && !capableNodes.Contains(x.AssignedNode!)))
         {
-            var only = _nodes[0];
+            agent.Detach();
+        }
+
+        if (capableNodes.Count == 0)
+        {
+            return;
+        }
+
+        if (capableNodes.Count == 1)
+        {
+            var only = capableNodes[0];
             foreach (var agent in agents)
             {
                 only.Assign(agent);
@@ -387,6 +426,16 @@ public partial class AssignmentGrid
         foreach (var agent in agents)
         {
             var preferred = preferredNodeFor(agent.Uri);
+
+            // GH-3954: the affinity preference follows another family's placements, and that family may
+            // well be running on a node that cannot host durability agents. An incapable preference is
+            // discarded rather than honoured -- co-location is an optimisation, capability is a hard
+            // requirement -- and the agent falls through to the even spread over the capable nodes.
+            if (preferred != null && !capableNodes.Contains(preferred))
+            {
+                preferred = null;
+            }
+
             if (preferred == null)
             {
                 remainder.Add(agent);
@@ -407,11 +456,11 @@ public partial class AssignmentGrid
         // counting only the remainder itself toward each node's fill. Counting the preferred placements
         // too would push every no-affinity agent onto whichever nodes hold no projections, which is
         // exactly backwards: those nodes have no pool open to ANY shard database yet.
-        var spread = (double)remainder.Count / _nodes.Count;
+        var spread = (double)remainder.Count / capableNodes.Count;
         var minimum = (int)Math.Floor(spread);
         var maximum = (int)Math.Ceiling(spread);
 
-        foreach (var node in _nodes)
+        foreach (var node in capableNodes)
         {
             var extras = node.ForCurrentlyAssigned(remainder).Skip(maximum).ToArray();
             foreach (var agent in extras)
@@ -422,7 +471,7 @@ public partial class AssignmentGrid
 
         var missing = new Queue<Agent>(remainder.Where(x => x.AssignedNode == null));
 
-        foreach (var node in _nodes)
+        foreach (var node in capableNodes)
         {
             if (missing.Count == 0)
             {
@@ -446,8 +495,8 @@ public partial class AssignmentGrid
         {
             var agent = missing.Dequeue();
 
-            var node = _nodes.FirstOrDefault(x => !x.IsLeader && x.ForCurrentlyAssigned(remainder).Count() < maximum)
-                       ?? _nodes.FirstOrDefault(x => !x.IsLeader) ?? _nodes.First();
+            var node = capableNodes.FirstOrDefault(x => !x.IsLeader && x.ForCurrentlyAssigned(remainder).Count() < maximum)
+                       ?? capableNodes.FirstOrDefault(x => !x.IsLeader) ?? capableNodes.First();
             node.Assign(agent);
         }
     }

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocalProcessing.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocalProcessing.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Wolverine.Persistence;
 
 namespace Wolverine.Runtime.Agents;
 
@@ -10,6 +11,18 @@ public partial class NodeAgentController
         foreach (var controller in _agentFamilies.Values.OfType<IStaticAgentFamily>())
         {
             current.Capabilities.AddRange(await controller.SupportedAgentsAsync());
+        }
+
+        // GH-3954: the durability agent family is deliberately NOT an IStaticAgentFamily -- its agent list
+        // grows at runtime as tenant databases are added -- so none of its wolverinedb:// Uris pass through
+        // the loop above, and the leader had no way to tell a node that runs durability agents from one with
+        // Durability.DurabilityAgentEnabled = false. It assigned to both, the incapable node threw
+        // "Unrecognized agent scheme 'wolverinedb'", and the assignment never converged while staged
+        // envelopes sat unrecovered. Publish a single node-level marker instead; see
+        // MessageStoreCollection.DurabilityCapabilityUri.
+        if (_agentFamilies.ContainsKey(_runtime.Stores.Scheme))
+        {
+            current.Capabilities.Add(MessageStoreCollection.DurabilityCapabilityUri);
         }
 
         // GH-3604 / D2: remember the capabilities so we can re-register with them if a peer ever deletes our

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocalProcessing.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocalProcessing.cs
@@ -20,7 +20,10 @@ public partial class NodeAgentController
         // "Unrecognized agent scheme 'wolverinedb'", and the assignment never converged while staged
         // envelopes sat unrecovered. Publish a single node-level marker instead; see
         // MessageStoreCollection.DurabilityCapabilityUri.
-        if (_agentFamilies.ContainsKey(_runtime.Stores.Scheme))
+        // Keyed on the setting rather than on _agentFamilies[_runtime.Stores.Scheme], which is the same
+        // condition -- the constructor registers the family if and only if this flag is set -- but reaches
+        // through Stores, and that is null on a runtime with no message store.
+        if (options.Durability.DurabilityAgentEnabled)
         {
             current.Capabilities.Add(MessageStoreCollection.DurabilityCapabilityUri);
         }


### PR DESCRIPTION
Closes #3954.

A node started with `Durability.DurabilityAgentEnabled = false` never registers the durability agent family, so it threw `Unrecognized agent scheme 'wolverinedb'` the moment the leader handed it one. The leader re-issued the identical assignment every five minutes forever, no durability agent ran anywhere for that store, and `owner_id = 0` outgoing envelopes were never recovered — silently, with every queue table reading zero. The reporter found a nine-day backlog this way.

## ⚠️ The issue's premise is wrong, and following it would have made things worse

The issue states that the incapable node's capabilities correctly omit the scheme, so *"the leader has the data to avoid the node."*

**It does not.** `WolverineNode.Capabilities` is populated only from `_agentFamilies.Values.OfType<IStaticAgentFamily>()` (`NodeAgentController.StartLocalProcessing.cs:10`), and `MessageStoreCollection` is declared `: IAgentFamily, IAsyncDisposable` — **not** `IStaticAgentFamily`. There are exactly two sites that add to `Capabilities`, both fed by that same filter.

So no `wolverinedb://` Uri has ever appeared in `Capabilities` on *any* node, capable or not. The suggested fix — per-agent `Node.Capabilities.Contains(agent.Uri)` — would have found **zero** capable nodes everywhere and stranded the durability agent cluster-wide.

Per-agent matching is wrong here for a second, independent reason: `Capabilities` is a **startup snapshot**, while this family's agent list *grows* at runtime as tenant databases are added. Per-agent matching would strand every later-added tenant database's durability agent.

## What this does instead

Whether a node can run these agents is genuinely a **per-node** property — the setting turns the whole family on or off — so that is what gets published:

- `MessageStoreCollection.DurabilityCapabilityUri`, written into `Capabilities` at startup when the family is actually registered
- consulted by a new capability-aware overload of `DistributeEvenlyWithAffinity`

Only `MessageStoreCollection` and `MultiTenantedMessageDatabase` call that method, so the change is scoped to the store/durability family exactly as intended — `DistributeEvenlyWithBlueGreenSemantics` and `DistributeByGroupAffinity` are untouched.

It is deliberately **not** gated on `AllNodesHaveSameCapabilities`, which returns true trivially both when there is a single node (`_nodes.Skip(1)` is empty) and when every node is equally incapable — precisely the two configurations in the report. A fix modelled on the blue/green path would have changed neither.

Two more cases handled:

- **The GH-3785 affinity preference** follows another family's placements and may name a node that cannot host durability agents. An incapable preference is now discarded rather than honoured — co-location is an optimisation, capability is not.
- **When no node is capable**, nothing is assigned and a warning names the condition and the setting. The original failure was silent in both directions; leaving the agents unassigned without saying why would only trade one quiet failure for another.

## Verification

- 9 new `AssignmentGrid` tests. Confirmed **5/9 fail against the ungated overload** and 9/9 pass with the gate, so the gate is demonstrably what's doing the work (a plain stash can't serve as the red baseline here, since the tests reference new API).
- 2 new end-to-end tests asserting a normal Balanced Postgres host **publishes the marker and still gets its durability agent** — the regression that would matter most if the marker ever stopped being published.
- Existing `durability_modes` suite still 7/7, including its Balanced-mode running-agent count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC