### PR TITLE
GH-3972: coalesce outgoing SignalR messages into one envelope per destination

### DIFF
--- a/docs/guide/messaging/transports/signalr.md
+++ b/docs/guide/messaging/transports/signalr.md
@@ -369,6 +369,65 @@ public static class RequestSumHandler
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/SignalR/Wolverine.SignalR.Tests/SampleCode.cs#L84-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sending_response_to_originating_signalr_caller' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Coalescing Outgoing Messages <Badge type="tip" text="6.29" />
+
+A system that pushes a lot of small messages at the same clients can coalesce them into a single SignalR
+invocation on a flush interval:
+
+```csharp
+opts.PublishAllMessages().ToSignalR()
+    .CoalesceOutgoing(o =>
+    {
+        o.FlushInterval = 100.Milliseconds();
+        o.MaxBatchSize  = 200;
+    });
+```
+
+Both settings are optional and default to the values above. `MaxBatchSize` flushes early when that many
+messages have accumulated, so the flush interval is a ceiling on latency rather than a fixed cadence.
+
+::: tip
+This is a **sender side** buffer, and that is the point. The alternative — routing outbound messages through a
+local queue to get them batched — makes that queue a cascade target for its own handlers, so a handler that
+forwards with `SendAsync` can re-send onto the very queue it was read from. Nothing round-trips a queue here.
+
+It also sits **after** the outbox, unlike an application-level accumulator, so it is safe for messages that tell
+a client to go and read something.
+:::
+
+### What the client receives
+
+Buffers are keyed by destination, so a message bound for one connection is never coalesced together with one
+bound for another connection or group.
+
+A coalesced batch is delivered on the **`ReceiveCoalescedMessages`** client operation, carrying the individual
+CloudEvents documents in arrival order. Each item is a complete CloudEvents document — that is what preserves
+the per-item message type, since the CloudEvents envelope is per-outer-message.
+
+A batch that turns out to hold a single message is sent on the normal `ReceiveMessage` operation instead, so
+the common trickle case still reaches a client that knows nothing about coalescing.
+
+::: warning
+Browser clients must handle `ReceiveCoalescedMessages` to receive coalesced batches — a client that only
+listens for `ReceiveMessage` will simply not see them. The operation is deliberately distinct rather than
+wrapped into `ReceiveMessage`, so an un-updated client fails obviously instead of receiving a payload it tries
+to read as a single document and fails on per message.
+
+```javascript
+connection.on("ReceiveCoalescedMessages", json => {
+    const batch = JSON.parse(json);
+    for (const item of batch.items) {
+        handleCloudEvent(JSON.parse(item));
+    }
+});
+```
+:::
+
+Wolverine's own [SignalR client transport](#signalr-client-transport) handles this automatically — it registers
+the unwrap unconditionally, so turning coalescing on at the server needs no client change.
+
+Anything still buffered is flushed when the host shuts down.
+
 In the next section we'll learn a bit more about working with SignalR groups.
 
 ## SignalR Groups

