### PR TITLE
GH-3965: stop the ConventionalRouting tests leaking Rabbit consumers

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_2681_handler_type_naming_binds_all_exchanges.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_2681_handler_type_naming_binds_all_exchanges.cs
@@ -46,7 +46,13 @@ public class Bug_2681_handler_type_naming_binds_all_exchanges : IAsyncLifetime, 
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_host != null) await _host.StopAsync();
+    }
 
     [Fact]
     public void handler_queue_is_bound_to_every_handled_message_exchange()
@@ -127,7 +133,13 @@ public class Bug_2681_custom_bindings_are_not_double_added : IAsyncLifetime, IDi
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_host != null) await _host.StopAsync();
+    }
 
     [Fact]
     public void user_custom_binding_is_not_double_added_by_the_convention()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_3041_saga_and_handler_with_handler_type_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/Bug_3041_saga_and_handler_with_handler_type_naming.cs
@@ -39,7 +39,13 @@ public class Bug_3041_saga_and_handler_with_handler_type_naming : IAsyncLifetime
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_host != null) await _host.StopAsync();
+    }
 
     [Fact]
     public void both_the_saga_and_the_regular_handler_get_listener_queues()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/ConventionalRoutingContext.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/ConventionalRoutingContext.cs
@@ -14,7 +14,16 @@ public static class ConventionalRoutingTestDefaults
 }
 
 
-public abstract class ConventionalRoutingContext : IDisposable
+/// <summary>
+///     GH-3965. Note the async disposal. Every conventionally routed <see cref="ConventionallyRoutedMessage" />
+///     lands on one FIXED queue -- the type carries <c>[MessageIdentity("routed")]</c>, so the queue is
+///     literally <c>routed</c> -- and several classes in this namespace stand up listeners on it.
+///     <see cref="IHost.Dispose" /> does NOT run <c>IHostedService.StopAsync</c>, so disposing synchronously
+///     left those consumers attached to the broker after the test finished, and a later test's message was
+///     delivered to a leaked consumer belonging to an already-completed class. That shows up as a tracked
+///     session containing <c>Sent</c> and no <c>Received</c> at all.
+/// </summary>
+public abstract class ConventionalRoutingContext : IDisposable, IAsyncDisposable
 {
     private IHost _host = null!;
 
@@ -53,6 +62,22 @@ public abstract class ConventionalRoutingContext : IDisposable
     public void Dispose()
     {
         _host?.Dispose();
+    }
+
+    public ValueTask DisposeAsync() => DisposeHostAsync();
+
+    /// <summary>
+    ///     Stops the host so its Rabbit consumers are actually cancelled, then disposes it. Derived classes
+    ///     that implement <c>IAsyncLifetime</c> shadow the interface implementation above, so they must call
+    ///     this from their own <c>DisposeAsync</c> rather than returning a completed ValueTask.
+    /// </summary>
+    protected async ValueTask DisposeHostAsync()
+    {
+        if (_host == null) return;
+
+        await _host.StopAsync();
+        _host.Dispose();
+        _host = null!;
     }
 
     internal async Task ConfigureConventions(Action<RabbitMqMessageRoutingConvention> configure)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing.cs
@@ -27,7 +27,14 @@ public class end_to_end_with_conventional_routing : IAsyncLifetime, IDisposable
         });
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_sender != null) await _sender.StopAsync();
+        if (_receiver != null) await _receiver.StopAsync();
+    }
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_custom_exchange.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_custom_exchange.cs
@@ -57,7 +57,14 @@ public class end_to_end_with_conventional_routing_custom_exchange : IAsyncLifeti
 
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_sender != null) await _sender.StopAsync();
+        if (_receiver != null) await _receiver.StopAsync();
+    }
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/end_to_end_with_conventional_routing_with_prefix.cs
@@ -38,7 +38,14 @@ public class end_to_end_with_conventional_routing_with_prefix : IAsyncLifetime, 
         });
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_sender != null) await _sender.StopAsync();
+        if (_receiver != null) await _receiver.StopAsync();
+    }
 
     public void Dispose()
     {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_all_defaults.cs
@@ -17,7 +17,8 @@ public class when_discovering_a_listening_endpoint_with_all_defaults : Conventio
         theEndpoint = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<RabbitMqQueue>();
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: shadows ConventionalRoutingContext.DisposeAsync -- must stop the host itself.
+    ValueTask IAsyncDisposable.DisposeAsync() => DisposeHostAsync();
 
     [Fact]
     public void endpoint_should_be_a_listener()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_listening_endpoint_with_overridden_queue_naming.cs
@@ -22,7 +22,8 @@ public class when_discovering_a_listening_endpoint_with_overridden_queue_naming 
         theEndpoint = (await theRuntime()).Endpoints.EndpointFor(theExpectedUri).ShouldBeOfType<RabbitMqQueue>();
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: shadows ConventionalRoutingContext.DisposeAsync -- must stop the host itself.
+    ValueTask IAsyncDisposable.DisposeAsync() => DisposeHostAsync();
 
     [Fact]
     public void endpoint_should_be_a_listener()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_discovering_a_sender_with_all_defaults.cs
@@ -20,7 +20,8 @@ public class when_discovering_a_sender_with_all_defaults : ConventionalRoutingCo
         theRoute = ((await PublishingRoutesFor<ConventionallyRoutedMessage>()).Single() as MessageRoute)!;
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: shadows ConventionalRoutingContext.DisposeAsync -- must stop the host itself.
+    ValueTask IAsyncDisposable.DisposeAsync() => DisposeHostAsync();
 
     [Fact]
     public void should_have_exactly_one_route()

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_using_handler_type_naming.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/ConventionalRouting/when_using_handler_type_naming.cs
@@ -31,7 +31,13 @@ public class when_using_handler_type_naming : IAsyncLifetime, IDisposable
         _runtime = _host.Services.GetRequiredService<IWolverineRuntime>();
     }
 
-    ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
+    // GH-3965: IHost.Dispose() does not run StopAsync, so a synchronous teardown left this
+    // class's Rabbit consumers attached to a SHARED, fixed queue name and stealing later
+    // tests' messages. Stop the hosts for real.
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_host != null) await _host.StopAsync();
+    }
 
     [Fact]
     public void listener_endpoint_should_be_named_after_handler_type()


### PR DESCRIPTION
Closes #3965. Test infrastructure only — no shipped code path depends on `Dispose()` stopping a host.

## The evidence

`end_to_end_with_conventional_routing.send_from_one_node_to_another_all_with_conventional_routing` failed in a full `Wolverine.RabbitMQ.Tests` run and passed 3/3 in isolation. The tracked session is what pinned it:

```
System.TimeoutException : This TrackedSession timed out before all activity completed.
| Service (Node Id)  | Message Id | Message Type | Time (ms) | Event |
| Sender (7db8333a…) | 08defbc1-… | routed       |         2 | Sent  |
```

**Sent, and never Received by anyone.** Not "received by the wrong host" — nothing in the session consumed it at all.

## The cause

`ConventionallyRoutedMessage` carries `[MessageIdentity("routed")]`, so every conventionally routed instance lands on one **fixed** queue named `routed`. Five classes in this namespace stand up hosts against it, several with conventional discovery on, which gives them a live listener via `RoutedMessageHandler`.

Every one of them tore down like this:

```csharp
ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
public void Dispose() => _host.Dispose();
```

`IHost.Dispose()` does **not** run `IHostedService.StopAsync`, so the Rabbit listeners were never cancelled and their consumers stayed attached to `routed` on the broker after the class finished. A later class's message was delivered to one of those orphans, and the real receiver never saw it.

## The trap in the fix

Making `ConventionalRoutingContext` implement `IAsyncDisposable` is **not sufficient on its own**. Its derived classes implement `IAsyncLifetime`, whose explicit `ValueTask IAsyncDisposable.DisposeAsync()` **shadows** the base implementation — so the base would simply never run. Each derived class therefore calls the new `protected DisposeHostAsync()` explicitly.

## Deliberately not touched

`discover_with_naming_prefix` and `Bug_3633_conventional_routing_respects_named_broker` leak the same way, but they use prefixed and named-broker queue names that don't collide with plain `routed`, so they don't contribute to this interference. They also build their hosts in a constructor, so converting them means restructuring to `IAsyncLifetime` — a larger change than this fix warrants. Worth a follow-up if the suite ever shows symptoms from them.

## Verification

- `Wolverine.RabbitMQ.Tests.ConventionalRouting` namespace: **33/34 → 34/34**
- Full suite result to follow in a comment

## Note on timing

The full suite was recorded at 503/503 on 2026-08-15, so something tipped the ordering or shutdown timing recently — #3796, #3960 and #3961 all touched `RabbitMqListener` shutdown and are the candidates. The leak itself predates all of them, and is the defect regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC