### PR TITLE
GH-3950: quiesce a Rabbit channel that the broker has already closed

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/stale_delivery_tag_settling.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/stale_delivery_tag_settling.cs
@@ -74,6 +74,65 @@ public class stale_delivery_tag_settling
 
         await host.StopAsync(TestContext.Current.CancellationToken);
     }
+
+    /// <summary>
+    /// GH-3950. A rejected settle now proactively rebuilds the listener's channel rather than leaving
+    /// deliveries streaming into a teardown. This asserts the listener is still CONSUMING afterwards.
+    /// </summary>
+    /// <remarks>
+    /// This is the guard for the hazard that proactive rebuild introduces rather than for the bug it
+    /// mitigates. #3391 is the precedent: a rebuild that only swaps the channel leaves a listener sitting
+    /// on an open channel with ZERO consumers while still reporting Connected — silently dead, and no
+    /// existing assertion catches it because the poisoned message itself is redelivered by the broker
+    /// regardless. Publishing a fresh batch AFTER the rebuild is what distinguishes "recovered" from
+    /// "quietly stopped listening".
+    /// </remarks>
+    [Fact]
+    public async Task the_listener_keeps_consuming_after_a_rejected_settle_rebuilds_the_channel()
+    {
+        var queueName = RabbitTesting.NextQueueName();
+
+        StaleTagHandler.Reset(poisonAt: 2);
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+                opts.PublishAllMessages().ToRabbitQueue(queueName).SendInline();
+                opts.ListenToRabbitQueue(queueName).ProcessInline();
+            })
+            .StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var bus = host.MessageBus();
+
+        var first = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var id in first)
+        {
+            await bus.PublishAsync(new StaleTagMessage(id));
+        }
+
+        await StaleTagHandler.WaitForAll(first.Length, TimeSpan.FromSeconds(60));
+
+        // Let the rejection, the proactive quiesce and the rebuild actually happen -- all of which land
+        // after the last message of the first batch has been handled.
+        await StaleTagHandler.WaitForRedelivery(first.Length, TimeSpan.FromSeconds(30));
+
+        // The assertion that matters: brand new messages published after the rebuild still arrive.
+        var second = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var id in second)
+        {
+            await bus.PublishAsync(new StaleTagMessage(id));
+        }
+
+        await StaleTagHandler.WaitForIds(second, TimeSpan.FromSeconds(60));
+
+        foreach (var id in second)
+        {
+            StaleTagHandler.HandledIds.ShouldContain(id);
+        }
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
 }
 
 public record StaleTagMessage(Guid Id);
@@ -137,6 +196,28 @@ public static class StaleTagHandler
             $"deliveries for {firstPassCount} messages. Either the override no longer produces an unknown " +
             $"delivery tag, or the settle path silently succeeded — in both cases this test is no longer " +
             $"covering what it claims to.");
+    }
+
+    /// <summary>
+    /// Polls for a specific set of ids rather than a count. The _source TCS is completed exactly once,
+    /// when the FIRST batch reaches _expected, so a second WaitForAll in the same test returns
+    /// immediately on the already-completed task and asserts against nothing.
+    /// </summary>
+    public static async Task WaitForIds(IEnumerable<Guid> ids, TimeSpan timeout)
+    {
+        var wanted = ids.ToArray();
+        var deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (wanted.All(_ids.ContainsKey)) return;
+            await Task.Delay(250);
+        }
+
+        var missing = wanted.Where(x => !_ids.ContainsKey(x)).ToArray();
+        throw new TimeoutException(
+            $"{missing.Length} of {wanted.Length} messages published AFTER the channel rebuild were never " +
+            $"handled within {timeout}. The listener stopped consuming rather than recovering.");
     }
 
     public static void Handle(StaleTagMessage message, Envelope envelope)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
@@ -42,6 +42,9 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
                 if (isUnknownDeliveryTag(exception))
                 {
                     logger.LogInformation("Encountered an unknown delivery tag, discarding the envelope");
+
+                    // GH-3950: the broker has already closed that channel. Stop feeding it.
+                    e.RabbitMqListener.QuiesceAfterRejectedSettle(e);
                 }
             }
         }, logger, cancellationToken);
@@ -129,6 +132,9 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
             if (isUnknownDeliveryTag(exception))
             {
                 Logger.LogInformation("Encountered an unknown delivery tag, discarding the envelope");
+
+                // GH-3950: the broker has already closed that channel. Stop feeding it.
+                envelope.RabbitMqListener.QuiesceAfterRejectedSettle(envelope);
                 return;
             }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqListener.cs
@@ -80,6 +80,9 @@ internal class RabbitMqInteropFriendlyCallback : IChannelCallback, ISupportDeadL
                 // way to the dead letter queue, so there is nothing left to do.
                 _logger.LogInformation(
                     "Encountered an unknown delivery tag while settling a dead lettered message, discarding the envelope");
+
+                // GH-3950: the broker has already closed that channel. Stop feeding it.
+                e.RabbitMqListener.QuiesceAfterRejectedSettle(e);
             }
         }
     }
@@ -419,6 +422,68 @@ internal class RabbitMqListener : RabbitMqChannelAgent, IListener, ISupportDeadL
     /// `Channel!` threw a NullReferenceException mid-reconnect -- can never succeed on any later
     /// channel, and just burns the retry budget while the same message cycles round again.
     /// </summary>
