### PR TITLE
GH-3973: say out loud when a batch cannot be sequenced against its unbatched siblings

### DIFF
--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -417,6 +417,23 @@ the batched and unbatched handlers for a group id to be sequenced against each o
 [GH-3867](https://github.com/JasperFx/wolverine/issues/3867).
 :::
 
+### Wolverine tells you when it could not sequence them <Badge type="tip" text="6.29" />
+
+When a batched element type also has unbatched handlers and Wolverine could **not** point the batch at a shared
+partitioned topology, it logs a warning at startup naming the message type, the queue the batch landed on, and the fix.
+Two independent writers to one entity is otherwise invisible until it isn't — it surfaces as intermittent concurrency
+or stream-version collisions under load, and only in the deployments that lack a partitioned topology.
+
+That asymmetry is the real hazard: a defect can be unreachable in the configuration your tests use and reachable in the
+one that ships. To make it a startup failure instead of a load-dependent one:
+
+```csharp
+opts.AssertBatchExecutionIsSequenced();
+```
+
+Note that `Sequential()` on the batch queue does **not** close this. It serializes the batch against itself, and
+against nothing else. See [GH-3973](https://github.com/JasperFx/wolverine/issues/3973).
+
 ## Batch identity with `IBatchContext`
 
 A batched handler can inject `IBatchContext` to get read-only information about the batch it is processing —

--- a/src/Testing/CoreTests/Acceptance/unsequenced_batch_execution_validation.cs
+++ b/src/Testing/CoreTests/Acceptance/unsequenced_batch_execution_validation.cs
@@ -1,0 +1,241 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+///     GH-3973, following up GH-3867. A batched element type that also has unbatched handlers has two
+///     independent execution paths writing the same entity unless a partitioned topology sequences them.
+///     Without one, the failure is intermittent concurrency collisions under load — the silent version is
+///     the bug, so startup says it out loud.
+/// </summary>
+public class unsequenced_batch_execution_validation
+{
+    [Fact]
+    public async Task throws_when_the_batch_cannot_be_sequenced_against_its_unbatched_siblings()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Discovery.DisableConventionalDiscovery()
+                        .IncludeType(typeof(UnsequencedProbeHandler))
+                        .IncludeType(typeof(UnsequencedProbeBatchHandler));
+
+                    // Both handlers legitimately run under Separated -- which is exactly when there are
+                    // two writers
+                    opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+                    opts.BatchMessagesOf<UnsequencedProbe>();
+
+                    opts.AssertBatchExecutionIsSequenced();
+                }).StartAsync(TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain("Unsequenced batch execution");
+        ex.Message.ShouldContain(nameof(UnsequencedProbe));
+
+        // The message has to name the fix, not just the problem
+        ex.Message.ShouldContain("GlobalPartitioned");
+
+        // And it has to head off the obvious wrong fix
+        ex.Message.ShouldContain("Sequential() on the batch queue does NOT close this");
+    }
+
+    /// <summary>
+    ///     A partitioned topology is what GH-3867 uses to point the batch at the same slots as its
+    ///     unbatched siblings, so every writer for one group id really is a single writer.
+    /// </summary>
+    [Fact]
+    public async Task does_not_complain_when_a_partitioned_topology_sequences_them()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(PartitionedProbeHandler))
+                    .IncludeType(typeof(PartitionedProbeBatchHandler));
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+
+                // Same harness GH-3867's own resolution test uses -- this is what gives the batch
+                // execution slots to share with its unbatched siblings
+                opts.MessagePartitioning.PublishToPartitionedLocalMessaging("gh3973", 4,
+                    topology => { topology.MessagesImplementing<IPartitionedProbeMessage>(); });
+
+                opts.BatchMessagesOf<PartitionedProbe>();
+
+                // Would throw if the batch were left unsequenced
+                opts.AssertBatchExecutionIsSequenced();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        host.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    ///     No unbatched sibling means no second writer, so there is nothing to warn about.
+    /// </summary>
+    [Fact]
+    public async Task silent_when_the_element_type_has_no_unbatched_handler()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(BatchOnlyProbeBatchHandler));
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+                opts.BatchMessagesOf<BatchOnlyProbe>();
+
+                opts.AssertBatchExecutionIsSequenced();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        host.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    ///     Under the default Classic behaviour the direct handler wins and the batch handler never runs at
+    ///     all, so there is only ever one writer. That shape is already reported by
+    ///     <c>warnOrAssertBatchHandlerConflicts</c> and must not be double-reported here.
+    /// </summary>
+    [Fact]
+    public async Task silent_under_classic_behavior_where_the_batch_never_runs()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(ClassicProbeHandler))
+                    .IncludeType(typeof(ClassicProbeBatchHandler));
+
+                // The default, stated explicitly for the sake of the test
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.ClassicCombineIntoOneLogicalHandler;
+                opts.BatchMessagesOf<ClassicProbe>();
+
+                opts.AssertBatchExecutionIsSequenced();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        host.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task warns_rather_than_throwing_by_default()
+    {
+        var logger = new RecordingLoggerProvider();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(x => x.AddProvider(logger))
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(UnsequencedProbeHandler))
+                    .IncludeType(typeof(UnsequencedProbeBatchHandler));
+
+                opts.MultipleHandlerBehavior = MultipleHandlerBehavior.Separated;
+                opts.BatchMessagesOf<UnsequencedProbe>();
+
+                // Deliberately NOT calling AssertBatchExecutionIsSequenced()
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        logger.Warnings.ShouldContain(x => x.Contains("Unsequenced batch execution"));
+    }
+}
+
+public record UnsequencedProbe(string GroupId);
+
+[WolverineIgnore]
+public static class UnsequencedProbeHandler
+{
+    public static void Handle(UnsequencedProbe message)
+    {
+    }
+}
+
+[WolverineIgnore]
+public static class UnsequencedProbeBatchHandler
+{
+    public static void Handle(UnsequencedProbe[] batch)
+    {
+    }
+}
+
+public interface IPartitionedProbeMessage;
+
+public record PartitionedProbe(string GroupId) : IPartitionedProbeMessage;
+
+[WolverineIgnore]
+public static class PartitionedProbeHandler
+{
+    public static void Handle(PartitionedProbe message)
+    {
+    }
+}
+
+[WolverineIgnore]
+public static class PartitionedProbeBatchHandler
+{
+    public static void Handle(PartitionedProbe[] batch)
+    {
+    }
+}
+
+public record BatchOnlyProbe(string GroupId);
+
+[WolverineIgnore]
+public static class BatchOnlyProbeBatchHandler
+{
+    public static void Handle(BatchOnlyProbe[] batch)
+    {
+    }
+}
+
+public record ClassicProbe(string GroupId);
+
+[WolverineIgnore]
+public static class ClassicProbeHandler
+{
+    public static void Handle(ClassicProbe message)
+    {
+    }
+}
+
+[WolverineIgnore]
+public static class ClassicProbeBatchHandler
+{
+    public static void Handle(ClassicProbe[] batch)
+    {
+    }
+}
+
+public class RecordingLoggerProvider : ILoggerProvider
+{
+    public List<string> Warnings { get; } = [];
+
+    public ILogger CreateLogger(string categoryName) => new RecordingLogger(Warnings);
+
+    public void Dispose()
+    {
+    }
+
+    private class RecordingLogger(List<string> warnings) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel < LogLevel.Warning) return;
+
+            lock (warnings)
+            {
+                warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -135,6 +135,12 @@ public partial class WolverineRuntime
             // block.
             resolveBatchExecutionTopologies();
 
+            // GH-3973. Follow-up to GH-3867: say out loud when the batch could NOT be sequenced
+            // against its unbatched siblings, because that leaves two concurrent writers and the
+            // silent version of that is the bug. Must run AFTER resolveBatchExecutionTopologies,
+            // which is what decides whether a topology was found.
+            warnOrAssertUnsequencedBatchExecution();
+
             // Pre-populate the message-type-name cache so the per-message ToMessageTypeName()
             // hot path inside Envelope construction never pays the first-occurrence reflection
             // cost (attribute reads, interface walks, generic-type pretty-printing).
@@ -743,6 +749,79 @@ public partial class WolverineRuntime
                 $"otherwise remove one of the two handlers. (Call opts.AssertNoBatchHandlerConflicts() to make Wolverine throw on this instead of warning.)";
 
             if (Options.AssertsNoBatchHandlerConflicts)
+            {
+                throw new InvalidOperationException(message);
+            }
+
+            Logger.LogWarning(message);
+        }
+    }
+
+    /// <summary>
+    /// GH-3973. A batched element type that ALSO has unbatched handlers has two independent execution
+    /// paths writing the same entity: the assembled batch on its own local queue, and the unbatched
+    /// siblings on the listener receiver's own execution block. A partitioned topology resolves that —
+    /// <see cref="resolveBatchExecutionTopologies" /> points the batch at the same slots, so every writer
+    /// for one group id is genuinely a single writer. Without one, nothing sequences them.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>Sequential()</c> on the batch queue does not close this: it serializes the batch against
+    ///         itself and against nothing else.
+    ///     </para>
+    ///     <para>
+    ///         The asymmetry is what makes this worth a startup message rather than documentation. With a
+    ///         <c>GlobalPartitioned</c> topology the configuration is safe; without one — embedded hosts,
+    ///         single-node deployments, most test fixtures — the same code has two concurrent writers to one
+    ///         event stream, and it surfaces as intermittent stream-version collisions under load. A defect
+    ///         is therefore unreachable in the configuration the tests use and reachable in the one that
+    ///         ships.
+    ///     </para>
+    /// </remarks>
+    private void warnOrAssertUnsequencedBatchExecution()
+    {
+        if (Options.BatchDefinitions.Count == 0)
+        {
+            return;
+        }
+
+        // Under Classic the direct handler wins and the batch never runs at all, so there is only ever
+        // one writer. warnOrAssertBatchHandlerConflicts() covers that shape.
+        if (Options.MultipleHandlerBehavior != MultipleHandlerBehavior.Separated)
+        {
+            return;
+        }
+
+        foreach (var batch in Options.BatchDefinitions)
+        {
+            // Sequenced onto a shared partitioned topology by GH-3867 -- single writer per group id.
+            if (batch.ExecutionSlots is { Count: > 0 })
+            {
+                continue;
+            }
+
+            // No unbatched sibling means no second writer.
+            var directChain = Handlers.ChainFor(batch.ElementType);
+            if (directChain == null)
+            {
+                continue;
+            }
+
+            var elementType = batch.ElementType.NameInCode();
+            var directHandlers = directChain.Handlers
+                .Select(x => $"{x.HandlerType.NameInCode()}.{x.Method.Name}()").Join(", ");
+
+            var message =
+                $"Unsequenced batch execution for message type '{batch.ElementType.FullNameInCode()}': it has BOTH unbatched handlers ({directHandlers}) " +
+                $"and a BatchMessagesOf<{elementType}>() batch handler ({elementType}[]), and Wolverine could not sequence them against each other. " +
+                $"The assembled batch executes on local queue '{batch.LocalExecutionQueueName}' while the unbatched handlers execute on the listener's own " +
+                $"execution block, so both may write the same entity concurrently -- which typically surfaces as intermittent concurrency or stream-version " +
+                $"collisions under load rather than as an obvious failure. " +
+                $"To sequence them, put '{elementType}' into a GlobalPartitioned message topology, which lets Wolverine choose the batch's execution slot from " +
+                $"the batch's group id. Note Sequential() on the batch queue does NOT close this: it serializes the batch against itself only. " +
+                $"(Call opts.AssertBatchExecutionIsSequenced() to make Wolverine throw on this instead of warning.)";
+
+            if (Options.AssertsBatchExecutionIsSequenced)
             {
                 throw new InvalidOperationException(message);
             }

--- a/src/Wolverine/WolverineOptions.Batching.cs
+++ b/src/Wolverine/WolverineOptions.Batching.cs
@@ -23,6 +23,26 @@ public sealed partial class WolverineOptions
         AssertsNoBatchHandlerConflicts = true;
     }
 
+    internal bool AssertsBatchExecutionIsSequenced { get; private set; }
+
+    /// <summary>
+    /// GH-3973. Make Wolverine throw at startup (instead of only logging a warning) when a batched message
+    /// type also has unbatched handlers that Wolverine could not sequence the batch against — that is, when
+    /// the element type is not part of a <c>GlobalPartitioned</c> topology.
+    /// </summary>
+    /// <remarks>
+    /// In that configuration the assembled batch runs on its own local queue while the unbatched handlers
+    /// run on the listener's own execution block, so both can write the same entity concurrently. It
+    /// surfaces as intermittent concurrency or stream-version collisions under load rather than as an
+    /// obvious failure, and it is reachable in production while being unreachable in a test fixture that
+    /// happens to configure a partitioned topology (or vice versa). Turn this on to make the asymmetry a
+    /// startup failure rather than a load-dependent one.
+    /// </remarks>
+    public void AssertBatchExecutionIsSequenced()
+    {
+        AssertsBatchExecutionIsSequenced = true;
+    }
+
     /// <summary>
     /// Configure batch processing of an incoming (or local) message type. Note that Wolverine
     /// will require you to use the Array of that element type for the actual batch handler


### PR DESCRIPTION
Closes #3973. Follow-up to #3867, taking **the second of the two acceptance paths the issue offers**.

## The gap

On a host with `BatchMessagesOf<T>` and **no** partitioned topology there are two independent execution paths writing the same entity:

- the assembled batch, on its own local queue
- the unbatched sibling handlers, inside the listener receiver's own execution block

#3867 already resolves this *when a topology exists* — `resolveBatchExecutionTopologies` points the batch at the same slots, so every writer for one group id really is a single writer. Without one, `findPartitionedExecutionSlots` returns `null` and nothing sequences them. Its own closing comment says so:

> A sharded topology over an EXTERNAL transport has no local queue to enqueue a batch onto — its unbatched handlers execute inside the listener's own sharded block. Nothing to target.

`Sequential()` on the batch queue does not close it: that serializes the batch against *itself*, and against nothing else.

## Why a startup message and not documentation

The asymmetry is the hazard. With a `GlobalPartitioned` topology the configuration is safe; without one — embedded hosts, single-node deployments, most test fixtures — the same code has two concurrent writers to one event stream, surfacing as intermittent stream-version collisions under load. A defect is therefore unreachable in the configuration the tests use and reachable in the one that ships, or the reverse.

The docs already described this limitation in prose, which is exactly the state the issue is complaining about ("currently documents it in prose rather than enforcing it"). Startup now says it:

```
Unsequenced batch execution for message type 'Telemetry.ServiceUpdates': it has BOTH unbatched
handlers (ServiceUpdatesHandler.Handle()) and a BatchMessagesOf<ServiceUpdates>() batch handler
(ServiceUpdates[]), and Wolverine could not sequence them against each other. The assembled batch
executes on local queue 'telemetry.serviceupdates-batch' while the unbatched handlers execute on the
listener's own execution block, so both may write the same entity concurrently -- which typically
surfaces as intermittent concurrency or stream-version collisions under load rather than as an
obvious failure. To sequence them, put 'ServiceUpdates' into a GlobalPartitioned message topology,
which lets Wolverine choose the batch's execution slot from the batch's group id. Note Sequential()
on the batch queue does NOT close this: it serializes the batch against itself only. (Call
opts.AssertBatchExecutionIsSequenced() to make Wolverine throw on this instead of warning.)
```

It names the fix *and* heads off the wrong fix, both asserted in tests. `opts.AssertBatchExecutionIsSequenced()` escalates it to a startup throw.

## Scoping decisions

- **Only under `MultipleHandlerBehavior.Separated`.** Under the default Classic behaviour the direct handler wins and the batch never runs at all, so there is only one writer — that shape is already reported by `warnOrAssertBatchHandlerConflicts` and must not be double-reported.
- **A new opt-in rather than reusing `AssertNoBatchHandlerConflicts`.** That flag is documented as having no effect under `Separated`; widening it would start throwing for someone who already set it.
- **Option 1 is not attempted.** Making the listener's `ShardedExecutionBlock` an addressable lane a batch can join means restructuring the receivers — the block is not a queue and cannot be enqueued to. The issue explicitly accepts option 2 as closing it, and says "Option 2 is a perfectly good answer if option 1 is structurally awkward."

## Tests

Five in `unsequenced_batch_execution_validation` — the throw and its message content, silence when a partitioned topology *does* sequence them, silence with no unbatched sibling, silence under Classic, and warn-not-throw by default.

Batching regression: 123/123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC