### PR TITLE
GH-3970: release an agent this node cannot build or start to a capable peer

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/failed_agent_start_release.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/failed_agent_start_release.cs
@@ -1,0 +1,376 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Coverage for GH-3970: an agent this node cannot BUILD OR START is released to a capable peer, instead
+/// of being requested on the same node again on every assignment tick forever.
+///
+/// <para>This is the gap GH-3888 could not cover. That release is driven by the stall detector sweeping
+/// the agents this node is actually running (<c>NodeAgentController.Agents</c>) and reading
+/// <c>LocalRestartsExhausted</c> off the live instance. When <c>IAgentFamily.BuildAgentAsync</c> throws
+/// there IS no instance — nothing is ever registered — so no restart budget is ever consumed and that
+/// sweep structurally cannot see the agent. The exception was caught, logged, and dropped.</para>
+///
+/// <para>The leader, meanwhile, learns only that the agent is "unconfirmed", which it deliberately does
+/// not treat as a failure — GH-3750 fixed exactly the opposite bug, where slow starts got re-placed onto
+/// other nodes. So the assignment stands and the same agent is requested on the same node again next
+/// tick. The field failure: a blue/green fleet where the two sides carry disjoint projection versions,
+/// each handed agents for the other's version, failing with
+/// <c>ArgumentOutOfRangeException: Unable to find a shard with path '…/v19/&lt;tenant&gt;'</c>. Fleet-wide
+/// projection progress was byte-identical across 54 minutes; only a pod restart ever cleared it.</para>
+///
+/// <para>The fix counts consecutive failed starts on the node that caught them, and feeds an exhausted
+/// budget into GH-3888's existing release — the same capability embargo, so the leader cannot hand the
+/// agent straight back.</para>
+/// </summary>
+public class failed_agent_start_release
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly IWolverineObserver _observer = Substitute.For<IWolverineObserver>();
+    private readonly INodeAgentPersistence _persistence = Substitute.For<INodeAgentPersistence>();
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly List<WolverineNode> _reregistrations = new();
+
+    private static readonly Uri AgentUri =
+        new("event-subscriptions://marten/main/claims438/claim_lines/all/v19/01009333");
+
+    public failed_agent_start_release()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false;
+        _options.Durability.CheckAssignmentPeriod = 1.Hours();
+
+        // One attempt per tick keeps the tests counting assignment ticks rather than inner retries; the
+        // budget under test is the OUTER one. See MaxAgentStartFailuresBeforeRelease.
+        _options.Durability.AgentStartRetryAttempts = 0;
+        _options.Durability.AgentStartRetryDelay = TimeSpan.Zero;
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(_observer);
+
+        _persistence.MarkHealthCheckAsync(Arg.Any<WolverineNode>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _persistence
+            .When(x => x.ReregisterNodeAsync(Arg.Any<WolverineNode>(), Arg.Any<CancellationToken>()))
+            .Do(call => _reregistrations.Add(call.Arg<WolverineNode>()));
+    }
+
+    private void nodeStateHas(params WolverineNode[] peers)
+    {
+        _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new NodeAgentState(peers.ToList(), new AgentRestrictions([])));
+    }
+
+    private static WolverineNode peer(bool advertisesAgent, TimeSpan? heartbeatAge = null)
+    {
+        var node = new WolverineNode
+        {
+            NodeId = Guid.NewGuid(),
+            AssignedNodeNumber = 2,
+            LastHealthCheck = DateTimeOffset.UtcNow.Subtract(heartbeatAge ?? TimeSpan.Zero)
+        };
+
+        if (advertisesAgent)
+        {
+            node.Capabilities.Add(AgentUri);
+        }
+
+        return node;
+    }
+
+    private async Task<(NodeAgentController Controller, UnbuildableAgentFamily Family)> controllerAsync()
+    {
+        var family = new UnbuildableAgentFamily("event-subscriptions", AgentUri);
+
+        var controller = new NodeAgentController(_runtime, _persistence, [family],
+            NullLogger<NodeAgentController>.Instance, _cancellation.Token);
+
+        // Captures the node's advertised capabilities, so a release is observable as a capability set
+        // that shrinks. The family advertises the agent even though it cannot build it — which is
+        // exactly the reported shape: the leader had every reason to think this node could run it.
+        await controller.StartLocalAgentProcessingAsync(_options);
+
+        return (controller, family);
+    }
+
+    /// <summary>
+    /// Drive one assignment tick's worth of work: the leader asks this node to start the agent, and the
+    /// start throws. Mirrors StartAgents.StartBatchAsync, which catches and logs.
+    /// </summary>
+    private static async Task failOneStartAsync(NodeAgentController controller)
+    {
+        await Should.ThrowAsync<Exception>(() => controller.StartAgentAsync(AgentUri));
+    }
+
+    [Fact]
+    public async Task a_start_that_keeps_throwing_is_released_to_a_capable_peer()
+    {
+        var (controller, family) = await controllerAsync();
+        nodeStateHas(peer(advertisesAgent: true));
+
+        for (var i = 0; i < _options.Durability.MaxAgentStartFailuresBeforeRelease; i++)
+        {
+            await failOneStartAsync(controller);
+        }
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        // The assignment row is dropped even though nothing was ever running here, which is what lets the
+        // leader place the agent somewhere else. Before the fix this row was the only thing the leader
+        // had, and it never changed.
+        await _persistence.Received(1)
+            .RemoveAssignmentAsync(_options.UniqueNodeId, AgentUri, Arg.Any<CancellationToken>());
+
+        // The anti-bounce half: this node no longer advertises the capability, so capability-matched
+        // distribution cannot hand the agent straight back to the node that just failed it.
+        _reregistrations.ShouldNotBeEmpty();
+        _reregistrations.Last().Capabilities.ShouldNotContain(AgentUri);
+
+        await _observer.Received(1).AgentReleased(AgentUri, Arg.Any<ShardFailure?>());
+
+        family.BuildAttempts.ShouldBe(_options.Durability.MaxAgentStartFailuresBeforeRelease);
+    }
+
+    [Fact]
+    public async Task the_budget_is_not_spent_early()
+    {
+        var (controller, _) = await controllerAsync();
+        nodeStateHas(peer(advertisesAgent: true));
+
+        // One short of the budget. A start failure is not on its own evidence that this node can never
+        // run the agent — GH-3519's first-assignment race is a real, self-healing case — so the release
+        // must stay patient.
+        for (var i = 0; i < _options.Durability.MaxAgentStartFailuresBeforeRelease - 1; i++)
+        {
+            await failOneStartAsync(controller);
+            await controller.ReportFailedLocalAgentsAsync();
+        }
+
+        _reregistrations.ShouldBeEmpty();
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task a_successful_start_clears_the_run_of_failures()
+    {
+        var (controller, family) = await controllerAsync();
+        nodeStateHas(peer(advertisesAgent: true));
+
+        await failOneStartAsync(controller);
+        await failOneStartAsync(controller);
+
+        // Whatever the start was racing has come up. The count is CONSECUTIVE failures, so this has to
+        // wipe the slate — otherwise a long-lived node accumulates unrelated failures over days and
+        // releases a perfectly healthy agent on one later blip.
+        family.CanBuild = true;
+        await controller.StartAgentAsync(AgentUri);
+
+        // Now wedge it and fail again. Reporting Stopped while still registered sends the next start
+        // through GH-3519's wedge recovery, which evicts the registration and re-drives the build — so
+        // this really is a fresh failed start rather than the idempotent early return.
+        family.Built.ShouldNotBeNull().Wedge();
+        family.CanBuild = false;
+
+        await failOneStartAsync(controller);
+        await controller.ReportFailedLocalAgentsAsync();
+
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+        _reregistrations.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task keeps_retrying_locally_when_no_live_peer_advertises_the_capability()
+    {
+        var (controller, _) = await controllerAsync();
+
+        // A live peer exists but cannot run this agent. Releasing would strand the agent entirely, so the
+        // sweep declines and local retries continue — the least-bad option.
+        nodeStateHas(peer(advertisesAgent: false));
+
+        for (var i = 0; i < _options.Durability.MaxAgentStartFailuresBeforeRelease; i++)
+        {
+            await failOneStartAsync(controller);
+        }
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        _reregistrations.ShouldBeEmpty();
+        await _persistence.DidNotReceive()
+            .RemoveAssignmentAsync(Arg.Any<Guid>(), Arg.Any<Uri>(), Arg.Any<CancellationToken>());
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task a_stale_peer_advertising_the_capability_does_not_count()
+    {
+        var (controller, _) = await controllerAsync();
+
+        // The only capable peer stopped heartbeating long ago — releasing to it would freeze the agent in
+        // a different place. Same outcome as having no capable peer at all.
+        nodeStateHas(peer(advertisesAgent: true, heartbeatAge: 10.Minutes()));
+
+        for (var i = 0; i < _options.Durability.MaxAgentStartFailuresBeforeRelease; i++)
+        {
+            await failOneStartAsync(controller);
+        }
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        _reregistrations.ShouldBeEmpty();
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task a_declined_release_refunds_the_budget_rather_than_releasing_on_the_next_tick()
+    {
+        var (controller, _) = await controllerAsync();
+        nodeStateHas(peer(advertisesAgent: false));
+
+        for (var i = 0; i < _options.Durability.MaxAgentStartFailuresBeforeRelease; i++)
+        {
+            await failOneStartAsync(controller);
+        }
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        // The refund means the very next failure must NOT immediately re-trigger a release attempt; a
+        // full fresh budget has to be burned first. Otherwise a node with no capable peer re-evaluates
+        // (and re-reads the whole node table) on every single tick forever.
+        await failOneStartAsync(controller);
+        await controller.ReportFailedLocalAgentsAsync();
+
+        await _persistence.Received(1).LoadNodeAgentStateAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task release_can_be_disabled_entirely()
+    {
+        _options.Durability.MaxAgentStartFailuresBeforeRelease = 0;
+
+        var (controller, _) = await controllerAsync();
+        nodeStateHas(peer(advertisesAgent: true));
+
+        for (var i = 0; i < 10; i++)
+        {
+            await failOneStartAsync(controller);
+            await controller.ReportFailedLocalAgentsAsync();
+        }
+
+        // The pre-GH-3970 behaviour, kept available for anyone who depends on it: retry here forever.
+        _reregistrations.ShouldBeEmpty();
+        await _observer.DidNotReceive().AgentReleased(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+    }
+
+    [Fact]
+    public async Task the_capability_is_advertised_again_after_the_release_cooldown()
+    {
+        var clock = new FrozenClock(DateTimeOffset.UtcNow);
+        var (controller, _) = await controllerAsync();
+        controller.TimeProvider = clock;
+        nodeStateHas(peer(advertisesAgent: true));
+
+        for (var i = 0; i < _options.Durability.MaxAgentStartFailuresBeforeRelease; i++)
+        {
+            await failOneStartAsync(controller);
+        }
+
+        await controller.ReportFailedLocalAgentsAsync();
+        _reregistrations.Last().Capabilities.ShouldNotContain(AgentUri);
+
+        await controller.RestoreExpiredReleaseEmbargoesAsync();
+        _reregistrations.Last().Capabilities.ShouldNotContain(AgentUri);
+
+        // A node whose transient fault has passed — a deployment that finally carries the right
+        // projection version — becomes an ordinary candidate again rather than being written off.
+        clock.Advance(_options.Durability.AgentReleaseCooldown + 1.Minutes());
+        await controller.RestoreExpiredReleaseEmbargoesAsync();
+        _reregistrations.Last().Capabilities.ShouldContain(AgentUri);
+    }
+
+    private sealed class FrozenClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    /// <summary>
+    /// A family that ADVERTISES the agent but cannot build it — the reported blue/green shape, where a
+    /// node's capability set and what it can actually construct had diverged. Throws the same exception
+    /// type the field report carried.
+    /// </summary>
+    private class UnbuildableAgentFamily : IStaticAgentFamily
+    {
+        private readonly Uri _uri;
+
+        public UnbuildableAgentFamily(string scheme, Uri uri)
+        {
+            Scheme = scheme;
+            _uri = uri;
+        }
+
+        public string Scheme { get; }
+        public bool CanBuild { get; set; }
+        public int BuildAttempts { get; private set; }
+        public BuiltAgent? Built { get; private set; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>([_uri]);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>([_uri]);
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+        {
+            BuildAttempts++;
+
+            if (!CanBuild)
+            {
+                throw new ArgumentOutOfRangeException("shardPath",
+                    "Unable to find a shard with path 'claim_lines/all/v19/01009333'");
+            }
+
+            Built = new BuiltAgent(uri);
+            return ValueTask.FromResult<IAgent>(Built);
+        }
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    private class BuiltAgent : IAgent
+    {
+        public BuiltAgent(Uri uri) => Uri = uri;
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Status = AgentStatus.Stopped;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Report Stopped while still registered — the GH-3519 wedged-shard shape.</summary>
+        public void Wedge() => Status = AgentStatus.Stopped;
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -357,6 +357,27 @@ public class DurabilitySettings : IDescribeMyself
     public int MaxLocalAgentRestartsBeforeRelease { get; set; } = 3;
 
     /// <summary>
+    ///     GH-3970: how many consecutive assignment ticks may fail to <i>build or start</i> an agent on this
+    ///     node before the node releases it to a capable peer, using the same embargo as
+    ///     <see cref="MaxLocalAgentRestartsBeforeRelease" />.
+    ///
+    ///     <para>This is the counterpart budget for a failure that happens <b>before</b> there is an agent
+    ///     instance at all. A start that throws out of <c>IAgentFamily.BuildAgentAsync</c> leaves nothing
+    ///     registered on the node, so the stall detector — which sweeps the agents this node is actually
+    ///     running — never sees it, and no restart budget is ever consumed. Without this the leader learns
+    ///     only that the agent is "unconfirmed", which it deliberately does not treat as a failure
+    ///     (GH-3750), so the assignment stands and the same agent is requested on the same node again on
+    ///     every tick, forever.</para>
+    ///
+    ///     <para>Note each tick has already made <see cref="AgentStartRetryAttempts" /> + 1 attempts of its
+    ///     own before it counts as one failure here, so the default is a deliberately patient
+    ///     three-strikes over three separate assignment cycles rather than a hair trigger. A successful
+    ///     start clears the count. Set to 0 or a negative number to disable release for failed starts and
+    ///     keep the pre-GH-3970 behavior of retrying on the same node indefinitely. Default 3.</para>
+    /// </summary>
+    public int MaxAgentStartFailuresBeforeRelease { get; set; } = 3;
+
+    /// <summary>
     ///     GH-3888: how long a node withholds a released agent's URI from its advertised capabilities
     ///     after exhausting local restarts on it. While the embargo is live, the leader's
     ///     capability-matched distribution cannot hand the agent straight back to the node that just
@@ -535,6 +556,7 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(NodeRecordRetention), NodeRecordRetention);
         desc.AddValue(nameof(NodeRecordPruningPeriod), NodeRecordPruningPeriod);
         desc.AddValue(nameof(MaxLocalAgentRestartsBeforeRelease), MaxLocalAgentRestartsBeforeRelease);
+        desc.AddValue(nameof(MaxAgentStartFailuresBeforeRelease), MaxAgentStartFailuresBeforeRelease);
         desc.AddValue(nameof(AgentReleaseCooldown), AgentReleaseCooldown);
         desc.AddValue(nameof(SendingAgentIdleTimeout), SendingAgentIdleTimeout);
         desc.AddValue(nameof(DrainTimeout), DrainTimeout);

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -51,6 +51,25 @@ public partial class NodeAgentController
     // than on every sweep tick. Only touched from the serialized health-check path.
     private readonly HashSet<Uri> _reportedUnreleasable = new();
 
+    // GH-3970: consecutive failures to BUILD or START an agent here, keyed by agent Uri. A failed build
+    // leaves nothing in Agents, so the GH-3888 stall detector -- which sweeps the agents this node is
+    // actually running -- structurally cannot see it, and no restart budget is ever consumed. Counting
+    // the failures here is what gives that release path something to act on. A successful start removes
+    // the entry. A ConcurrentDictionary because starts run with bounded parallelism (StartBatchAsync)
+    // while the serialized health-check path reads the counts.
+    private readonly ConcurrentDictionary<Uri, FailedStartRecord> _failedStarts = new();
+
+    /// <summary>
+    /// GH-3970: how many times in a row this node has failed to build/start one agent, and why it failed
+    /// the last time. The exception is kept so the release decision can say what actually went wrong --
+    /// for the reported field failure that is an <c>ArgumentOutOfRangeException</c> naming the projection
+    /// version this node does not carry, which is exactly the detail an operator needs to see.
+    /// </summary>
+    internal sealed record FailedStartRecord(int Count, Exception? Failure)
+    {
+        public FailedStartRecord Next(Exception? failure) => new(Count + 1, failure ?? Failure);
+    }
+
     /// <summary>
     /// GH-3888: clock for the release-embargo bookkeeping. Tests substitute it so the cooldown can be
     /// exercised without waiting it out; everything else uses the system clock.
@@ -315,13 +334,31 @@ public partial class NodeAgentController
             }
         }
 
-        var agent = await startWithRetriesAsync(agentUri);
+        IAgent agent;
+        try
+        {
+            agent = await startWithRetriesAsync(agentUri);
+        }
+        catch (Exception e)
+        {
+            // GH-3970: count it before it propagates. The caller (StartBatchAsync) logs and swallows, and
+            // the leader is told only that the agent is "unconfirmed" -- which it deliberately does not
+            // treat as a failure (GH-3750) -- so without this ledger nothing anywhere distinguishes "this
+            // node is still working on it" from "this node threw and will throw again". This node caught
+            // the exception; it is the only place that knows.
+            _failedStarts.AddOrUpdate(agentUri, _ => new FailedStartRecord(1, e), (_, existing) => existing.Next(e));
+            throw;
+        }
 
         Agents[agentUri] = agent;
 
         // GH-3638: a start that succeeded supersedes whatever failure was last reported for this agent, so
         // a later failure alerts again instead of being swallowed as a duplicate of the old one.
         _reportedFailures.TryRemove(agentUri, out _);
+
+        // GH-3970: likewise for the failed-start budget -- the count is CONSECUTIVE failures, so anything
+        // that comes up clears it and a later relapse gets a full budget of its own.
+        _failedStarts.TryRemove(agentUri, out _);
 
         await upsertAssignmentAsync(agentUri);
     }
@@ -423,6 +460,12 @@ public partial class NodeAgentController
         // deferred start still queued or in flight for this agent. See StartAgentGuardedAsync.
         _stopRevocations[agentUri] = Interlocked.Increment(ref _commandSequence);
 
+        // GH-3970: a stop ends this node's run of consecutive failed starts, whatever the reason for it.
+        // Without this an agent that failed here, was placed elsewhere, and came back much later would
+        // resume an ancient count and be released on its first fresh failure instead of getting the full
+        // budget the setting promises.
+        _failedStarts.TryRemove(agentUri, out _);
+
         if (Agents.TryGetValue(agentUri, out var agent))
         {
             try
@@ -503,7 +546,7 @@ public partial class NodeAgentController
     /// </summary>
     internal async Task ReportFailedLocalAgentsAsync()
     {
-        List<(Uri Uri, IEventSubscriptionAgent Agent)>? exhausted = null;
+        List<ReleaseCandidate>? exhausted = null;
 
         foreach (var entry in Agents.ToArray())
         {
@@ -517,7 +560,7 @@ public partial class NodeAgentController
             // short-circuit below — a stalled shard still reads Running.
             if (subscription.LocalRestartsExhausted)
             {
-                (exhausted ??= new()).Add((entry.Key, subscription));
+                (exhausted ??= new()).Add(new ReleaseCandidate(entry.Key, subscription, null));
                 continue;
             }
 
@@ -542,10 +585,43 @@ public partial class NodeAgentController
             await reportAgentPausedAsync(entry.Key, failure);
         }
 
+        // GH-3970: the other half of the sweep. These agents are NOT in Agents -- the start threw before
+        // anything could be registered -- so the loop above structurally cannot reach them. They ride the
+        // same release policy: a bounded budget, a live capable peer required, and the same capability
+        // embargo to stop the leader handing the agent straight back.
+        var startBudget = _runtime.Options.Durability.MaxAgentStartFailuresBeforeRelease;
+        if (startBudget > 0)
+        {
+            foreach (var entry in _failedStarts.ToArray())
+            {
+                if (entry.Value.Count < startBudget) continue;
+
+                // A start that failed and then succeeded on a later tick has already cleared itself out
+                // of the ledger, so anything still here has failed every attempt since.
+                (exhausted ??= new()).Add(new ReleaseCandidate(entry.Key, null, entry.Value.Failure));
+            }
+        }
+
         if (exhausted != null)
         {
             await tryReleaseExhaustedAgentsAsync(exhausted);
         }
+    }
+
+    /// <summary>
+    /// An agent this node wants to hand back so the leader can place it on a capable peer. Two sources,
+    /// deliberately sharing one release policy and one embargo:
+    ///
+    /// <para><b>GH-3888</b> — a running <see cref="IEventSubscriptionAgent" /> that burned its node-local
+    /// auto-restart budget without ever advancing. <see cref="Agent" /> is the live instance.</para>
+    ///
+    /// <para><b>GH-3970</b> — an agent that could not be built or started here at all, so there is no
+    /// instance to carry a budget or report a <c>ShardFailure</c>. <see cref="Agent" /> is null and
+    /// <see cref="StartFailure" /> is the last exception the start threw.</para>
+    /// </summary>
+    internal sealed record ReleaseCandidate(Uri Uri, IEventSubscriptionAgent? Agent, Exception? StartFailure)
+    {
+        public bool IsFailedStart => Agent is null;
     }
 
     /// <summary>
@@ -565,7 +641,7 @@ public partial class NodeAgentController
     /// The embargo is written to the node row FIRST, then the assignment is dropped, so no evaluation can
     /// observe the freed agent while this node still advertises for it.</para>
     /// </summary>
-    private async Task tryReleaseExhaustedAgentsAsync(List<(Uri Uri, IEventSubscriptionAgent Agent)> exhausted)
+    private async Task tryReleaseExhaustedAgentsAsync(List<ReleaseCandidate> exhausted)
     {
         IReadOnlyList<WolverineNode> nodes;
         try
@@ -585,7 +661,7 @@ public partial class NodeAgentController
             .Where(x => x.NodeId != selfId && x.LastHealthCheck >= staleTime)
             .ToArray();
 
-        var releasable = new List<(Uri Uri, IEventSubscriptionAgent Agent)>();
+        var releasable = new List<ReleaseCandidate>();
         foreach (var pair in exhausted)
         {
             if (peers.Any(p => p.Capabilities.Contains(pair.Uri)))
@@ -597,14 +673,32 @@ public partial class NodeAgentController
                 // Nowhere better to go: no live peer advertises this agent, so releasing it would
                 // strand the shard entirely. Keep the pre-existing local retries — the least-bad
                 // option — and say so once per episode rather than on every tick.
+                //
+                // GH-3970: this is also the branch every agent whose family is NOT an IStaticAgentFamily
+                // lands in, permanently and by construction. Only static families contribute to a node's
+                // advertised Capabilities, so a wolverinedb:// durability agent can never match a peer
+                // here. That is the correct outcome — those agents have no capability-matched alternative
+                // node to be released TO — and it means the pre-GH-3970 behaviour of retrying locally is
+                // preserved exactly for them.
                 if (_reportedUnreleasable.Add(pair.Uri))
                 {
                     _logger.LogWarning(
-                        "Agent {AgentUri} on node {NodeNumber} exhausted its local auto-restart budget, but no live peer advertises the capability to run it. Local restarts continue.",
-                        pair.Uri, _runtime.Options.Durability.AssignedNodeNumber);
+                        "Agent {AgentUri} on node {NodeNumber} exhausted its local {Budget} budget, but no live peer advertises the capability to run it. Local retries continue.",
+                        pair.Uri, _runtime.Options.Durability.AssignedNodeNumber,
+                        pair.IsFailedStart ? "start" : "auto-restart");
                 }
 
-                pair.Agent.ResetLocalRestartBudget();
+                // Refund the budget so local retries continue rather than freezing here. For a failed
+                // start that means clearing the count: the next tick starts a fresh budget, and the
+                // release is reconsidered only after another full run of failures.
+                if (pair.IsFailedStart)
+                {
+                    _failedStarts.TryRemove(pair.Uri, out _);
+                }
+                else
+                {
+                    pair.Agent!.ResetLocalRestartBudget();
+                }
             }
         }
 
@@ -641,16 +735,34 @@ public partial class NodeAgentController
             return;
         }
 
-        foreach (var (uri, agent) in releasable)
+        foreach (var candidate in releasable)
         {
-            var failure = agent.Failure;
-            _logger.LogWarning(
-                "Agent {AgentUri} on node {NodeNumber} is being released after exhausting its local auto-restart budget without advancing. A live peer advertises the same capability, and the leader will reassign it there. This node will not advertise the capability again before {EmbargoUntil:u}. Last reported failure: {Failure}",
-                uri, _runtime.Options.Durability.AssignedNodeNumber, embargoUntil,
-                failure?.ToString() ?? "none reported");
+            var uri = candidate.Uri;
+            var failure = candidate.Agent?.Failure;
+
+            if (candidate.IsFailedStart)
+            {
+                _logger.LogWarning(
+                    "Agent {AgentUri} on node {NodeNumber} is being released after failing to start here {Attempts} consecutive times. A live peer advertises the same capability, and the leader will reassign it there. This node will not advertise the capability again before {EmbargoUntil:u}. Last start failure: {Failure}",
+                    uri, _runtime.Options.Durability.AssignedNodeNumber,
+                    _runtime.Options.Durability.MaxAgentStartFailuresBeforeRelease, embargoUntil,
+                    candidate.StartFailure?.ToString() ?? "none reported");
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Agent {AgentUri} on node {NodeNumber} is being released after exhausting its local auto-restart budget without advancing. A live peer advertises the same capability, and the leader will reassign it there. This node will not advertise the capability again before {EmbargoUntil:u}. Last reported failure: {Failure}",
+                    uri, _runtime.Options.Durability.AssignedNodeNumber, embargoUntil,
+                    failure?.ToString() ?? "none reported");
+            }
 
             try
             {
+                // Still the right call for a failed start even though nothing is running: StopAgentAsync
+                // skips the agent block when Agents has no entry and goes straight to
+                // RemoveAssignmentAsync. Dropping that assignment row is the point — the embargo alone
+                // stops this node being chosen again, but the row is what lets the leader place the agent
+                // somewhere else.
                 await StopAgentAsync(uri);
             }
             catch (Exception e)
@@ -664,6 +776,7 @@ public partial class NodeAgentController
 
             _reportedFailures.TryRemove(uri, out _);
             _reportedUnreleasable.Remove(uri);
+            _failedStarts.TryRemove(uri, out _);
 
             try
             {


### PR DESCRIPTION
Fixes #3970.

## The gap

When `IAgentFamily.BuildAgentAsync` throws, `StartAgents.StartBatchAsync` catches, logs, and drops it. The agent is simply absent from the confirmed set, so the leader learns only that it is *unconfirmed* — which it deliberately does not treat as a failure (GH-3750 fixed exactly the opposite bug, where slow starts got re-placed onto other nodes). The assignment stands, the same agent is requested on the same node again on the next tick, forever.

GH-3888 is the right remedy but structurally cannot reach this case: its release is driven by the stall detector sweeping the agents this node is actually **running**, reading `LocalRestartsExhausted` off the live instance. A start that throws leaves no instance at all, so no restart budget is ever consumed.

## The fix

Count consecutive failed starts on the node that catches them — the only place that can tell "still working on it" from "threw, and will throw again here" — and feed an exhausted budget into GH-3888's existing release path. Same policy throughout: a live peer must advertise the capability, the same capability embargo stops the leader handing the agent straight back, and the assignment row is dropped so the agent can be placed elsewhere. `StopAgentAsync` already handles having nothing registered, so it does the right thing for a failed build unchanged.

- New `DurabilitySettings.MaxAgentStartFailuresBeforeRelease` (default 3), the counterpart to `MaxLocalAgentRestartsBeforeRelease`. Each tick has already spent `AgentStartRetryAttempts + 1` inner attempts before it counts as one failure here, so this is three strikes over three assignment cycles. 0 or negative restores the previous behaviour.
- The count is **consecutive**: a successful start clears it, and so does any stop, so an agent that fails here, moves away, and returns much later gets a fresh budget rather than resuming an ancient count.
- Agents whose family is not an `IStaticAgentFamily` (`wolverinedb://` durability agents) are never in a node's `Capabilities`, so they never match a peer and always take the decline branch — local retries stay exactly as before. That is correct: there is no capability-matched alternative node to release them to.

## Scope

This is the *recovery* gap, which is provable from the code alone. The reporter's original suspicion — that `DistributeByGroupAffinity` was misplacing version-exclusive agents across a blue/green fleet — was tested against `AssignmentGrid` in two shapes and **both passed**, so GH-3792 is doing its job and the misplacement itself is not addressed here.

## Tests

`CoreTests/Runtime/Agents/failed_agent_start_release.cs` — 8 tests: release after the budget, budget not spent early, a successful start clearing the run, no live capable peer, a stale peer advertising the capability not counting, the cooldown re-advertising, a declined release refunding the budget, and the feature disabled entirely. All green; full `wolverine.slnx` builds clean at `-f net9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3