--- a/src/Transports/SignalR/Wolverine.SignalR.Tests/outgoing_coalescing.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR.Tests/outgoing_coalescing.cs
@@ -1,0 +1,315 @@
+using System.Text.Json;
+using JasperFx.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.SignalR.Client;
+using Wolverine.SignalR.Internals;
+using Wolverine.Tracking;
+using Wolverine.Util;
+
+namespace Wolverine.SignalR.Tests;
+
+/// <summary>
+///     GH-3972. Coalescing outbound messages into one envelope per destination on a flush interval.
+/// </summary>
+public class outgoing_coalescing : IAsyncLifetime
+{
+    private WebApplication theWebApp = null!;
+    private readonly int Port = PortFinder.GetAvailablePort();
+    private readonly List<IHost> _clientHosts = new();
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.ConfigureKestrel(opts => opts.ListenLocalhost(Port));
+
+        builder.Services.AddSignalR();
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ServiceName = "Server";
+            opts.UseSignalR();
+
+            #region sample_signalr_coalesce_outgoing
+            opts.PublishMessage<FromFirst>().ToSignalR()
+                .CoalesceOutgoing(o =>
+                {
+                    o.FlushInterval = 100.Milliseconds();
+                    o.MaxBatchSize = 200;
+                });
+            #endregion
+        });
+
+        var app = builder.Build();
+        app.MapWolverineSignalRHub();
+        await app.StartAsync();
+
+        theWebApp = app;
+    }
+
+    private async Task<IHost> startClientHost()
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Client";
+                opts.UseClientToSignalR(Port);
+            }).StartAsync();
+
+        _clientHosts.Add(host);
+        return host;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theWebApp.StopAsync();
+        await theWebApp.DisposeAsync();
+
+        foreach (var clientHost in _clientHosts)
+        {
+            await clientHost.StopAsync();
+            clientHost.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///     The round trip that matters: several messages published in one window arrive at the client as
+    ///     individual messages again, in the order they were sent. If the wrapper or the client unwrap were
+    ///     wrong, they would either not arrive or arrive as unreadable payloads.
+    /// </summary>
+    [Fact]
+    public async Task coalesced_messages_round_trip_to_the_client_in_order()
+    {
+        using var client = await startClientHost();
+
+        var names = Enumerable.Range(0, 10).Select(i => $"Receiver-{i}").ToArray();
+
+        var tracked = await theWebApp
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .AlsoTrack(client)
+            .Timeout(30.Seconds())
+            .ExecuteAndWaitAsync(new Func<IMessageContext, Task>(async c =>
+            {
+                foreach (var name in names)
+                {
+                    await c.PublishAsync(new FromFirst(name));
+                }
+            }));
+
+        var received = tracked.Received.RecordsInOrder()
+            .Where(x => x.Envelope?.Message is FromFirst)
+            .Select(x => ((FromFirst)x.Envelope!.Message!).Name)
+            .ToArray();
+
+        received.Length.ShouldBe(names.Length);
+
+        // Arrival order within a coalesced envelope, which is what the issue specifies
+        received.ShouldBe(names);
+    }
+}
+
+/// <summary>
+///     GH-3972. The parts that do not need a live hub.
+/// </summary>
+public class outgoing_coalescing_internals
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerOptions.Web);
+
+    [Fact]
+    public void the_wrapper_round_trips_its_items()
+    {
+        var items = new[] { "{\"a\":1}", "{\"b\":2}", "{\"c\":3}" };
+
+        var json = CoalescedSignalRMessage.ToJson(items, JsonOptions);
+
+        CoalescedSignalRMessage.TryReadItems(json, JsonOptions, out var read).ShouldBeTrue();
+        read.ShouldBe(items);
+    }
+
+    [Fact]
+    public void reading_a_non_batch_payload_fails_rather_than_guessing()
+    {
+        CoalescedSignalRMessage.TryReadItems("this is not json", JsonOptions, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void flush_interval_must_be_positive()
+    {
+        var options = new OutgoingCoalescingOptions();
+        Should.Throw<ArgumentOutOfRangeException>(() => options.FlushInterval = TimeSpan.Zero);
+        Should.Throw<ArgumentOutOfRangeException>(() => options.FlushInterval = -1.Seconds());
+    }
+
+    [Fact]
+    public void max_batch_size_must_be_at_least_one()
+    {
+        var options = new OutgoingCoalescingOptions();
+        Should.Throw<ArgumentOutOfRangeException>(() => options.MaxBatchSize = 0);
+    }
+
+    [Fact]
+    public void has_sane_defaults()
+    {
+        var options = new OutgoingCoalescingOptions();
+        options.FlushInterval.ShouldBe(100.Milliseconds());
+        options.MaxBatchSize.ShouldBe(200);
+    }
+
+    /// <summary>
+    ///     The correctness property the issue calls out: "Key the buffer by destination (connection / group).
+    ///     An app that only ever broadcasts gets away with one global queue; the transport must not, or it
+    ///     cross-delivers."
+    /// </summary>
+    [Fact]
+    public async Task buffers_are_keyed_by_destination_so_messages_never_cross_deliver()
+    {
+        var hub = new RecordingHubContext();
+        var options = new OutgoingCoalescingOptions { MaxBatchSize = 2 };
+
+        await using var coalescer = new OutgoingCoalescer(options, hub.Context, JsonOptions, null);
+
+        // Two messages for connection A and two for connection B, interleaved. With a single global
+        // buffer, MaxBatchSize = 2 would flush A's first message together with B's first.
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("A"), "op", "\"a1\"");
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("B"), "op", "\"b1\"");
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("A"), "op", "\"a2\"");
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("B"), "op", "\"b2\"");
+
+        var toA = hub.SendsTo("A");
+        var toB = hub.SendsTo("B");
+
+        toA.Count.ShouldBe(1);
+        toB.Count.ShouldBe(1);
+
+        CoalescedSignalRMessage.TryReadItems(toA[0].Payload, JsonOptions, out var aItems).ShouldBeTrue();
+        CoalescedSignalRMessage.TryReadItems(toB[0].Payload, JsonOptions, out var bItems).ShouldBeTrue();
+
+        aItems.ShouldBe(["\"a1\"", "\"a2\""]);
+        bItems.ShouldBe(["\"b1\"", "\"b2\""]);
+    }
+
+    [Fact]
+    public async Task a_batch_of_one_is_sent_on_the_normal_operation()
+    {
+        var hub = new RecordingHubContext();
+        var options = new OutgoingCoalescingOptions { MaxBatchSize = 1 };
+
+        await using var coalescer = new OutgoingCoalescer(options, hub.Context, JsonOptions, null);
+
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("A"), SignalRTransport.DefaultOperation,
+            "\"only\"");
+
+        var sends = hub.SendsTo("A");
+        sends.Count.ShouldBe(1);
+
+        // Not wrapped -- a client that never opted into coalescing still works for the trickle case
+        sends[0].Operation.ShouldBe(SignalRTransport.DefaultOperation);
+        sends[0].Payload.ShouldBe("\"only\"");
+    }
+
+    /// <summary>
+    ///     Drain on shutdown, so messages enqueued just before stop are not dropped.
+    /// </summary>
+    [Fact]
+    public async Task disposing_drains_whatever_is_still_buffered()
+    {
+        var hub = new RecordingHubContext();
+
+        // Long interval and a high ceiling, so nothing flushes on its own
+        var options = new OutgoingCoalescingOptions { FlushInterval = 5.Minutes(), MaxBatchSize = 1000 };
+
+        var coalescer = new OutgoingCoalescer(options, hub.Context, JsonOptions, null);
+
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("A"), "op", "\"a1\"");
+        await coalescer.EnqueueAsync(new WebSocketRouting.Connection("A"), "op", "\"a2\"");
+
+        hub.SendsTo("A").ShouldBeEmpty("nothing should have flushed yet");
+
+        await coalescer.DisposeAsync();
+
+        var sends = hub.SendsTo("A");
+        sends.Count.ShouldBe(1);
+        CoalescedSignalRMessage.TryReadItems(sends[0].Payload, JsonOptions, out var items).ShouldBeTrue();
+        items.ShouldBe(["\"a1\"", "\"a2\""]);
+    }
+}
+
+/// <summary>
+///     Captures what the coalescer actually sent, and to whom. Hand written rather than substituted:
+///     <c>SendAsync</c> is an extension method over <see cref="IClientProxy.SendCoreAsync" />, and the
+///     indirection makes a mocked setup easy to get subtly wrong in a way that silently records nothing.
+/// </summary>
+public class RecordingHubContext
+{
+    private readonly Dictionary<string, List<SentMessage>> _byDestination = new();
+    private readonly object _lock = new();
+
+    public record SentMessage(string Operation, string Payload);
+
+    public IHubContext<Hub> Context { get; }
+
+    public RecordingHubContext()
+    {
+        Context = new FakeHubContext(this);
+    }
+
+    internal void Record(string destination, SentMessage message)
+    {
+        lock (_lock)
+        {
+            if (!_byDestination.TryGetValue(destination, out var list))
+            {
+                list = [];
+                _byDestination[destination] = list;
+            }
+
+            list.Add(message);
+        }
+    }
+
+    public IReadOnlyList<SentMessage> SendsTo(string destination)
+    {
+        lock (_lock)
+        {
+            return _byDestination.TryGetValue(destination, out var list) ? list.ToArray() : [];
+        }
+    }
+
+    private class FakeHubContext(RecordingHubContext parent) : IHubContext<Hub>
+    {
+        public IHubClients Clients { get; } = new FakeHubClients(parent);
+        public IGroupManager Groups => throw new NotSupportedException();
+    }
+
+    private class FakeHubClients(RecordingHubContext parent) : IHubClients
+    {
+        public IClientProxy All => new FakeClientProxy(parent, "All");
+        public IClientProxy Client(string connectionId) => new FakeClientProxy(parent, connectionId);
+        public IClientProxy Group(string groupName) => new FakeClientProxy(parent, $"Group:{groupName}");
+
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) =>
+            throw new NotSupportedException();
+
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => throw new NotSupportedException();
+
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) =>
+            throw new NotSupportedException();
+
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => throw new NotSupportedException();
+        public IClientProxy User(string userId) => throw new NotSupportedException();
+        public IClientProxy Users(IReadOnlyList<string> userIds) => throw new NotSupportedException();
+    }
+
+    private class FakeClientProxy(RecordingHubContext parent, string destination) : IClientProxy
+    {
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+        {
+            parent.Record(destination, new SentMessage(method, (string)args[0]!));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Client/SignalRClientEndpoint.cs
@@ -85,7 +85,45 @@ public class SignalRClientEndpoint : Endpoint, IListener, ISender
             return ReceiveAsync(json);
         }));
 
+        // GH-3972: the matching unwrap for a coalesced batch. Registered unconditionally -- the server
+        // decides whether to coalesce, and a client that only listened for it when locally configured to
+        // would silently drop every batch when the server turned coalescing on.
+        _connection.On(SignalRTransport.CoalescedOperation, [typeof(string)], (args =>
+        {
+            var json = args[0] as string;
+
+            if (json is null)
+            {
+                Logger.LogDebug("Received an empty coalesced batch, ignoring");
+                return Task.CompletedTask;
+            }
+
+            return ReceiveCoalescedAsync(json);
+        }));
+
         return this;
+    }
+
+    /// <summary>
+    ///     GH-3972. Unwraps a coalesced batch and feeds each inner CloudEvents document through the normal
+    ///     receive path, in the order the server accumulated them.
+    /// </summary>
+    internal async Task ReceiveCoalescedAsync(string json)
+    {
+        if (!CoalescedSignalRMessage.TryReadItems(json, JsonOptions, out var items))
+        {
+            Logger?.LogError(
+                "Received a payload on {Operation} that could not be read as a coalesced batch, discarding it",
+                SignalRTransport.CoalescedOperation);
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            // Sequentially and in order: a coalesced batch preserves arrival order, and fanning these out
+            // concurrently would throw that away for no gain.
+            await ReceiveAsync(item);
+        }
     }
 
     internal async Task ReceiveAsync(string json)

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/CoalescedSignalRMessage.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/CoalescedSignalRMessage.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Wolverine.SignalR.Internals;
+
+/// <summary>
+///     GH-3972. The wire format for a coalesced batch of outgoing SignalR messages.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Sent on a dedicated operation (<see cref="SignalRTransport.CoalescedOperation" />) rather than
+///         wrapped into the normal one. A client that does not know about coalescing then simply never receives
+///         these, instead of receiving something on <c>ReceiveMessage</c> that it will try to read as a single
+///         CloudEvents document and fail on — a silent, per-message failure would be much worse than an obvious
+///         "nothing arrived".
+///     </para>
+///     <para>
+///         Each item is a complete CloudEvents document, exactly as it would have been sent on its own. That is
+///         what carries the per-item message type: the CloudEvents envelope is per-outer-message, so a wrapper
+///         that flattened the items into bare payloads would lose the type of every one of them.
+///     </para>
+/// </remarks>
+public class CoalescedSignalRMessage
+{
+    /// <summary>
+    ///     Marks the payload as a coalesced batch, so a client reading a message it did not expect can tell
+    ///     what it is looking at rather than guessing from shape.
+    /// </summary>
+    [JsonPropertyName("wolverineBatch")]
+    public bool WolverineBatch => true;
+
+    /// <summary>
+    ///     The coalesced CloudEvents documents, in arrival order.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public string[] Items { get; set; } = [];
+
+    public static string ToJson(IReadOnlyList<string> items, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Serialize(new CoalescedSignalRMessage { Items = items.ToArray() }, options);
+    }
+
+    /// <summary>
+    ///     Reads a coalesced payload back into its individual CloudEvents documents.
+    /// </summary>
+    public static bool TryReadItems(string json, JsonSerializerOptions options, out string[] items)
+    {
+        try
+        {
+            var message = JsonSerializer.Deserialize<CoalescedSignalRMessage>(json, options);
+            if (message?.Items is { Length: > 0 })
+            {
+                items = message.Items;
+                return true;
+            }
+
+            // An empty batch is still a well-formed batch; the caller has nothing to do with it
+            items = [];
+            return message != null;
+        }
+        catch (JsonException)
+        {
+            items = [];
+            return false;
+        }
+    }
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/OutgoingCoalescer.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/OutgoingCoalescer.cs
@@ -1,0 +1,235 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.SignalR.Internals;
+
+/// <summary>
+///     GH-3972. Accumulates outgoing SignalR messages per destination and flushes each destination's backlog as
+///     one <see cref="CoalescedSignalRMessage" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is a <b>sender-side</b> buffer, which is the whole point of the issue. Getting the same effect
+///         by routing outbound messages through a local queue is what produced a three-issue bug family: a
+///         handler forwarding with <c>SendAsync</c> re-sent onto the very queue it was read from, and the queue
+///         filled until back pressure blocked the producer. Nothing round-trips a queue here, so there is no
+///         queue to re-enter. It also sits after the outbox, unlike an application-level accumulator.
+///     </para>
+///     <para>
+///         Buffers are keyed by <b>destination and operation</b>. An application that only ever broadcasts
+///         would get away with one global buffer; the transport must not, because coalescing a message bound
+///         for connection A together with one bound for connection B delivers each of them to both.
+///     </para>
+/// </remarks>
+internal class OutgoingCoalescer : IAsyncDisposable
+{
+    private readonly ConcurrentDictionary<string, DestinationBuffer> _buffers = new();
+    private readonly OutgoingCoalescingOptions _options;
+    private readonly IHubContext<Hub> _hubContext;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly ILogger? _logger;
+    private volatile bool _disposed;
+
+    public OutgoingCoalescer(OutgoingCoalescingOptions options, IHubContext<Hub> hubContext,
+        JsonSerializerOptions jsonOptions, ILogger? logger)
+    {
+        _options = options;
+        _hubContext = hubContext;
+        _jsonOptions = jsonOptions;
+        _logger = logger;
+    }
+
+    public ValueTask EnqueueAsync(WebSocketRouting.ILocator locator, string operation, string json)
+    {
+        if (_disposed)
+        {
+            // Racing shutdown -- send it directly rather than dropping it into a buffer that will never
+            // be flushed
+            return new ValueTask(locator.Find(_hubContext).SendAsync(operation, json));
+        }
+
+        var key = $"{operation}|{locator}";
+        var buffer = _buffers.GetOrAdd(key, _ => new DestinationBuffer(locator, operation, this));
+
+        return buffer.EnqueueAsync(json);
+    }
+
+    /// <summary>
+    ///     Flush every destination. Called on shutdown so messages enqueued just before stop are not dropped.
+    /// </summary>
+    public async Task DrainAsync()
+    {
+        foreach (var buffer in _buffers.Values)
+        {
+            await buffer.FlushAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+
+        // Drain BEFORE latching, or anything already buffered is lost -- the drain-on-shutdown the issue
+        // asks for is the entire reason a sender-side buffer is safe to use for delivery.
+        await DrainAsync();
+
+        _disposed = true;
+
+        foreach (var buffer in _buffers.Values)
+        {
+            buffer.Dispose();
+        }
+
+        _buffers.Clear();
+    }
+
+    private async Task SendCoalescedAsync(WebSocketRouting.ILocator locator, string operation,
+        IReadOnlyList<string> items)
+    {
+        try
+        {
+            if (items.Count == 1)
+            {
+                // A "batch" of one is just the message. Sending it on the normal operation keeps a client
+                // that has not opted into coalescing working for the common trickle case.
+                await locator.Find(_hubContext).SendAsync(operation, items[0]);
+                return;
+            }
+
+            var json = CoalescedSignalRMessage.ToJson(items, _jsonOptions);
+
+            if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
+            {
+                _logger.LogDebug("Sent a coalesced batch of {Count} messages via SignalR to {Destination}",
+                    items.Count, locator);
+            }
+
+            await locator.Find(_hubContext).SendAsync(SignalRTransport.CoalescedOperation, json);
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e,
+                "Error while sending a coalesced batch of {Count} messages via SignalR to {Destination}",
+                items.Count, locator);
+        }
+    }
+
+    /// <summary>
+    ///     One destination's backlog. The timer is started by the first message of a window rather than run
+    ///     continuously, so an idle destination costs nothing.
+    /// </summary>
+    private class DestinationBuffer : IDisposable
+    {
+        private readonly WebSocketRouting.ILocator _locator;
+        private readonly string _operation;
+        private readonly OutgoingCoalescer _parent;
+        private readonly List<string> _pending = [];
+        private readonly SemaphoreSlim _lock = new(1, 1);
+        private CancellationTokenSource? _timer;
+
+        public DestinationBuffer(WebSocketRouting.ILocator locator, string operation, OutgoingCoalescer parent)
+        {
+            _locator = locator;
+            _operation = operation;
+            _parent = parent;
+        }
+
+        public async ValueTask EnqueueAsync(string json)
+        {
+            List<string>? toSend = null;
+
+            await _lock.WaitAsync();
+            try
+            {
+                _pending.Add(json);
+
+                if (_pending.Count >= _parent._options.MaxBatchSize)
+                {
+                    toSend = drainLocked();
+                }
+                else if (_timer == null)
+                {
+                    startTimerLocked();
+                }
+            }
+            finally
+            {
+                _lock.Release();
+            }
+
+            if (toSend != null)
+            {
+                await _parent.SendCoalescedAsync(_locator, _operation, toSend);
+            }
+        }
+
+        public async Task FlushAsync()
+        {
+            List<string>? toSend;
+
+            await _lock.WaitAsync();
+            try
+            {
+                toSend = drainLocked();
+            }
+            finally
+            {
+                _lock.Release();
+            }
+
+            if (toSend != null)
+            {
+                await _parent.SendCoalescedAsync(_locator, _operation, toSend);
+            }
+        }
+
+        private List<string>? drainLocked()
+        {
+            _timer?.Cancel();
+            _timer?.Dispose();
+            _timer = null;
+
+            if (_pending.Count == 0) return null;
+
+            // Arrival order, which is what the issue specifies for ordering within a coalesced envelope
+            var copy = new List<string>(_pending);
+            _pending.Clear();
+            return copy;
+        }
+
+        private void startTimerLocked()
+        {
+            var cts = new CancellationTokenSource();
+            _timer = cts;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(_parent._options.FlushInterval, cts.Token);
+                    if (!cts.Token.IsCancellationRequested)
+                    {
+                        await FlushAsync();
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Flushed early by MaxBatchSize or by a drain
+                }
+                catch (Exception e)
+                {
+                    _parent._logger?.LogError(e, "Error while flushing a coalesced SignalR batch");
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            _timer?.Cancel();
+            _timer?.Dispose();
+            _lock.Dispose();
+        }
+    }
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/OutgoingCoalescingOptions.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/OutgoingCoalescingOptions.cs
@@ -1,0 +1,50 @@
+using JasperFx.Core;
+
+namespace Wolverine.SignalR.Internals;
+
+/// <summary>
+///     GH-3972. Settings for coalescing outgoing SignalR messages into a single envelope per flush.
+/// </summary>
+public class OutgoingCoalescingOptions
+{
+    private TimeSpan _flushInterval = 100.Milliseconds();
+    private int _maxBatchSize = 200;
+
+    /// <summary>
+    ///     How long the transport accumulates outgoing messages for one destination before flushing them as a
+    ///     single envelope. Default is 100ms.
+    /// </summary>
+    public TimeSpan FlushInterval
+    {
+        get => _flushInterval;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(FlushInterval),
+                    "The flush interval must be greater than zero. Omit CoalesceOutgoing() entirely to send each message immediately.");
+            }
+
+            _flushInterval = value;
+        }
+    }
+
+    /// <summary>
+    ///     Flush as soon as this many messages have accumulated for one destination, without waiting out the
+    ///     rest of <see cref="FlushInterval" />. Default is 200.
+    /// </summary>
+    public int MaxBatchSize
+    {
+        get => _maxBatchSize;
+        set
+        {
+            if (value < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaxBatchSize),
+                    "The maximum batch size must be at least one message.");
+            }
+
+            _maxBatchSize = value;
+        }
+    }
+}

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRSubscriberConfiguration.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRSubscriberConfiguration.cs
@@ -20,4 +20,48 @@ public class SignalRSubscriberConfiguration : SubscriberConfiguration<SignalRSub
         add(e => e.JsonOptions = options);
         return this;
     }
+
+    /// <summary>
+    ///     GH-3972. Coalesce outgoing messages into a single envelope per destination on a flush interval,
+    ///     rather than sending one SignalR invocation per message.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is a sender-side buffer, which is the point: the alternative — routing outbound messages
+    ///         through a local queue to get them batched — makes the queue a cascade target for its own
+    ///         handlers, and that recursion is the direct cause of a whole family of hard-to-see bugs. Nothing
+    ///         round-trips a queue here, so there is no queue to re-enter, and the buffer sits <b>after</b> the
+    ///         outbox rather than before it.
+    ///     </para>
+    ///     <para>
+    ///         Buffers are keyed by destination, so a message bound for one connection is never coalesced
+    ///         together with one bound for another.
+    ///     </para>
+    ///     <para>
+    ///         Batches are delivered on the <c>ReceiveCoalescedMessages</c> client operation, carrying the
+    ///         individual CloudEvents documents in arrival order. Clients must handle that operation to receive
+    ///         them; Wolverine's own SignalR client does so automatically.
+    ///     </para>
+    /// </remarks>
+    /// <example>
+    ///     <code>
+    ///     opts.PublishAllMessages().ToSignalR()
+    ///         .CoalesceOutgoing(o =>
+    ///         {
+    ///             o.FlushInterval = 100.Milliseconds();
+    ///             o.MaxBatchSize  = 200;
+    ///         });
+    ///     </code>
+    /// </example>
+    public SignalRSubscriberConfiguration CoalesceOutgoing(Action<OutgoingCoalescingOptions>? configure = null)
+    {
+        add(e =>
+        {
+            var options = new OutgoingCoalescingOptions();
+            configure?.Invoke(options);
+            e.Coalescing = options;
+        });
+
+        return this;
+    }
 }

--- a/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
+++ b/src/Transports/SignalR/Wolverine.SignalR/Internals/SignalRTransport.cs
@@ -21,6 +21,14 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
     public static readonly string ProtocolName = "signalr";
     public static readonly string DefaultOperation = "ReceiveMessage";
 
+    /// <summary>
+    ///     GH-3972. The client operation coalesced batches are sent on. Deliberately distinct from
+    ///     <see cref="DefaultOperation" />: a client that does not know about coalescing then never receives
+    ///     these at all, instead of receiving something on ReceiveMessage that it tries to read as a single
+    ///     CloudEvents document and fails on per message.
+    /// </summary>
+    public static readonly string CoalescedOperation = "ReceiveCoalescedMessages";
+
     public SignalRTransport() : base($"{ProtocolName}://wolverine".ToUri(), EndpointRole.Application)
     {
         IsListener = true;
@@ -68,6 +76,11 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
         var hubContextType = typeof(IHubContext<>).MakeGenericType(HubType);
         HubContext ??= (IHubContext<Hub>)runtime.Services.GetRequiredService(hubContextType);
 
+        if (Coalescing != null)
+        {
+            Coalescer ??= new OutgoingCoalescer(Coalescing, HubContext!, JsonOptions, Logger);
+        }
+
         return new ValueTask();
     }
 
@@ -85,6 +98,16 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
 
     [IgnoreDescription]
     public JsonSerializerOptions JsonOptions { get; set; }
+
+    /// <summary>
+    ///     GH-3972. When set, outgoing messages are accumulated per destination and flushed as a single
+    ///     envelope. Null (the default) sends each message immediately.
+    /// </summary>
+    [IgnoreDescription]
+    internal OutgoingCoalescingOptions? Coalescing { get; set; }
+
+    [IgnoreDescription]
+    internal OutgoingCoalescer? Coalescer { get; private set; }
 
     [IgnoreDescription]
     public IReceiver? Receiver { get; private set; }
@@ -134,16 +157,24 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
         return new ValueTask();
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        return new ValueTask();
+        // GH-3972: drains any buffered outgoing messages so ones enqueued just before stop are not dropped
+        if (Coalescer != null)
+        {
+            await Coalescer.DisposeAsync();
+            Coalescer = null;
+        }
     }
 
     public Uri Address => Uri;
 
-    ValueTask IListener.StopAsync()
+    async ValueTask IListener.StopAsync()
     {
-        return new ValueTask();
+        if (Coalescer != null)
+        {
+            await Coalescer.DrainAsync();
+        }
     }
     
     protected override bool supportsMode(EndpointMode mode)
@@ -185,6 +216,12 @@ public class SignalRTransport : Endpoint, ITransport, IListener, ISender
         if (Logger != null && Logger.IsEnabled(LogLevel.Debug))
         {
             Logger.LogDebug("Sent JSON via SignalR: {Json}", json);
+        }
+
+        // GH-3972: when coalescing is on, buffer per destination rather than sending immediately
+        if (Coalescer is { } coalescer)
+        {
+            return coalescer.EnqueueAsync(locator, operation, json);
         }
 
         return new ValueTask(locator.Find(HubContext!).SendAsync(operation, json));


### PR DESCRIPTION
Closes #3972.

`Wolverine.SignalR` had no batching, buffering or coalescing of any kind, and Wolverine offers no sender-side hook for it — so an application that wanted it had to route outbound messages through a **local queue** to get them batched. That detour is the direct cause of the three-issue bug family in the issue: a local queue carrying a handler's own output is a cascade target for that handler, so forwarding with `SendAsync` re-sends onto the very queue the message was read from, and the queue fills until back pressure blocks the producer.

A sending-agent buffer creates none of that, because nothing round-trips a queue — there is no queue to re-enter. It also sits **after** the outbox, unlike the `ConcurrentQueue`-plus-timer accumulator it replaces, which relayed *before* the commit and carried a standing "never use it for a message that tells the client to go and read something" caveat.

```csharp
opts.PublishAllMessages().ToSignalR()
    .CoalesceOutgoing(o =>
    {
        o.FlushInterval = 100.Milliseconds();
        o.MaxBatchSize  = 200;
    });
```

## The four design points, and what each became

**1. Envelope contract.** A batch carries the individual CloudEvents documents *verbatim* rather than flattening them into bare payloads. The CloudEvents envelope is per-outer-message, so flattening would lose the message type of every item; keeping whole documents gives each item its own type for free.

**2. Keyed by destination.** Buffers key on locator **and** operation. An application that only ever broadcasts would get away with one global buffer; the transport must not, because coalescing a message bound for connection A with one bound for connection B delivers each to both. There's a test that interleaves two connections at `MaxBatchSize = 2` and asserts they never mix.

**3. Ordering** is arrival order within a batch, asserted end-to-end.

**4. Drain on shutdown**, on both `IListener.StopAsync` and `DisposeAsync`. The drain deliberately runs *before* the disposal latch, or anything already buffered would be lost.

## A dedicated client operation, not a wrapped one

Batches go out on `ReceiveCoalescedMessages` rather than wrapped into `ReceiveMessage`. A client that doesn't know about coalescing then simply never receives them, instead of receiving something on `ReceiveMessage` that it tries to read as a single CloudEvents document and fails on *for every message*. An obvious "nothing arrived" is a much better failure than a silent per-message one.

A batch that holds a single message is sent on the normal operation anyway, so the common trickle case needs no client change at all.

Wolverine's own .NET SignalR client registers the unwrap **unconditionally** — the *server* decides whether to coalesce, and a client that only listened when locally configured to would silently drop every batch the moment the server turned it on.

## One correction to the issue

Design point 5 says "the TS client under `Wolverine.SignalR/Client` needs the matching unwrap." **There is no TS client in this repository** — that directory holds the .NET client, which is updated here. The only TypeScript/JS under the repo is Microsoft's vendored `signalr.js` inside a sample app. The docs carry a browser-side snippet showing the unwrap instead, so the guidance still lands for browser consumers.

## Tests

Nine, in two classes:

- **End-to-end**: ten messages published in one window arrive at a real client host as ten individual messages, in order — which only passes if the wrapper and the client unwrap agree.
- **Destination keying**: interleaved sends to two connections never cross-deliver.
- **Batch of one** goes out on the normal operation, unwrapped.
- **Dispose drains** what is still buffered (long interval, high ceiling, so nothing flushes on its own first).
- Wrapper round-trip, non-batch payload rejected rather than guessed at, and options validation.

Full `Wolverine.SignalR.Tests`: **37/37**. Full `wolverine.slnx` builds clean pinned to `net9.0`.

The test double is hand-written rather than substituted, deliberately: `SendAsync` is an extension over `IClientProxy.SendCoreAsync`, and the indirection makes a mocked setup easy to get subtly wrong in a way that silently records nothing — which is exactly what happened on the first attempt.

## Out of scope

Domain-level coalescing (accumulating N domain events into one summary message) stays in application code, as the issue specifies. This is delivery coalescing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG8Un6iNeyXECKJk3jo5uC