### PR TITLE
GH-3975: add a declarative way to run work AFTER the transactional commit

### DIFF
--- a/docs/guide/handlers/middleware.md
+++ b/docs/guide/handlers/middleware.md
@@ -137,7 +137,66 @@ Here's the conventions:
 |----------------------------------------------------------|-----------------------------|
 | Before the Handler(s)                                    | `Before`, `BeforeAsync`, `Load`, `LoadAsync`, `Validate`, `ValidateAsync` |
 | After the Handler(s)                                     | `After`, `AfterAsync`, `PostProcess`, `PostProcessAsync` |
+| After the transactional commit                           | `AfterCommit`, `AfterCommitAsync` |
 | In `finally` blocks after the Handlers & "After" methods | `Finally`, `FinallyAsync`   |
+
+## "After" is before the commit {#after-vs-after-commit}
+
+::: warning
+`After` runs after the *handler*, not after the *transaction*. If your side effect must only happen once
+the write is durable, use `AfterCommit` instead.
+:::
+
+This trips people up because the name reads the other way around. When a chain is transactional, the commit
+itself is a postprocessor contributed by the persistence provider — Marten's `SaveChangesAsync`, EF Core's
+`SaveChangesAsync`, and so on. `After` methods are inserted at the *front* of the postprocessors, so they run
+**before** that commit:
+
+```
+handler()
+After()            // <-- the write is NOT durable yet, and the transaction may still fail
+SaveChangesAsync() // <-- the commit
+FlushOutgoingMessages()
+AfterCommit()      // <-- the write is durable
+```
+
+So an `After` method that records "the alert was raised" or writes back to a cache is recording something for
+a transaction that can still roll back. That is exactly the shape of bug this distinction exists to prevent.
+
+Use `AfterCommit` / `AfterCommitAsync`, or the `[WolverineAfterCommit]` attribute, when the side effect must
+follow a durable write:
+
+```csharp
+public static class RaiseAlertHandler
+{
+    public static void Handle(RaiseAlert command, IDocumentSession session)
+    {
+        session.Events.Append(command.Id, new AlertRaised(command.Reason));
+    }
+
+    // Only runs if the append above actually committed
+    public static void AfterCommit(AlertLatch latch, RaiseAlert command)
+    {
+        latch.MarkRaised(command.Id);
+    }
+}
+```
+
+These methods bind parameters exactly like `After` methods do, and they work on message handlers, sagas and
+HTTP endpoints alike.
+
+Two behaviours worth knowing:
+
+* **They do not run when the commit throws.** The frames are concatenated without a `try`/`finally`, so an
+  exception from the commit unwinds straight past them. If you need something to run either way, that is what
+  `Finally` is for.
+* **They run after the outbox flush as well as the commit.** A cascading message returned from an
+  `AfterCommit` method is therefore sent through the normal end-of-pipeline flush rather than the transaction
+  that just committed. If a message has to be atomic with the write, cascade it from the handler instead.
+
+`After`'s position is unchanged and will stay that way — plenty of post-handler work has nothing to do with
+durability, and moving it would silently change behaviour for existing applications.
+
 
 The generated code for the conventionally applied methods would look like this basic structure:
 

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -207,6 +207,9 @@ public partial class HttpChain
         }
 
         foreach (var frame in Postprocessors) yield return frame;
+
+        // GH-3975: after EVERY postprocessor, including the persistence provider's commit frame.
+        foreach (var frame in PostCommitPostprocessors) yield return frame;
     }
 
     private bool requiresFlush(Frame[] actionsOnOtherReturnValues)

--- a/src/Persistence/CosmosDbTests/after_commit_runs_after_the_commit.cs
+++ b/src/Persistence/CosmosDbTests/after_commit_runs_after_the_commit.cs
@@ -1,0 +1,124 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+using Microsoft.Azure.Cosmos;
+using Wolverine.CosmosDb;
+
+namespace CosmosDbTests;
+
+/// <summary>
+///     GH-3975. The per-provider half: an <c>AfterCommit</c> method must be emitted after CosmosDb's own
+///     outbox flush, not merely after the handler.
+/// </summary>
+/// <remarks>
+///     Note CosmosDb has NO commit postprocessor: CosmosDbPersistenceFrameProvider.ApplyTransactionSupport adds a
+///     TransactionalFrame to the MIDDLEWARE (the outbox enlistment) and only FlushOutgoingMessages to the
+///     postprocessors. So the meaningful assertion here is that the after-commit call lands after that flush --
+///     i.e. after everything the provider contributes to the tail of the chain -- rather than after a
+///     SaveChangesAsync that this provider never emits.
+/// </remarks>
+public class after_commit_runs_after_the_commit
+{
+    private static string generateCode()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    // Dummy emulator connection string -- CosmosClient is lazy, no connection is made
+                    // during codegen. Same approach as transactional_frame_code_generation.
+                    opts.Services.AddSingleton(_ => new CosmosClient(
+                        "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="));
+                    opts.UseCosmosDbPersistence("wolverine_after_commit_codegen");
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(CosmosAfterCommitHandler));
+                })
+                .Build();
+
+            // Force HandlerGraph.Compile() without starting the host -- no live server is needed to
+            // assert on frame ordering
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(typeof(CosmosAfterCommitMessage));
+            chain.ShouldNotBeNull();
+
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            return generatedAssembly.GenerateCode(serviceVariableSource);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public void the_after_commit_call_is_emitted_after_the_commit()
+    {
+        var code = generateCode();
+
+        // Searching the emitted CALL form, not the bare name: the handler type name itself contains
+        // "AfterCommit", so a bare search matches the type name first and silently compares the wrong
+        // positions.
+        var commit = code.IndexOf("FlushOutgoingMessagesAsync", StringComparison.Ordinal);
+        var afterCommit = code.IndexOf(".AfterCommit(", StringComparison.Ordinal);
+
+        commit.ShouldBeGreaterThan(-1,
+            "CosmosDb's outbox flush was never emitted, so this test proves nothing");
+        afterCommit.ShouldBeGreaterThan(-1, "the AfterCommit method was never emitted");
+
+        afterCommit.ShouldBeGreaterThan(commit,
+            "the AfterCommit call must be emitted AFTER CosmosDb's outbox flush, or it observes a write that is not durable yet");
+    }
+
+    [Fact]
+    public void an_after_method_still_runs_before_the_commit()
+    {
+        var code = generateCode();
+
+        var commit = code.IndexOf("FlushOutgoingMessagesAsync", StringComparison.Ordinal);
+        var after = code.IndexOf(".PostProcess(", StringComparison.Ordinal);
+
+        after.ShouldBeGreaterThan(-1);
+
+        // Compatibility guard. After's pre-commit position is long-standing and deliberately NOT changed
+        // by GH-3975 -- the new hook exists precisely because this position was the only one available.
+        after.ShouldBeLessThan(commit,
+            "After methods must keep running BEFORE the commit; changing that would be a silent behaviour break");
+    }
+}
+
+public record CosmosAfterCommitMessage(Guid Id);
+
+[WolverineIgnore]
+public static class CosmosAfterCommitHandler
+{
+    // Takes Container so CosmosDbPersistenceFrameProvider.CanApply returns true
+    public static void Handle(CosmosAfterCommitMessage message, Container container)
+    {
+        _ = container;
+    }
+
+    // "PostProcess" is one of the After convention names, and unlike "After" it is not a substring of
+    // "AfterCommit" -- which matters because these assertions are string index comparisons
+    public static void PostProcess()
+    {
+    }
+
+    public static void AfterCommit()
+    {
+    }
+}

--- a/src/Persistence/EfCoreTests/after_commit_runs_after_the_commit.cs
+++ b/src/Persistence/EfCoreTests/after_commit_runs_after_the_commit.cs
@@ -1,0 +1,140 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+using IntegrationTests;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.SqlServer;
+
+namespace EfCoreTests;
+
+/// <summary>
+///     GH-3975. The per-provider half: an <c>AfterCommit</c> method must be emitted after EF Core's own
+///     SaveChangesAsync, not merely after the handler.
+/// </summary>
+/// <remarks>
+///     Asserting on the generated SOURCE rather than list membership: the guarantee is about where the
+///     frame lands relative to the commit EFCorePersistenceFrameProvider contributes from a different code path.
+/// </remarks>
+public class after_commit_runs_after_the_commit
+{
+    private static string generateCode()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services.AddDbContextWithWolverineIntegration<AfterCommitDbContext>(o =>
+                    {
+                        o.UseSqlServer(Servers.SqlServerConnectionString);
+                    });
+
+                    opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "after_commit_codegen");
+                    opts.UseEntityFrameworkCoreTransactions();
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(EfCoreAfterCommitHandler));
+                })
+                .Build();
+
+            // Force HandlerGraph.Compile() without starting the host -- no live server is needed to
+            // assert on frame ordering
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(typeof(EfCoreAfterCommitMessage));
+            chain.ShouldNotBeNull();
+
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            return generatedAssembly.GenerateCode(serviceVariableSource);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public void the_after_commit_call_is_emitted_after_the_commit()
+    {
+        var code = generateCode();
+
+        // Searching the emitted CALL form, not the bare name: the handler type name itself contains
+        // "AfterCommit", so a bare search matches the type name first and silently compares the wrong
+        // positions.
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var afterCommit = code.IndexOf(".AfterCommit(", StringComparison.Ordinal);
+
+        commit.ShouldBeGreaterThan(-1,
+            "EF Core's SaveChangesAsync was never emitted, so this test proves nothing");
+        afterCommit.ShouldBeGreaterThan(-1, "the AfterCommit method was never emitted");
+
+        afterCommit.ShouldBeGreaterThan(commit,
+            "the AfterCommit call must be emitted AFTER EF Core's SaveChangesAsync, or it observes a write that is not durable yet");
+    }
+
+    [Fact]
+    public void an_after_method_still_runs_before_the_commit()
+    {
+        var code = generateCode();
+
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var after = code.IndexOf(".PostProcess(", StringComparison.Ordinal);
+
+        after.ShouldBeGreaterThan(-1);
+
+        // Compatibility guard. After's pre-commit position is long-standing and deliberately NOT changed
+        // by GH-3975 -- the new hook exists precisely because this position was the only one available.
+        after.ShouldBeLessThan(commit,
+            "After methods must keep running BEFORE the commit; changing that would be a silent behaviour break");
+    }
+}
+
+public record EfCoreAfterCommitMessage(Guid Id);
+
+[WolverineIgnore]
+public static class EfCoreAfterCommitHandler
+{
+    // Takes the DbContext so EFCorePersistenceFrameProvider.CanApply returns true and the commit
+    // frame is actually added
+    public static void Handle(EfCoreAfterCommitMessage message, AfterCommitDbContext db)
+    {
+        _ = db;
+    }
+
+    // "PostProcess" is one of the After convention names, and unlike "After" it is not a substring of
+    // "AfterCommit" -- which matters because these assertions are string index comparisons
+    public static void PostProcess()
+    {
+    }
+
+    public static void AfterCommit()
+    {
+    }
+}
+
+public class AfterCommitDbContext : DbContext
+{
+    public AfterCommitDbContext(DbContextOptions<AfterCommitDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<AfterCommitRow> Rows => Set<AfterCommitRow>();
+}
+
+public class AfterCommitRow
+{
+    public Guid Id { get; set; }
+}

--- a/src/Persistence/FisherTests/after_commit_runs_after_the_commit.cs
+++ b/src/Persistence/FisherTests/after_commit_runs_after_the_commit.cs
@@ -1,0 +1,128 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+using Fisher;
+using JasperFx.Resources;
+using Wolverine.Fisher;
+
+namespace FisherTests;
+
+/// <summary>
+///     GH-3975. The per-provider half: an <c>AfterCommit</c> method must be emitted after Fisher's own
+///     commit frame, not merely after the handler.
+/// </summary>
+/// <remarks>
+///     Asserting on the generated SOURCE rather than on list membership is the point. Membership only proves
+///     the frame went into <c>PostCommitPostprocessors</c>; the guarantee is about where it lands relative to a
+///     frame this provider contributes from a completely different code path
+///     (<c>FisherPersistenceFrameProvider.ApplyTransactionSupport</c>), and only the emitted code shows that.
+/// </remarks>
+public class after_commit_runs_after_the_commit
+{
+    private static string generateCodeFor(Type handlerType, Type messageType)
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+                    opts.Services.AddFisher(o =>
+                    {
+                        // Codegen only -- the file is never opened
+                        o.Connection($"Data Source={Path.Combine(Path.GetTempPath(), "wolverine_after_commit_codegen.db")}");
+                        o.AutoCreateSchemaObjects = AutoCreate.None;
+                    }).IntegrateWithWolverine();
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType);
+                })
+                .Build();
+
+            // Force HandlerGraph.Compile() without starting the host -- no live server is needed to
+            // assert on frame ordering
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(messageType);
+            chain.ShouldNotBeNull();
+
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            return generatedAssembly.GenerateCode(serviceVariableSource);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public void the_after_commit_call_is_emitted_after_the_commit()
+    {
+        var code = generateCodeFor(typeof(FisherAfterCommitHandler), typeof(FisherAfterCommitMessage));
+
+        // Searching the emitted CALL form, not the bare name: the handler type name itself contains
+        // "AfterCommit", so a bare search matches the type name first and silently compares the wrong
+        // positions.
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var afterCommit = code.IndexOf(".AfterCommit(", StringComparison.Ordinal);
+
+        commit.ShouldBeGreaterThan(-1,
+            "Fisher's commit frame was never emitted, so this test proves nothing");
+        afterCommit.ShouldBeGreaterThan(-1, "the AfterCommit method was never emitted");
+
+        afterCommit.ShouldBeGreaterThan(commit,
+            "the AfterCommit call must be emitted AFTER Fisher's commit frame, or it observes a write that is not durable yet");
+    }
+
+    [Fact]
+    public void an_after_method_still_runs_before_the_commit()
+    {
+        var code = generateCodeFor(typeof(FisherAfterCommitHandler), typeof(FisherAfterCommitMessage));
+
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var after = code.IndexOf(".PostProcess(", StringComparison.Ordinal);
+
+        after.ShouldBeGreaterThan(-1);
+
+        // Compatibility guard. After's pre-commit position is long-standing behaviour and is deliberately
+        // NOT changed by GH-3975 -- the new hook exists precisely because this position was the only one
+        // available.
+        after.ShouldBeLessThan(commit,
+            "After methods must keep running BEFORE the commit; changing that would be a silent behaviour break");
+    }
+}
+
+public record FisherAfterCommitMessage(Guid Id);
+
+[WolverineIgnore]
+public static class FisherAfterCommitHandler
+{
+    // Takes IDocumentSession so FisherPersistenceFrameProvider.CanApply returns true and the commit
+    // frame is actually added
+    public static void Handle(FisherAfterCommitMessage message, IDocumentSession session)
+    {
+        _ = session;
+    }
+
+    // "PostProcess" is one of the After convention names, and unlike "After" it is not a substring of
+    // "AfterCommit" -- which matters because these assertions are string index comparisons
+    public static void PostProcess()
+    {
+    }
+
+    public static void AfterCommit()
+    {
+    }
+}

--- a/src/Persistence/MartenTests/after_commit_runs_after_the_commit.cs
+++ b/src/Persistence/MartenTests/after_commit_runs_after_the_commit.cs
@@ -1,0 +1,159 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace MartenTests;
+
+/// <summary>
+///     GH-3975. The per-provider half: an <c>AfterCommit</c> method must be emitted after Marten's own commit
+///     frame, not merely after the handler.
+/// </summary>
+/// <remarks>
+///     Asserting on the generated SOURCE rather than on list membership is the point. Membership only proves
+///     the frame went into <c>PostCommitPostprocessors</c>; the guarantee being made is about where it lands
+///     relative to a frame this provider contributes from a completely different code path
+///     (<c>MartenPersistenceFrameProvider.ApplyTransactionSupport</c>), and only the emitted code shows that.
+/// </remarks>
+public class after_commit_runs_after_the_commit
+{
+    [Fact]
+    public void the_after_commit_call_is_emitted_after_save_changes()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "after_commit_codegen";
+                    }).IntegrateWithWolverine();
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType(typeof(MartenAfterCommitHandler));
+                })
+                .Build();
+
+            // Force HandlerGraph.Compile() without starting the host
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(typeof(MartenAfterCommitMessage));
+            chain.ShouldNotBeNull();
+
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            var code = generatedAssembly.GenerateCode(serviceVariableSource);
+
+            // Searching the emitted CALL form, not the bare name: the handler type is called
+            // MartenAfterCommitHandler, so a bare "AfterCommit" search matches the type name first and
+            // silently compares the wrong positions.
+            var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+            var afterCommit = code.IndexOf($".{nameof(MartenAfterCommitHandler.AfterCommit)}(", StringComparison.Ordinal);
+
+            commit.ShouldBeGreaterThan(-1, "Marten's commit frame was never emitted, so this test proves nothing");
+            afterCommit.ShouldBeGreaterThan(-1, "the AfterCommit method was never emitted");
+
+            afterCommit.ShouldBeGreaterThan(commit,
+                "the AfterCommit call must be emitted AFTER Marten's SaveChangesAsync, or it observes a write that is not durable yet");
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public void an_after_method_still_runs_before_the_commit()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services.AddMarten(m =>
+                    {
+                        m.DisableNpgsqlLogging = true;
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "after_commit_codegen";
+                    }).IntegrateWithWolverine();
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType(typeof(MartenAfterCommitHandler));
+                })
+                .Build();
+
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(typeof(MartenAfterCommitMessage))!;
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            var code = generatedAssembly.GenerateCode(serviceVariableSource);
+
+            var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+            var after = code.IndexOf($".{nameof(MartenAfterCommitHandler.PostProcess)}(", StringComparison.Ordinal);
+
+            after.ShouldBeGreaterThan(-1);
+
+            // Compatibility guard. After's pre-commit position is long-standing behaviour and is deliberately
+            // NOT changed by GH-3975 -- the new hook exists precisely because this position was the only one
+            // available.
+            after.ShouldBeLessThan(commit,
+                "After methods must keep running BEFORE the commit; changing that would be a silent behaviour break");
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+}
+
+public record MartenAfterCommitMessage(Guid Id);
+
+public class MartenAfterCommitDoc
+{
+    public Guid Id { get; set; }
+}
+
+[WolverineIgnore]
+public static class MartenAfterCommitHandler
+{
+    // Takes IDocumentSession so MartenPersistenceFrameProvider.CanApply returns true and the commit
+    // frame is actually added
+    public static void Handle(MartenAfterCommitMessage message, IDocumentSession session)
+    {
+        session.Store(new MartenAfterCommitDoc { Id = message.Id });
+    }
+
+    // "PostProcess" is one of the After convention names, and unlike "After" it is not a substring of
+    // "AfterCommit" -- which matters because these assertions are string index comparisons
+    public static void PostProcess()
+    {
+    }
+
+    public static void AfterCommit()
+    {
+    }
+}

--- a/src/Persistence/PolecatTests/after_commit_runs_after_the_commit.cs
+++ b/src/Persistence/PolecatTests/after_commit_runs_after_the_commit.cs
@@ -1,0 +1,126 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+using IntegrationTests;
+using Polecat;
+using Wolverine.Polecat;
+
+namespace PolecatTests;
+
+/// <summary>
+///     GH-3975. The per-provider half: an <c>AfterCommit</c> method must be emitted after Polecat's own
+///     commit frame, not merely after the handler.
+/// </summary>
+/// <remarks>
+///     Asserting on the generated SOURCE rather than on list membership is the point. Membership only proves
+///     the frame went into <c>PostCommitPostprocessors</c>; the guarantee is about where it lands relative to a
+///     frame this provider contributes from a completely different code path
+///     (<c>PolecatPersistenceFrameProvider.ApplyTransactionSupport</c>), and only the emitted code shows that.
+/// </remarks>
+public class after_commit_runs_after_the_commit
+{
+    private static string generateCodeFor(Type handlerType, Type messageType)
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "after_commit_codegen";
+                    }).IntegrateWithWolverine();
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType);
+                })
+                .Build();
+
+            // Force HandlerGraph.Compile() without starting the host -- no live server is needed to
+            // assert on frame ordering
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(messageType);
+            chain.ShouldNotBeNull();
+
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            return generatedAssembly.GenerateCode(serviceVariableSource);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public void the_after_commit_call_is_emitted_after_the_commit()
+    {
+        var code = generateCodeFor(typeof(PolecatAfterCommitHandler), typeof(PolecatAfterCommitMessage));
+
+        // Searching the emitted CALL form, not the bare name: the handler type name itself contains
+        // "AfterCommit", so a bare search matches the type name first and silently compares the wrong
+        // positions.
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var afterCommit = code.IndexOf(".AfterCommit(", StringComparison.Ordinal);
+
+        commit.ShouldBeGreaterThan(-1,
+            "Polecat's commit frame was never emitted, so this test proves nothing");
+        afterCommit.ShouldBeGreaterThan(-1, "the AfterCommit method was never emitted");
+
+        afterCommit.ShouldBeGreaterThan(commit,
+            "the AfterCommit call must be emitted AFTER Polecat's commit frame, or it observes a write that is not durable yet");
+    }
+
+    [Fact]
+    public void an_after_method_still_runs_before_the_commit()
+    {
+        var code = generateCodeFor(typeof(PolecatAfterCommitHandler), typeof(PolecatAfterCommitMessage));
+
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var after = code.IndexOf(".PostProcess(", StringComparison.Ordinal);
+
+        after.ShouldBeGreaterThan(-1);
+
+        // Compatibility guard. After's pre-commit position is long-standing behaviour and is deliberately
+        // NOT changed by GH-3975 -- the new hook exists precisely because this position was the only one
+        // available.
+        after.ShouldBeLessThan(commit,
+            "After methods must keep running BEFORE the commit; changing that would be a silent behaviour break");
+    }
+}
+
+public record PolecatAfterCommitMessage(Guid Id);
+
+[WolverineIgnore]
+public static class PolecatAfterCommitHandler
+{
+    // Takes IDocumentSession so PolecatPersistenceFrameProvider.CanApply returns true and the commit
+    // frame is actually added
+    public static void Handle(PolecatAfterCommitMessage message, IDocumentSession session)
+    {
+        _ = session;
+    }
+
+    // "PostProcess" is one of the After convention names, and unlike "After" it is not a substring of
+    // "AfterCommit" -- which matters because these assertions are string index comparisons
+    public static void PostProcess()
+    {
+    }
+
+    public static void AfterCommit()
+    {
+    }
+}

--- a/src/Persistence/RavenDbTests/after_commit_runs_after_the_commit.cs
+++ b/src/Persistence/RavenDbTests/after_commit_runs_after_the_commit.cs
@@ -1,0 +1,131 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.RavenDb;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace RavenDbTests;
+
+/// <summary>
+///     GH-3975. The per-provider half: an <c>AfterCommit</c> method must be emitted after RavenDb's own
+///     <c>SaveChangesAsync</c> commit frame, not merely after the handler.
+/// </summary>
+/// <remarks>
+///     No embedded server here on purpose. RavenDB's <c>DocumentStore.Initialize()</c> does not open a
+///     connection — the request executor is lazy — so a store pointed at a URL nothing is listening on is
+///     enough to compile the chain, and frame ordering is a pure codegen property. That keeps this assertion
+///     fast and independent of the <c>DatabaseFixture</c> the behavioural RavenDb tests need.
+/// </remarks>
+public class after_commit_runs_after_the_commit
+{
+    private static string generateCode()
+    {
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+
+        using var store = new DocumentStore
+        {
+            Urls = ["http://localhost:8080"],
+            Database = "wolverine_after_commit_codegen"
+        };
+        store.Initialize();
+
+        try
+        {
+            using var host = Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services.AddSingleton<IDocumentStore>(store);
+                    opts.UseRavenDbPersistence();
+                    opts.Durability.Mode = DurabilityMode.Solo;
+
+                    opts.Policies.AutoApplyTransactions();
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType(typeof(RavenAfterCommitHandler));
+                })
+                .Build();
+
+            // Force HandlerGraph.Compile() without starting the host
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var handlerGraph = host.Services.GetRequiredService<HandlerGraph>();
+            var serviceVariableSource = host.Services.GetService<IServiceVariableSource>();
+            var generatedAssembly = handlerGraph.StartAssembly(handlerGraph.Rules);
+
+            var chain = handlerGraph.ChainFor(typeof(RavenAfterCommitMessage));
+            chain.ShouldNotBeNull();
+
+            ((ICodeFile)chain).AssembleTypes(generatedAssembly);
+            return generatedAssembly.GenerateCode(serviceVariableSource);
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+
+    [Fact]
+    public void the_after_commit_call_is_emitted_after_the_commit()
+    {
+        var code = generateCode();
+
+        // Searching the emitted CALL form, not the bare name: the handler type name itself contains
+        // "AfterCommit", so a bare search matches the type name first and silently compares the wrong
+        // positions.
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var afterCommit = code.IndexOf(".AfterCommit(", StringComparison.Ordinal);
+
+        commit.ShouldBeGreaterThan(-1,
+            "RavenDb's SaveChangesAsync was never emitted, so this test proves nothing");
+        afterCommit.ShouldBeGreaterThan(-1, "the AfterCommit method was never emitted");
+
+        afterCommit.ShouldBeGreaterThan(commit,
+            "the AfterCommit call must be emitted AFTER RavenDb's SaveChangesAsync, or it observes a write that is not durable yet");
+    }
+
+    [Fact]
+    public void an_after_method_still_runs_before_the_commit()
+    {
+        var code = generateCode();
+
+        var commit = code.IndexOf(".SaveChangesAsync(", StringComparison.Ordinal);
+        var after = code.IndexOf(".PostProcess(", StringComparison.Ordinal);
+
+        after.ShouldBeGreaterThan(-1);
+
+        // Compatibility guard. After's pre-commit position is long-standing and deliberately NOT changed
+        // by GH-3975 -- the new hook exists precisely because this position was the only one available.
+        after.ShouldBeLessThan(commit,
+            "After methods must keep running BEFORE the commit; changing that would be a silent behaviour break");
+    }
+}
+
+public record RavenAfterCommitMessage(Guid Id);
+
+[WolverineIgnore]
+public static class RavenAfterCommitHandler
+{
+    // Takes IAsyncDocumentSession so RavenDbPersistenceFrameProvider.CanApply returns true and the
+    // commit frame is actually added
+    public static void Handle(RavenAfterCommitMessage message, IAsyncDocumentSession session)
+    {
+        _ = session;
+    }
+
+    // "PostProcess" is one of the After convention names, and unlike "After" it is not a substring of
+    // "AfterCommit" -- which matters because these assertions are string index comparisons
+    public static void PostProcess()
+    {
+    }
+
+    public static void AfterCommit()
+    {
+    }
+}

--- a/src/Testing/CoreTests/Acceptance/after_commit_middleware.cs
+++ b/src/Testing/CoreTests/Acceptance/after_commit_middleware.cs
@@ -1,0 +1,155 @@
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Attributes;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+///     GH-3975. <c>After</c> methods are inserted at the FRONT of the postprocessors, and the transactional
+///     commit is itself a postprocessor, so <c>After</c> runs <b>before</b> the write is durable. These pin the
+///     new <c>AfterCommit</c> convention and <c>[WolverineAfterCommit]</c> attribute, which append to a separate
+///     list concatenated after every postprocessor.
+/// </summary>
+/// <remarks>
+///     The ordering guarantee is deliberately structural rather than positional — see
+///     <see cref="Wolverine.Configuration.IChain.PostCommitPostprocessors" />. These tests assert the chain
+///     composition and the observed call order; the per-provider tests assert that the emitted call really does
+///     land after each persistence provider's own commit frame.
+/// </remarks>
+public class after_commit_middleware
+{
+    private static async Task<IHost> hostFor(Type handlerType)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType);
+            }).StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task after_commit_lands_in_its_own_list_not_in_postprocessors()
+    {
+        using var host = await hostFor(typeof(AfterCommitOrderHandler));
+        var chain = host.Services.GetRequiredService<HandlerGraph>()
+            .HandlerFor<AfterCommitOrderMessage>()!.As<MessageHandler>().Chain!;
+
+        chain.Postprocessors.OfType<MethodCall>()
+            .ShouldContain(x => x.Method.Name == nameof(AfterCommitOrderHandler.After));
+
+        // The load-bearing distinction: NOT in Postprocessors, where a persistence provider's commit frame
+        // could end up after it.
+        chain.Postprocessors.OfType<MethodCall>()
+            .ShouldNotContain(x => x.Method.Name == nameof(AfterCommitOrderHandler.AfterCommit));
+
+        chain.PostCommitPostprocessors.OfType<MethodCall>()
+            .ShouldContain(x => x.Method.Name == nameof(AfterCommitOrderHandler.AfterCommit));
+    }
+
+    [Fact]
+    public async Task the_conventional_method_name_and_the_attribute_both_work()
+    {
+        using var host = await hostFor(typeof(AfterCommitAttributeHandler));
+        var chain = host.Services.GetRequiredService<HandlerGraph>()
+            .HandlerFor<AfterCommitAttributeMessage>()!.As<MessageHandler>().Chain!;
+
+        chain.PostCommitPostprocessors.OfType<MethodCall>()
+            .Select(x => x.Method.Name)
+            .ShouldBe([nameof(AfterCommitAttributeHandler.RunMeLast)]);
+    }
+
+    [Fact]
+    public async Task runs_in_order_after_the_handler_and_after_the_after_method()
+    {
+        AfterCommitOrderHandler.Calls.Clear();
+
+        using var host = await hostFor(typeof(AfterCommitOrderHandler));
+        await host.InvokeMessageAndWaitAsync(new AfterCommitOrderMessage());
+
+        AfterCommitOrderHandler.Calls.ShouldBe(["Handle", "After", "AfterCommit"]);
+    }
+
+    /// <summary>
+    ///     The reason to want "after the commit" is almost always that the side effect must not happen for a
+    ///     write that did not land. Frames are concatenated without a try/finally, so a postprocessor that
+    ///     throws unwinds straight past the after-commit frames — this pins that so it stays true.
+    /// </summary>
+    /// <remarks>
+    ///     The handler's own throwing <c>After</c> method stands in for the persistence provider's commit
+    ///     frame here. Both are plain postprocessor frames sitting ahead of
+    ///     <see cref="Wolverine.Configuration.IChain.PostCommitPostprocessors" />, so they exercise the same
+    ///     unwinding path; the per-provider tests cover the real commit frame.
+    /// </remarks>
+    [Fact]
+    public async Task does_not_run_when_an_earlier_postprocessor_throws()
+    {
+        ThrowingCommitHandler.AfterCommitRan = false;
+
+        using var host = await hostFor(typeof(ThrowingCommitHandler));
+
+        try
+        {
+            await host.InvokeMessageAndWaitAsync(new ThrowingCommitMessage());
+        }
+        catch (Exception)
+        {
+            // expected -- the stand-in commit threw
+        }
+
+        ThrowingCommitHandler.AfterCommitRan.ShouldBeFalse(
+            "an after-commit method must not run when the commit threw");
+    }
+}
+
+public record AfterCommitOrderMessage;
+
+[WolverineIgnore]
+public static class AfterCommitOrderHandler
+{
+    public static readonly List<string> Calls = [];
+
+    public static void Handle(AfterCommitOrderMessage message) => Calls.Add("Handle");
+
+    public static void After() => Calls.Add("After");
+
+    public static void AfterCommit() => Calls.Add("AfterCommit");
+}
+
+public record AfterCommitAttributeMessage;
+
+[WolverineIgnore]
+public static class AfterCommitAttributeHandler
+{
+    public static void Handle(AfterCommitAttributeMessage message)
+    {
+    }
+
+    // Deliberately NOT named AfterCommit -- proves the attribute alone is enough
+    [WolverineAfterCommit]
+    public static void RunMeLast()
+    {
+    }
+}
+
+public record ThrowingCommitMessage;
+
+[WolverineIgnore]
+public static class ThrowingCommitHandler
+{
+    public static bool AfterCommitRan;
+
+    public static void Handle(ThrowingCommitMessage message)
+    {
+    }
+
+    // Stands in for a persistence provider's commit frame -- a postprocessor ahead of the after-commit list
+    public static void After() => throw new InvalidOperationException("the commit failed");
+
+    public static void AfterCommit() => AfterCommitRan = true;
+}

--- a/src/Wolverine/Attributes/HandlerMethodAttributes.cs
+++ b/src/Wolverine/Attributes/HandlerMethodAttributes.cs
@@ -70,6 +70,48 @@ public class WolverineAfterAttribute : ScopedMiddlewareAttribute
 }
 
 /// <summary>
+///     Marks a method on middleware types or handler types as a method that should be called
+///     <b>after the transactional commit</b>, rather than merely after the handler.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="WolverineAfterAttribute" /> and the <c>After()</c> convention run after the handler but
+///         <b>before</b> the commit: the commit is itself a postprocessor contributed by the persistence
+///         provider, and <c>After</c> methods are inserted at the FRONT of the postprocessor list. That is a
+///         reasonable default for "after the handler", but it means an <c>After</c> method observing a write
+///         is observing one that is not durable yet and may still fail.
+///     </para>
+///     <para>
+///         A method marked with this attribute — or conventionally named <c>AfterCommit</c> /
+///         <c>AfterCommitAsync</c> — is appended to <see cref="IChain.PostCommitPostprocessors" />, which is
+///         concatenated after every postprocessor at frame assembly time. The position is therefore structural
+///         and does not depend on the order policies happened to run in.
+///     </para>
+///     <para>
+///         These methods do NOT run when the commit throws: the frames are concatenated without a
+///         try/finally, so the exception unwinds straight past them. That is deliberate — the reason to want
+///         "after the commit" is almost always that the side effect must not happen for a write that did not
+///         land.
+///     </para>
+///     <para>
+///         Note this runs after the outbox flush as well as the commit, so cascading messages returned from an
+///         after-commit method are sent through the normal end-of-pipeline flush rather than the just-committed
+///         transaction's outbox. If a message must be atomic with the write, cascade it from the handler.
+///     </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+public class WolverineAfterCommitAttribute : ScopedMiddlewareAttribute
+{
+    public WolverineAfterCommitAttribute(MiddlewareScoping scoping) : base(scoping)
+    {
+    }
+
+    public WolverineAfterCommitAttribute()
+    {
+    }
+}
+
+/// <summary>
 ///     Marks a method on middleware types or handler types as a method
 ///     that should be called after the actual handler in the finally block of
 ///     a try/finally block around the message handlers

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -38,6 +38,13 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
 
     public List<Frame> Postprocessors { get; } = [];
 
+    /// <summary>
+    ///     GH-3975. Runs after everything in <see cref="Postprocessors" />, including the transactional commit.
+    ///     See <see cref="IChain.PostCommitPostprocessors" /> for why this is a separate list rather than a
+    ///     position.
+    /// </summary>
+    public List<Frame> PostCommitPostprocessors { get; } = [];
+
     [IgnoreDescription]
     public Dictionary<string, object> Tags { get; } = new();
 
@@ -359,6 +366,20 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
                     var frame = new MethodCall(handlerType, afters[i]);
                     Postprocessors.Insert(i, frame);
                 }
+            }
+
+            // GH-3975: AfterCommit methods are APPENDED to a separate list rather than inserted into
+            // Postprocessors. The commit frame is itself a postprocessor contributed by the persistence
+            // provider, so the Insert() above deliberately puts After methods BEFORE the commit; there was
+            // previously no supported way to ask for the other side of it.
+            var afterCommits = MiddlewarePolicy.FilterMethods<WolverineAfterCommitAttribute>(this,
+                handlerType.GetMethods(), MiddlewarePolicy.AfterCommitMethodNames);
+
+            foreach (var afterCommit in afterCommits)
+            {
+                var frame = new MethodCall(handlerType, afterCommit);
+                ApplyParameterMatching(frame);
+                PostCommitPostprocessors.Add(frame);
             }
 
             // Discover OnException methods from handler types

--- a/src/Wolverine/Configuration/IChain.cs
+++ b/src/Wolverine/Configuration/IChain.cs
@@ -117,6 +117,27 @@ public interface IChain
     List<Frame> Postprocessors { get; }
 
     /// <summary>
+    ///     GH-3975. Frames that run after everything in <see cref="Postprocessors" /> — which is to say
+    ///     after the transactional commit, because the commit is itself a postprocessor added by the
+    ///     persistence provider's <c>ApplyTransactionSupport</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is a SEPARATE list rather than a position within <see cref="Postprocessors" /> on purpose.
+    ///         "After the commit" cannot be expressed positionally without depending on the order the policies
+    ///         happened to run in — the commit frame may not exist yet when a middleware policy appends, and an
+    ///         application that gets the position right today gets it wrong the moment policy ordering changes,
+    ///         silently and with every test still green. Concatenating a distinct list at frame-assembly time
+    ///         makes the guarantee structural instead.
+    ///     </para>
+    ///     <para>
+    ///         Frames here are NOT wrapped in a try/finally, so a commit that throws unwinds past them and they
+    ///         do not run — which is the entire point of asking for "after the commit".
+    ///     </para>
+    /// </remarks>
+    List<Frame> PostCommitPostprocessors { get; }
+
+    /// <summary>
     ///     A description of this frame
     /// </summary>
     string Description { get; }

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -17,6 +17,11 @@ public class MiddlewarePolicy : IChainPolicy
 {
     public static readonly string[] BeforeMethodNames = ["Before", "BeforeAsync", "Load", "LoadAsync", "Validate", "ValidateAsync"];
     public static readonly string[] AfterMethodNames = ["After", "AfterAsync", "PostProcess", "PostProcessAsync"];
+    /// <summary>
+    ///     GH-3975. Runs AFTER the transactional commit, unlike <see cref="AfterMethodNames" />, which is
+    ///     inserted at the front of the postprocessors and therefore runs BEFORE it.
+    /// </summary>
+    public static readonly string[] AfterCommitMethodNames = ["AfterCommit", "AfterCommitAsync"];
     public static readonly string[] FinallyMethodNames = ["Finally", "FinallyAsync"];
     public static readonly string[] OnExceptionMethodNames = ["OnException", "OnExceptionAsync"];
 
@@ -97,6 +102,11 @@ public class MiddlewarePolicy : IChainPolicy
             //chain.Postprocessors.AddRange(afters);
         }
 
+        // GH-3975: APPENDED, not inserted. These have to land after the persistence provider's commit
+        // frame, and Insert(0) is precisely what puts the After methods above on the wrong side of it.
+        var afterCommits = applications.SelectMany(x => x.BuildAfterCommitCalls(chain, rules)).ToArray();
+        chain.PostCommitPostprocessors.AddRange(afterCommits);
+
         // Build exception handlers from all applications
         ApplyExceptionHandling(applications, rules, chain);
     }
@@ -167,6 +177,7 @@ public class MiddlewarePolicy : IChainPolicy
     {
         private readonly IChain? _chain;
         private readonly MethodInfo[] _afters;
+        private readonly MethodInfo[] _afterCommits;
         private readonly MethodInfo[] _befores;
         private readonly ConstructorInfo? _constructor;
         private readonly MethodInfo[] _finals;
@@ -210,11 +221,13 @@ public class MiddlewarePolicy : IChainPolicy
 
             _befores = FilterMethods<WolverineBeforeAttribute>(chain, methods, BeforeMethodNames).ToArray();
             _afters = FilterMethods<WolverineAfterAttribute>(chain, methods, AfterMethodNames).ToArray();
+            _afterCommits = FilterMethods<WolverineAfterCommitAttribute>(chain, methods, AfterCommitMethodNames).ToArray();
             _finals = FilterMethods<WolverineFinallyAttribute>(chain, methods, FinallyMethodNames).ToArray();
             _onExceptions = FilterMethods<WolverineOnExceptionAttribute>(chain, methods, OnExceptionMethodNames).ToArray();
 
             if (_befores.Length == 0 &&
                 _afters.Length == 0 &&
+                _afterCommits.Length == 0 &&
                 _finals.Length == 0 &&
                 _onExceptions.Length == 0)
             {
@@ -351,6 +364,51 @@ public class MiddlewarePolicy : IChainPolicy
             }
 
             foreach (var after in afters) yield return after;
+        }
+
+        /// <summary>
+        ///     GH-3975. Mirrors <see cref="BuildAfterCalls" />, but the frames are appended to
+        ///     <see cref="IChain.PostCommitPostprocessors" /> so they run after the transactional commit.
+        /// </summary>
+        public IEnumerable<Frame> BuildAfterCommitCalls(IChain chain, GenerationRules rules)
+        {
+            var afterCommits = buildAfterCommits(chain).ToArray();
+
+            if (afterCommits.Length != 0 && !MiddlewareType.IsStatic())
+            {
+                if (chain.Middleware.OfType<ConstructorFrame>().All(x => x.Variable.VariableType != MiddlewareType))
+                {
+                    yield return new ConstructorFrame(MiddlewareType, _constructor!);
+                }
+            }
+
+            foreach (var afterCommit in afterCommits) yield return afterCommit;
+        }
+
+        private IEnumerable<Frame> buildAfterCommits(IChain chain)
+        {
+            if (!Filter(chain))
+            {
+                yield break;
+            }
+
+            foreach (var afterCommit in _afterCommits)
+            {
+                if (MatchByMessageType)
+                {
+                    var messageType = afterCommit.MessageType();
+                    if (messageType != null && chain.InputType().CanBeCastTo(messageType))
+                    {
+                        yield return new MethodCallAgainstMessage(MiddlewareType, afterCommit, chain.InputType()!);
+                    }
+                }
+                else
+                {
+                    var call = new MethodCall(MiddlewareType, afterCommit);
+                    chain.ApplyParameterMatching(call);
+                    yield return call;
+                }
+            }
         }
 
         public IEnumerable<(Type ExceptionType, MethodCall Call)> BuildOnExceptionCalls(IChain chain, GenerationRules rules)