+    // The channel generation we have already quiesced, so a burst of rejected settles on the same dead
+    // channel triggers exactly one rebuild rather than one per envelope.
+    private object? _quiescedChannel;
+
+    /// <summary>
+    /// GH-3950. Called when the broker rejects a settle with <c>PRECONDITION_FAILED - unknown delivery
+    /// tag</c>, which means the broker has ALREADY closed the channel the tag arrived on.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The damage that motivates this is not the rejected tag itself, which Wolverine has always handled.
+    /// It is that RabbitMQ.Client races itself while a channel is being torn down with deliveries still in
+    /// flight on it: an inbound frame arrives for a channel number just removed from the session map,
+    /// <c>SessionManager.Lookup</c> does an indexer read and throws <c>KeyNotFoundException</c>, and the
+    /// client escalates that into a library-initiated close of the WHOLE connection (code=541) — every
+    /// listener and sender on it, not just this channel.
+    /// </para>
+    /// <para>
+    /// Wolverine cannot catch that; it is thrown on the client's own MainLoop after our ack has already
+    /// gone out. What we CAN do is stop feeding a channel we now know is dead: cancel its consumer, tear
+    /// it down and rebuild, rather than leaving deliveries streaming into a teardown. This narrows the
+    /// window for further frames on the dead channel and gets the listener back on a healthy one sooner.
+    /// It does not, and cannot, prevent the connection death that a single rejected tag has already set in
+    /// motion.
+    /// </para>
+    /// </remarks>
+    internal void QuiesceAfterRejectedSettle(RabbitMqEnvelope envelope)
+    {
+        var channel = envelope.DeliveredOn;
+        if (channel is null || IsDisposed || _cancellation.IsCancellationRequested)
+        {
+            return;
+        }
+
+        // One rebuild per channel generation. Exchange returns the PREVIOUS value, so the first caller for
+        // a given channel sees something else and proceeds; every later one sees its own channel back.
+        if (ReferenceEquals(Interlocked.Exchange(ref _quiescedChannel, channel), channel))
+        {
+            return;
+        }
+
+        Logger.LogWarning(
+            "A Rabbit MQ delivery tag was rejected as unknown at {Uri}, which means the broker has already closed that channel. Proactively rebuilding the listener's channel so that in flight deliveries are not left racing its teardown. See GH-3950.",
+            Address);
+
+        // Deliberately not awaited: this runs from a settle path (a RetryBlock, or the dead letter
+        // callback) and ReconnectedAsync takes _reconnectLock and does real broker work.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await ReconnectedAsync();
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e,
+                    "Error while proactively rebuilding the Rabbit MQ channel for {Uri} after a rejected delivery tag",
+                    Address);
+            }
+        });
+    }
+
     internal bool CanSettle(RabbitMqEnvelope envelope)
     {
         var channel = Channel;


### PR DESCRIPTION
Addresses suggestion 3 of #3950. (Suggestion 2 shipped as #3961; suggestion 1 is the upstream `SessionManager.Lookup` defect and is not ours.)

When the broker rejects a settle with `PRECONDITION_FAILED - unknown delivery tag`, it has **already closed** the channel that tag arrived on. Wolverine logged the rejection and carried on, leaving deliveries streaming into a channel being torn down — which is precisely the condition that makes RabbitMQ.Client race itself: an inbound frame arrives for a channel number just removed from the session map, `SessionManager.Lookup` does an indexer read and throws `KeyNotFoundException`, and the client escalates that into a library-initiated close of the **whole connection** (`code=541`), taking down every listener and sender on it.

A rejected settle now cancels that channel's consumer, tears it down and rebuilds, through the existing `ReconnectedAsync()` path. Latched per channel generation so a burst of rejected settles on one dead channel triggers exactly one rebuild, and dispatched off the settle path because `ReconnectedAsync` takes the reconnect lock and does real broker work. Wired into all three sites that recognise the rejection.

## What this does not do

**It does not prevent the connection death.** The `KeyNotFoundException` is raised on the client's own `MainLoop` after our ack has already gone out, and the issue's own measurements show a *single* poisoned tag killed the connection on 4 of 5 runs — far too early for anything here to intervene.

What it does is narrow the window for further frames on a channel already known to be dead, and get the listener back onto a healthy one sooner. I'd rather state that plainly than let the change read as a fix for the 541s. The real fix is upstream: `SessionManager.Lookup` should `TryGetValue` and drop frames for a dead channel rather than throwing.

## About the test

The new test guards the hazard this change **introduces**, not the bug it mitigates.

#3391 is the precedent: a rebuild that only swaps the channel leaves a listener sitting on an open channel with **zero consumers** while still reporting Connected — silently dead. The poisoned message is redelivered by the broker either way, so no existing assertion would catch that; only a fresh batch published *after* the rebuild distinguishes "recovered" from "quietly stopped listening."

It also needed a poll-based wait helper: the existing `WaitForAll` completes a single `TaskCompletionSource`, so a second call in the same test returns immediately on the already-completed task and asserts against nothing. The first version of this test "passed" in 985ms that way.

## Verification

- `stale_delivery_tag_settling` 2/2, including the existing test
- Full `Wolverine.RabbitMQ.Tests` suite results to follow in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC