### PR TITLE
GH-3941: a store-agnostic EventsToAppend return type in core

### DIFF
--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/core_events_return_3941.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/core_events_return_3941.cs
@@ -5,19 +5,22 @@ using Shouldly;
 using Wolverine;
 using Wolverine.Marten;
 using Wolverine.Persistence.EventSourcing;
-using Events = Wolverine.Persistence.EventSourcing.Events;
 
 namespace MartenTests.AggregateHandlerWorkflow;
 
-// GH-3941: the store-agnostic Events return type. Wolverine.Marten.Events, Wolverine.Polecat.Events
-// and Wolverine.Fisher.Events are identical and store-named, so a handler compiled against more than
-// one store could not name any of them and had to fall back to a bare IEnumerable<object> return.
+// GH-3941: the store-agnostic EventsToAppend return type. Wolverine.Marten.Events,
+// Wolverine.Polecat.Events and Wolverine.Fisher.Events are identical and store-named, so a handler
+// compiled against more than one store could not name any of them and had to fall back to a bare
+// IEnumerable<object> return. That fallback works but is positional: IEnumerable<T> is covariant, so
+// EVERY reference-typed collection in a return tuple is a candidate and FirstOrDefault takes
+// whichever lands first in Creates. Nothing fails at codegen and nothing fails at runtime - the wrong
+// collection just becomes the events. ambiguous_sibling_collection_does_not_become_the_events is the
+// fact that matters here; the other two would pass against the old fallback too.
 //