--- a/src/Wolverine/Persistence/Sagas/SagaChain.cs
+++ b/src/Wolverine/Persistence/Sagas/SagaChain.cs
@@ -282,7 +282,9 @@ public class SagaChain : HandlerChain
 
         // .Concat(handlerReturnValueFrames)
 
-        return Middleware.Concat(container.TryCreateConstructorFrames(Handlers)).Concat(list).Concat(Postprocessors).ToList();
+        return Middleware.Concat(container.TryCreateConstructorFrames(Handlers)).Concat(list).Concat(Postprocessors)
+            .Concat(PostCommitPostprocessors) // GH-3975
+            .ToList();
     }
 
     private void generateCodeForMaybeExisting(IServiceContainer container, IPersistenceFrameProvider frameProvider,

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -714,6 +714,9 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
             .Concat(handlerReturnValueFrames)
             .Concat(causation)
             .Concat(Postprocessors)
+            // GH-3975: after EVERY postprocessor, which is what makes "after the commit" structural rather
+            // than a position that policy ordering can silently move.
+            .Concat(PostCommitPostprocessors)
             .Append(scopeActivator)
             .ToList();
     }


### PR DESCRIPTION
Closes #3975.

`After` reads like a post-handler hook that runs at the end. It does not run after the commit. The commit is itself a postprocessor — each provider's `ApplyTransactionSupport` appends one — and `After` methods are *inserted at the front* of that list, so they run **before** the write is durable. There was no supported way to express the other side of it, even though Wolverine uses that position itself for `FlushOutgoingMessages`.

## What's added

`AfterCommit` / `AfterCommitAsync` as a conventional method name, and `[WolverineAfterCommit]` for methods named something else. Same parameter binding `After` already has; works on message handlers, sagas and HTTP endpoints.

```csharp
public static class RaiseAlertHandler
{
    public static void Handle(RaiseAlert command, IDocumentSession session)
        => session.Events.Append(command.Id, new AlertRaised(command.Reason));

    // Only runs if the append above actually committed
    public static void AfterCommit(AlertLatch latch, RaiseAlert command)
        => latch.MarkRaised(command.Id);
}
```

## The position is structural, not positional

This is the part that matters. Frames go into a new `IChain.PostCommitPostprocessors` list that is concatenated after every postprocessor at frame-assembly time — **not** appended to `Postprocessors` from a policy sequenced after the persistence policy.

That's the issue's actual complaint: an application that gets the position right by luck of policy ordering gets it wrong the moment that ordering changes, silently, with every test still green. A separate list can't drift that way.

`After`'s pre-commit position is deliberately unchanged, and there's a compatibility guard per provider asserting it stays there. Plenty of post-handler work has nothing to do with durability.

## Verified per provider, not once

Each of **Marten, Polecat, Fisher, EF Core, RavenDb and CosmosDb** gets a codegen test asserting the emitted `AfterCommit` call really does land after *that provider's* commit frame, plus the guard that `After` still lands before it. List membership alone would only prove the frame went into the right list; the guarantee is about where it ends up relative to a frame contributed from a completely different code path, and only the emitted source shows that.

These are pure codegen assertions, so **none needs a live server** — including RavenDb, whose `DocumentStore.Initialize()` doesn't open a connection.

One provider difference worth flagging: **CosmosDb has no commit postprocessor at all.** Its `ApplyTransactionSupport` puts a `TransactionalFrame` in the *middleware* (the outbox enlistment) and only `FlushOutgoingMessages` in the postprocessors. Its test asserts against the flush rather than a `SaveChangesAsync` it never emits.

## Core behaviour pinned

- the frame lands in `PostCommitPostprocessors` and **not** in `Postprocessors`
- the attribute works without the conventional name
- observed call order is `Handle → After → AfterCommit`
- an after-commit method does **not** run when an earlier postprocessor throws — frames are concatenated without a `try`/`finally`, so the exception unwinds past them. The issue asked for this to be pinned so it stays true.

## Docs

The issue's nice-to-have was that the `After` name "points the wrong way for anyone thinking about durability." `docs/guide/handlers/middleware.md` now shows the emitted order explicitly, with the two caveats: these don't run when the commit throws, and they run after the outbox flush, so a cascade from one isn't atomic with the write.

## Verification

- `CoreTests` middleware area: 33/33; new `after_commit_middleware` 4/4
- Marten / Polecat / Fisher / EF Core / RavenDb / CosmosDb: 2/2 each
- Full `wolverine.slnx` builds clean pinned to `net9.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC