### PR TITLE
GH-3983: MySQL migration idempotency, Weasel 9.25.1, and a green CIFisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 ## Unreleased
 
+### WolverineFx.MySql
+
+- **The envelope storage migration no longer fails on every startup.**
+  ([#3985](https://github.com/JasperFx/wolverine/pull/3985), closes
+  [#3983](https://github.com/JasperFx/wolverine/issues/3983)) On MySQL every node logged an `Error` from
+  `MySqlMessageStore` on every start: `Cannot drop index 'fk_wolverine_node_assignments_node_id': needed
+  in a foreign key constraint`. The first migration against an empty database is a pure `CREATE`, so this
+  was unreachable until the second run — it reproduced against a brand-new database and then repeated
+  forever.
+
+  There were four drift items, not one, and only the first threw — so the migration runner logged it and
+  the rest never ran. `wolverine_nodes.node_number` and `wolverine_node_records.id` folded `AUTO_INCREMENT`
+  into the column *type* string; the catalog reports the type as plain `INT` and carries `auto_increment`
+  separately, so neither column ever compared equal and both emitted a `MODIFY COLUMN` on every check.
+  They now use Weasel's `AutoIncrement()`. The generated DDL is unchanged apart from where the keyword
+  sits, so **existing databases need no migration**.
+
+  The other three were `Weasel.MySql` bugs, fixed in [weasel#445](https://github.com/JasperFx/weasel/pull/445)
+  and shipped in Weasel 9.25.0.
+
+### WolverineFx.Oracle
+
+- **Oracle schema migration passes the Oracle command builder.**
+  ([#3985](https://github.com/JasperFx/wolverine/pull/3985)) `SchemaMigration.DetermineAsync(conn, ct, objects)`
+  builds a plain `DbCommandBuilder`, whose `StartNewCommand()` is a no-op — correct for providers that
+  accept several statements in one command, wrong for Oracle. Weasel 9.25 raised Oracle's table
+  introspection from one query to six ([weasel#474](https://github.com/JasperFx/weasel/issues/474)), so
+  those boundaries stopped being decorative: without them ODP.NET receives one command holding six
+  `SELECT`s and rejects it with `ORA-03048`.
+
+  Every Oracle call site now passes `OracleMigrator.CreateCommandBuilder(conn)`, which is what Weasel
+  documents for this. Nothing outside Oracle is affected — the no-op is correct everywhere else.
+
+### Dependencies
+
+- **Weasel bumped to 9.25.1**, the identifier release. If your schema names are all plain lowercase
+  identifiers the emitted DDL is byte-identical to 9.24 and there is nothing to do. Otherwise three
+  changes are worth knowing about, and Weasel's
+  [upgrade notes](https://weasel.jasperfx.net/release-9-25) carry the full list:
+
+  - **Oracle can now see index, foreign key and primary key drift**, which it previously could not detect
+    at all. Expect a first run that applies index and foreign key changes it had been silently ignoring —
+    that is the backlog being worked off, not new drift.
+  - **SQLite no longer drops the table to change a column.** A change that `ALTER TABLE` cannot express
+    used to be answered by dropping the object and recreating it, losing every row.
+  - **Column names are no longer case-folded or rewritten.** Wolverine's NServiceBus PostgreSQL queue
+    table declared PascalCase columns and relied on Weasel folding them to lowercase; a real
+    NServiceBus-provisioned table has lowercase columns, so the declaration was wrong all along and is now
+    stated as lowercase directly. No behavior change against an NServiceBus-owned table.
+  - **Oracle table introspection is now six queries rather than one**, which is what made the Oracle
+    command-builder bug above reachable.
+
 ### WolverineFx (core)
 
 - **`AfterCommit` — a declarative way to run work after the transactional commit.**

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,13 +137,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.24.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.24.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.24.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.24.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.24.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.24.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.24.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.25.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.25.1" />
+    <PackageVersion Include="Weasel.MySql" Version="9.25.1" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.25.1" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.25.1" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.25.1" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.25.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,18 +41,18 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.6.1" />
-    <PackageVersion Include="JasperFx" Version="2.47.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.47.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.47.0" />
+    <PackageVersion Include="JasperFx" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.47.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.53.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Polecat" Version="[5.12.0,6.0.0)" />
-    <PackageVersion Include="Fisher" Version="1.0.0" />
+    <PackageVersion Include="Fisher" Version="1.0.2" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.23.0" />
     <PackageVersion Include="Marten.Newtonsoft" Version="9.23.0" />

--- a/src/Persistence/FisherTests/NoParallelization.cs
+++ b/src/Persistence/FisherTests/NoParallelization.cs
@@ -1,0 +1,10 @@
+// FisherTests bootstraps Wolverine hosts from most of its classes, and
+// after_commit_runs_after_the_commit flips DynamicCodeBuilder.WithinCodegenCommand -- a
+// process-wide static -- to force codegen without starting a host. It resets the flag in a
+// finally, so the window is small, but any host bootstrapping in a *concurrent* class inside
+// that window silently comes up in DurabilityMode.MediatorOnly and then throws
+// "This operation is not allowed with Wolverine is bootstrapped in MediatorOnly mode" on the
+// first PublishAsync. That reads as an unrelated failure several classes away.
+//
+// Same reasoning, and the same one-liner, as PolecatTests.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/Persistence/MySql/MySqlTests/Bug_3983_repeated_envelope_storage_migration.cs
+++ b/src/Persistence/MySql/MySqlTests/Bug_3983_repeated_envelope_storage_migration.cs
@@ -1,0 +1,74 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql;
+using Wolverine;
+using Wolverine.MySql;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+
+namespace MySqlTests;
+
+/// <summary>
+///     GH-3983: MySQL implicitly creates a backing index for the wolverine_node_assignments
+///     foreign key and names it after the constraint, so the schema diff saw a permanently
+///     "extra" index and emitted a DROP INDEX that InnoDB refuses (error 1553). The first
+///     migration against an empty database is a pure CREATE and never hit it — every start
+///     after that logged an error.
+/// </summary>
+[Collection("mysql")]
+public class Bug_3983_repeated_envelope_storage_migration
+{
+    private const string SchemaName = "bug_3983";
+
+    private static MySqlMessageStore buildStore()
+    {
+        var dataSource = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString);
+        var settings = new DatabaseSettings
+        {
+            SchemaName = SchemaName,
+            CommandQueuesEnabled = true,
+            Role = MessageStoreRole.Main
+        };
+
+        return new MySqlMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<MySqlMessageStore>.Instance);
+    }
+
+    [Fact]
+    public async Task migrating_an_already_current_database_is_a_no_op()
+    {
+        var store = buildStore();
+
+        await store.Admin.MigrateAsync();
+
+        // The second pass is the one the issue reports: nothing has changed, so it must
+        // neither throw nor leave the database in a state that still reports drift.
+        await store.Admin.MigrateAsync();
+        await store.Admin.MigrateAsync();
+
+        await store.AssertDatabaseMatchesConfigurationAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task the_node_assignments_foreign_key_reports_no_drift()
+    {
+        var store = buildStore();
+        await store.Admin.MigrateAsync();
+
+        var assignments = store.AllObjects()
+            .OfType<Weasel.MySql.Tables.Table>()
+            .Single(x => x.Identifier.Name == DatabaseConstants.NodeAssignmentsTableName);
+
+        await using var conn = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString)
+            .CreateConnection();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        var delta = await assignments.FindDeltaAsync(conn, TestContext.Current.CancellationToken);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+
+        await conn.CloseAsync();
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -487,8 +487,12 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
         {
             var nodeTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeTableName));
             nodeTable.AddColumn<Guid>("id").AsPrimaryKey();
-            // MySQL requires AUTO_INCREMENT to be part of a key - add unique index
-            nodeTable.AddColumn("node_number", "INT AUTO_INCREMENT").NotNull()
+            // MySQL requires AUTO_INCREMENT to be part of a key - add unique index.
+            // AUTO_INCREMENT belongs in AutoIncrement(), not in the type: the catalog reports
+            // the type as plain INT, so folding it into the type string made this column
+            // report drift on every schema check (GH-3983).
+            nodeTable.AddColumn<int>("node_number").NotNull()
+                .AutoIncrement()
                 .AddIndex(idx => idx.IsUnique = true);
             nodeTable.AddColumn<string>("description").NotNull();
             nodeTable.AddColumn<string>("uri").NotNull();
@@ -530,7 +534,7 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             }
 
             var eventTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
-            eventTable.AddColumn("id", "INT AUTO_INCREMENT").AsPrimaryKey();
+            eventTable.AddColumn<int>("id").AsPrimaryKey().AutoIncrement();
             eventTable.AddColumn<int>("node_number").NotNull();
             eventTable.AddColumn<string>("event_name").NotNull();
             eventTable.AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("(UTC_TIMESTAMP(6))").NotNull();

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Admin.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Admin.cs
@@ -82,7 +82,12 @@ internal partial class OracleMessageStore
         // Now recreate all tables
         foreach (var obj in objects)
         {
-            var migration = await SchemaMigration.DetermineAsync(conn, _cancellation, obj);
+            // The Oracle builder, not the default one: ODP.NET will not execute several statements
+            // from one command, and Oracle's Table registers six introspection queries as of Weasel
+            // 9.25 (weasel#474). DbCommandBuilder.StartNewCommand is a no-op, so the default builder
+            // runs them together and Oracle rejects the batch with ORA-03048.
+            var builder = new OracleMigrator().CreateCommandBuilder(conn);
+            var migration = await SchemaMigration.DetermineAsync(conn, builder, _cancellation, obj);
             if (migration.Difference != SchemaPatchDifference.None)
             {
                 try
@@ -146,7 +151,12 @@ internal partial class OracleMessageStore
         var objects = AllObjects().ToArray();
         foreach (var obj in objects)
         {
-            var migration = await SchemaMigration.DetermineAsync(conn, _cancellation, obj);
+            // The Oracle builder, not the default one: ODP.NET will not execute several statements
+            // from one command, and Oracle's Table registers six introspection queries as of Weasel
+            // 9.25 (weasel#474). DbCommandBuilder.StartNewCommand is a no-op, so the default builder
+            // runs them together and Oracle rejects the batch with ORA-03048.
+            var builder = new OracleMigrator().CreateCommandBuilder(conn);
+            var migration = await SchemaMigration.DetermineAsync(conn, builder, _cancellation, obj);
             if (migration.Difference != SchemaPatchDifference.None)
             {
                 try

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -434,7 +434,12 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
         await using var conn = CreateConnection();
         await conn.OpenAsync();
 
-        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, table);
+        // The Oracle builder, not the default one: ODP.NET will not execute several statements from
+        // one command, and Oracle's Table registers six introspection queries as of Weasel 9.25
+        // (weasel#474). DbCommandBuilder.StartNewCommand is a no-op, so the default builder runs
+        // them together and Oracle rejects the batch with ORA-03048.
+        var builder = new OracleMigrator().CreateCommandBuilder(conn);
+        var migration = await SchemaMigration.DetermineAsync(conn, builder, CancellationToken.None, table);
         if (migration.Difference != SchemaPatchDifference.None)
         {
             await new OracleMigrator().ApplyAllAsync(conn, migration, AutoCreate.CreateOrUpdate);

--- a/src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Sagas/OracleSagaSchema.cs
@@ -91,7 +91,12 @@ public class OracleSagaSchema<T, TId> : IDatabaseSagaSchema<TId, T> where T : Sa
         await using var conn = new OracleConnection(_settings.ConnectionString);
         await conn.OpenAsync(cancellationToken);
 
-        var migration = await SchemaMigration.DetermineAsync(conn, cancellationToken, Table);
+        // The Oracle builder, not the default one: ODP.NET will not execute several statements from
+        // one command, and Oracle's Table registers six introspection queries as of Weasel 9.25
+        // (weasel#474). DbCommandBuilder.StartNewCommand is a no-op, so the default builder runs
+        // them together and Oracle rejects the batch with ORA-03048.
+        var builder = new OracleMigrator().CreateCommandBuilder(conn);
+        var migration = await SchemaMigration.DetermineAsync(conn, builder, cancellationToken, Table);
 
         if (migration.Difference != SchemaPatchDifference.None)
         {

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueListener.cs
@@ -27,19 +27,19 @@ internal class NServiceBusPostgresqlQueueListener : DatabaseListener
         _mapper = queue.BuildMapper(runtime);
         _sender = new NServiceBusPostgresqlQueueSender(queue, runtime);
 
-        // Destructive competing-consumer pop honoring NServiceBus FIFO-by-Seq ordering. The
-        // column identifiers are left unquoted: Weasel provisions the queue table with
-        // case-folded (lowercase) column names, so unquoted references resolve correctly.
+        // Destructive competing-consumer pop honoring NServiceBus FIFO-by-seq ordering. The
+        // column identifiers are left unquoted, which PostgreSQL folds to lowercase — matching
+        // the lowercase columns both NServiceBus and NServiceBusQueueTable declare.
         _receiveSql = $@"
 WITH message AS (
     DELETE FROM {queue.TableIdentifier}
     WHERE ctid IN (
         SELECT ctid FROM {queue.TableIdentifier}
-        ORDER BY Seq
+        ORDER BY seq
         LIMIT :count
         FOR UPDATE SKIP LOCKED)
-    RETURNING Id, Headers, Body)
-SELECT Id, Headers, Body FROM message;";
+    RETURNING id, headers, body)
+SELECT id, headers, body FROM message;";
     }
 
     protected override int MaximumMessagesToReceive => _queue.MaximumMessagesToReceive;

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueSender.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusPostgresqlQueueSender.cs
@@ -22,10 +22,10 @@ internal class NServiceBusPostgresqlQueueSender : ISender
         Destination = queue.Uri;
 
         // The documented NServiceBus PostgreSQL send statement. The column identifiers are left
-        // unquoted: Weasel provisions the queue table with case-folded (lowercase) column names,
-        // so unquoted references resolve correctly.
+        // unquoted, which PostgreSQL folds to lowercase — matching the lowercase columns both
+        // NServiceBus and NServiceBusQueueTable declare.
         _sendSql =
-            $@"INSERT INTO {queue.TableIdentifier} (Id, Expires, Headers, Body) VALUES (:id, :expires, :headers, :body)";
+            $@"INSERT INTO {queue.TableIdentifier} (id, expires, headers, body) VALUES (:id, :expires, :headers, :body)";
     }
 
     // NServiceBus delayed delivery uses a separate timeout table + mover; not supported in v1.

--- a/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/NServiceBus/NServiceBusQueueTable.cs
@@ -14,14 +14,21 @@ internal class NServiceBusQueueTable : Table
 {
     public NServiceBusQueueTable(DbObjectName identifier) : base(identifier)
     {
-        AddColumn<Guid>("Id").AsPrimaryKey();
-        AddColumn("Expires", "timestamp");
-        AddColumn<string>("Headers").NotNull();
-        AddColumn("Body", "bytea");
+        // Lowercase deliberately. A real NServiceBus-provisioned queue table has case-folded
+        // column names — verified against a live NServiceBus.Transport.PostgreSql host — so
+        // these have to be lowercase to line up with a table NServiceBus owns, and to keep the
+        // unquoted identifiers in the send/receive SQL resolving. Weasel used to case-fold
+        // declared names on its way to the database and hid the difference; as of 9.25 it
+        // preserves and quotes what it is given, which would have made "Seq" a genuinely
+        // distinct column from NServiceBus's seq.
+        AddColumn<Guid>("id").AsPrimaryKey();
+        AddColumn("expires", "timestamp");
+        AddColumn<string>("headers").NotNull();
+        AddColumn("body", "bytea");
 
-        AddColumn<int>("Seq").AutoIncrement().NotNull();
+        AddColumn<int>("seq").AutoIncrement().NotNull();
 
-        // Seq is what the destructive receive orders by (FIFO), so a Wolverine-provisioned table
+        // seq is what the destructive receive orders by (FIFO), so a Wolverine-provisioned table
         // needs an index on it or the ORDER BY degrades to a full sort once a backlog builds — a
         // soak that let the table grow collapsed receiver throughput by ~60x without this. We use a
         // *non-unique* index (NOT a unique one): NServiceBus puts a UNIQUE *constraint* on seq and
@@ -30,7 +37,7 @@ internal class NServiceBusQueueTable : Table
         // NServiceBus-owned table. The transport never needs to enforce seq uniqueness itself.
         Indexes.Add(new IndexDefinition(PostgresqlIdentifier.Shorten($"idx_{identifier.Name}_seq"))
         {
-            Columns = ["Seq"]
+            Columns = ["seq"]
         });
     }
 }


### PR DESCRIPTION
Closes #3983. Supersedes #3985, which was cut before Weasel 9.25.1 existed and carries a stale 9.25.0 pin on a branch that cannot be force-pushed.

Three commits: the MySQL fix the issue is about, the Weasel upgrade it needs, and the two unrelated defects that upgrade exposed — plus the CIFisher breakage that has been red on `main` independently.

## 1. GH-3983 — the MySQL bug

@cyclr-adrian's report was exactly right, including the diagnosis. Reproducing it turned up **four** drift items on every startup, not one:

```
ALTER TABLE <schema>.wolverine_nodes MODIFY COLUMN `node_number` INT AUTO_INCREMENT NOT NULL;
DROP INDEX `fk_wolverine_node_assignments_node_id` ON <schema>.wolverine_node_assignments;
ALTER TABLE <schema>.wolverine_node_assignments DROP FOREIGN KEY `fk_wolverine_node_assignments_node_id`;
ALTER TABLE <schema>.wolverine_node_assignments ADD CONSTRAINT `fk_wolverine_node_assignments_node_id` ...;
ALTER TABLE <schema>.wolverine_node_records MODIFY COLUMN `id` INT AUTO_INCREMENT NOT NULL;
```

Only the `DROP INDEX` throws, which is why the rest went unnoticed — the runner logs the first failure and the remaining statements never run. The first migration against an empty database is a pure `CREATE`, so none of it is reachable until the second run.

`wolverine_nodes.node_number` and `wolverine_node_records.id` folded `AUTO_INCREMENT` into the column **type** string. `information_schema` reports the type as plain `INT` and carries `auto_increment` separately in `EXTRA`, so neither column ever compared equal. Now uses Weasel's `AutoIncrement()`; the DDL is unchanged apart from where the keyword sits, so **existing databases need no migration**. The other three were `Weasel.MySql` defects, fixed in [weasel#445](https://github.com/JasperFx/weasel/pull/445).

## 2. Two bugs the Weasel upgrade exposed, both ours

**NServiceBus PostgreSQL interop.** 9.25 stops case-folding column names. `NServiceBusQueueTable` declared PascalCase columns and referenced them unquoted, with a comment saying it relied on Weasel folding them to lowercase. Under 9.25 the table gets a case-sensitive `"Seq"` and the destructive pop fails with `42703: column "Seq" does not exist`. The declaration was wrong all along — a real NServiceBus table has **lowercase** columns, verified against a live `NServiceBus.Transport.PostgreSql` host when this transport was built. Declared lowercase now.

**Oracle schema migration — 94 of 115 `OracleTests` down.** `SchemaMigration.DetermineAsync(conn, ct, objects)` builds a plain `DbCommandBuilder`, whose `StartNewCommand()` is a no-op — correct for providers that take several statements per command, wrong for Oracle. 9.25 raised Oracle's table introspection from one query to six ([weasel#474](https://github.com/JasperFx/weasel/issues/474)), so those boundaries stopped being decorative: ODP.NET gets one command holding six `SELECT`s and rejects it with `ORA-03048`. All four Oracle call sites now pass `OracleMigrator.CreateCommandBuilder(conn)`, which is what Weasel documents.

## 3. CIFisher — red on `main`, two unrelated causes

`CIFisher` is the **only** failing job on main's own run of `af4807b5f`, so this is not a regression from this branch — but Fisher 1.0.2 requires Weasel 9.25.1, so the fix has to ride here to get CI at all.

**Version skew (4 tests).** "Bumping to Fisher 1.0" moved Fisher but left the JasperFx family on 2.47.0, while Fisher 1.0 pulls `JasperFx.Events` 2.52.0. A 2.47-era source generator emitting dispatchers for a 2.52 runtime gives `No source-generated dispatcher found`, with no compile error pointing at it. Fisher → **1.0.2**, JasperFx family → **2.53.0**.

**Test parallelism against a process-wide static (5 tests), predating the Fisher bump.** `after_commit_runs_after_the_commit` flips `DynamicCodeBuilder.WithinCodegenCommand` to force codegen without starting a host. It resets in a `finally`, so the window is small — but `FisherTests` had no `NoParallelization.cs`, so xUnit ran its classes concurrently. Any host bootstrapping inside that window came up in `DurabilityMode.MediatorOnly` and threw on its first `PublishAsync`, several classes away from the test that set the flag: passing in isolation, failing in the suite. `PolecatTests` already carries this guard.

## Why 9.25.1 and not 9.25.0

9.25.0's extended identifier validation rejected an over-long primary key constraint name PostgreSQL had always silently truncated, breaking `tenant_partitioned_natural_key_aggregate`. [weasel#485](https://github.com/JasperFx/weasel/issues/485) settled it — local identifiers are checked for safety, not length — and 9.25.1 carries that, so those tests are green with no Marten change required.

## Testing

New `Bug_3983_repeated_envelope_storage_migration`: migrate an already-current database and assert no drift. The existing `can_migrate_schema_directly` migrates **once**, against an empty database, where the migration is a pure `CREATE`.

| Suite | Result |
| --- | --- |
| MySql | 125 / 125 |
| PostgreSQL | 481 / 482 (1 skipped) |
| SQL Server | 396 / 398 (2 skipped) |
| SQLite | 168 / 169 (1 skipped) |
| EF Core | 205 / 205 |
| Marten | **610 / 610** (was 607/610) |
| Fisher | **27 / 27** (was 18/27), stable over 3 runs |
| Oracle | `CIOracle` green on the previous push |
| `wolverine.slnx` Release `-f net9.0` | clean, 0 warnings |

CI on the previous push came back with `CIOracle`, `CIMySql` and `CIMartenDistribution` all green and `CIFisher` the only red — which is what this push addresses.

## Note on Polecat

Polecat's pin is a **range**, `[5.12.0,6.0.0)`, and NuGet resolves a range to its floor — so the build has been on **5.12.0**, not the latest 5.x. Upgrading it to 5.19.1 is a separate PR; it also needs JasperFx 2.53.0, so the two will conflict trivially in `Directory.Packages.props` and whichever merges second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3