-// That fallback works but is positional: IEnumerable<T> is covariant, so EVERY reference-typed
-// collection in a return tuple is a candidate and FirstOrDefault takes whichever lands first in
-// Creates. Nothing fails at codegen and nothing fails at runtime - the wrong collection just becomes
-// the events. ambiguous_sibling_collection_does_not_become_the_events is the fact that matters here;
-// the others would pass against the old fallback too.
+// Note that this file imports BOTH Wolverine.Marten and Wolverine.Persistence.EventSourcing with no
+// using alias, which is the combination a real store-agnostic handler needs -- the store integration
+// plus [WriteModel]. That compiles only because the core type is not also called Events: naming it
+// so collided with CS0104 on the two handler signatures at the bottom of this file.
 public class core_events_return_3941 : IAsyncLifetime
 {
     private IHost theHost = null!;
@@ -88,9 +91,9 @@ public class core_events_return_3941 : IAsyncLifetime
     {
         var streamId = await givenAccount(50m);
 
-        // The handler returns (Events, IReadOnlyList<string>). Both are castable to
+        // The handler returns (EventsToAppend, IReadOnlyList<string>). Both are castable to
         // IEnumerable<object>, so under the old fallback alone the audit lines could be appended as
-        // events instead - which throws nothing and simply corrupts the stream. Declaring Events is
+        // events instead - which throws nothing and simply corrupts the stream. Declaring EventsToAppend is
         // what makes the choice deterministic.
         await theHost.InvokeAsync(new RecordAuditedDeposit(streamId, 5m));
 
@@ -111,15 +114,15 @@ public record RecordAuditedDeposit(Guid AccountId, decimal Amount);
 
 public static class RecordCoreDepositHandler
 {
-    public static Events Handle(RecordCoreDeposit command, [WriteModel] Account account)
+    public static EventsToAppend Handle(RecordCoreDeposit command, [WriteModel] Account account)
         => new(Enumerable.Range(0, command.Repeat).Select(object (_) => new AmountDeposited(command.Amount)));
 }
 
 public static class RecordAuditedDepositHandler
 {
-    public static (Events, IReadOnlyList<string>) Handle(
+    public static (EventsToAppend, IReadOnlyList<string>) Handle(
         RecordAuditedDeposit command,
         [WriteModel] Account account)
-        => (new Events { new AmountDeposited(command.Amount) },
+        => (new EventsToAppend { new AmountDeposited(command.Amount) },
             new[] { $"deposit of {command.Amount} against {command.AccountId}" });
 }

--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/core_events_return_3941.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/core_events_return_3941.cs
@@ -1,0 +1,125 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence.EventSourcing;
+using Events = Wolverine.Persistence.EventSourcing.Events;
+
+namespace MartenTests.AggregateHandlerWorkflow;
+
+// GH-3941: the store-agnostic Events return type. Wolverine.Marten.Events, Wolverine.Polecat.Events
+// and Wolverine.Fisher.Events are identical and store-named, so a handler compiled against more than
+// one store could not name any of them and had to fall back to a bare IEnumerable<object> return.
+//
+// That fallback works but is positional: IEnumerable<T> is covariant, so EVERY reference-typed
+// collection in a return tuple is a candidate and FirstOrDefault takes whichever lands first in
+// Creates. Nothing fails at codegen and nothing fails at runtime - the wrong collection just becomes
+// the events. ambiguous_sibling_collection_does_not_become_the_events is the fact that matters here;
+// the others would pass against the old fallback too.
+public class core_events_return_3941 : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(RecordCoreDepositHandler))
+                    .IncludeType(typeof(RecordAuditedDepositHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "core_events_return_3941";
+                }).IntegrateWithWolverine();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task<Guid> givenAccount(decimal opening)
+    {
+        var streamId = Guid.NewGuid();
+        await using var session = theHost.DocumentStore().LightweightSession();
+        session.Events.StartStream<Account>(streamId, new AmountDeposited(opening));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return streamId;
+    }
+
+    private async Task<Account> loadAccount(Guid streamId)
+    {
+        await using var session = theHost.DocumentStore().LightweightSession();
+        return (await session.Events.AggregateStreamAsync<Account>(streamId,
+            token: TestContext.Current.CancellationToken))!;
+    }
+
+    [Fact]
+    public async Task the_core_events_type_is_appended_to_the_stream()
+    {
+        var streamId = await givenAccount(100m);
+
+        await theHost.InvokeAsync(new RecordCoreDeposit(streamId, 25m));
+
+        (await loadAccount(streamId)).Balance.ShouldBe(125m);
+    }
+
+    [Fact]
+    public async Task every_event_in_the_collection_is_appended()
+    {
+        var streamId = await givenAccount(0m);
+
+        await theHost.InvokeAsync(new RecordCoreDeposit(streamId, 10m, Repeat: 3));
+
+        (await loadAccount(streamId)).Balance.ShouldBe(30m);
+    }
+
+    [Fact]
+    public async Task ambiguous_sibling_collection_does_not_become_the_events()
+    {
+        var streamId = await givenAccount(50m);
+
+        // The handler returns (Events, IReadOnlyList<string>). Both are castable to
+        // IEnumerable<object>, so under the old fallback alone the audit lines could be appended as
+        // events instead - which throws nothing and simply corrupts the stream. Declaring Events is
+        // what makes the choice deterministic.
+        await theHost.InvokeAsync(new RecordAuditedDeposit(streamId, 5m));
+
+        (await loadAccount(streamId)).Balance.ShouldBe(55m);
+
+        await using var session = theHost.DocumentStore().LightweightSession();
+        var events = await session.Events.FetchStreamAsync(streamId,
+            token: TestContext.Current.CancellationToken);
+
+        events.Count.ShouldBe(2);
+        events.ShouldAllBe(x => x.Data is AmountDeposited);
+    }
+}
+
+public record RecordCoreDeposit(Guid AccountId, decimal Amount, int Repeat = 1);
+
+public record RecordAuditedDeposit(Guid AccountId, decimal Amount);
+
+public static class RecordCoreDepositHandler
+{
+    public static Events Handle(RecordCoreDeposit command, [WriteModel] Account account)
+        => new(Enumerable.Range(0, command.Repeat).Select(object (_) => new AmountDeposited(command.Amount)));
+}
+
+public static class RecordAuditedDepositHandler
+{
+    public static (Events, IReadOnlyList<string>) Handle(
+        RecordAuditedDeposit command,
+        [WriteModel] Account account)
+        => (new Events { new AmountDeposited(command.Amount) },
+            new[] { $"deposit of {command.Amount} against {command.AccountId}" });
+}

--- a/src/Wolverine/Persistence/EventSourcing/DcbModelAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/DcbModelAttribute.cs
@@ -240,7 +240,7 @@ public class DcbModelAttribute : WolverineParameterAttribute, IDataRequirement, 
         // in IEventSourcingFrameProvider — the core Events is an IWolverineReturnType, which the
         // fallback excludes (GH-3941).
         var eventsVariable = firstCall.Creates.FirstOrDefault(x => x.VariableType == provider.EventsCollectionType) ??
-                             firstCall.Creates.FirstOrDefault(x => x.VariableType == typeof(Events)) ??
+                             firstCall.Creates.FirstOrDefault(x => x.VariableType == typeof(EventsToAppend)) ??
                              firstCall.Creates.FirstOrDefault(x =>
                                  x.VariableType.CanBeCastTo<IEnumerable<object>>() &&
                                  !x.VariableType.CanBeCastTo<IWolverineReturnType>());

--- a/src/Wolverine/Persistence/EventSourcing/DcbModelAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/DcbModelAttribute.cs
@@ -236,7 +236,11 @@ public class DcbModelAttribute : WolverineParameterAttribute, IDataRequirement, 
             return;
         }
 
+        // Matched explicitly and ahead of the fallback for the same reason as the single-stream path
+        // in IEventSourcingFrameProvider — the core Events is an IWolverineReturnType, which the
+        // fallback excludes (GH-3941).
         var eventsVariable = firstCall.Creates.FirstOrDefault(x => x.VariableType == provider.EventsCollectionType) ??
+                             firstCall.Creates.FirstOrDefault(x => x.VariableType == typeof(Events)) ??
                              firstCall.Creates.FirstOrDefault(x =>
                                  x.VariableType.CanBeCastTo<IEnumerable<object>>() &&
                                  !x.VariableType.CanBeCastTo<IWolverineReturnType>());

--- a/src/Wolverine/Persistence/EventSourcing/Events.cs
+++ b/src/Wolverine/Persistence/EventSourcing/Events.cs
@@ -1,0 +1,57 @@
+using Wolverine.Configuration;
+
+namespace Wolverine.Persistence.EventSourcing;
+
+/// <summary>
+///     Tells Wolverine handlers that this value contains a list of events to be appended to the
+///     current stream — the store-agnostic sibling of <c>Wolverine.Marten.Events</c>,
+///     <c>Wolverine.Polecat.Events</c> and <c>Wolverine.Fisher.Events</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The three store-specific types are identical and store-named, so a handler that wants to
+///         be store-agnostic could not use any of them. The store-agnostic path did exist — a bare
+///         <c>IReadOnlyList&lt;object&gt;</c> return is picked up by the
+///         <c>IEnumerable&lt;object&gt;</c> fallback in
+///         <see cref="EventSourcingFrameProviderExtensions.DetermineEventCaptureHandling" /> — but
+///         that fallback is <b>positional and implicit</b>. Because <c>IEnumerable&lt;T&gt;</c> is
+///         covariant, every reference-typed collection in a return tuple is castable to
+///         <c>IEnumerable&lt;object&gt;</c>, so a handler returning
+///         <c>(IReadOnlyList&lt;object&gt;, IReadOnlyList&lt;string&gt;)</c> has two candidates and
+///         whichever lands first in <c>Creates</c> silently becomes the appended events. Nothing
+///         fails at codegen and nothing fails at runtime; the wrong collection just ends up in the
+///         event stream.
+///     </para>
+///     <para>
+///         <c>OutgoingMessages</c> escapes that only because it is an
+///         <see cref="IWolverineReturnType" />, which the fallback explicitly excludes — a happy
+///         accident of an unrelated marker rather than a designed guarantee, and one that does not
+///         extend to a user's own collection type. Returning this type instead makes the intent
+///         declared, so <c>(Events, OutgoingMessages)</c> is unambiguous.
+///     </para>
+///     <para>
+///         The store-specific types stay exactly as they are for existing code, the same way
+///         <c>WriteAggregateAttribute</c> was kept alongside <c>WriteModelAttribute</c> in GH-3907.
+///     </para>
+///     <para>
+///         Single-stream only: this is for the case where <c>[WriteModel]</c> pins the aggregate and
+///         every event goes to its stream. Appending to a variable number of <em>different</em>
+///         streams is a separate gap and is deliberately not addressed here.
+///     </para>
+/// </remarks>
+public class Events : List<object>, IWolverineReturnType
+{
+    public Events()
+    {
+    }
+
+    public Events(IEnumerable<object> collection) : base(collection)
+    {
+    }
+
+    public static Events operator +(Events events, object @event)
+    {
+        events.Add(@event);
+        return events;
+    }
+}

--- a/src/Wolverine/Persistence/EventSourcing/EventsToAppend.cs
+++ b/src/Wolverine/Persistence/EventSourcing/EventsToAppend.cs
@@ -27,11 +27,22 @@ namespace Wolverine.Persistence.EventSourcing;
 ///         <see cref="IWolverineReturnType" />, which the fallback explicitly excludes — a happy
 ///         accident of an unrelated marker rather than a designed guarantee, and one that does not
 ///         extend to a user's own collection type. Returning this type instead makes the intent
-///         declared, so <c>(Events, OutgoingMessages)</c> is unambiguous.
+///         declared, so <c>(EventsToAppend, OutgoingMessages)</c> is unambiguous.
 ///     </para>
 ///     <para>
 ///         The store-specific types stay exactly as they are for existing code, the same way
 ///         <c>WriteAggregateAttribute</c> was kept alongside <c>WriteModelAttribute</c> in GH-3907.
+///     </para>
+///     <para>
+///         <b>Why this is not just called <c>Events</c>,</b> which would have mirrored the three
+///         store-specific types: it cannot be. This type lives beside
+///         <see cref="WriteModelAttribute" />, and <c>[WriteModel]</c> is what makes a
+///         store-agnostic handler possible in the first place — so the handler that wants this type
+///         imports <c>Wolverine.Persistence.EventSourcing</c> by necessity, and a real application
+///         imports its store's <c>Wolverine.Marten</c> / <c>.Polecat</c> / <c>.Fisher</c> as well.
+///         Naming this <c>Events</c> made those two imports collide with CS0104 <em>on the handler's
+///         return type itself</em>, forcing a <c>using</c> alias onto precisely the code this exists
+///         to serve. The name says when the append happens, which the bare noun did not.
 ///     </para>
 ///     <para>
 ///         Single-stream only: this is for the case where <c>[WriteModel]</c> pins the aggregate and
@@ -39,17 +50,17 @@ namespace Wolverine.Persistence.EventSourcing;
 ///         streams is a separate gap and is deliberately not addressed here.
 ///     </para>
 /// </remarks>
-public class Events : List<object>, IWolverineReturnType
+public class EventsToAppend : List<object>, IWolverineReturnType
 {
-    public Events()
+    public EventsToAppend()
     {
     }
 
-    public Events(IEnumerable<object> collection) : base(collection)
+    public EventsToAppend(IEnumerable<object> collection) : base(collection)
     {
     }
 
-    public static Events operator +(Events events, object @event)
+    public static EventsToAppend operator +(EventsToAppend events, object @event)
     {
         events.Add(@event);
         return events;

--- a/src/Wolverine/Persistence/EventSourcing/IEventSourcingFrameProvider.cs
+++ b/src/Wolverine/Persistence/EventSourcing/IEventSourcingFrameProvider.cs
@@ -151,7 +151,7 @@ internal static class EventSourcingFrameProviderExtensions
         // IWolverineReturnType, which is exactly what the fallback excludes, so leaving it to be
         // picked up implicitly would skip it (GH-3941).
         var eventsVariable = firstCall.Creates.FirstOrDefault(x => x.VariableType == provider.EventsCollectionType) ??
-                             firstCall.Creates.FirstOrDefault(x => x.VariableType == typeof(Events)) ??
+                             firstCall.Creates.FirstOrDefault(x => x.VariableType == typeof(EventsToAppend)) ??
                              firstCall.Creates.FirstOrDefault(x =>
                                  x.VariableType.CanBeCastTo<IEnumerable<object>>() &&
                                  !x.VariableType.CanBeCastTo<IWolverineReturnType>());

--- a/src/Wolverine/Persistence/EventSourcing/IEventSourcingFrameProvider.cs
+++ b/src/Wolverine/Persistence/EventSourcing/IEventSourcingFrameProvider.cs
@@ -147,7 +147,11 @@ internal static class EventSourcingFrameProviderExtensions
             return;
         }
 
+        // The core Events has to be matched explicitly and ahead of the fallback: it is an
+        // IWolverineReturnType, which is exactly what the fallback excludes, so leaving it to be
+        // picked up implicitly would skip it (GH-3941).
         var eventsVariable = firstCall.Creates.FirstOrDefault(x => x.VariableType == provider.EventsCollectionType) ??
+                             firstCall.Creates.FirstOrDefault(x => x.VariableType == typeof(Events)) ??
                              firstCall.Creates.FirstOrDefault(x =>
                                  x.VariableType.CanBeCastTo<IEnumerable<object>>() &&
                                  !x.VariableType.CanBeCastTo<IWolverineReturnType>());


### PR DESCRIPTION
Closes #3941 in mechanism — but **please read the naming section first, because the type name is a genuine problem and I think it should change before this merges.**

---

## ⚠️ The `Events` name collides, and it collides on exactly the use case this feature exists for

The issue proposed naming the core type `Events`, mirroring the three store-specific ones. Implementing it, that turns out to be a source-breaking change for the primary intended usage.

The two namespaces a store-agnostic handler needs are:

- `Wolverine.Persistence.EventSourcing` — where `[WriteModel]` / `[ReadModel]` / `[DeciderFunction]` live, i.e. the GH-3907 vocabulary that makes store-agnostic handlers possible at all
- `Wolverine.Marten` (or `.Polecat` / `.Fisher`) — which any real Marten app already imports

Put the core `Events` in the first and a handler importing both cannot name `Events` unqualified:

```
error CS0104: 'Events' is an ambiguous reference between
  'Wolverine.Persistence.EventSourcing.Events' and 'Wolverine.Marten.Events'
```

**Demonstrated, not theorized.** The regression test in this PR carries an explicit `using Events = Wolverine.Persistence.EventSourcing.Events;` alias. Removing that alias fails the build with CS0104 on **the handler signature lines themselves** — lines 113 and 119, i.e. the return types. Both TFMs, 8 errors.

So the collision does not land on some incidental call site. It lands on the declaration the feature is for, in any app that already uses a store integration — which is every app.

### Options

1. **Rename the core type.** `EventsToAppend` and `StreamEvents` are both free across the whole repo (checked). `AppendEvents` is **not** — it is already `Wolverine.Persistence.EventSideEffects.AppendEvents : ISideEffectAware`, so it is out. My preference is `EventsToAppend`: it reads correctly in a signature — `public static (EventsToAppend, OutgoingMessages) Handle(...)` — is self-documenting about *when* the append happens, and carries zero collision risk.
2. **Keep `Events`** and document that users combining both namespaces need a `using` alias. Symmetric with the store types, but it taxes precisely the users the feature targets, and the error they hit first is a compile break in code that used to build.

I have left it as `Events` so the diff matches the issue as written and the decision is yours. **Say the word and I will rename** — it is a mechanical change to one file plus the two resolution sites plus the test.

---

## The mechanism

`Wolverine.Marten.Events`, `Wolverine.Polecat.Events` and `Wolverine.Fisher.Events` are identical and store-named, so a handler that wants to be store-agnostic could not name any of them. The store-agnostic path existed — a bare `IEnumerable<object>` return is picked up by the fallback — but that fallback is **positional**: `IEnumerable<T>` is covariant, so every reference-typed collection in a return tuple is a candidate and `FirstOrDefault` takes whichever lands first in `Creates`. Nothing fails at codegen and nothing fails at runtime; the wrong collection simply becomes the appended events.

`OutgoingMessages` escapes that only because it is an `IWolverineReturnType`, which the fallback excludes — an accident of an unrelated marker rather than a guarantee, and one that does not extend to a user's own collection type.

### The design detail

The core type **cannot** just be added and left to the fallback: being an `IWolverineReturnType` is exactly what the fallback excludes, so it would be silently skipped. It needs an explicit match ahead of the fallback, added in both places that resolve an events return:

- `IEventSourcingFrameProvider.DetermineEventCaptureHandling` (single-stream)
- `DcbModelAttribute` (DCB boundary)

### Two sites the issue named that need no change

Worth recording so nobody re-investigates:

- `RegisterEventsFrame.FindMethod` and `RegisterBoundaryEventsFrame.FindMethod` branch on `CanBeCastTo<IEnumerable<object>>()` to choose `AppendMany` over `AppendOne` — and `Events : List<object>` already satisfies that.
- `HandlerChain` already skips `IEnumerable<object>` variables when collecting publishable message types, so a returned `Events` is not also routed as a message.

The store-specific types stay exactly as they are, the same way `WriteAggregateAttribute` was kept alongside `WriteModelAttribute` in GH-3907.

Single-stream only. Appending to a variable number of *different* streams is a separate gap and is deliberately untouched.

## Tests

`core_events_return_3941`, 3 facts. The one that matters is `ambiguous_sibling_collection_does_not_become_the_events` — a handler returning `(Events, IReadOnlyList<string>)`. The other two would pass against the old fallback too.

**Proven both ways:** with the new resolution line removed, all 3 fail — `Events` falls through to a fallback that excludes it, and the audit strings are appended to the event stream instead. That is the silent corruption the issue describes, reproduced.

Green on net9.0 and net10.0. Also built `MartenTests`, `PolecatTests` and `FisherTests` — the heaviest importers of both namespaces — with 0 errors, though see the naming section for why that is weaker evidence than it looks: those files happen not to reference `Events` as a type.