### PR TITLE
Upgrade to Polecat 5.19.1 (and JasperFx 2.53.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,17 +41,17 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.6.1" />
-    <PackageVersion Include="JasperFx" Version="2.47.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.47.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.47.0" />
+    <PackageVersion Include="JasperFx" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.47.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.53.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="[5.12.0,6.0.0)" />
+    <PackageVersion Include="Polecat" Version="5.19.1" />
     <PackageVersion Include="Fisher" Version="1.0.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageVersion Include="Marten.AspNetCore" Version="9.23.0" />


### PR DESCRIPTION
## The pin was a range, so the build has been on 5.12.0

```xml
<PackageVersion Include="Polecat" Version="[5.12.0,6.0.0)" />
```

NuGet resolves a version *range* to its **floor**, not its ceiling — so this has been restoring **Polecat 5.12.0** all along, not "the latest 5.x" that the range reads like. Confirmed against `project.assets.json`:

```
Polecat/5.12.0
```

Seven minor versions have shipped since (5.15.1, 5.16.0, 5.17.0, 5.18.0, 5.19.0, 5.19.1). Pinned explicitly to **5.19.1** so the version moves when someone moves it, rather than sitting at a floor that looks like a ceiling.

## JasperFx 2.53.0 comes with it

Polecat 5.19.1 depends on `JasperFx` / `JasperFx.Events` **2.53.0**; Wolverine pins the family at 2.47.0, which is a downgrade and will not resolve. The whole family moves to 2.53.0 — `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator` — which is also current.

`JasperFx.Events.SourceGenerator` has to move in lockstep with the runtime: a generator emitting dispatchers for a different `JasperFx.Events` version fails at *runtime* with `No source-generated dispatcher found` and no compile error to point at it. That is a real failure mode, not a hypothetical — it is half of what has had `CIFisher` red on `main`.

## Testing

| Suite | Result |
| --- | --- |
| PolecatTests | 288 / 290 (2 skipped) |
| `wolverine.slnx` Release `-f net9.0` | clean, 0 warnings |

`PolecatIncidentService.Tests` targets net10.0 only, so it is not covered by the pinned-framework run — `CIPolecatWorkflow` exercises it.

The JasperFx 2.53.0 lift is also verified more broadly on #3991, where it takes MartenTests from 607/610 to **610/610** and FisherTests from 18/27 to **27/27**.

## Conflicts with #3991

[#3991](https://github.com/JasperFx/wolverine/pull/3991) bumps JasperFx to 2.53.0 too, for Fisher 1.0.2. The two will conflict on those four lines in `Directory.Packages.props`; whichever merges second rebases. Nothing else overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3