### PR TITLE
GH-3983: make the MySQL envelope storage migration idempotent, and upgrade to Weasel 9.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### WolverineFx.MySql
+
+- **The envelope storage migration no longer fails on every startup.**
+  ([#3985](https://github.com/JasperFx/wolverine/pull/3985), closes
+  [#3983](https://github.com/JasperFx/wolverine/issues/3983)) On MySQL every node logged an `Error` from
+  `MySqlMessageStore` on every start: `Cannot drop index 'fk_wolverine_node_assignments_node_id': needed
+  in a foreign key constraint`. The first migration against an empty database is a pure `CREATE`, so this
+  was unreachable until the second run — it reproduced against a brand-new database and then repeated
+  forever.
+
+  There were four drift items, not one, and only the first threw — so the migration runner logged it and
+  the rest never ran. `wolverine_nodes.node_number` and `wolverine_node_records.id` folded `AUTO_INCREMENT`
+  into the column *type* string; the catalog reports the type as plain `INT` and carries `auto_increment`
+  separately, so neither column ever compared equal and both emitted a `MODIFY COLUMN` on every check.
+  They now use Weasel's `AutoIncrement()`. The generated DDL is unchanged apart from where the keyword
+  sits, so **existing databases need no migration**.
+
+  The other three were `Weasel.MySql` bugs, fixed in [weasel#445](https://github.com/JasperFx/weasel/pull/445)
+  and shipped in Weasel 9.25.0.
+
+### Dependencies
+
+- **Weasel bumped to 9.25.0**, the identifier release. If your schema names are all plain lowercase
+  identifiers the emitted DDL is byte-identical to 9.24 and there is nothing to do. Otherwise three
+  changes are worth knowing about, and Weasel's
+  [upgrade notes](https://weasel.jasperfx.net/release-9-25) carry the full list:
+
+  - **Oracle can now see index, foreign key and primary key drift**, which it previously could not detect
+    at all. Expect a first run that applies index and foreign key changes it had been silently ignoring —
+    that is the backlog being worked off, not new drift.
+  - **SQLite no longer drops the table to change a column.** A change that `ALTER TABLE` cannot express
+    used to be answered by dropping the object and recreating it, losing every row.
+  - **Column names are no longer case-folded or rewritten.** Wolverine's NServiceBus PostgreSQL queue
+    table declared PascalCase columns and relied on Weasel folding them to lowercase; a real
+    NServiceBus-provisioned table has lowercase columns, so the declaration was wrong all along and is now
+    stated as lowercase directly. No behavior change against an NServiceBus-owned table.
+
 ### WolverineFx (core)
 
 - **`AfterCommit` — a declarative way to run work after the transactional commit.**

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,13 +137,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.24.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.24.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.24.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.24.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.24.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.24.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.24.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.25.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.25.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.25.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.25.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.25.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.25.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.25.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.

--- a/src/Persistence/MySql/MySqlTests/Bug_3983_repeated_envelope_storage_migration.cs
+++ b/src/Persistence/MySql/MySqlTests/Bug_3983_repeated_envelope_storage_migration.cs
@@ -1,0 +1,74 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql;
+using Wolverine;
+using Wolverine.MySql;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+
+namespace MySqlTests;
+
+/// <summary>
+///     GH-3983: MySQL implicitly creates a backing index for the wolverine_node_assignments
+///     foreign key and names it after the constraint, so the schema diff saw a permanently
+///     "extra" index and emitted a DROP INDEX that InnoDB refuses (error 1553). The first
+///     migration against an empty database is a pure CREATE and never hit it — every start
+///     after that logged an error.
+/// </summary>
+[Collection("mysql")]
+public class Bug_3983_repeated_envelope_storage_migration
+{
+    private const string SchemaName = "bug_3983";
+
+    private static MySqlMessageStore buildStore()
+    {
+        var dataSource = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString);
+        var settings = new DatabaseSettings
+        {
+            SchemaName = SchemaName,
+            CommandQueuesEnabled = true,
+            Role = MessageStoreRole.Main
+        };
+
+        return new MySqlMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<MySqlMessageStore>.Instance);
+    }
+
+    [Fact]
+    public async Task migrating_an_already_current_database_is_a_no_op()
+    {
+        var store = buildStore();
+
+        await store.Admin.MigrateAsync();
+
+        // The second pass is the one the issue reports: nothing has changed, so it must
+        // neither throw nor leave the database in a state that still reports drift.
+        await store.Admin.MigrateAsync();
+        await store.Admin.MigrateAsync();
+
+        await store.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task the_node_assignments_foreign_key_reports_no_drift()
+    {
+        var store = buildStore();
+        await store.Admin.MigrateAsync();
+
+        var assignments = store.AllObjects()
+            .OfType<Weasel.MySql.Tables.Table>()
+            .Single(x => x.Identifier.Name == DatabaseConstants.NodeAssignmentsTableName);
+
+        await using var conn = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString)
+            .CreateConnection();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        var delta = await assignments.FindDeltaAsync(conn, TestContext.Current.CancellationToken);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+
+        await conn.CloseAsync();
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -487,8 +487,12 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
         {
             var nodeTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeTableName));
             nodeTable.AddColumn<Guid>("id").AsPrimaryKey();
-            // MySQL requires AUTO_INCREMENT to be part of a key - add unique index
-            nodeTable.AddColumn("node_number", "INT AUTO_INCREMENT").NotNull()
+            // MySQL requires AUTO_INCREMENT to be part of a key - add unique index.
+            // AUTO_INCREMENT belongs in AutoIncrement(), not in the type: the catalog reports
+            // the type as plain INT, so folding it into the type string made this column
+            // report drift on every schema check (GH-3983).
+            nodeTable.AddColumn<int>("node_number").NotNull()
+                .AutoIncrement()
                 .AddIndex(idx => idx.IsUnique = true);
             nodeTable.AddColumn<string>("description").NotNull();
             nodeTable.AddColumn<string>("uri").NotNull();
@@ -530,7 +534,7 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             }
 
             var eventTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
-            eventTable.AddColumn("id", "INT AUTO_INCREMENT").AsPrimaryKey();
+            eventTable.AddColumn<int>("id").AsPrimaryKey().AutoIncrement();
             eventTable.AddColumn<int>("node_number").NotNull();
             eventTable.AddColumn<string>("event_name").NotNull();
             eventTable.AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("(UTC_TIMESTAMP(6))").NotNull();

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
@@ -27,19 +27,19 @@ internal class NServiceBusPostgresqlQueueListener : DatabaseListener
         _mapper = queue.BuildMapper(runtime);
         _sender = new NServiceBusPostgresqlQueueSender(queue, runtime);
 
-        // Destructive competing-consumer pop honoring NServiceBus FIFO-by-Seq ordering. The
-        // column identifiers are left unquoted: Weasel provisions the queue table with
-        // case-folded (lowercase) column names, so unquoted references resolve correctly.
+        // Destructive competing-consumer pop honoring NServiceBus FIFO-by-seq ordering. The
+        // column identifiers are left unquoted, which PostgreSQL folds to lowercase — matching
+        // the lowercase columns both NServiceBus and NServiceBusQueueTable declare.
         _receiveSql = $@"
 WITH message AS (
     DELETE FROM {queue.TableIdentifier}
     WHERE ctid IN (
         SELECT ctid FROM {queue.TableIdentifier}
-        ORDER BY Seq
+        ORDER BY seq
         LIMIT :count
         FOR UPDATE SKIP LOCKED)
-    RETURNING Id, Headers, Body)
-SELECT Id, Headers, Body FROM message;";
+    RETURNING id, headers, body)
+SELECT id, headers, body FROM message;";
     }
 
     protected override int MaximumMessagesToReceive => _queue.MaximumMessagesToReceive;

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueSender.cs
@@ -22,10 +22,10 @@ internal class NServiceBusPostgresqlQueueSender : ISender
         Destination = queue.Uri;
 
         // The documented NServiceBus PostgreSQL send statement. The column identifiers are left
-        // unquoted: Weasel provisions the queue table with case-folded (lowercase) column names,
-        // so unquoted references resolve correctly.
+        // unquoted, which PostgreSQL folds to lowercase — matching the lowercase columns both
+        // NServiceBus and NServiceBusQueueTable declare.
         _sendSql =
-            $@"INSERT INTO {queue.TableIdentifier} (Id, Expires, Headers, Body) VALUES (:id, :expires, :headers, :body)";
+            $@"INSERT INTO {queue.TableIdentifier} (id, expires, headers, body) VALUES (:id, :expires, :headers, :body)";
     }
 
     // NServiceBus delayed delivery uses a separate timeout table + mover; not supported in v1.

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
@@ -14,14 +14,21 @@ internal class NServiceBusQueueTable : Table
 {
     public NServiceBusQueueTable(DbObjectName identifier) : base(identifier)
     {
-        AddColumn<Guid>("Id").AsPrimaryKey();
-        AddColumn("Expires", "timestamp");
-        AddColumn<string>("Headers").NotNull();
-        AddColumn("Body", "bytea");
+        // Lowercase deliberately. A real NServiceBus-provisioned queue table has case-folded
+        // column names — verified against a live NServiceBus.Transport.PostgreSql host — so
+        // these have to be lowercase to line up with a table NServiceBus owns, and to keep the
+        // unquoted identifiers in the send/receive SQL resolving. Weasel used to case-fold
+        // declared names on its way to the database and hid the difference; as of 9.25 it
+        // preserves and quotes what it is given, which would have made "Seq" a genuinely
+        // distinct column from NServiceBus's seq.
+        AddColumn<Guid>("id").AsPrimaryKey();
+        AddColumn("expires", "timestamp");
+        AddColumn<string>("headers").NotNull();
+        AddColumn("body", "bytea");
 
-        AddColumn<int>("Seq").AutoIncrement().NotNull();
+        AddColumn<int>("seq").AutoIncrement().NotNull();
 
-        // Seq is what the destructive receive orders by (FIFO), so a Wolverine-provisioned table
+        // seq is what the destructive receive orders by (FIFO), so a Wolverine-provisioned table
         // needs an index on it or the ORDER BY degrades to a full sort once a backlog builds — a
         // soak that let the table grow collapsed receiver throughput by ~60x without this. We use a
         // *non-unique* index (NOT a unique one): NServiceBus puts a UNIQUE *constraint* on seq and
@@ -30,7 +37,7 @@ internal class NServiceBusQueueTable : Table
         // NServiceBus-owned table. The transport never needs to enforce seq uniqueness itself.
         Indexes.Add(new IndexDefinition(PostgresqlIdentifier.Shorten($"idx_{identifier.Name}_seq"))
         {
-            Columns = ["Seq"]
+            Columns = ["seq"]
         });
     }
 }


### PR DESCRIPTION
Closes #3983.

> ⛔ **Blocked on [JasperFx/marten#5271](https://github.com/JasperFx/marten/pull/5271).** Draft until that ships and the Marten pin moves off 9.23.0. Everything else is green. See *Merge order* below.
>
> The original blocker — weasel#445 — **is resolved**: it merged and shipped in **Weasel 9.25.0**, which this PR now pins.

@cyclr-adrian's report was exactly right, including the diagnosis. Reproducing it turned up **four** drift items on every startup, not one:

```
ALTER TABLE <schema>.wolverine_nodes MODIFY COLUMN `node_number` INT AUTO_INCREMENT NOT NULL;
DROP INDEX `fk_wolverine_node_assignments_node_id` ON <schema>.wolverine_node_assignments;
ALTER TABLE <schema>.wolverine_node_assignments DROP FOREIGN KEY `fk_wolverine_node_assignments_node_id`;
ALTER TABLE <schema>.wolverine_node_assignments ADD CONSTRAINT `fk_wolverine_node_assignments_node_id` ...;
ALTER TABLE <schema>.wolverine_node_records MODIFY COLUMN `id` INT AUTO_INCREMENT NOT NULL;
```

Only the `DROP INDEX` throws, which is why the rest went unnoticed — the migration runner logs the first failure and the remaining statements never run. The first migration against an empty database is a pure `CREATE`, so none of it is reachable until the second run.

## 1. The Wolverine bug: `AUTO_INCREMENT` in the column type

`wolverine_nodes.node_number` and `wolverine_node_records.id` folded `AUTO_INCREMENT` into the column **type** string. `information_schema` reports the type as plain `INT` and carries `auto_increment` separately in `EXTRA`, so neither column ever compared equal and both emitted a `MODIFY COLUMN` forever. `Weasel.MySql` has a first-class `AutoIncrement()` for this. The generated DDL is unchanged apart from where the keyword sits, so **existing databases need no migration**.

## 2. The Weasel bugs, now shipped

The other three were `Weasel.MySql` defects, fixed in [weasel#445](https://github.com/JasperFx/weasel/pull/445) and released in **9.25.0**: the foreign key's backing index being diffed as an extra index, `WriteUpdate` emitting index changes before foreign key changes (so *removing* a foreign key failed the same way), and `Table(DbObjectName)` not normalizing to `MySqlObjectName` — which is what made the constraint report as `Different` on every check.

## 3. Fallout from the 9.25 upgrade: NServiceBus PostgreSQL interop

9.25 is Weasel's identifier release, and it **stops case-folding and rewriting column names**. `NServiceBusQueueTable` declared PascalCase columns and the send/receive SQL referenced them unquoted — with a comment saying outright that it relied on Weasel folding them to lowercase. Under 9.25 the table gets a genuinely case-sensitive `"Seq"` and the destructive pop fails:

```
Npgsql.PostgresException : 42703: column "Seq" does not exist
```

**The PascalCase declaration was wrong all along.** A real NServiceBus-provisioned queue table has lowercase columns — verified against a live `NServiceBus.Transport.PostgreSql` host when this transport was built — so Wolverine was only ever interoperating because Weasel silently folded the difference away. The columns are now declared lowercase directly, which is what both sides actually use. No behavior change against an NServiceBus-owned table.

## Testing

New `Bug_3983_repeated_envelope_storage_migration`: migrate an already-current database and assert no drift. The existing `can_migrate_schema_directly` migrates **once**, against an empty database — none of this is reachable until the second run, which is precisely the shape of the bug report.

Full suites on Weasel 9.25.0, all green:

| Suite | Result |
| --- | --- |
| MySql | 125 / 125 |
| PostgreSQL | 481 / 482 (1 skipped) |
| SQL Server | 396 / 398 (2 skipped) |
| SQLite | 168 / 169 (1 skipped) |
| EF Core | 205 / 205 |
| `wolverine.slnx` Release `-f net9.0` | clean, 0 warnings |

`MartenTests` is **607 / 610** — see below. `FisherTests` has 9 failures that are **pre-existing on `main`** and unrelated to this PR (verified against a clean `origin/main` checkout); worth a separate issue.

## The remaining blocker: a Marten defect this bump exposes

`mt_natural_key_X` shortens every name it writes — foreign keys and its index — but left the primary key constraint on Weasel's `pkey_{table}_{columns}` default, which is 64 characters for a 16-character aggregate name under conjoined tenancy. PostgreSQL truncated it silently; Weasel 9.25 validates primary key constraint names ([weasel#448](https://github.com/JasperFx/weasel/issues/448)) and refuses to emit one that would be cut.

Baselined both ways: `tenant_partitioned_natural_key_aggregate` passes on Weasel 9.24.0 and fails on 9.25.0. Fixed upstream in [JasperFx/marten#5271](https://github.com/JasperFx/marten/pull/5271); verified end-to-end by pointing `MartenTests` at a locally-built Marten carrying that commit — 0/3 → **3/3**.

This is not test-only: it affects any `[NaturalKey]` aggregate with a type name of 16+ characters under conjoined tenancy.

## Merge order

1. Merge and release [JasperFx/marten#5271](https://github.com/JasperFx/marten/pull/5271).
2. Bump the `Marten` pins in `Directory.Packages.props` off 9.23.0.
3. Undraft this and confirm `CIMySql` and `CIMarten` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3