### PR TITLE
GH-516 parity for HTTP: Before middleware can replace an immutable request body

### DIFF
--- a/docs/guide/http/middleware.md
+++ b/docs/guide/http/middleware.md
@@ -49,7 +49,7 @@ Which is registered like this (or as described in [`Registering Middleware by Me
 opts.AddMiddlewareByMessageType(typeof(FakeAuthenticationMiddleware));
 opts.AddMiddlewareByMessageType(typeof(CanShipOrderMiddleWare));
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L348-L352' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_http_middleware_by_type' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L352-L356' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_http_middleware_by_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The key point to notice there is that `IResult` is a "return value" of the middleware. In the case of an HTTP endpoint,
@@ -116,6 +116,68 @@ public class ValidatedCompoundEndpoint2
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Validation/ValidatedCompoundEndpoint.cs#L33-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_optional_iresult_with_openapi_metadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Replacing an Immutable Request Body
+
+A middleware method that both **accepts the request body type and returns that same type** replaces the request body for
+the rest of the chain. Use this to enrich an immutable `record` request with server-supplied values (timestamps, user
+identity) before the endpoint method runs, keeping the endpoint signature a pure decider:
+
+<!-- snippet: sample_replacing_an_immutable_request_from_http_middleware -->
+<a id='snippet-sample_replacing_an_immutable_request_from_http_middleware'></a>
+```cs
+public record StampedRequest
+{
+    public string Name { get; init; } = string.Empty;
+
+    // Server-stamped by middleware, never accepted from the client
+    [JsonIgnore]
+    public string StampedBy { get; init; } = string.Empty;
+
+    [JsonIgnore]
+    public bool Enriched { get; init; }
+}
+
+public static class StampedRequestEndpoint
+{
+    // Implied middleware on the endpoint class itself. Because the methods accept
+    // the request type *and* return it, the returned value replaces the request
+    // body for the rest of the chain
+    public static StampedRequest Before(StampedRequest request)
+    {
+        return request with { StampedBy = "sync" };
+    }
+
+    public static Task<StampedRequest> BeforeAsync(StampedRequest request)
+    {
+        return Task.FromResult(request with { Name = request.Name + "-async" });
+    }
+
+    // The replaced request can also ride along in a tuple with a short-circuiting IResult
+    public static (StampedRequest, IResult) Before(StampedRequest request, HttpContext context)
+    {
+        return request.Name.StartsWith("stop")
+            ? (request, Results.StatusCode(423))
+            : (request with { Enriched = true }, WolverineContinue.Result());
+    }
+
+    [WolverinePost("/middleware/stamped")]
+    public static string Handle(StampedRequest request)
+    {
+        return $"{request.Name}:{request.StampedBy}:{request.Enriched}";
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/MessageReplacementEndpoints.cs#L9-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_an_immutable_request_from_http_middleware' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The replacing method may be synchronous or asynchronous, and the request may be returned inside a tuple alongside an
+`IResult` for conditional short-circuiting.
+
+::: warning
+This applies to `Before` / `BeforeAsync` methods declared on the endpoint class itself. Middleware types registered
+externally (through `[Middleware]` or by policy) are not currently allowed to return the request type.
+:::
 
 ## Using Configure(chain) Methods
 

--- a/src/Http/Wolverine.Http.Tests/middleware_replacing_immutable_request.cs
+++ b/src/Http/Wolverine.Http.Tests/middleware_replacing_immutable_request.cs
@@ -1,0 +1,38 @@
+using Alba;
+using Shouldly;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests;
+
+// GH-516 parity for HTTP chains: a Before middleware method may return the request
+// type to replace an immutable record request body before the handler runs
+public class middleware_replacing_immutable_request : IntegrationContext
+{
+    public middleware_replacing_immutable_request(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task able_to_use_the_replaced_request()
+    {
+        var body = await Scenario(x =>
+        {
+            x.Post.Json(new StampedRequest { Name = "original" }).ToUrl("/middleware/stamped");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // The sync Before stamped StampedBy, the async Before rewrote Name,
+        // and the tuple Before flipped Enriched
+        (await body.ReadAsTextAsync()).ShouldBe("original-async:sync:True");
+    }
+
+    [Fact]
+    public async Task tuple_returning_before_can_still_short_circuit()
+    {
+        await Scenario(x =>
+        {
+            x.Post.Json(new StampedRequest { Name = "stop" }).ToUrl("/middleware/stamped");
+            x.StatusCodeShouldBe(423);
+        });
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs
+++ b/src/Http/Wolverine.Http.Tests/using_newtonsoft_for_serialization.cs
@@ -58,6 +58,41 @@ public class using_newtonsoft_for_serialization
         text.ShouldBe("{\"$type\":\"Wolverine.Http.Tests.MathResponse, Wolverine.Http.Tests\",\"Sum\":7,\"Product\":12}");
 
     }
+
+    // The Newtonsoft body reader is a MethodCall whose ReturnVariable IS the chain's
+    // RequestBodyVariable, so the middleware message-replacement pass in
+    // HttpChain.DetermineFrames must not flip the reader's own variable declaration
+    // into an assignment. This covers both that guard and message replacement working
+    // with the Newtonsoft serializer at all
+    [Fact]
+    public async Task before_middleware_can_replace_the_request_body()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.Services.AddScoped<IUserService, UserService>();
+
+        builder.Services.AddMarten(Servers.PostgresConnectionString)
+            .IntegrateWithWolverine();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(GetType().Assembly);
+        });
+
+        builder.Services.AddWolverineHttp();
+        builder.Services.AddWolverineHttpNewtonsoft();
+
+        await using var host = await AlbaHost.For(builder, app =>
+        {
+            app.MapWolverineEndpoints(opts => opts.UseNewtonsoftJsonForSerialization());
+        });
+
+        var result = await host.Scenario(x =>
+        {
+            x.Post.Json(new StampedNumberRequest(3, 4)).ToUrl("/newtonsoft/stamped");
+        });
+
+        (await result.ReadAsTextAsync()).ShouldBe("7:newtonsoft");
+    }
 }
 
 public record NumberRequest(int X, int Y);
@@ -69,5 +104,25 @@ public static class MathEndpoint
     public static MathResponse Post(NumberRequest request)
     {
         return new MathResponse(request.X + request.Y, request.X * request.Y);
+    }
+}
+
+public record StampedNumberRequest(int X, int Y)
+{
+    [JsonIgnore]
+    public string StampedBy { get; init; } = string.Empty;
+}
+
+public static class StampedNumberEndpoint
+{
+    public static StampedNumberRequest Before(StampedNumberRequest request)
+    {
+        return request with { StampedBy = "newtonsoft" };
+    }
+
+    [WolverinePost("/newtonsoft/stamped")]
+    public static string Post(StampedNumberRequest request)
+    {
+        return $"{request.X + request.Y}:{request.StampedBy}";
     }
 }

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -150,6 +150,18 @@ public partial class HttpChain
             Middleware.Insert(0, new AuditToActivityFrame(this, auditInputType));
         }
 
+        // Allow for immutable request types that get overwritten by middleware
+        if (RequestBodyVariable != null)
+        {
+            foreach (var methodCall in Middleware.OfType<MethodCall>())
+            {
+                // Skip the frame that reads the request body in the first place
+                if (ReferenceEquals(methodCall.ReturnVariable, RequestBodyVariable)) continue;
+
+                methodCall.TryReplaceVariableCreationWithAssignment(RequestBodyVariable);
+            }
+        }
+
         var index = 0;
         foreach (var frame in Middleware)
         {

--- a/src/Http/WolverineWebApi/MessageReplacementEndpoints.cs
+++ b/src/Http/WolverineWebApi/MessageReplacementEndpoints.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+using Wolverine.Http;
+
+namespace WolverineWebApi;
+
+// GH-516 brought to HTTP: middleware that returns the request type replaces the
+// (possibly immutable record) request body for the rest of the chain
+
+#region sample_replacing_an_immutable_request_from_http_middleware
+
+public record StampedRequest
+{
+    public string Name { get; init; } = string.Empty;
+
+    // Server-stamped by middleware, never accepted from the client
+    [JsonIgnore]
+    public string StampedBy { get; init; } = string.Empty;
+
+    [JsonIgnore]
+    public bool Enriched { get; init; }
+}
+
+public static class StampedRequestEndpoint
+{
+    // Implied middleware on the endpoint class itself. Because the methods accept
+    // the request type *and* return it, the returned value replaces the request
+    // body for the rest of the chain
+    public static StampedRequest Before(StampedRequest request)
+    {
+        return request with { StampedBy = "sync" };
+    }
+
+    public static Task<StampedRequest> BeforeAsync(StampedRequest request)
+    {
+        return Task.FromResult(request with { Name = request.Name + "-async" });
+    }
+
+    // The replaced request can also ride along in a tuple with a short-circuiting IResult
+    public static (StampedRequest, IResult) Before(StampedRequest request, HttpContext context)
+    {
+        return request.Name.StartsWith("stop")
+            ? (request, Results.StatusCode(423))
+            : (request with { Enriched = true }, WolverineContinue.Result());
+    }
+
+    [WolverinePost("/middleware/stamped")]
+    public static string Handle(StampedRequest request)
+    {
+        return $"{request.Name}:{request.StampedBy}:{request.Enriched}";
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Motivation

Handler chains have supported middleware replacing an immutable message since GH-516: a `Before`/`BeforeAsync` accepting the message type and returning it (optionally in a tuple) overwrites the message for the rest of the chain. HTTP chains lack the equivalent pass, so the same pattern on an endpoint class fails compilation with a colliding local (CS0841/CS0136):

```csharp
public static Command Before(Command input, TimeProvider clock) =>
    input with { RejectedAt = clock.GetUtcNow() };

[WolverinePost("/reject")]
public static IResult Handle(Command command, State state) => ...;
```

## Changes

Mirrors the `HandlerChain.DetermineFrames` GH-516 pass onto `HttpChain.DetermineFrames` (12 lines), with two HTTP-specific guards:

- skip chains with no request body
- skip the frame that reads the request body itself — the Newtonsoft reader is a `MethodCall` whose `ReturnVariable` is the request body variable; flipping it would delete the declaration

Sync, async, and tuple-returning `Before` methods behave identically to the handler side.

## Out of scope

Registered middleware (`Policies.AddMiddleware`, `[Middleware]`) returning the request type is still blocked by the existing `MiddlewarePolicy` exception.

## Tests

- `middleware_replacing_immutable_request`: Bug_516-style chained sync/async/tuple fact + tuple `IResult` short-circuit
- `using_newtonsoft_for_serialization`: regression for the body-reader skip
- Docs section in `docs/guide/http/middleware.md`

Full net9.0-pinned `wolverine.slnx` build clean; `Wolverine.Http.Tests` and `CoreTests` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)