### PR TITLE
GH-3986: ClearAllAsync must delete node records another process wrote (RavenDb + SQLite)

### DIFF
--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
@@ -21,7 +21,13 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
 
         foreach (var node in nodes)
         {
-            session.Delete(node);
+            // GH-3986: delete by document id rather than by entity. LoadAllNodesAsync opens and
+            // disposes its own session, so these WolverineNode instances are tracked by a session
+            // that is already gone, and RavenDB's Delete<T>(T entity) overload throws
+            // "... is not associated with the session, cannot delete unknown entity instance".
+            // Deleting by id matches what DeleteAsync(Guid, int) already does for a single node,
+            // and what the AgentAssignment deletes below have always done.
+            session.Delete(node.NodeId.ToString());
             foreach (var agent in node.ActiveAgents)
             {
                 session.Delete(AgentAssignment.ToId(agent));

--- a/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
@@ -44,7 +44,15 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
     public async Task ClearAllAsync(CancellationToken cancellationToken)
     {
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        await conn.CreateCommand($"delete from {_nodeTable}")
+
+        // GH-3986: the assignment rows have to go explicitly. PostgreSQL and Sql Server get this from
+        // the node_id foreign key's ON DELETE CASCADE, but the SQLite assignment table has no foreign
+        // key -- SQLite would not enforce one anyway without PRAGMA foreign_keys=ON per connection.
+        // Left behind, the rows are invisible to LoadAllNodesAsync (it only attaches an assignment to a
+        // node id it actually loaded) right up until a node re-registers under the same id, which is
+        // exactly the GH-3604 ejection/re-registration path -- and then it comes back owning agents it
+        // was never reassigned.
+        await conn.CreateCommand($"delete from {_assignmentTable};delete from {_nodeTable};")
             .ExecuteNonQueryAsync(cancellationToken);
     }
 
@@ -86,8 +94,10 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
         }
 
         await using var conn = await _dataSource.OpenConnectionAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // GH-3986: same missing cascade as ClearAllAsync -- delete this node's assignments by hand.
         await conn.CreateCommand(
-                $"delete from {_nodeTable} where id = @id;update {IncomingTable} set {OwnerId} = 0 where {OwnerId} = @number;update {OutgoingTable} set {OwnerId} = 0 where {OwnerId} = @number;")
+                $"delete from {_assignmentTable} where {NodeId} = @id;delete from {_nodeTable} where id = @id;update {IncomingTable} set {OwnerId} = 0 where {OwnerId} = @number;update {OutgoingTable} set {OwnerId} = 0 where {OwnerId} = @number;")
             .With("id", nodeId.ToString())
             .With("number", assignedNodeNumber)
             .ExecuteNonQueryAsync();

--- a/src/Testing/Wolverine.ComplianceTests/NodePersistenceCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/NodePersistenceCompliance.cs
@@ -279,4 +279,37 @@ public abstract class NodePersistenceCompliance : IAsyncLifetime
         resurrected.ActiveAgents.OrderBy(x => x.ToString()).ShouldBe([agent2, agent1]);
     }
 
+    [Fact]
+    public async Task clear_all_wipes_node_records_and_their_assignments()
+    {
+        // GH-3986. ClearAllAsync() is what a Solo-mode start calls to sweep the node records a previous
+        // Balanced-mode run left behind, so it has to work when the rows it deletes were written by an
+        // earlier *process*, not by this one. RavenDB's implementation deleted by tracked entity, which
+        // only works if the same session loaded it, and threw InvalidOperationException on every stale
+        // node. Two nodes, so a provider that only clears the first one is caught as well.
+        var first = createNode();
+        var second = createNode();
+
+        first.AssignedNodeNumber = await _database.Nodes.PersistAsync(first, CancellationToken.None);
+        second.AssignedNodeNumber = await _database.Nodes.PersistAsync(second, CancellationToken.None);
+
+        var agent1 = new Uri("red://leader");
+        var agent2 = new Uri("red://five");
+        var agent3 = new Uri("blue://leader");
+
+        await _database.Nodes.AssignAgentsAsync(first.NodeId, new[] { agent1, agent2 }, CancellationToken.None);
+        await _database.Nodes.AssignAgentsAsync(second.NodeId, new[] { agent3 }, CancellationToken.None);
+
+        await _database.Nodes.ClearAllAsync(CancellationToken.None);
+
+        (await _database.Nodes.LoadAllNodesAsync(CancellationToken.None)).ShouldBeEmpty();
+
+        // The assignments have to go too, not just the node rows. Re-registering the same node id is the
+        // provider-agnostic way to see them: if the assignment records survived, they reattach here.
+        await _database.Nodes.ReregisterNodeAsync(first, CancellationToken.None);
+
+        var reregistered = (await _database.Nodes.LoadAllNodesAsync(CancellationToken.None)).Single();
+        reregistered.NodeId.ShouldBe(first.NodeId);
+        reregistered.ActiveAgents.ShouldBeEmpty();
+    }
 }


### PR DESCRIPTION
Fixes #3986.

## The reported bug

`ClearAllAsync` is what a Solo-mode start calls to sweep the `WolverineNode` records a previous Balanced-mode run left behind — so by construction it deletes rows *this* process did not write. RavenDB's implementation could not:

```csharp
var nodes = await LoadAllNodesAsync(cancellationToken); // opens + disposes session A
using var session = _store.OpenAsyncSession();          // session B
session.Delete(node);                                   // throws
```

`Delete<T>(T entity)` requires the entity to be tracked by the session it is called on, so every stale node threw `InvalidOperationException: WolverineNode is not associated with the session, cannot delete unknown entity instance` and the app could not start at all.

Deleting by document id is what `DeleteAsync(Guid, int)` already does for a single node, and what the `AgentAssignment` deletes in the very same loop have always done.

## A second one the compliance test found

`NodePersistenceCompliance` never exercised `ClearAllAsync` at all, which is how a provider could ship it broken. Adding that coverage turned up SQLite as well.

SQLite's assignment table declares no foreign key to the node table — PostgreSQL, Sql Server and Oracle all use `ON DELETE CASCADE`, and SQLite would not enforce a constraint anyway without `PRAGMA foreign_keys=ON` per connection. So both `ClearAllAsync` and `DeleteAsync` deleted the node rows and left the assignment rows behind permanently.

Those orphans are invisible to `LoadAllNodesAsync`, which only attaches an assignment to a node id it actually loaded — right up until a node re-registers under the same id. That is exactly the GH-3604 ejection/re-registration path, and there the node comes back owning agents it was never reassigned. Both statements now delete the assignments explicitly.

## Coverage

`clear_all_wipes_node_records_and_their_assignments` on `NodePersistenceCompliance`, so every provider gets it. Two nodes, so a provider that clears only the first is caught; and a re-registration afterwards, which is the provider-agnostic way to make surviving assignment rows visible.

- **RavenDb** — verified red (the exact reported exception, from `RavenDbMessageStore.NodeAgents.cs:24`) then green.
- **PostgreSQL, Sql Server, MySQL** — green, no change needed; the FK cascade already did it.
- **SQLite** — verified red then green.
- **CosmosDb, Oracle** — correct by inspection (Cosmos deletes by id explicitly, Oracle has the cascade); covered by their CI jobs.

Full `wolverine.slnx` builds clean at `-f net9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3