### PR TITLE
docs: fix shrug emoticon rendering in sagas tip

### DIFF
--- a/docs/guide/durability/sagas.md
+++ b/docs/guide/durability/sagas.md
@@ -9,7 +9,7 @@ For practical examples of building sagas with Wolverine, see the blog posts
 ::: tip
 To be honest, we're just not going to get hung up on "process manager" vs. "saga" here. The key point is that what
 Wolverine is calling a "saga" really just means a long running, multi-step process where you need to track some state
-between the steps. If that annoys Greg Young, then ¯\_(ツ)_/¯.
+between the steps. If that annoys Greg Young, then `¯\_(ツ)_/¯`.
 :::
 
 As is so common in these docs, I would direct you to this from the old "EIP" book: [Process Manager](http://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html). A stateful saga in Wolverine is used


### PR DESCRIPTION
Closes #3981

The tip in docs/guide/durability/sagas.md contains `¯\\_(ツ)_/¯`, but under CommonMark `\\_` is an escape for a literal underscore, so the rendered page shows `¯_(ツ)_/¯` without the backslash.

Wrapping the emoticon in a code span makes it render exactly as typed.