### PR TITLE
Do not report success when message storage was not provisioned

### DIFF
--- a/src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs
+++ b/src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs
@@ -17,11 +17,14 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
 {
     private const string SchemaName = "autocreate_none";
 
+    private const string AncillarySchemaName = "autocreate_none_ancillary";
+
     public async ValueTask InitializeAsync()
     {
         await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
         await conn.OpenAsync();
         await conn.DropSchemaAsync(SchemaName);
+        await conn.DropSchemaAsync(AncillarySchemaName);
         await conn.CloseAsync();
     }
 
@@ -30,7 +33,21 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
         return ValueTask.CompletedTask;
     }
 
-    private static IHostBuilder configureHost()
+    private static IHostBuilder configureHost(
+        ResourceMigrationFailureMode failureMode = ResourceMigrationFailureMode.FailFast)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.AutoBuildMessageStorageOnStartup = AutoCreate.None;
+                opts.ResourceMigrationFailureMode = failureMode;
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName)
+                    .OverrideAutoCreateResources(AutoCreate.None);
+            });
+    }
+
+    private static IHostBuilder configureHostWithAncillaryStore()
     {
         return Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
@@ -39,7 +56,18 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
                 opts.AutoBuildMessageStorageOnStartup = AutoCreate.None;
                 opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName)
                     .OverrideAutoCreateResources(AutoCreate.None);
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, AncillarySchemaName,
+                        MessageStoreRole.Ancillary)
+                    .OverrideAutoCreateResources(AutoCreate.None);
             });
+    }
+
+    private static async Task dropAsync(string tableName)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand($"drop table {SchemaName}.{tableName}").ExecuteNonQueryAsync();
+        await conn.CloseAsync();
     }
 
     private static async Task<bool> envelopeTablesExist()
@@ -97,10 +125,120 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
         }
         catch (Exception)
         {
-            // The host may well fail during startup because the message storage was
-            // never provisioned. This test only cares that startup did not create it
+            // Startup is expected to fail here - see the test below. This one only cares that it did
+            // not create the storage on its way past.
         }
 
         (await envelopeTablesExist()).ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     AutoCreate.None is a claim that something else provisioned the storage, so startup verifies the
+    ///     claim instead of carrying on. Before this it logged "skipping ... must have been provisioned ahead
+    ///     of time" and continued, and the first agent to touch a missing table then failed with a bare
+    ///     "relation wolverine_nodes does not exist" from somewhere much further into startup - which names
+    ///     neither the storage nor the setup step that was skipped.
+    /// </summary>
+    [Fact]
+    public async Task host_startup_with_auto_build_none_fails_naming_the_setup_it_skipped()
+    {
+        using var host = configureHost().Build();
+
+        var exception = await Should.ThrowAsync<Exception>(
+            () => host.StartAsync(TestContext.Current.CancellationToken));
+
+        // ToString rather than Message: the assert can surface wrapped, and what matters is that the
+        // provisioning step is named somewhere in the failure the operator actually sees.
+        exception.ToString().ShouldContain("resources setup");
+    }
+
+    /// <summary>
+    ///     The check has to cover the same stores <c>MigrateAsync</c> does. An ancillary store whose schema
+    ///     was never provisioned would otherwise pass startup unnoticed and fail whenever something first
+    ///     used it, which can be a long way from here.
+    /// </summary>
+    [Fact]
+    public async Task an_unprovisioned_ancillary_store_is_caught_as_well()
+    {
+        // Only the main store, so the ancillary schema is genuinely absent afterwards.
+        using (var mainOnly = configureHost().Build())
+        {
+            await mainOnly.SetupResources(cancellation: TestContext.Current.CancellationToken);
+        }
+
+        using var host = configureHostWithAncillaryStore().Build();
+
+        var exception = await Should.ThrowAsync<Exception>(
+            () => host.StartAsync(TestContext.Current.CancellationToken));
+
+        exception.ToString().ShouldContain("resources setup");
+    }
+
+    /// <summary>
+    ///     And the other way round, so the test above cannot pass because setup never reached the ancillary
+    ///     store in the first place.
+    /// </summary>
+    [Fact]
+    public async Task setup_resources_provisions_the_ancillary_store_too()
+    {
+        using var host = configureHostWithAncillaryStore().Build();
+
+        await host.SetupResources(cancellation: TestContext.Current.CancellationToken);
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     The GH-3130 compatibility path. Storage that is merely <em>out of date</em> rather than absent is
+    ///     the case this matters for: the assert is strict about any difference, but a host whose code never
+    ///     touches the drifted object used to start perfectly well - so a deployment that provisions after
+    ///     its replicas has to be able to keep that behaviour.
+    /// </summary>
+    [Fact]
+    public async Task continue_on_failures_starts_the_host_when_the_storage_is_out_of_date()
+    {
+        using (var provisioned = configureHost().Build())
+        {
+            await provisioned.SetupResources(cancellation: TestContext.Current.CancellationToken);
+        }
+
+        // Nothing in the startup path reads the dead letter table, so this is drift the host can tolerate -
+        // and the assert still has to see it, or the test proves nothing.
+        await dropAsync(DatabaseConstants.DeadLetterTable);
+
+        using var host = configureHost(ResourceMigrationFailureMode.ContinueOnFailures).Build();
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task fail_fast_stops_the_host_when_the_storage_is_out_of_date()
+    {
+        using (var provisioned = configureHost().Build())
+        {
+            await provisioned.SetupResources(cancellation: TestContext.Current.CancellationToken);
+        }
+
+        await dropAsync(DatabaseConstants.DeadLetterTable);
+
+        using var host = configureHost().Build();
+
+        var exception = await Should.ThrowAsync<Exception>(
+            () => host.StartAsync(TestContext.Current.CancellationToken));
+
+        exception.ToString().ShouldContain("resources setup");
+    }
+
+    [Fact]
+    public async Task host_startup_with_auto_build_none_succeeds_once_the_storage_is_provisioned()
+    {
+        using var host = configureHost().Build();
+
+        await host.SetupResources(cancellation: TestContext.Current.CancellationToken);
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        await host.StopAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/src/Testing/CoreTests/Transports/BrokerResourceSetupTests.cs
+++ b/src/Testing/CoreTests/Transports/BrokerResourceSetupTests.cs
@@ -1,0 +1,98 @@
+using CoreTests.Runtime;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+///     <see cref="BrokerResource.Setup" /> used to log a per-endpoint failure and return, so
+///     <c>resources setup</c> reported success having created nothing. A deploy step that provisions broker
+///     objects ahead of its hosts then exited 0 while the hosts failed on the missing queue - the failure
+///     surfaced a long way from its cause, in a different process.
+/// </summary>
+public class BrokerResourceSetupTests
+{
+    private readonly MockWolverineRuntime theRuntime = new();
+
+    [Fact]
+    public async Task throws_when_an_endpoint_cannot_be_set_up()
+    {
+        var resource = new BrokerResource(transportWith(new StubBrokerEndpoint { WillFail = true }), theRuntime);
+
+        var aggregate = await Should.ThrowAsync<AggregateException>(() => resource.Setup(CancellationToken.None));
+
+        aggregate.InnerExceptions.Count.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Collect-then-throw, matching <see cref="BrokerResource.Check" />: one broker object that cannot be
+    ///     provisioned must not stop the others from being attempted, or a single failure hides the state of
+    ///     everything after it.
+    /// </summary>
+    [Fact]
+    public async Task attempts_every_endpoint_before_throwing()
+    {
+        var failing = new StubBrokerEndpoint { WillFail = true };
+        var succeeding = new StubBrokerEndpoint();
+
+        var resource = new BrokerResource(transportWith(failing, succeeding), theRuntime);
+
+        await Should.ThrowAsync<AggregateException>(() => resource.Setup(CancellationToken.None));
+
+        succeeding.WasSetUp.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task does_not_throw_when_every_endpoint_can_be_set_up()
+    {
+        var endpoints = new[] { new StubBrokerEndpoint(), new StubBrokerEndpoint() };
+
+        await new BrokerResource(transportWith(endpoints), theRuntime).Setup(CancellationToken.None);
+
+        endpoints.ShouldAllBe(x => x.WasSetUp);
+    }
+
+    private static IBrokerTransport transportWith(params StubBrokerEndpoint[] endpoints)
+    {
+        var transport = Substitute.For<IBrokerTransport>();
+        transport.Name.Returns("Fake");
+        transport.ResourceUri.Returns(new Uri("fake://"));
+        transport.Endpoints().Returns(endpoints);
+
+        return transport;
+    }
+
+    private class StubBrokerEndpoint()
+        : Endpoint(new Uri("fake://queue"), EndpointRole.Application), IBrokerEndpoint
+    {
+        public bool WillFail { get; init; }
+
+        public bool WasSetUp { get; private set; }
+
+        public ValueTask SetupAsync(ILogger logger)
+        {
+            if (WillFail)
+            {
+                throw new DivideByZeroException("the calling role has no rights to create this");
+            }
+
+            WasSetUp = true;
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<bool> CheckAsync() => throw new NotSupportedException();
+
+        public ValueTask TeardownAsync(ILogger logger) => throw new NotSupportedException();
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver) =>
+            throw new NotSupportedException();
+
+        protected override ISender CreateSender(IWolverineRuntime runtime) => throw new NotSupportedException();
+    }
+}

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -313,6 +313,36 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    ///     Verify that every store's durable objects exist and match configuration, throwing when they do
+    ///     not. The counterpart to <see cref="MigrateAsync" /> for a system that provisions its storage ahead
+    ///     of startup instead of building it there, and it has to cover the same set of stores: an ancillary
+    ///     store whose schema was never provisioned fails whenever something first uses it, which can be a
+    ///     long way from startup.
+    /// </summary>
+    public async Task AssertStorageExistsAsync(CancellationToken token)
+    {
+        var stores = await FindAllAsync();
+        var exceptions = new List<Exception>();
+
+        foreach (var store in stores)
+        {
+            try
+            {
+                await store.Admin.AssertStorageExistsAsync(token);
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+        }
+
+        if (exceptions.Count != 0)
+        {
+            throw new AggregateException(exceptions);
+        }
+    }
+
     public string Scheme => PersistenceConstants.AgentScheme;
     public async ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
     {

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -294,6 +294,27 @@ public partial class WolverineRuntime
         {
             Logger.LogInformation(
                 "Skipping automatic message storage migration on startup because AutoBuildMessageStorageOnStartup is None. The message storage must have been provisioned ahead of time, e.g. with 'resources setup' / IHost.SetupResources()");
+
+            // None is a claim that something else provisioned the storage, so verify the claim here rather
+            // than letting the first agent or listener to touch a missing table fail with a bare "relation
+            // does not exist" from somewhere much further into startup - which names neither the storage
+            // nor the setup step that was skipped. Same failure policy as the migration above, so a rolling
+            // deploy that deliberately tolerates a replica starting ahead of its provisioning step still
+            // can. Stores that cannot introspect their own schema no-op this (IMessageStoreAdmin default).
+            //
+            // The whole collection rather than Storage alone, so that it covers what MigrateAsync above
+            // covers: an ancillary store whose schema was never provisioned would otherwise go unchecked and
+            // fail whenever something first used it.
+            try
+            {
+                await _stores.Value.AssertStorageExistsAsync(Cancellation);
+            }
+            catch (Exception e) when (Options.ResourceMigrationFailureMode ==
+                                      ResourceMigrationFailureMode.ContinueOnFailures)
+            {
+                Logger.LogError(e,
+                    "The Wolverine message storage is missing or out of date and AutoBuildMessageStorageOnStartup is None. Continuing startup anyway because ResourceMigrationFailureMode is ContinueOnFailures.");
+            }
         }
 
         _hasMigratedStorage = true;

--- a/src/Wolverine/Transports/BrokerResource.cs
+++ b/src/Wolverine/Transports/BrokerResource.cs
@@ -80,6 +80,14 @@ public class BrokerResource : IStatefulResource
     {
         await _transport.ConnectAsync(_runtime);
 
+        // Every endpoint is attempted before anything is thrown, so one broker object that cannot be
+        // provisioned does not hide the state of the others - the same collect-then-throw shape as Check
+        // above. Throwing at all is the point: this used to log and return, so "resources setup" reported
+        // success having created nothing, and a deploy step that provisions ahead of its hosts exited 0
+        // while the hosts then failed on the missing queue. Teardown below stays best-effort on purpose -
+        // tearing down what you can is the useful outcome there.
+        var failures = new List<Exception>();
+
         foreach (var endpoint in _transport.Endpoints().OfType<IBrokerEndpoint>())
         {
             try
@@ -89,7 +97,14 @@ public class BrokerResource : IStatefulResource
             catch (Exception e)
             {
                 _runtime.Logger.LogError(e, "Error while attempting to setup broker endpoint {Uri}", endpoint.Uri);
+                failures.Add(new InvalidOperationException($"Unable to set up broker endpoint {endpoint.Uri}", e));
             }
+        }
+
+        if (failures.Count != 0)
+        {
+            throw new AggregateException(
+                $"Unable to set up {failures.Count} of the {_transport.Name} broker endpoints", failures);
         }
     }
 


### PR DESCRIPTION
Two small changes with one theme: when message-storage provisioning does not happen, say so at the point it did not happen. Both came out of a production incident where the eventual error was several layers and one process away from the cause.

They are independent commits and can be taken separately.

## 1. `resources setup` reported success having created nothing

`BrokerResource.Setup` logged a per-endpoint failure and returned:

```csharp
foreach (var endpoint in _transport.Endpoints().OfType<IBrokerEndpoint>())
{
    try { await endpoint.SetupAsync(_runtime.Logger); }
    catch (Exception e) { _runtime.Logger.LogError(e, "Error while attempting to setup broker endpoint {Uri}", endpoint.Uri); }
}
```

So a deploy step that runs `resources setup` ahead of its hosts exits 0 while the hosts then fail on the missing queue — and the exit code that was supposed to gate the rollout says everything is fine. In our case the step ran with the credentials that *could* provision and the hosts ran with credentials that could not, which is the whole reason for splitting them, and the split silently bought us nothing.

Now the failures are collected and thrown at the end, so every endpoint is still attempted — one broker object that cannot be provisioned does not hide the state of the others — but the operation fails. That is the same collect-then-throw shape `Check` right above it already uses.

`Teardown` deliberately keeps log-and-continue: tearing down what you can is the useful outcome there.

## 2. `AutoCreate.None` warned, then failed obscurely later

`AutoBuildMessageStorageOnStartup = None` is a claim that something else provisioned the storage. When the claim was wrong, the runtime logged that it was skipping the migration and carried on, and the first agent to touch a missing table failed with:

```
Npgsql.PostgresException 42P01: relation "wolverine.wolverine_nodes" does not exist
   at Wolverine.Runtime.Agents.NodeAgentController.StartSoloModeAsync()
```

That names neither the storage nor the setup step that was skipped, and it arrives well after the log line that would have explained it. `IMessageStoreAdmin.AssertStorageExistsAsync` already exists for exactly this question and is what `resources check` uses — this just calls it on the `None` branch, so the failure is "the storage is missing or out of date, run 'resources setup'" at the point the runtime decided not to provision.

Two things I tried to keep intact:

- **The same `ResourceMigrationFailureMode` policy as the migration above**, so a rolling deploy that deliberately tolerates a replica starting ahead of its provisioning step still can (GH-3130).
- **Stores that cannot introspect their own schema are unaffected** — they keep `IMessageStoreAdmin`'s no-op default.

## Where this came from

We run Wolverine's PostgreSQL envelope storage with `AutoCreate.None` and provision it from our own migration job, because the application role holds no DDL rights. Getting there cost a QA outage and a long diagnosis, and each of the two changes above is one of the signposts that was missing on the way.

The root cause was actually in Weasel, and I have opened [JasperFx/weasel#495](https://github.com/JasperFx/weasel/pull/495) for it: `PostgresqlMigrator` emits `CREATE SCHEMA IF NOT EXISTS` for every schema a migration touches, and PostgreSQL checks `CREATE` on the *database* before it evaluates `IF NOT EXISTS` — so a role granted `CREATE` on its schema but not the database is refused even when the schema already exists, and the whole migration script aborts on statement one. Neither change here depends on that one.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — succeeds.
- New `CoreTests/Transports/BrokerResourceSetupTests.cs`: throws when an endpoint fails, **attempts every endpoint before throwing**, and does not throw when all succeed. Verified against the pre-change code: the first two fail, the third passes.
- `explicit_resource_setup_with_auto_create_none` gains two cases: startup fails naming the skipped setup step, and startup succeeds once `SetupResources` has run. The first was verified to fail against the pre-change code. The existing `host_startup_with_auto_build_none_does_not_create_the_message_storage` had a `catch (Exception)` with a comment saying startup "may well fail" — that is now an assertion instead of a maybe, and I updated the comment to point at it.
- `CoreTests` on `net10.0`: 2426 passed, 4 failed — all 4 fail identically on unmodified `38b65dd0b` (`Bug_2896_mixed_lifetime_enumerable_dependency`, three `result_types_end_to_end` cases).
- `PostgresqlTests` on `net10.0`: 492 passed, 2 failed. `inline_rabbitmq_listener_replay_does_not_loop` fails on master here too (no RabbitMQ running locally). The other differed between two full runs — `cascaded_response_with_outbox` in the first, `leader_pinned_listener_recovers_its_own_dormant_inbox_end_to_end` in the second — and both pass in isolation, so they read as timing-sensitive rather than related to these changes. Worth a second opinion from CI.

The `net9.0` test leg does not run on this machine (that runtime is not installed), so everything above is `net10.0`.
