### PR TITLE
GH-3988 / GH-3990: chains carry their Event Modeling roles + `event-model` export

### DIFF
--- a/.github/workflows/command-line.yml
+++ b/.github/workflows/command-line.yml
@@ -64,3 +64,23 @@ jobs:
           echo "::endgroup::"
 
           echo "describe-handlers smoke test passed"
+
+      - name: event-model export smoke test
+        run: |
+          set -euo pipefail
+
+          echo "::group::event-model writes the merged Event Model as JSON without starting the host"
+          mkdir -p artifacts
+          dotnet run --project src/Samples/Quickstart --framework net9.0 -- \
+            event-model --json artifacts/quickstart-event-model.json
+          test -s artifacts/quickstart-event-model.json
+          cat artifacts/quickstart-event-model.json | head -c 2000; echo
+          grep -q '"name": "Quickstart"' artifacts/quickstart-event-model.json
+          grep -q '"slices"' artifacts/quickstart-event-model.json
+          grep -q '"name": "CreateIssue"' artifacts/quickstart-event-model.json
+          grep -q '"triggerKind": "MessageHandler"' artifacts/quickstart-event-model.json
+          grep -q '"pattern": "Command"' artifacts/quickstart-event-model.json
+          grep -q '"elements"' artifacts/quickstart-event-model.json
+          echo "::endgroup::"
+
+          echo "event-model smoke test passed"

--- a/.github/workflows/command-line.yml
+++ b/.github/workflows/command-line.yml
@@ -70,17 +70,18 @@ jobs:
           set -euo pipefail
 
           echo "::group::event-model writes the merged Event Model as JSON without starting the host"
-          mkdir -p artifacts
+          # dotnet run --project runs in the sample's directory, so name the output absolutely
+          out="$GITHUB_WORKSPACE/artifacts/quickstart-event-model.json"
           dotnet run --project src/Samples/Quickstart --framework net9.0 -- \
-            event-model --json artifacts/quickstart-event-model.json
-          test -s artifacts/quickstart-event-model.json
-          cat artifacts/quickstart-event-model.json | head -c 2000; echo
-          grep -q '"name": "Quickstart"' artifacts/quickstart-event-model.json
-          grep -q '"slices"' artifacts/quickstart-event-model.json
-          grep -q '"name": "CreateIssue"' artifacts/quickstart-event-model.json
-          grep -q '"triggerKind": "MessageHandler"' artifacts/quickstart-event-model.json
-          grep -q '"pattern": "Command"' artifacts/quickstart-event-model.json
-          grep -q '"elements"' artifacts/quickstart-event-model.json
+            event-model --json "$out"
+          test -s "$out"
+          head -c 2000 "$out"; echo
+          grep -q '"name": "Quickstart"' "$out"
+          grep -q '"slices"' "$out"
+          grep -q '"name": "CreateIssue"' "$out"
+          grep -q '"triggerKind": "MessageHandler"' "$out"
+          grep -q '"pattern": "Command"' "$out"
+          grep -q '"elements"' "$out"
           echo "::endgroup::"
 
           echo "event-model smoke test passed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@
 
 ### WolverineFx (core)
 
+- **`.ExternalSystem("Stripe")` names the external system on an endpoint, and the Event Model renders the
+  boundary.** ([#3989](https://github.com/JasperFx/wolverine/issues/3989)) Every listener and subscriber
+  configuration gains `ExternalSystem(string name)` (stored as `Endpoint.ExternalSystemName`, surfaced as the typed
+  `EndpointDescriptor.ExternalSystem` in capabilities). The Wolverine-derived Event Model attaches an inbound
+  external-system element to the slice a named listener triggers — a handler stuck to it, or the handler of its
+  `DefaultIncomingMessage<T>()` — making it a `Translation` slice triggered `External` (a named listener bound to
+  no slice still renders as a trigger-only boundary), and an outbound element to every slice whose published
+  messages or emitted events the named endpoint subscribes to. The edge is derived; only the name is declared,
+  on the endpoint, never in the overlay (jasperfx#687 decision 5).
+
 - **Chains carry their Event Modeling roles, and `event-model` exports them.**
   ([#3988](https://github.com/JasperFx/wolverine/issues/3988), [#3990](https://github.com/JasperFx/wolverine/issues/3990))
   Every message handler chain now derives its Event Modeling slice — command, handler, the aggregate(s) it decides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### WolverineFx.Http
 
+- **HTTP chains carry their Event Modeling roles.** ([#3988](https://github.com/JasperFx/wolverine/issues/3988))
+  Every routed `HttpChain` derives the same slice a message handler does — triggered by its verb + route, the
+  request body as the command, the endpoint type as the handler, `[WriteAggregate]` / `[ReadAggregate]` and friends
+  as aggregates and read models, `[EmptyResponse]` returns as emitted events, and a `GET` that writes nothing as a
+  `View` slice reading its resource type — through an `IEventModelDefinitionSource` that `AddWolverineHttp()`
+  registers, so it reaches `ServiceCapabilities.EventModel` and the `event-model` export with no further wiring.
+
 - **`Before` middleware can replace an immutable request body.**
   ([#3984](https://github.com/JasperFx/wolverine/pull/3984)) Handler chains have supported this since
   GH-516: a `Before` / `BeforeAsync` that accepts the message type *and* returns it overwrites the message
@@ -69,6 +76,19 @@
   how two providers could ship it broken. It does now.
 
 ### WolverineFx (core)
+
+- **Chains carry their Event Modeling roles, and `event-model` exports them.**
+  ([#3988](https://github.com/JasperFx/wolverine/issues/3988), [#3990](https://github.com/JasperFx/wolverine/issues/3990))
+  Every message handler chain now derives its Event Modeling slice — command, handler, the aggregate(s) it decides
+  against (`[WriteModel]` / `[DeciderFunction]` / `[DcbModel]` and the store spellings), emitted events from its
+  declarative returns, read models (`[ReadModel]`, `[Entity]`, `IStorageAction<T>`), cascaded messages, trigger kind
+  (message handler / job scheduler / gRPC when an RPC forwards the message) and slice pattern — as a JasperFx
+  `EventModelSliceDescriptor`. It is surfaced on `MessageHandlerDescriptor.EventModel`, as the assembled
+  `ServiceCapabilities.EventModel`, and through a `WolverineEventModelSource : IEventModelDefinitionSource` that
+  `UseWolverine()` registers ahead of every overlay so derived roles win on merge. `dotnet run -- event-model
+  [--json <path>]` writes the merged model as JSON from a host that is built but never started — no transports,
+  no database, no runtime compiler. Imperative `session.Events.Append(...)` in a handler body stays invisible by
+  decision of record; only declarative returns are reported. Bumps JasperFx to 2.54.0 for the descriptor.
 
 - **An agent this node cannot build is released to a node that can.**
   ([#3994](https://github.com/JasperFx/wolverine/pull/3994), closes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.6.1" />
-    <PackageVersion Include="JasperFx" Version="2.53.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0" />
+    <PackageVersion Include="JasperFx" Version="2.54.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.54.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.54.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.53.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.54.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -338,3 +338,28 @@ component with the same output CritterWatch shows for the same host.
 What is deliberately *not* visible here: imperative `session.Events.Append(...)` inside a handler body. That is
 invisible at runtime, so only declarative returns are reported; CritterWatch's source generator covers the
 imperative case.
+
+### Naming the external system on an endpoint
+
+The *edge* of a translation slice is derived — a listener that receives from, or a subscriber that publishes to,
+something outside your application *is* the external-system boundary — but the **name** of that system is the one
+thing code cannot say. Declare it on the endpoint, never in the event-model overlay:
+
+```cs
+opts.ListenToRabbitQueue("stripe-events")
+    .ExternalSystem("Stripe")
+    .DefaultIncomingMessage<StripeChargeSucceeded>();
+
+opts.PublishMessage<IssueStripeRefund>()
+    .ToRabbitQueue("stripe-refunds")
+    .ExternalSystem("Stripe");
+```
+
+`.ExternalSystem("...")` is available on every listener and subscriber configuration. The name flows out through
+the endpoint's `EndpointDescriptor.ExternalSystem` in the capabilities snapshot, and the Event Model attaches a
+**Stripe** external-system element — inbound — to the slice the listener triggers (a handler stuck to that
+listener, or the handler of its `DefaultIncomingMessage<T>()`), which makes that slice a `Translation` slice
+triggered `External`; a named listener bound to no slice still renders as a trigger-only boundary. On the outbound
+side, every slice whose published messages or emitted events the named endpoint subscribes to gets the system on
+its far end (a pure relay becomes a `Translation` slice; a command slice that also notifies Stripe stays a command
+slice).

--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -302,7 +302,39 @@ start it, so no database or message-broker connections are opened.
 * Wolverine has direct support for [Oakton](https://jasperfx.github.io/oakton) environment checks and resource management that
   can be very helpful for Wolverine integrations with message brokers or database servers
 
+## Exporting the Event Model
 
+::: tip
+Added with GH-3988 / GH-3990. The design-time Event Modeling viewer that renders this file is the
+Bobcat viewer; CritterWatch renders the same descriptor live from a running service.
+:::
 
+Every Wolverine message handler chain, HTTP endpoint chain and gRPC-forwarded RPC *derives* its own
+[Event Modeling](https://eventmodeling.org/) roles — the inbound command, the handler, the aggregate(s) the
+handler decides against (`[WriteAggregate]` / `[WriteModel]`, `[AggregateHandler]` / `[DeciderFunction]`, the
+DCB `[DcbModel]` / `[BoundaryModel]`), the events it emits (its declarative return values), the read models it loads
+(`[ReadAggregate]` / `[ReadModel]`, `[Entity]`) or produces (`IStorageAction<T>`), the messages it cascades, how it is
+triggered and which of the four slice patterns it is. Nothing is declared; it is all read off the chain, and it
+flows out through the `ServiceCapabilities` snapshot CritterWatch already consumes and through JasperFx's
+`IEventModelDefinitionSource` seam.
 
+The `event-model` command writes that whole picture — Wolverine's derived slices, Wolverine.HTTP's, and any
+[overlay](https://github.com/JasperFx/jasperfx/issues/687) the application registered with
+`services.AddEventModel(...)` — as one JSON `EventModelDescriptor`, **without a running fleet**:
 
+```bash
+dotnet run -- event-model                       # writes event-model.json in the working directory
+dotnet run -- event-model --json ./docs/orders.json
+dotnet run -- event-model --json ./out.json --name Orders
+```
+
+The host is built but **never started**: the handler graph is compiled the same way
+`wolverine-diagnostics describe-handlers` does it, so no transport is opened, no database is touched, and no
+runtime compiler is needed — a `TypeLoadMode.Dynamic` application without `WolverineFx.RuntimeCompilation`
+still exports. The JSON is written camelCase with enums as strings, exactly as CritterWatch puts the descriptor
+on the wire, so the file round-trips through `EventModelDescriptor` and renders in the shared Event Modeling
+component with the same output CritterWatch shows for the same host.
+
+What is deliberately *not* visible here: imperative `session.Events.Append(...)` inside a handler body. That is
+invisible at runtime, so only declarative returns are reported; CritterWatch's source generator covers the
+imperative case.

--- a/src/Http/Wolverine.Http.Tests/Marten/event_model_roles_3988.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/event_model_roles_3988.cs
@@ -1,0 +1,74 @@
+using JasperFx.Events.EventModeling;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Http.Diagnostics;
+using Wolverine.Tracking;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+// GH-3988: an HTTP chain derives the same Event Modeling roles a message handler chain does — with the
+// route + verb as its trigger — and reaches CritterWatch through the capabilities snapshot and the
+// registered IEventModelDefinitionSource. No source generator anywhere in this test project.
+public class event_model_roles_3988(AppFixture fixture) : IntegrationContext(fixture)
+{
+    [Fact]
+    public void an_http_aggregate_endpoint_is_a_command_slice_triggered_by_the_route()
+    {
+        // POST /orders/ship3 is Ship3(ShipOrder command, [WriteAggregate] Order order) => OrderShipped, [EmptyResponse]
+        var chain = HttpChains.ChainFor("POST", "/orders/ship3");
+        chain.ShouldNotBeNull();
+
+        var slice = HttpEventModelSource.ForChain(chain);
+
+        slice.Name.ShouldBe(nameof(ShipOrder));
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.TriggerKind.ShouldBe(TriggerKind.Http);
+        slice.TriggerOrigin!.HttpMethod.ShouldBe("POST");
+        slice.TriggerOrigin.HttpRoute.ShouldBe("/orders/ship3");
+        slice.TriggerLabel.ShouldBe("POST /orders/ship3");
+        slice.CommandType!.Name.ShouldBe(nameof(ShipOrder));
+        slice.HandlerType!.Name.ShouldBe(nameof(MarkItemEndpoint));
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(OrderShipped) });
+        slice.PublishedMessages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_get_endpoint_reading_an_aggregate_is_a_view_slice()
+    {
+        // GET /orders/latest/{id} is GetLatest(Guid id, [ReadAggregate] Order order) => order
+        var chain = HttpChains.ChainFor("GET", "/orders/latest/{id}");
+        chain.ShouldNotBeNull();
+
+        var slice = HttpEventModelSource.ForChain(chain);
+
+        slice.Pattern.ShouldBe(SlicePattern.View);
+        slice.TriggerKind.ShouldBe(TriggerKind.Http);
+        slice.Name.ShouldBe("GET /orders/latest/{id}");
+        slice.CommandType.ShouldBeNull();
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        slice.EmittedEvents.ShouldBeEmpty();
+        slice.PublishedMessages.ShouldBeEmpty();
+        slice.AggregateTypes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_http_slices_reach_discovery_and_the_capabilities_snapshot()
+    {
+        var assembled = await EventModelDiscovery.AssembleAsync(Host.Services, TestContext.Current.CancellationToken);
+        var viaSeam = assembled.SelectMany(x => x.Slices).Single(x => x.Name == nameof(ShipOrder));
+        viaSeam.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        viaSeam.EmittedEvents.Select(x => x.Name).ShouldContain(nameof(OrderShipped));
+
+        var capabilities = await ServiceCapabilities.ReadFrom(Host.GetRuntime(), null, CancellationToken.None);
+        capabilities.EventModel.ShouldNotBeNull();
+        var fromCapabilities = capabilities.EventModel.Slices.Single(x => x.Name == nameof(ShipOrder));
+        fromCapabilities.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        fromCapabilities.EmittedEvents.Select(x => x.Name).ShouldContain(nameof(OrderShipped));
+
+        // the model carries the aggregate element, with the events Order applies
+        var order = capabilities.EventModel.Aggregates.Single(x => x.Type.Name == nameof(Order));
+        order.AppliedEvents.Select(x => x.Name).ShouldContain(nameof(OrderShipped));
+    }
+}

--- a/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
+++ b/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
@@ -28,10 +28,31 @@ internal sealed class HttpEventModelSource : IEventModelDefinitionSource
         var graph = _options.Endpoints;
         if (graph is null) return Task.FromResult<EventModelDescriptor?>(null);
 
-        return Task.FromResult<EventModelDescriptor?>(Describe(_wolverineOptions.ServiceName, graph.Chains));
+        return Task.FromResult<EventModelDescriptor?>(Describe(_wolverineOptions, graph.Chains));
     }
 
     /// <summary>Describe every routed HTTP chain as an Event Model slice.</summary>
+    public static EventModelDescriptor Describe(WolverineOptions options, IEnumerable<HttpChain> chains)
+    {
+        var chainList = chains.ToList();
+        var model = Describe(options.ServiceName, chainList);
+
+        var knownTypes = new Dictionary<string, Type>(StringComparer.Ordinal);
+        foreach (var chain in chainList)
+        {
+            if (chain.RequestType?.FullName is { } request) knownTypes.TryAdd(request, chain.RequestType);
+            foreach (var variable in chain.Method.Creates)
+            {
+                if (variable.VariableType.FullName is { } fullName) knownTypes.TryAdd(fullName, variable.VariableType);
+            }
+        }
+
+        // GH-3989: an endpoint publishing to a named external system puts that system on the far end
+        // of the HTTP slice too; HTTP chains have no listener, so only outbound edges apply
+        return WolverineEventModelSource.ApplyExternalSystems(model, options, knownTypes: knownTypes, includeInbound: false);
+    }
+
+    /// <summary>Describe every routed HTTP chain as an Event Model slice, without endpoint-derived external systems.</summary>
     public static EventModelDescriptor Describe(string serviceName, IEnumerable<HttpChain> chains)
     {
         var slices = new List<EventModelSliceDescriptor>();

--- a/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
+++ b/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
@@ -1,0 +1,85 @@
+using JasperFx.Events.EventModeling;
+using Wolverine.Configuration.EventModeling;
+
+namespace Wolverine.Http.Diagnostics;
+
+/// <summary>
+///     The Wolverine.HTTP-derived <see cref="IEventModelDefinitionSource" /> (GH-3988): one Event Model
+///     slice per <see cref="HttpChain" />, triggered by the route and verb, with the command being the
+///     request body and the roles derived off the endpoint signature by <see cref="EventModelRoles" />
+///     exactly as for a message handler chain. Contributes to the same model as Wolverine core's source —
+///     named for the service — so the assembled picture is one model per service.
+/// </summary>
+internal sealed class HttpEventModelSource : IEventModelDefinitionSource
+{
+    private readonly WolverineHttpOptions _options;
+    private readonly WolverineOptions _wolverineOptions;
+
+    public HttpEventModelSource(WolverineHttpOptions options, WolverineOptions wolverineOptions)
+    {
+        _options = options;
+        _wolverineOptions = wolverineOptions;
+    }
+
+    public Uri Subject { get; } = new($"{WolverineEventModelSource.Scheme}://wolverine-http");
+
+    public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+    {
+        var graph = _options.Endpoints;
+        if (graph is null) return Task.FromResult<EventModelDescriptor?>(null);
+
+        return Task.FromResult<EventModelDescriptor?>(Describe(_wolverineOptions.ServiceName, graph.Chains));
+    }
+
+    /// <summary>Describe every routed HTTP chain as an Event Model slice.</summary>
+    public static EventModelDescriptor Describe(string serviceName, IEnumerable<HttpChain> chains)
+    {
+        var slices = new List<EventModelSliceDescriptor>();
+        var aggregates = new List<AggregateDescriptor>();
+        var aggregateNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var chain in chains.Where(x => x.RoutePattern is not null)
+                     .OrderBy(x => x.RoutePattern!.RawText, StringComparer.Ordinal)
+                     .ThenBy(x => x.HttpMethods.OrderBy(m => m).FirstOrDefault(), StringComparer.Ordinal))
+        {
+            slices.Add(ForChain(chain));
+            foreach (var aggregate in EventModelRoles.AggregatesFor(chain))
+            {
+                if (aggregateNames.Add(aggregate.Type.FullName)) aggregates.Add(aggregate);
+            }
+        }
+
+        return WolverineEventModelSource.FinishModel(new EventModelDescriptor(serviceName, slices) { Aggregates = aggregates });
+    }
+
+    /// <summary>
+    ///     Describe one HTTP chain. The slice is named for the request type when there is one — the same
+    ///     key a message handler for that type would use, so an endpoint and a handler for the same command
+    ///     fold into one slice — else for the verb and route.
+    /// </summary>
+    public static EventModelSliceDescriptor ForChain(HttpChain chain)
+    {
+        var route = chain.RoutePattern?.RawText ?? string.Empty;
+        var methods = chain.HttpMethods.OrderBy(x => x, StringComparer.Ordinal).ToArray();
+        var verb = methods.FirstOrDefault() ?? "GET";
+        var requestType = chain.RequestType is { } req && req != typeof(void) ? req : null;
+        var resourceType = chain.ResourceType is { } res && res != typeof(void) ? res : null;
+
+        var seed = new EventModelSliceSeed(
+            requestType?.Name ?? $"{verb} {route}",
+            TriggerKind.Http,
+            new PublisherOrigin { HttpRoute = route, HttpMethod = verb, Label = $"{verb} {route}" },
+            requestType,
+            chain.EndpointType)
+        {
+            ResponseType = resourceType,
+            // Wolverine.HTTP's convention: the first return value is the response body unless the
+            // endpoint is [EmptyResponse] / NoContent, in which case every return value is a message
+            // (or an event) — mirrors HttpGraphUsageSource's cascading-message rule
+            FirstReturnValueIsResponse = !chain.NoContent && chain.Method.Creates.Any(),
+            IsQuery = methods.All(m => m is "GET" or "HEAD")
+        };
+
+        return EventModelRoles.Describe(chain, seed);
+    }
+}

--- a/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpEndpointRouteBuilderExtensions.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Wolverine.Configuration;
 using JasperFx.Events;
+using JasperFx.Events.EventModeling;
 using Wolverine.Configuration.Capabilities;
 using Wolverine.Http.ApiVersioning;
 using Wolverine.Http.CodeGen;
@@ -192,6 +193,13 @@ public static class WolverineHttpEndpointRouteBuilderExtensions
         // registered for back-compat with monitoring agents that haven't
         // shipped the richer reader yet.
         services.AddSingleton<IHttpGraphUsageSource, HttpGraphUsageSource>();
+
+        // GH-3988 — the Wolverine.HTTP-derived Event Model source. Inserted at the front, like Wolverine
+        // core's, so an overlay registered earlier cannot overwrite a derived role on merge.
+        if (services.All(x => x.ImplementationType != typeof(HttpEventModelSource)))
+        {
+            services.Insert(0, ServiceDescriptor.Singleton<IEventModelDefinitionSource, HttpEventModelSource>());
+        }
 
         // Registered unconditionally — harmless when no versioned endpoint uses it.
         services.AddSingleton<ApiVersionHeaderWriter>(sp =>

--- a/src/Persistence/MartenTests/EventModeling/event_model_roles_3988.cs
+++ b/src/Persistence/MartenTests/EventModeling/event_model_roles_3988.cs
@@ -1,0 +1,215 @@
+using IntegrationTests;
+using JasperFx.Events;
+using JasperFx.Events.EventModeling;
+using JasperFx.Resources;
+using Marten;
+using MartenTests.Dcb.University;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.EventModeling;
+
+// GH-3988: a Marten-backed host with an aggregate handler ([WriteAggregate]), a decider-function
+// handler ([AggregateHandler]), a read-aggregate handler and a DCB handler ([BoundaryModel]) reports
+// complete Event Modeling roles for all four — with NO source generator anywhere in this test project.
+// The roles come off the chains themselves, through the registered IEventModelDefinitionSource and
+// the ServiceCapabilities snapshot.
+public class event_model_roles_3988 : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DROP SCHEMA IF EXISTS event_model_roles_3988 CASCADE;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "event-model-roles-3988";
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "event_model_roles_3988";
+
+                        // the DCB half (same setup as agnostic_dcb_model)
+                        m.Events.RegisterTagType<StudentId>("student")
+                            .ForAggregate<SubscriptionState>();
+                        m.Events.RegisterTagType<CourseId>("course")
+                            .ForAggregate<SubscriptionState>();
+                        m.Events.RegisterTagType<FacultyId>("faculty");
+                        m.Projections.LiveStreamAggregation<SubscriptionState>();
+                        m.Events.AddEventType<CourseCreated>();
+                        m.Events.AddEventType<CourseCapacityChanged>();
+
+                        m.Events.StreamIdentity = StreamIdentity.AsString;
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(EndTripHandler))
+                    .IncludeType(typeof(ConfirmTripHandler))
+                    .IncludeType(typeof(TripSummaryHandler))
+                    .IncludeType(typeof(WithDcbChangeCourseCapacityHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public void the_write_aggregate_handler_reports_aggregate_and_emitted_events()
+    {
+        var model = WolverineEventModelSource.Describe(theHost.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(EndTrip));
+
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+        slice.CommandType!.Name.ShouldBe(nameof(EndTrip));
+        slice.HandlerType!.Name.ShouldBe(nameof(EndTripHandler));
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Trip) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(TripEnded) });
+        slice.PublishedMessages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_decider_function_handler_infers_its_aggregate()
+    {
+        var model = WolverineEventModelSource.Describe(theHost.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(ConfirmTrip));
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Trip) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(TripConfirmed) });
+    }
+
+    [Fact]
+    public void the_read_aggregate_handler_reads_the_aggregate_as_a_read_model()
+    {
+        var model = WolverineEventModelSource.Describe(theHost.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(GetTripSummary));
+
+        slice.AggregateTypes.ShouldBeEmpty();
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Trip) });
+        slice.EmittedEvents.ShouldBeEmpty();
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(TripSummary) });
+    }
+
+    [Fact]
+    public void the_dcb_handler_reports_the_boundary_model_and_its_event()
+    {
+        var model = WolverineEventModelSource.Describe(theHost.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(ChangeCourseCapacity));
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(WithDcbChangeCourseCapacityHandler.State) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(CourseCapacityChanged) });
+
+        model.Aggregates.Single(x => x.Type.Name == nameof(WithDcbChangeCourseCapacityHandler.State)).Kind
+            .ShouldBe(AggregateKind.BoundaryModel);
+    }
+
+    [Fact]
+    public void the_aggregate_elements_carry_kind_and_applied_events()
+    {
+        var model = WolverineEventModelSource.Describe(theHost.GetRuntime());
+
+        var trip = model.Aggregates.Single(x => x.Type.Name == nameof(Trip));
+        trip.Kind.ShouldBe(AggregateKind.WriteAggregate);
+        trip.AppliedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(TripStarted), nameof(TripEnded), nameof(TripConfirmed) });
+    }
+
+    [Fact]
+    public async Task the_roles_reach_the_capabilities_snapshot_and_the_discovery_seam()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(theHost.GetRuntime(), null, CancellationToken.None);
+
+        capabilities.EventModel.ShouldNotBeNull();
+        var fromCapabilities = capabilities.EventModel.Slices.Single(x => x.Name == nameof(EndTrip));
+        fromCapabilities.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Trip) });
+        fromCapabilities.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(TripEnded) });
+
+        var perHandler = capabilities.Messages.Single(x => x.Type.Name == nameof(EndTrip)).Handlers.Single().EventModel!;
+        perHandler.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Trip) });
+
+        var discovered = await EventModelDiscovery.AssembleAsync(theHost.Services, TestContext.Current.CancellationToken);
+        var viaSeam = discovered.Single(x => x.Name == "event-model-roles-3988").Slices.Single(x => x.Name == nameof(EndTrip));
+        viaSeam.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(TripEnded) });
+    }
+
+    [Fact]
+    public async Task the_roles_survive_the_aggregate_workflow_actually_running()
+    {
+        // Codegen applies the aggregate handler workflow, which records AggregateHandling on the chain's
+        // tags — the same roles, now also from the tag path. Drive one message through to prove the two
+        // agree once the chain has been assembled.
+        var tripId = $"trip-{Guid.NewGuid():N}";
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<Trip>(tripId, new TripStarted());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await theHost.InvokeMessageAndWaitAsync(new EndTrip(tripId));
+
+        var slice = WolverineEventModelSource.Describe(theHost.GetRuntime()).Slices.Single(x => x.Name == nameof(EndTrip));
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Trip) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(TripEnded) });
+    }
+}
+
+public record StartTrip(string TripId);
+public record EndTrip(string TripId);
+public record ConfirmTrip(string TripId);
+public record GetTripSummary(string TripId);
+public record TripStarted;
+public record TripEnded;
+public record TripConfirmed;
+public record TripSummary(string TripId, bool Ended);
+
+public class Trip
+{
+    public string Id { get; set; } = null!;
+    public bool Ended { get; set; }
+    public bool Confirmed { get; set; }
+
+    public void Apply(TripStarted started) { }
+    public void Apply(TripEnded ended) => Ended = true;
+    public void Apply(TripConfirmed confirmed) => Confirmed = true;
+}
+
+public static class EndTripHandler
+{
+    public static TripEnded Handle(EndTrip command, [WriteAggregate] Trip trip) => new();
+}
+
+[AggregateHandler]
+public static class ConfirmTripHandler
+{
+    public static TripConfirmed Handle(ConfirmTrip command, Trip trip) => new();
+}
+
+public static class TripSummaryHandler
+{
+    public static TripSummary Handle(GetTripSummary query, [ReadAggregate] Trip trip) => new(trip.Id, trip.Ended);
+}

--- a/src/Testing/CoreTests/Acceptance/event_model_roles_3988.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_roles_3988.cs
@@ -1,0 +1,360 @@
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Persistence;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel3988;
+
+// GH-3988: every chain derives its own Event Modeling roles — command, handler, aggregates, emitted
+// events, read models, published messages, trigger kind, slice pattern — and writes them as the
+// JasperFx EventModelSliceDescriptor. Nothing here is declared; it is all read off the chain. These
+// tests need no store: the roles are read from the handler signature (and from the chain's tags when
+// the aggregate workflow has run), so a chain whose code has not been generated yet reports the same.
+public class event_model_roles_on_chains_3988
+{
+    private static HandlerChain chainFor<THandler>(System.Linq.Expressions.Expression<Action<THandler>> expression)
+        => HandlerChain.For(expression, new HandlerGraph());
+
+    [Fact]
+    public void a_plain_handler_with_a_cascading_message_is_a_command_slice_publishing_a_message()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<PlaceOrderHandler>(x => PlaceOrderHandler.Handle(null!)));
+
+        slice.Name.ShouldBe(nameof(PlaceOrder));
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+        slice.CommandType!.Name.ShouldBe(nameof(PlaceOrder));
+        slice.HandlerType!.Name.ShouldBe(nameof(PlaceOrderHandler));
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
+        slice.EmittedEvents.ShouldBeEmpty();
+        slice.AggregateTypes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void write_model_parameter_makes_the_returns_emitted_events_on_that_aggregate()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<ShipOrderHandler>(x => ShipOrderHandler.Handle(null!, null!)));
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(OrderShipped) });
+        slice.PublishedMessages.ShouldBeEmpty();
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void decider_function_infers_the_aggregate_from_the_signature_and_reads_every_return_as_an_event()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<ConfirmOrderHandler>(x => ConfirmOrderHandler.Handle(null!, null!)));
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(OrderConfirmed), nameof(OrderNotified) });
+        slice.PublishedMessages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void read_model_and_entity_parameters_are_read_models_and_the_dto_is_a_published_message()
+    {
+        var readModel = EventModelRoles.ForHandlerChain(chainFor<GetOrderHandler>(x => GetOrderHandler.Handle(null!, null!)));
+        readModel.ReadModelTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
+        readModel.AggregateTypes.ShouldBeEmpty();
+        readModel.EmittedEvents.ShouldBeEmpty();
+        readModel.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderSummary) });
+
+        var entity = EventModelRoles.ForHandlerChain(chainFor<GetCustomerHandler>(x => GetCustomerHandler.Handle(null!, null!)));
+        entity.ReadModelTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Customer) });
+    }
+
+    [Fact]
+    public void dcb_model_parameter_is_a_boundary_aggregate()
+    {
+        var chain = chainFor<ChangeCourseCapacityHandler>(x => ChangeCourseCapacityHandler.Handle(null!, null!));
+        var slice = EventModelRoles.ForHandlerChain(chain);
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(CourseState) });
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(CourseCapacityChanged) });
+
+        var aggregate = EventModelRoles.AggregatesFor(chain).ShouldHaveSingleItem();
+        aggregate.Type.Name.ShouldBe(nameof(CourseState));
+        aggregate.Kind.ShouldBe(AggregateKind.BoundaryModel);
+    }
+
+    [Fact]
+    public void storage_action_returns_are_read_models_the_slice_produces()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<RegisterCustomerHandler>(x => RegisterCustomerHandler.Handle(null!)));
+
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Customer) });
+        slice.PublishedMessages.ShouldBeEmpty();
+        slice.EmittedEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_timeout_message_is_triggered_by_the_job_scheduler()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<ShipmentTimeoutHandler>(x => ShipmentTimeoutHandler.Handle(null!)));
+        slice.TriggerKind.ShouldBe(TriggerKind.JobScheduler);
+    }
+
+    [Fact]
+    public void a_saga_returned_from_its_own_start_is_not_a_published_message()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<OrderSaga>(x => OrderSaga.Start(null!)));
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
+    }
+
+    [Fact]
+    public void the_aggregate_element_carries_the_events_the_type_applies()
+    {
+        var chain = chainFor<ShipOrderHandler>(x => ShipOrderHandler.Handle(null!, null!));
+        var aggregate = EventModelRoles.AggregatesFor(chain).ShouldHaveSingleItem();
+
+        aggregate.Type.Name.ShouldBe(nameof(Order));
+        aggregate.Kind.ShouldBe(AggregateKind.WriteAggregate);
+        aggregate.AppliedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlaced), nameof(OrderShipped), nameof(OrderConfirmed) });
+    }
+
+    [Fact]
+    public void a_slice_whose_command_is_an_event_another_slice_emits_is_an_automation()
+    {
+        var ship = EventModelRoles.ForHandlerChain(chainFor<ShipOrderHandler>(x => ShipOrderHandler.Handle(null!, null!)));
+        var reaction = EventModelRoles.ForHandlerChain(chainFor<OrderShippedHandler>(x => OrderShippedHandler.Handle(null!)));
+        reaction.Pattern.ShouldBe(SlicePattern.Command); // on its own it looks like a command slice
+
+        var model = WolverineEventModelSource.FinishModel(new EventModelDescriptor("app", new[] { ship, reaction }));
+
+        model.Slices.Single(x => x.Name == nameof(OrderShipped)).Pattern.ShouldBe(SlicePattern.Automation);
+        model.Slices.Single(x => x.Name == nameof(ShipOrder)).Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void a_grpc_rpc_that_forwards_a_message_is_that_slices_trigger()
+    {
+        var place = EventModelRoles.ForHandlerChain(chainFor<PlaceOrderHandler>(x => PlaceOrderHandler.Handle(null!)));
+        var model = new EventModelDescriptor("app", new[] { place });
+
+        var manifest = new StubGrpcManifest(
+            new GrpcEndpointDescriptor("Orders", "Place", typeof(PlaceOrder), null, typeof(PlaceOrderHandler), GrpcServiceDiscoveryMode.CodeFirst, GrpcRpcStreamKind.Unary),
+            new GrpcEndpointDescriptor("Orders", "Cancel", typeof(CancelOrder), null, typeof(PlaceOrderHandler), GrpcServiceDiscoveryMode.CodeFirst, GrpcRpcStreamKind.Unary));
+
+        var applied = WolverineEventModelSource.ApplyGrpcTriggers(model, manifest);
+
+        var placeSlice = applied.Slices.Single(x => x.Name == nameof(PlaceOrder));
+        placeSlice.TriggerKind.ShouldBe(TriggerKind.Grpc);
+        placeSlice.TriggerOrigin!.GrpcService.ShouldBe("Orders");
+        placeSlice.TriggerOrigin.GrpcMethod.ShouldBe("Place");
+        placeSlice.HandlerType!.Name.ShouldBe(nameof(PlaceOrderHandler)); // the handler roles survive
+
+        // No handler chain for CancelOrder in this process: a trigger-only slice so the RPC still renders
+        var cancel = applied.Slices.Single(x => x.Name == nameof(CancelOrder));
+        cancel.TriggerKind.ShouldBe(TriggerKind.Grpc);
+        cancel.CommandType!.Name.ShouldBe(nameof(CancelOrder));
+        cancel.HandlerType.ShouldBeNull();
+    }
+
+    private sealed class StubGrpcManifest(params GrpcEndpointDescriptor[] endpoints) : IGrpcEndpointManifest
+    {
+        public IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; } = endpoints;
+    }
+}
+
+// GH-3988 / GH-3990: the roles reach the outside through the registered IEventModelDefinitionSource,
+// the ServiceCapabilities snapshot, and the event-model export — all from a booted host, none of
+// which needs a source generator.
+public class event_model_sources_and_capabilities_3988 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                // Registered BEFORE UseWolverine() on purpose: the derived source must still win on
+                // merge, so the overlay may only fill gaps (the trigger label) — never a derived role
+                services.AddEventModel("Overlay", model =>
+                {
+                    model.InDomain("Sales");
+                    model.Slice(nameof(PlaceOrder)).TriggeredBy("UI: Place order");
+                });
+            })
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "event-model-3988";
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(PlaceOrderHandler))
+                    .IncludeType(typeof(ShipmentTimeoutHandler));
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void the_wolverine_source_is_registered_first()
+    {
+        var sources = _host.Services.GetServices<IEventModelDefinitionSource>().ToArray();
+        sources.First().ShouldBeOfType<WolverineEventModelSource>();
+        sources.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task discovery_assembles_the_derived_roles_with_the_overlay_only_filling_gaps()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services, token: TestContext.Current.CancellationToken);
+
+        model.Name.ShouldBe("event-model-3988");
+        var slice = model.Slices.Single(x => x.Name == nameof(PlaceOrder));
+
+        // derived
+        slice.CommandType!.Name.ShouldBe(nameof(PlaceOrder));
+        slice.HandlerType!.Name.ShouldBe(nameof(PlaceOrderHandler));
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
+        slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+
+        // overlay
+        slice.TriggerLabel.ShouldBe("UI: Place order");
+        slice.Domain.ShouldBe("Sales");
+
+        model.Slices.Single(x => x.Name == nameof(ShipmentTimeout)).TriggerKind.ShouldBe(TriggerKind.JobScheduler);
+    }
+
+    [Fact]
+    public async Task the_capabilities_snapshot_carries_the_model_and_the_per_handler_slice()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+
+        capabilities.EventModel.ShouldNotBeNull();
+        capabilities.EventModel.Name.ShouldBe("event-model-3988");
+        capabilities.EventModel.Slices.Select(x => x.Name).ShouldContain(nameof(PlaceOrder));
+
+        var handler = capabilities.Messages.Single(x => x.Type.Name == nameof(PlaceOrder)).Handlers.Single();
+        handler.EventModel.ShouldNotBeNull();
+        handler.EventModel.CommandType!.Name.ShouldBe(nameof(PlaceOrder));
+        handler.EventModel.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
+    }
+
+    [Fact]
+    public async Task the_export_round_trips_through_the_wire_descriptor()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services, token: TestContext.Current.CancellationToken);
+
+        var json = WolverineEventModelExport.ToJson(model);
+
+        // the wire shape CritterWatch serialises: camelCase, enums as strings, rendering contract present
+        json.ShouldContain("\"triggerKind\": \"MessageHandler\"");
+        json.ShouldContain("\"pattern\": \"Command\"");
+        json.ShouldContain("\"elements\"");
+        json.ShouldContain("\"edges\"");
+
+        var back = WolverineEventModelExport.FromJson(json)!;
+        back.Name.ShouldBe(model.Name);
+        back.Slices.Select(x => x.Name).ShouldBe(model.Slices.Select(x => x.Name));
+        var slice = back.Slices.Single(x => x.Name == nameof(PlaceOrder));
+        slice.CommandType!.FullName.ShouldBe(typeof(PlaceOrder).FullName);
+        slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
+        slice.TriggerLabel.ShouldBe("UI: Place order");
+        slice.Elements.Count.ShouldBe(model.Slices.Single(x => x.Name == nameof(PlaceOrder)).Elements.Count);
+    }
+}
+
+#region sample types for GH-3988
+
+public record PlaceOrder(string OrderId);
+public record CancelOrder(string OrderId);
+public record OrderPlacedNotification(string OrderId);
+
+public class PlaceOrderHandler
+{
+    public static OrderPlacedNotification Handle(PlaceOrder command) => new(command.OrderId);
+}
+
+public record ShipOrder(string OrderId);
+public record ConfirmOrder(string OrderId);
+public record GetOrder(string OrderId);
+public record OrderPlaced;
+public record OrderShipped;
+public record OrderConfirmed;
+public record OrderNotified;
+public record OrderSummary(string OrderId);
+
+public class Order
+{
+    public string Id { get; set; } = null!;
+    public static Order Create(OrderPlaced placed) => new();
+    public void Apply(OrderShipped shipped) { }
+    public void Apply(OrderConfirmed confirmed) { }
+}
+
+public class ShipOrderHandler
+{
+    public static OrderShipped Handle(ShipOrder command, [WriteModel] Order order) => new();
+}
+
+public class ConfirmOrderHandler
+{
+    [DeciderFunction]
+    public static (OrderConfirmed, OrderNotified) Handle(ConfirmOrder command, Order order) => (new(), new());
+}
+
+public class GetOrderHandler
+{
+    public static OrderSummary Handle(GetOrder query, [ReadModel] Order order) => new(order.Id);
+}
+
+public class OrderShippedHandler
+{
+    public static void Handle(OrderShipped shipped) { }
+}
+
+public record GetCustomer(string CustomerId);
+public record RegisterCustomer(string CustomerId);
+public class Customer { public string Id { get; set; } = null!; }
+
+public class GetCustomerHandler
+{
+    public static OrderSummary Handle(GetCustomer query, [Entity] Customer customer) => new(customer.Id);
+}
+
+public class RegisterCustomerHandler
+{
+    public static IStorageAction<Customer> Handle(RegisterCustomer command) => Storage.Insert(new Customer { Id = command.CustomerId });
+}
+
+public record ChangeCourseCapacity(string CourseId, int Capacity);
+public record CourseCapacityChanged(int Capacity);
+public class CourseState { public int Capacity { get; set; } }
+
+public class ChangeCourseCapacityHandler
+{
+    public static CourseCapacityChanged Handle(ChangeCourseCapacity command, [DcbModel] CourseState state) => new(command.Capacity);
+}
+
+public record ShipmentTimeout(string OrderId) : TimeoutMessage(TimeSpan.FromMinutes(5));
+
+public class ShipmentTimeoutHandler
+{
+    public static void Handle(ShipmentTimeout timeout) { }
+}
+
+public class OrderSaga : Saga
+{
+    public string Id { get; set; } = null!;
+
+    public static (OrderSaga, OrderPlacedNotification) Start(PlaceOrder command) => (new OrderSaga { Id = command.OrderId }, new(command.OrderId));
+
+    public void Handle(OrderShipped shipped) => MarkCompleted();
+}
+
+#endregion

--- a/src/Testing/CoreTests/Acceptance/external_system_3989.cs
+++ b/src/Testing/CoreTests/Acceptance/external_system_3989.cs
@@ -1,0 +1,191 @@
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Acceptance.ExternalSystem3989;
+
+// GH-3989: the *edge* of a translation slice is derived — a listening or sending endpoint to something
+// outside the application IS the external-system boundary — but the *name* ("Stripe") is the one thing
+// code cannot say, so it is declared on the endpoint with .ExternalSystem("Stripe"), never in the event
+// model overlay. It flows out through EndpointDescriptor and lands on the slice as an external-system
+// element. TCP endpoints here so no broker is needed; the RabbitMQ-flavoured twin lives in
+// Wolverine.RabbitMQ.Tests.
+public class external_system_3989 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private int _stripeInboundPort;
+    private int _stripeOutboundPort;
+    private int _erpInboundPort;
+    private int _ledgerPort;
+
+    public async ValueTask InitializeAsync()
+    {
+        _stripeInboundPort = PortFinder.GetAvailablePort();
+        _stripeOutboundPort = PortFinder.GetAvailablePort();
+        _erpInboundPort = PortFinder.GetAvailablePort();
+        _ledgerPort = PortFinder.GetAvailablePort();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "external-system-3989";
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StripeChargeSucceededHandler))
+                    .IncludeType(typeof(RefundOrderHandler))
+                    .IncludeType(typeof(PlaceOrderHandler));
+
+                // inbound: Stripe pushes charge events onto this listener; DefaultIncomingMessage<T> is what
+                // binds the listener to the slice (the other binding is a handler stuck to the listener). The
+                // TCP helper returns the interface, so reach the generic base for DefaultIncomingMessage<T>;
+                // the broker configurations (RabbitMqListenerConfiguration etc.) expose it directly.
+                ((ListenerConfiguration)opts.ListenAtPort(_stripeInboundPort))
+                    .DefaultIncomingMessage<StripeChargeSucceeded>()
+                    .ExternalSystem("Stripe");
+
+                // inbound, bound to nothing: still a boundary to render
+                opts.ListenAtPort(_erpInboundPort).ExternalSystem("Legacy ERP").Named("erp-feed");
+
+                // outbound: refund requests go to Stripe
+                opts.PublishMessage<IssueStripeRefund>().ToPort(_stripeOutboundPort).ExternalSystem("Stripe");
+
+                // outbound: a plain internal subscriber, no external system
+                opts.PublishMessage<OrderPlacedNotification>().ToPort(_ledgerPort);
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void the_endpoint_descriptor_reports_the_external_system_name()
+    {
+        var endpoint = _host.GetRuntime().Options.Transports.AllEndpoints()
+            .Single(x => x.Uri.Port == _stripeInboundPort);
+
+        endpoint.ExternalSystemName.ShouldBe("Stripe");
+        new EndpointDescriptor(endpoint).ExternalSystem.ShouldBe("Stripe");
+
+        var ledger = _host.GetRuntime().Options.Transports.AllEndpoints().Single(x => x.Uri.Port == _ledgerPort);
+        new EndpointDescriptor(ledger).ExternalSystem.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task the_capabilities_snapshot_carries_the_name_on_the_messaging_endpoint()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+
+        capabilities.MessagingEndpoints.Single(x => x.Uri.Port == _stripeInboundPort).ExternalSystem.ShouldBe("Stripe");
+        capabilities.MessagingEndpoints.Single(x => x.Uri.Port == _stripeOutboundPort).ExternalSystem.ShouldBe("Stripe");
+        capabilities.MessagingEndpoints.Single(x => x.Uri.Port == _ledgerPort).ExternalSystem.ShouldBeNull();
+    }
+
+    [Fact]
+    public void an_inbound_listener_is_the_trigger_of_the_slice_for_its_message_type()
+    {
+        var model = WolverineEventModelSource.Describe(_host.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded));
+
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Stripe");
+        system.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+        system.EndpointUri.ShouldBe($"tcp://localhost:{_stripeInboundPort}/");
+
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+        slice.TriggerLabel.ShouldNotBeNull();
+
+        // and the handler roles are untouched
+        slice.CommandType!.Name.ShouldBe(nameof(StripeChargeSucceeded));
+        slice.HandlerType!.Name.ShouldBe(nameof(StripeChargeSucceededHandler));
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(RecordPayment) });
+
+        // the external system renders as an element on the wireframe lane
+        slice.Elements.ShouldContain(x => x.Kind == EventModelElementKind.ExternalSystem && x.Label == "Stripe");
+    }
+
+    [Fact]
+    public void an_outbound_subscriber_puts_the_external_system_on_the_publishing_slice()
+    {
+        var model = WolverineEventModelSource.Describe(_host.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(RefundOrder));
+
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Stripe");
+        system.Direction.ShouldBe(ExternalSystemDirection.Outbound);
+        system.EndpointUri.ShouldBe($"tcp://localhost:{_stripeOutboundPort}/");
+
+        // a pure relay — no aggregate, no events of its own — is a translation slice
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+
+        // an internal subscriber is not an external system
+        model.Slices.Single(x => x.Name == nameof(PlaceOrder)).ExternalSystems.ShouldBeEmpty();
+        model.Slices.Single(x => x.Name == nameof(PlaceOrder)).Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void a_named_listener_bound_to_no_slice_still_renders_as_a_boundary()
+    {
+        var model = WolverineEventModelSource.Describe(_host.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == "erp-feed");
+
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+        slice.CommandType.ShouldBeNull();
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Legacy ERP");
+        system.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+    }
+
+    [Fact]
+    public async Task the_external_systems_survive_assembly_and_the_wire()
+    {
+        var assembled = await WolverineEventModelExport.AssembleAsync(_host.Services, token: TestContext.Current.CancellationToken);
+        assembled.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded)).ExternalSystems.Single().Name.ShouldBe("Stripe");
+
+        var json = WolverineEventModelExport.ToJson(assembled);
+        json.ShouldContain("\"externalSystems\"");
+        json.ShouldContain("\"direction\": \"Inbound\"");
+        json.ShouldContain("\"direction\": \"Outbound\"");
+        json.ShouldContain("\"pattern\": \"Translation\"");
+
+        var back = WolverineEventModelExport.FromJson(json)!;
+        var slice = back.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded));
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Stripe");
+        system.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+        system.EndpointUri.ShouldBe($"tcp://localhost:{_stripeInboundPort}/");
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+    }
+}
+
+public record StripeChargeSucceeded(string ChargeId);
+public record RecordPayment(string ChargeId);
+public record RefundOrder(string OrderId);
+public record IssueStripeRefund(string OrderId);
+public record PlaceOrder(string OrderId);
+public record OrderPlacedNotification(string OrderId);
+
+public class StripeChargeSucceededHandler
+{
+    public static RecordPayment Handle(StripeChargeSucceeded charge) => new(charge.ChargeId);
+}
+
+public class RefundOrderHandler
+{
+    public static IssueStripeRefund Handle(RefundOrder command) => new(command.OrderId);
+}
+
+public class PlaceOrderHandler
+{
+    public static OrderPlacedNotification Handle(PlaceOrder command) => new(command.OrderId);
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/external_system_3989.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/external_system_3989.cs
@@ -1,0 +1,91 @@
+using JasperFx.Events.EventModeling;
+using JasperFx.Resources;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// GH-3989 acceptance: a host with ListenToRabbitQueue("stripe-events").ExternalSystem("Stripe") reports
+// the name on that endpoint's descriptor, and the merged EventModelDescriptor carries an external-system
+// element named "Stripe" attached to the slice whose trigger is that endpoint.
+public class external_system_3989 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "external-system-3989";
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StripeChargeSucceededHandler))
+                    .IncludeType(typeof(RefundOrderHandler));
+
+                opts.ListenToRabbitQueue("stripe-events")
+                    .ExternalSystem("Stripe")
+                    .DefaultIncomingMessage<StripeChargeSucceeded>();
+
+                opts.PublishMessage<IssueStripeRefund>().ToRabbitQueue("stripe-refunds").ExternalSystem("Stripe");
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_rabbit_endpoints_report_the_external_system()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+
+        capabilities.MessagingEndpoints.Single(x => x.Uri == new Uri("rabbitmq://queue/stripe-events")).ExternalSystem.ShouldBe("Stripe");
+        capabilities.MessagingEndpoints.Single(x => x.Uri == new Uri("rabbitmq://queue/stripe-refunds")).ExternalSystem.ShouldBe("Stripe");
+    }
+
+    [Fact]
+    public async Task the_merged_event_model_attaches_stripe_to_the_slices_the_queues_trigger_and_feed()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services, token: TestContext.Current.CancellationToken);
+
+        var inbound = model.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded));
+        var trigger = inbound.ExternalSystems.ShouldHaveSingleItem();
+        trigger.Name.ShouldBe("Stripe");
+        trigger.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+        trigger.EndpointUri.ShouldBe("rabbitmq://queue/stripe-events");
+        inbound.Pattern.ShouldBe(SlicePattern.Translation);
+        inbound.TriggerKind.ShouldBe(TriggerKind.External);
+        inbound.Elements.ShouldContain(x => x.Kind == EventModelElementKind.ExternalSystem && x.Label == "Stripe");
+
+        var outbound = model.Slices.Single(x => x.Name == nameof(RefundOrder));
+        var target = outbound.ExternalSystems.ShouldHaveSingleItem();
+        target.Name.ShouldBe("Stripe");
+        target.Direction.ShouldBe(ExternalSystemDirection.Outbound);
+        target.EndpointUri.ShouldBe("rabbitmq://queue/stripe-refunds");
+    }
+}
+
+public record StripeChargeSucceeded(string ChargeId);
+public record RecordPayment(string ChargeId);
+public record RefundOrder(string OrderId);
+public record IssueStripeRefund(string OrderId);
+
+public class StripeChargeSucceededHandler
+{
+    public static RecordPayment Handle(StripeChargeSucceeded charge) => new(charge.ChargeId);
+}
+
+public class RefundOrderHandler
+{
+    public static IssueStripeRefund Handle(RefundOrder command) => new(command.OrderId);
+}

--- a/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
@@ -43,16 +43,27 @@ public class EndpointDescriptor : OptionsDescription
         Mode = endpoint.Mode;
         IsListener = endpoint.IsListener;
         DeadLetterStorage = endpoint.DeadLetterStorage;
+        ExternalSystem = endpoint.ExternalSystemName;
 
         // Mode and IsListener are now first-class typed fields (GH-3009); DeadLetterStorage is
         // likewise a typed field (GH-3104). Drop the generic OptionsDescription rows the base ctor
         // reflected off the Endpoint so we don't ship them twice — CritterWatch reads the typed
         // fields at the service-overview level, and Properties is becoming lazy-fetchable downstream.
         Properties.RemoveAll(x =>
-            x.Name is nameof(Endpoint.Mode) or nameof(Endpoint.IsListener) or nameof(Endpoint.DeadLetterStorage));
+            x.Name is nameof(Endpoint.Mode) or nameof(Endpoint.IsListener) or nameof(Endpoint.DeadLetterStorage)
+                or nameof(Endpoint.ExternalSystemName));
     }
 
     public Uri Uri { get; set; } = null!;
+
+    /// <summary>
+    /// The name of the external system on the other end of this endpoint — "Stripe", "Legacy ERP" —
+    /// when the application declared one with <c>.ExternalSystem("...")</c> on the listener or subscriber
+    /// configuration (GH-3989). Null when none was declared. Lifted from
+    /// <see cref="Endpoint.ExternalSystemName"/> into a first-class typed field so the Event Model can attach
+    /// the external-system element to the slice this endpoint triggers or feeds.
+    /// </summary>
+    public string? ExternalSystem { get; init; }
 
     /// <summary>
     /// Human-readable description of the transport type (e.g., "RabbitMQ Queue", "Local Queue", "Kafka Topic")

--- a/src/Wolverine/Configuration/Capabilities/MessageHandlerDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/MessageHandlerDescriptor.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Wolverine.Configuration.EventModeling;
 using Wolverine.Runtime.Handlers;
 
 namespace Wolverine.Configuration.Capabilities;
@@ -23,6 +25,18 @@ public class MessageHandlerDescriptor : OptionsDescription
         CodeFileName = chain.TypeName;
 
         StickyEndpoints = chain.Endpoints.Select(x => x.Uri).ToArray();
+
+        // GH-3988: the chain's Event Modeling roles — command / handler / aggregates / emitted events /
+        // read models / published messages — derived off the chain itself. Diagnostic: a chain the
+        // reader cannot make sense of simply has no slice, the rest of the descriptor is unaffected.
+        try
+        {
+            EventModel = EventModelRoles.ForHandlerChain(chain);
+        }
+        catch (Exception)
+        {
+            EventModel = null;
+        }
     }
 
     // TODO -- use this later to retrieve a preview of the source code
@@ -30,4 +44,12 @@ public class MessageHandlerDescriptor : OptionsDescription
     public Uri[] StickyEndpoints { get; set; } = [];
 
     public List<HandlerMethod> Handlers { get; set; } = new();
+
+    /// <summary>
+    ///     The Event Modeling slice this handler chain implements (GH-3988): the inbound message as the
+    ///     command, the handler, the aggregate(s) it decides against, the events it emits, the read models
+    ///     it loads and the messages it cascades — derived from the chain, never declared. Null only when
+    ///     the roles could not be read.
+    /// </summary>
+    public EventModelSliceDescriptor? EventModel { get; set; }
 }

--- a/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
+++ b/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
@@ -6,6 +6,8 @@ using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.Events.Descriptors;
+using JasperFx.Events.EventModeling;
+using Wolverine.Configuration.EventModeling;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Wolverine.Persistence;
@@ -134,6 +136,15 @@ public class ServiceCapabilities : OptionsDescription
 
     public List<EndpointDescriptor> MessagingEndpoints { get; set; } = [];
 
+    /// <summary>
+    ///     The service's assembled Event Model (GH-3988): every <see cref="IEventModelDefinitionSource" />
+    ///     registered in the container — Wolverine's own derived chain roles, Wolverine.HTTP's, and any
+    ///     jasperfx#687 overlay the application registered — folded into one <see cref="EventModelDescriptor" />
+    ///     named for the service. Slices merge by name with derived roles winning over overlay names. Null
+    ///     when the section could not be read.
+    /// </summary>
+    public EventModelDescriptor? EventModel { get; set; }
+
     public DatabaseCardinality MessageStoreCardinality { get; set; } = DatabaseCardinality.None;
 
     public List<BrokerDescription> Brokers { get; set; } = [];
@@ -190,6 +201,8 @@ public class ServiceCapabilities : OptionsDescription
 
         readSection(runtime, nameof(AdditionalCapabilities), token,
             () => readAdditionalCapabilities(runtime, capabilities));
+
+        await readSectionAsync(runtime, nameof(EventModel), token, () => readEventModel(runtime, token, capabilities));
 
         return capabilities;
     }
@@ -502,6 +515,18 @@ public class ServiceCapabilities : OptionsDescription
         capabilities.MessageStores.AddRange(stores.Select(MessageStore.For).OrderBy(x => x.Uri.ToString()));
 
         capabilities.MessageStoreCardinality = collection.Cardinality();
+    }
+
+    /// <summary>
+    ///     GH-3988: assemble the Event Model from every registered <see cref="IEventModelDefinitionSource" />.
+    ///     Wolverine core registers its derived source ahead of everything else, so derived roles win on
+    ///     merge; Wolverine.HTTP adds its chains; an application's overlays only name, group and link.
+    /// </summary>
+    private static async Task readEventModel(IWolverineRuntime runtime, CancellationToken token,
+        ServiceCapabilities capabilities)
+    {
+        capabilities.EventModel =
+            await WolverineEventModelExport.AssembleAsync(runtime.Services, runtime.Options.ServiceName, token);
     }
 
     private static void readAdditionalCapabilities(IWolverineRuntime runtime, ServiceCapabilities capabilities)

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -401,6 +401,17 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// tenant id
     /// </summary>
     public virtual string? TenantId { get; set; }
+
+    /// <summary>
+    ///     The name of the external system on the other end of this endpoint — "Stripe", "Legacy ERP" —
+    ///     when a listener receives from, or a sender publishes to, something outside this application.
+    ///     Optional and purely descriptive (GH-3989): the <em>edge</em> of an Event Modeling translation
+    ///     slice is derived from the endpoint itself, but the name is the one thing code cannot say, so it
+    ///     is declared here and flows out through <c>EndpointDescriptor.ExternalSystem</c> and onto the
+    ///     slice as an external-system element. Set with <c>.ExternalSystem("Stripe")</c> on the listener
+    ///     or subscriber configuration.
+    /// </summary>
+    public string? ExternalSystemName { get; set; }
     
     internal IEnumerable<IEnvelopeRule> RulesForIncoming()
     {

--- a/src/Wolverine/Configuration/EventModeling/EventModelCommand.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelCommand.cs
@@ -123,6 +123,11 @@ public class EventModelCommand : JasperFxAsyncCommand<EventModelInput>
             var model = await WolverineEventModelExport.AssembleAsync(host.Services, input.NameFlag);
 
             var path = input.JsonFlag.ToFullPath();
+            if (Path.GetDirectoryName(path) is { Length: > 0 } directory)
+            {
+                Directory.CreateDirectory(directory);
+            }
+
             await using (var stream = new FileStream(path, FileMode.Create))
             {
                 await WolverineEventModelExport.WriteAsync(model, stream);

--- a/src/Wolverine/Configuration/EventModeling/EventModelCommand.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelCommand.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.CodeGeneration;
+using JasperFx.CommandLine;
+using JasperFx.Core;
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Wolverine.Configuration.EventModeling;
+
+/// <summary>
+///     Assembles the full Event Model of a host — Wolverine's derived chain roles, Wolverine.HTTP's, and
+///     any jasperfx#687 overlay the application registered — and writes it as JSON (GH-3990). The JSON is
+///     the wire descriptor exactly as CritterWatch serialises it (camelCase, enums as strings), so the
+///     file round-trips through <see cref="EventModelDescriptor" /> and renders in the shared Event
+///     Modeling component with the same output CritterWatch shows for the same host.
+/// </summary>
+public static class WolverineEventModelExport
+{
+    /// <summary>
+    ///     The serializer settings the export writes with — the same shape CritterWatch puts on the wire.
+    /// </summary>
+    public static JsonSerializerOptions SerializerOptions { get; } = buildSerializerOptions();
+
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CLI / diagnostic path, not dispatch; the non-generic JsonStringEnumConverter is what CritterWatch's wire format uses, and the descriptor tree is reflection-serialised like ServiceCapabilities.")]
+    private static JsonSerializerOptions buildSerializerOptions() => new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    /// <summary>
+    ///     Walk every registered <see cref="IEventModelDefinitionSource" /> through
+    ///     <see cref="EventModelDiscovery" /> and fold the result into one model named for the service
+    ///     (or <paramref name="modelName" />).
+    /// </summary>
+    public static async Task<EventModelDescriptor> AssembleAsync(IServiceProvider services, string? modelName = null,
+        CancellationToken token = default)
+    {
+        var assembled = await EventModelDiscovery.AssembleAsync(services, token).ConfigureAwait(false);
+        var name = modelName ?? services.GetService<WolverineOptions>()?.ServiceName ?? "Wolverine";
+        return EventModelDescriptor.Merge(name, assembled);
+    }
+
+    /// <summary>Serialize a model with <see cref="SerializerOptions" />.</summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CLI / diagnostic path, not dispatch; the descriptor tree is bounded and reflection-serialised like ServiceCapabilities.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CLI / diagnostic path, not dispatch; the descriptor tree is bounded and reflection-serialised like ServiceCapabilities.")]
+    public static Task WriteAsync(EventModelDescriptor model, Stream stream, CancellationToken token = default)
+        => JsonSerializer.SerializeAsync(stream, model, SerializerOptions, token);
+
+    /// <summary>Serialize a model with <see cref="SerializerOptions" />.</summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CLI / diagnostic path, not dispatch; the descriptor tree is bounded and reflection-serialised like ServiceCapabilities.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CLI / diagnostic path, not dispatch; the descriptor tree is bounded and reflection-serialised like ServiceCapabilities.")]
+    public static string ToJson(EventModelDescriptor model) => JsonSerializer.Serialize(model, SerializerOptions);
+
+    /// <summary>Read a model back from the JSON the export wrote.</summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "CLI / diagnostic path, not dispatch; the descriptor tree is bounded and reflection-serialised like ServiceCapabilities.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "CLI / diagnostic path, not dispatch; the descriptor tree is bounded and reflection-serialised like ServiceCapabilities.")]
+    public static EventModelDescriptor? FromJson(string json) => JsonSerializer.Deserialize<EventModelDescriptor>(json, SerializerOptions);
+}
+
+public class EventModelInput : NetCoreInput
+{
+    [Description("Path of the JSON file to write the Event Model to")]
+    [FlagAlias("json", 'j')]
+    public string JsonFlag { get; set; } = "event-model.json";
+
+    [Description("Optional name for the assembled model; defaults to the Wolverine service name")]
+    public string? NameFlag { get; set; }
+}
+
+/// <summary>
+///     <c>dotnet run -- event-model [--json &lt;path&gt;]</c>: write the host's merged Event Model as JSON
+///     without a running fleet (GH-3990). The host is built but <b>never started</b>: the handler graph is
+///     compiled by resolving the code file collections — the <c>wolverine-diagnostics describe-handlers</c>
+///     trick — so no transport is opened, no database is touched, and no runtime compiler is needed.
+/// </summary>
+[Description("Write the application's Event Model — the roles every handler, HTTP and gRPC chain derives about itself, plus any registered overlay — as JSON, without a running fleet",
+    Name = "event-model")]
+public class EventModelCommand : JasperFxAsyncCommand<EventModelInput>
+{
+    public EventModelCommand()
+    {
+        Usage("Write the Event Model to event-model.json");
+        Usage("Write the Event Model to the designated file").Arguments();
+    }
+
+    public override async Task<bool> Execute(EventModelInput input)
+    {
+        if (input.JsonFlag.IsEmpty())
+        {
+            Console.WriteLine("No file name supplied.");
+            return false;
+        }
+
+        // Set BEFORE the host is built, exactly as the codegen and wolverine-diagnostics commands do,
+        // so Wolverine bootstraps in lightweight mode — no handler registry consumption, no
+        // transport or durability side effects.
+        DynamicCodeBuilder.WithinCodegenCommand = true;
+
+        try
+        {
+            using var host = input.BuildHost();
+
+            // The host is NOT started. Resolving the code file collections compiles the handler graph
+            // (the same trick wolverine-diagnostics describe-handlers uses): no transports are opened,
+            // no database is touched, and no Roslyn is needed — a TypeLoadMode.Dynamic app without
+            // WolverineFx.RuntimeCompilation still exports. Wolverine.HTTP's chains were discovered
+            // when the application mapped its endpoints, before this command ran, so they are there too.
+            _ = host.Services.GetServices<ICodeFileCollection>().ToArray();
+
+            var model = await WolverineEventModelExport.AssembleAsync(host.Services, input.NameFlag);
+
+            var path = input.JsonFlag.ToFullPath();
+            await using (var stream = new FileStream(path, FileMode.Create))
+            {
+                await WolverineEventModelExport.WriteAsync(model, stream);
+                await stream.FlushAsync();
+            }
+
+            Console.WriteLine(
+                $"Wrote the Event Model '{model.Name}' ({model.Slices.Count} slices, {model.Aggregates.Count} aggregates) to {path}");
+
+            return true;
+        }
+        finally
+        {
+            DynamicCodeBuilder.WithinCodegenCommand = false;
+        }
+    }
+}

--- a/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
@@ -1,0 +1,423 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.EventModeling;
+using Wolverine.Persistence;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Configuration.EventModeling;
+
+/// <summary>
+///     The non-derivable half of a slice — what the chain's <em>kind</em> knows and its handler
+///     signature does not: the slice name, how the slice is triggered, the inbound command and the
+///     handler type. <see cref="EventModelRoles.Describe" /> derives everything else off the chain.
+/// </summary>
+/// <param name="SliceName">Display name of the slice — also the merge key across sources (GH-3988).</param>
+/// <param name="TriggerKind">What starts the slice — a message handler, an HTTP request, a gRPC call.</param>
+/// <param name="TriggerOrigin">Structured trigger detail (route + verb, service + method), when there is one.</param>
+/// <param name="CommandType">The inbound message / request type, when there is one.</param>
+/// <param name="HandlerType">The handler or endpoint type that processes it.</param>
+public sealed record EventModelSliceSeed(
+    string SliceName,
+    TriggerKind TriggerKind,
+    PublisherOrigin? TriggerOrigin,
+    Type? CommandType,
+    Type? HandlerType)
+{
+    /// <summary>
+    ///     The chain's response type, when it has one an HTTP resource, a gRPC response. A response is
+    ///     never an emitted event or a published message, so it is excluded from the return values
+    ///     <see cref="EventModelRoles.Describe" /> classifies. Null for chains that have no response concept.
+    /// </summary>
+    public Type? ResponseType { get; init; }
+
+    /// <summary>
+    ///     True when the first return value of the primary handler call <em>is</em> the response
+    ///     (Wolverine.HTTP's convention), so that variable is skipped even when its type cannot be
+    ///     named up front.
+    /// </summary>
+    public bool FirstReturnValueIsResponse { get; init; }
+
+    /// <summary>
+    ///     True for a read-only trigger — an HTTP <c>GET</c> / <c>HEAD</c>. A query chain that writes
+    ///     nothing is a <see cref="SlicePattern.View" /> slice reading its response type as a read model.
+    /// </summary>
+    public bool IsQuery { get; init; }
+}
+
+/// <summary>
+///     Derives a chain's Event Modeling roles — aggregates, emitted events, read models, published
+///     messages, slice pattern — from what the chain already knows about itself, and writes them
+///     as a JasperFx <see cref="EventModelSliceDescriptor" /> (GH-3988; jasperfx#687).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Everything here is derived, never declared</b> (Spec Driven Development decision D2). The
+///         roles come from two places: the chain's <see cref="IChain.Tags" /> — where the shared aggregate
+///         handler workflow (<c>AggregateHandling</c>) and the DCB workflow (<c>BoundaryHandling</c>) record
+///         what they loaded when the chain was customised — and the handler signature itself, so that a chain
+///         whose code has not been generated yet (Dynamic code generation assembles chains lazily) still
+///         reports the same roles. The two agree; the reflection walk is the one that cannot be late.
+///     </para>
+///     <para>
+///         <b>Out of scope by decision of record:</b> imperative <c>session.Events.Append(...)</c> inside a
+///         handler body is invisible at runtime — only <em>declarative</em> returns (typed events, the
+///         store's <c>Events</c> collection, <c>EventsToAppend</c>, <c>IStorageAction</c>) can be read here.
+///         CritterWatch's Roslyn source generator stays in place for exactly that case; it is not solved
+///         here, and this class does not try to.
+///     </para>
+/// </remarks>
+public static class EventModelRoles
+{
+    /// <summary>
+    ///     Describe a message handler chain. The slice is named for the message type, triggered by a
+    ///     message handler — or by the job scheduler for a <see cref="TimeoutMessage" /> — and the
+    ///     command is the message type itself.
+    /// </summary>
+    public static EventModelSliceDescriptor ForHandlerChain(HandlerChain chain)
+    {
+        var triggerKind = chain.MessageType.CanBeCastTo<TimeoutMessage>()
+            ? TriggerKind.JobScheduler
+            : TriggerKind.MessageHandler;
+
+        var handlerType = chain.Handlers.FirstOrDefault()?.HandlerType;
+
+        return Describe(chain, new EventModelSliceSeed(
+            chain.MessageType.Name,
+            triggerKind,
+            null,
+            chain.MessageType,
+            handlerType));
+    }
+
+    /// <summary>
+    ///     Derive the roles for any chain — message handler, HTTP endpoint, gRPC service — from its
+    ///     handler calls, its tags and the supplied <paramref name="seed" />.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    public static EventModelSliceDescriptor Describe(IChain chain, EventModelSliceSeed seed)
+    {
+        var roles = new RoleSet();
+
+        readTags(chain, roles);
+
+        foreach (var call in chain.HandlerCalls())
+        {
+            readSignature(chain, call, roles);
+        }
+
+        var returnTypes = returnedTypes(chain, seed).ToArray();
+
+        // A return value that is a collection-of-events — the store's Events, EventsToAppend, any
+        // IEnumerable<object> — says "this handler appends events" even though the element types
+        // cannot be read off it. That is enough to classify the chain, so the other return values
+        // are read as events rather than as cascaded messages.
+        if (returnTypes.Any(isUntypedEventCollection))
+        {
+            roles.IsEventSourced = true;
+        }
+
+        foreach (var type in returnTypes)
+        {
+            if (isUntypedEventCollection(type)) continue;
+
+            if (type.Closes(typeof(IStorageAction<>)))
+            {
+                // Store / Insert / Update / Delete of a document: the slice *produces* that read model
+                roles.ReadModels.Add(type.GetGenericArguments()[0]);
+                continue;
+            }
+
+            if (!isEventOrMessageCandidate(type)) continue;
+
+            if (roles.IsEventSourced)
+            {
+                roles.EmittedEvents.Add(type);
+            }
+            else
+            {
+                roles.PublishedMessages.Add(type);
+            }
+        }
+
+        var pattern = SlicePattern.Command;
+        if (seed.IsQuery && !roles.IsEventSourced && roles.EmittedEvents.Count == 0 &&
+            roles.PublishedMessages.Count == 0)
+        {
+            pattern = SlicePattern.View;
+            if (seed.ResponseType is { } response && response != typeof(void))
+            {
+                roles.ReadModels.Add(response);
+            }
+        }
+
+        return new EventModelSliceDescriptor(
+            seed.SliceName,
+            seed.TriggerOrigin?.Label,
+            null,
+            seed.CommandType is null ? null : TypeDescriptor.For(seed.CommandType),
+            seed.HandlerType is null ? null : TypeDescriptor.For(seed.HandlerType),
+            roles.EmittedEvents.Select(TypeDescriptor.For).ToList(),
+            Array.Empty<TypeDescriptor>(),
+            roles.ReadModels.Select(TypeDescriptor.For).ToList())
+        {
+            Pattern = pattern,
+            TriggerKind = seed.TriggerKind,
+            TriggerOrigin = seed.TriggerOrigin,
+            AggregateTypes = roles.Aggregates.Select(TypeDescriptor.For).ToList(),
+            PublishedMessages = roles.PublishedMessages.Select(TypeDescriptor.For).ToList(),
+        };
+    }
+
+    /// <summary>
+    ///     The aggregate <em>elements</em> behind a chain's <see cref="EventModelSliceDescriptor.AggregateTypes" />
+    ///     — one per aggregate type, with the kind the chain uses it as and the events the type applies
+    ///     (read off its conventional <c>Apply</c> / <c>Create</c> / <c>ShouldDelete</c> methods).
+    /// </summary>
+    public static IReadOnlyList<AggregateDescriptor> AggregatesFor(IChain chain)
+    {
+        var roles = new RoleSet();
+        readTags(chain, roles);
+        foreach (var call in chain.HandlerCalls())
+        {
+            readSignature(chain, call, roles);
+        }
+
+        return roles.AggregateKinds
+            .Select(pair => new AggregateDescriptor(TypeDescriptor.For(pair.Key), pair.Value, AppliedEventsOf(pair.Key)))
+            .ToList();
+    }
+
+    /// <summary>
+    ///     The event types an aggregate applies, read off its conventional <c>Apply</c> / <c>Create</c> /
+    ///     <c>ShouldDelete</c> methods (instance or static, <c>IEvent&lt;T&gt;</c> unwrapped). Empty when
+    ///     the type uses none of the conventions — a hand-written <c>Evolve(IEvent)</c>, for one.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Aggregate types come from handler discovery, which already roots them. Diagnostic surface only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Aggregate types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    public static IReadOnlyList<TypeDescriptor> AppliedEventsOf(Type aggregateType)
+    {
+        var names = new[] { "Apply", "Create", "ShouldDelete" };
+        var list = new List<TypeDescriptor>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in aggregateType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
+        {
+            if (!names.Contains(method.Name)) continue;
+            var parameters = method.GetParameters();
+            if (parameters.Length == 0) continue;
+
+            var eventType = parameters[0].ParameterType;
+            if (eventType.Closes(typeof(IEvent<>)))
+            {
+                eventType = eventType.GetGenericArguments()[0];
+            }
+
+            if (eventType == typeof(IEvent) || eventType == typeof(object)) continue;
+
+            var descriptor = TypeDescriptor.For(eventType);
+            if (seen.Add(descriptor.FullName)) list.Add(descriptor);
+        }
+
+        return list;
+    }
+
+    private static void readTags(IChain chain, RoleSet roles)
+    {
+        if (chain.Tags.TryGetValue(nameof(AggregateHandling), out var raw))
+        {
+            switch (raw)
+            {
+                case AggregateHandling handling:
+                    roles.AddWrite(handling.AggregateType, handling.AlwaysEnforceConsistency);
+                    break;
+                case List<AggregateHandling> list:
+                    foreach (var handling in list) roles.AddWrite(handling.AggregateType, handling.AlwaysEnforceConsistency);
+                    break;
+            }
+        }
+
+        if (chain.Tags.TryGetValue("BoundaryHandling", out var boundary) && boundary is BoundaryHandlingTag tag)
+        {
+            roles.AddBoundary(tag.AggregateType);
+        }
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Handler types and their methods come from handler discovery, which already roots them. Diagnostic surface only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    private static void readSignature(IChain chain, MethodCall call, RoleSet roles)
+    {
+        // [DeciderFunction] / [AggregateHandler] on the method or the handler type: the aggregate
+        // is the one the attribute names, else the one the workflow would infer from the signature
+        var decider = call.Method.GetAttribute<DeciderFunctionAttribute>()
+                      ?? call.HandlerType.GetAttribute<DeciderFunctionAttribute>();
+        if (decider != null)
+        {
+            var aggregateType = decider.AggregateType ?? tryDetermineAggregateType(chain);
+            if (aggregateType != null) roles.AddWrite(aggregateType, decider.AlwaysEnforceConsistency);
+        }
+
+        foreach (var parameter in call.Method.GetParameters())
+        {
+            var parameterType = parameter.ParameterType;
+
+            if (parameterType.Closes(typeof(IEventStream<>)))
+            {
+                roles.AddWrite(parameterType.GetGenericArguments()[0], false);
+                continue;
+            }
+
+            if (parameter.GetAttribute<WriteModelAttribute>() is { } write)
+            {
+                roles.AddWrite(parameterType, write.AlwaysEnforceConsistency);
+            }
+            else if (parameter.HasAttribute<DcbModelAttribute>())
+            {
+                roles.AddBoundary(parameterType);
+            }
+            else if (parameter.HasAttribute<ReadModelAttribute>())
+            {
+                roles.AddRead(parameterType);
+            }
+            else if (parameter.HasAttribute<EntityAttribute>())
+            {
+                // A loaded entity is a read model the slice reads from
+                roles.ReadModels.Add(parameterType);
+            }
+        }
+    }
+
+    private static Type? tryDetermineAggregateType(IChain chain)
+    {
+        try
+        {
+            return AggregateHandling.DetermineAggregateType(chain);
+        }
+        catch (Exception)
+        {
+            // Diagnostic read — a signature the workflow cannot make sense of is the workflow's
+            // exception to throw at codegen time, not this reader's
+            return null;
+        }
+    }
+
+    private static IEnumerable<Type> returnedTypes(IChain chain, EventModelSliceSeed seed)
+    {
+        var calls = chain.HandlerCalls();
+        for (var i = 0; i < calls.Length; i++)
+        {
+            var creates = calls[i].Creates.ToArray();
+            for (var j = 0; j < creates.Length; j++)
+            {
+                if (i == 0 && j == 0 && seed.FirstReturnValueIsResponse) continue;
+
+                var type = creates[j].VariableType;
+                if (seed.ResponseType != null && type == seed.ResponseType) continue;
+
+                yield return type;
+            }
+        }
+    }
+
+    private static bool isUntypedEventCollection(Type type)
+    {
+        if (type == typeof(IAsyncEnumerable<object>)) return true;
+        if (!type.CanBeCastTo<IEnumerable<object>>()) return false;
+
+        // OutgoingMessages is the one collection-of-objects that is explicitly NOT events
+        if (type.CanBeCastTo<OutgoingMessages>()) return false;
+
+        return true;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    private static bool isEventOrMessageCandidate(Type type)
+    {
+        if (type == typeof(void) || type == typeof(object) || type == typeof(object[])) return false;
+        if (type == typeof(Task) || type == typeof(ValueTask)) return false;
+        if (type == typeof(HandlerContinuation)) return false;
+        if (type.CanBeCastTo<IWolverineReturnType>()) return false; // side effects, responses, Events, OutgoingMessages
+        if (typeof(ISideEffectAware).IsAssignableFrom(type)) return false;
+        if (type.CanBeCastTo<Saga>()) return false; // a saga returned from its own handler is state, not a message
+        if (type.CanBeCastTo<IEnumerable<object>>()) return false;
+        if (type.Closes(typeof(IAsyncEnumerable<>))) return false;
+
+        return true;
+    }
+
+    private sealed class RoleSet
+    {
+        public bool IsEventSourced { get; set; }
+        public List<Type> Aggregates { get; } = new();
+        public Dictionary<Type, AggregateKind> AggregateKinds { get; } = new();
+        public OrderedTypeSet EmittedEvents { get; } = new();
+        public OrderedTypeSet PublishedMessages { get; } = new();
+        public OrderedTypeSet ReadModels { get; } = new();
+
+        public void AddWrite(Type aggregateType, bool consistent)
+        {
+            IsEventSourced = true;
+            add(aggregateType, consistent ? AggregateKind.ConsistentAggregate : AggregateKind.WriteAggregate);
+        }
+
+        public void AddBoundary(Type modelType)
+        {
+            IsEventSourced = true;
+            add(modelType, AggregateKind.BoundaryModel);
+        }
+
+        public void AddRead(Type aggregateType)
+        {
+            ReadModels.Add(aggregateType);
+            if (!AggregateKinds.ContainsKey(aggregateType))
+            {
+                AggregateKinds[aggregateType] = AggregateKind.ReadAggregate;
+            }
+        }
+
+        private void add(Type aggregateType, AggregateKind kind)
+        {
+            if (!Aggregates.Contains(aggregateType)) Aggregates.Add(aggregateType);
+
+            // A write wins over a read of the same type; consistent wins over plain write
+            if (!AggregateKinds.TryGetValue(aggregateType, out var existing) ||
+                existing == AggregateKind.ReadAggregate ||
+                (existing == AggregateKind.WriteAggregate && kind == AggregateKind.ConsistentAggregate))
+            {
+                AggregateKinds[aggregateType] = kind;
+            }
+        }
+    }
+
+    private sealed class OrderedTypeSet : IEnumerable<Type>
+    {
+        private readonly List<Type> _types = new();
+
+        public int Count => _types.Count;
+
+        public void Add(Type type)
+        {
+            if (!_types.Contains(type)) _types.Add(type);
+        }
+
+        public IEnumerator<Type> GetEnumerator() => _types.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -54,19 +54,45 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         var slices = new List<EventModelSliceDescriptor>();
         var aggregates = new List<AggregateDescriptor>();
         var aggregateNames = new HashSet<string>(StringComparer.Ordinal);
+        var stickyEndpoints = new Dictionary<string, HashSet<Uri>>(StringComparer.Ordinal);
+        var knownTypes = new Dictionary<string, Type>(StringComparer.Ordinal);
 
         void describe(HandlerChain chain)
         {
-            if (chain.Handlers.Count == 0) return;
             if (chain.MessageType.IsSystemMessageType()) return;
 
-            slices.Add(EventModelRoles.ForHandlerChain(chain));
+            // sticky handlers live on per-endpoint sub-chains, so walk those whether or not the
+            // parent chain has a default handler of its own
+            foreach (var sticky in chain.ByEndpoint) describe(sticky);
+
+            if (chain.Handlers.Count == 0) return;
+
+            var slice = EventModelRoles.ForHandlerChain(chain);
+            slices.Add(slice);
+
+            knownTypes.TryAdd(chain.MessageType.FullName!, chain.MessageType);
+            foreach (var call in chain.Handlers)
+            foreach (var variable in call.Creates)
+            {
+                if (variable.VariableType.FullName is { } fullName) knownTypes.TryAdd(fullName, variable.VariableType);
+            }
+
+            // a sticky handler chain is bound to these listeners — that is what makes a listener the
+            // trigger of this slice (GH-3989)
+            if (chain.Endpoints.Count > 0)
+            {
+                if (!stickyEndpoints.TryGetValue(slice.Name, out var uris))
+                {
+                    uris = new HashSet<Uri>();
+                    stickyEndpoints[slice.Name] = uris;
+                }
+
+                foreach (var endpoint in chain.Endpoints) uris.Add(endpoint.Uri);
+            }
             foreach (var aggregate in EventModelRoles.AggregatesFor(chain))
             {
                 if (aggregateNames.Add(aggregate.Type.FullName)) aggregates.Add(aggregate);
             }
-
-            foreach (var sticky in chain.ByEndpoint) describe(sticky);
         }
 
         foreach (var chain in options.HandlerGraph.Chains.OrderBy(x => x.MessageType.FullName, StringComparer.Ordinal))
@@ -76,7 +102,140 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
 
         var model = new EventModelDescriptor(options.ServiceName, slices) { Aggregates = aggregates };
         model = ApplyGrpcTriggers(model, grpc);
+        model = ApplyExternalSystems(model, options, stickyEndpoints, knownTypes, includeInbound: true);
         return FinishModel(model);
+    }
+
+    /// <summary>
+    ///     GH-3989: the <em>edge</em> of a translation slice is the endpoint — a listener receiving from, or a
+    ///     sender publishing to, something outside this application — and the external system's
+    ///     <em>name</em> is what the application declared on that endpoint with <c>.ExternalSystem("...")</c>.
+    ///     Inbound: the named listener is the trigger of every slice stuck to it, or whose command is its
+    ///     <see cref="Endpoint.MessageType"/>; a listener bound to no slice still renders, as a trigger-only
+    ///     translation slice. Outbound: every slice whose published messages or emitted events the named
+    ///     endpoint subscribes to gets the external system on its far end.
+    /// </summary>
+    /// <param name="model">The model to annotate.</param>
+    /// <param name="options">The Wolverine options — the endpoints come from <c>Transports.AllEndpoints()</c>.</param>
+    /// <param name="stickyEndpointsBySlice">Listener URIs each slice's chain is stuck to, by slice name. May be empty.</param>
+    /// <param name="knownTypes">The CLR types behind the slices' message / event descriptors, by full name, so a subscription's own matching rules decide the outbound edge. Descriptors with no known type fall back to a name match.</param>
+    /// <param name="includeInbound">False for a source whose slices have no listener (Wolverine.HTTP): only outbound edges apply.</param>
+    public static EventModelDescriptor ApplyExternalSystems(
+        EventModelDescriptor model,
+        WolverineOptions options,
+        IReadOnlyDictionary<string, HashSet<Uri>>? stickyEndpointsBySlice = null,
+        IReadOnlyDictionary<string, Type>? knownTypes = null,
+        bool includeInbound = true)
+    {
+        var named = options.Transports.AllEndpoints()
+            .Where(x => !string.IsNullOrWhiteSpace(x.ExternalSystemName))
+            .OrderBy(x => x.Uri.ToString(), StringComparer.Ordinal)
+            .ToArray();
+        if (named.Length == 0) return model;
+
+        var slices = model.Slices.ToList();
+
+        foreach (var endpoint in named)
+        {
+            var name = endpoint.ExternalSystemName!;
+            var uri = endpoint.Uri.ToString();
+
+            // Outbound: the endpoint subscribes to a message this slice publishes or an event it emits
+            for (var i = 0; i < slices.Count; i++)
+            {
+                var slice = slices[i];
+                var outgoing = slice.PublishedMessages.Concat(slice.EmittedEvents).ToArray();
+                if (outgoing.Length == 0) continue;
+
+                if (endpoint.Subscriptions.Any(subscription => outgoing.Any(type => matches(subscription, type, knownTypes))))
+                {
+                    slices[i] = withExternalSystem(slice, new ExternalSystemDescriptor(name, ExternalSystemDirection.Outbound, uri), flipPattern: false);
+                }
+            }
+
+            if (!includeInbound || !endpoint.IsListener) continue;
+
+            // Inbound: the listener is the trigger of a slice stuck to it, or whose command is its message type
+            var matched = false;
+            for (var i = 0; i < slices.Count; i++)
+            {
+                var slice = slices[i];
+                var stuck = stickyEndpointsBySlice != null &&
+                            stickyEndpointsBySlice.TryGetValue(slice.Name, out var uris) && uris.Contains(endpoint.Uri);
+                var byType = endpoint.MessageType != null && slice.CommandType?.FullName == endpoint.MessageType.FullName;
+                if (!stuck && !byType) continue;
+
+                matched = true;
+                var label = $"{name} → {endpoint.EndpointName}";
+                slices[i] = withExternalSystem(slice, new ExternalSystemDescriptor(name, ExternalSystemDirection.Inbound, uri), flipPattern: true)
+                    with
+                    {
+                        TriggerLabel = slice.TriggerLabel ?? label,
+                        TriggerKind = TriggerKind.External,
+                        TriggerOrigin = slice.TriggerOrigin ?? new PublisherOrigin { Label = label }
+                    };
+            }
+
+            if (!matched)
+            {
+                // Nothing binds the listener to a slice — there is still a boundary to render
+                slices.Add(new EventModelSliceDescriptor(
+                    endpoint.EndpointName,
+                    $"{name} → {endpoint.EndpointName}",
+                    null,
+                    endpoint.MessageType is null ? null : JasperFx.Descriptors.TypeDescriptor.For(endpoint.MessageType),
+                    null,
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>())
+                {
+                    Pattern = SlicePattern.Translation,
+                    TriggerKind = TriggerKind.External,
+                    TriggerOrigin = new PublisherOrigin { Label = $"{name} → {endpoint.EndpointName}" },
+                    ExternalSystems = new[] { new ExternalSystemDescriptor(name, ExternalSystemDirection.Inbound, uri) }
+                });
+            }
+        }
+
+        return model with { Slices = slices };
+
+        static bool matches(Wolverine.Runtime.Routing.Subscription subscription, JasperFx.Descriptors.TypeDescriptor descriptor,
+            IReadOnlyDictionary<string, Type>? knownTypes)
+        {
+            // Subscriptions match on Type; the slice carries TypeDescriptors. The source that derived the
+            // slice knows the types, so the subscription's own rules decide; a descriptor nobody resolved
+            // (an overlay's, say) gets the name-only approximation of the same rules.
+            if (knownTypes != null && knownTypes.TryGetValue(descriptor.FullName, out var type))
+            {
+                return subscription.Matches(type);
+            }
+
+            return subscription.Scope switch
+            {
+                Wolverine.Runtime.Routing.RoutingScope.Type => descriptor.Name.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase) ||
+                                                               descriptor.FullName.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.TypeName => descriptor.FullName.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.Namespace => descriptor.FullName.StartsWith(subscription.Match + ".", StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.Assembly => descriptor.AssemblyName.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.Implements => false,
+                _ => true,
+            };
+        }
+
+        static EventModelSliceDescriptor withExternalSystem(EventModelSliceDescriptor slice, ExternalSystemDescriptor system, bool flipPattern)
+        {
+            if (slice.ExternalSystems.Any(x => x.Name == system.Name && x.Direction == system.Direction)) return slice;
+
+            var systems = slice.ExternalSystems.Concat(new[] { system }).ToList();
+            // An external system on the inbound side makes this a translation slice. On the outbound side
+            // a slice keeps its own pattern (a command slice that also notifies Stripe is still a command
+            // slice) unless it is a pure relay — no aggregate, no events of its own.
+            var pattern = flipPattern || (slice.AggregateTypes.Count == 0 && slice.EmittedEvents.Count == 0 && slice.Pattern == SlicePattern.Command)
+                ? SlicePattern.Translation
+                : slice.Pattern;
+
+            return slice with { ExternalSystems = systems, Pattern = pattern };
+        }
     }
 
     /// <summary>

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -1,0 +1,155 @@
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Configuration.EventModeling;
+
+/// <summary>
+///     The Wolverine-derived <see cref="IEventModelDefinitionSource" /> (GH-3988): one slice per message
+///     handler chain, with the roles <see cref="EventModelRoles" /> derives off the chain, plus the gRPC
+///     trigger for any message an RPC forwards to the bus. Registered by <c>UseWolverine()</c> ahead of
+///     every other source so that <see cref="EventModelDiscovery.Assemble" /> lets the derived roles win
+///     over an overlay's names.
+/// </summary>
+/// <remarks>
+///     HTTP chains are described by <c>Wolverine.Http</c>'s sibling source — the HTTP graph is not known to
+///     Wolverine core — and both contribute to the same model, named for the service, so the
+///     assembled picture has one model per service however many sources fed it.
+/// </remarks>
+public sealed class WolverineEventModelSource : IEventModelDefinitionSource
+{
+    /// <summary>URI scheme for the Wolverine-derived source: <c>event-model://wolverine/{service}</c>.</summary>
+    public const string Scheme = "event-model";
+
+    public Uri Subject { get; } = new($"{Scheme}://wolverine");
+
+    public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+    {
+        // WolverineOptions rather than IWolverineRuntime on purpose: the export command (GH-3990)
+        // describes a host that was never started, and the options + a compiled handler graph are
+        // all this needs. A started host has the same options, so the two paths agree.
+        var options = services.GetService<WolverineOptions>();
+        if (options is null) return Task.FromResult<EventModelDescriptor?>(null);
+
+        var descriptor = Describe(options, services.GetService<IGrpcEndpointManifest>());
+        return Task.FromResult<EventModelDescriptor?>(descriptor);
+    }
+
+    /// <summary>
+    ///     Describe every message handler chain on the runtime's handler graph as an Event Model slice.
+    /// </summary>
+    public static EventModelDescriptor Describe(IWolverineRuntime runtime, IGrpcEndpointManifest? grpc = null)
+        => Describe(runtime.Options, grpc);
+
+    /// <summary>
+    ///     Describe every message handler chain on the runtime's handler graph as an Event Model slice.
+    ///     The model is named for the service; slices are named for their message type.
+    /// </summary>
+    /// <param name="options">The Wolverine options — the handler graph must have been compiled (a started host, or the code file collections resolved as the <c>event-model</c> command does).</param>
+    /// <param name="grpc">The gRPC endpoint manifest, when <c>Wolverine.Grpc</c> is in play, so an RPC that forwards a message to the bus is reported as that slice's trigger.</param>
+    public static EventModelDescriptor Describe(WolverineOptions options, IGrpcEndpointManifest? grpc = null)
+    {
+        var slices = new List<EventModelSliceDescriptor>();
+        var aggregates = new List<AggregateDescriptor>();
+        var aggregateNames = new HashSet<string>(StringComparer.Ordinal);
+
+        void describe(HandlerChain chain)
+        {
+            if (chain.Handlers.Count == 0) return;
+            if (chain.MessageType.IsSystemMessageType()) return;
+
+            slices.Add(EventModelRoles.ForHandlerChain(chain));
+            foreach (var aggregate in EventModelRoles.AggregatesFor(chain))
+            {
+                if (aggregateNames.Add(aggregate.Type.FullName)) aggregates.Add(aggregate);
+            }
+
+            foreach (var sticky in chain.ByEndpoint) describe(sticky);
+        }
+
+        foreach (var chain in options.HandlerGraph.Chains.OrderBy(x => x.MessageType.FullName, StringComparer.Ordinal))
+        {
+            describe(chain);
+        }
+
+        var model = new EventModelDescriptor(options.ServiceName, slices) { Aggregates = aggregates };
+        model = ApplyGrpcTriggers(model, grpc);
+        return FinishModel(model);
+    }
+
+    /// <summary>
+    ///     An RPC whose generated wrapper forwards its request to the message bus <em>is</em> the trigger of
+    ///     that message's slice — stamp the gRPC trigger onto it, or add a trigger-only slice when no
+    ///     handler chain exists for the request type in this process.
+    /// </summary>
+    internal static EventModelDescriptor ApplyGrpcTriggers(EventModelDescriptor model, IGrpcEndpointManifest? grpc)
+    {
+        if (grpc is null || grpc.Endpoints.Count == 0) return model;
+
+        var slices = model.Slices.ToList();
+        foreach (var endpoint in grpc.Endpoints.OrderBy(x => x.ServiceName + "::" + x.MethodName, StringComparer.Ordinal))
+        {
+            var origin = new PublisherOrigin
+            {
+                GrpcService = endpoint.ServiceName,
+                GrpcMethod = endpoint.MethodName,
+                Label = $"{endpoint.ServiceName}/{endpoint.MethodName}"
+            };
+
+            var index = slices.FindIndex(x => x.CommandType?.FullName == endpoint.RequestType.FullName);
+            if (index >= 0)
+            {
+                var existing = slices[index];
+                slices[index] = existing with
+                {
+                    TriggerKind = TriggerKind.Grpc,
+                    TriggerOrigin = existing.TriggerOrigin ?? origin
+                };
+            }
+            else
+            {
+                slices.Add(new EventModelSliceDescriptor(
+                    endpoint.RequestType.Name,
+                    origin.Label,
+                    null,
+                    JasperFx.Descriptors.TypeDescriptor.For(endpoint.RequestType),
+                    null,
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>())
+                {
+                    Pattern = SlicePattern.Command,
+                    TriggerKind = TriggerKind.Grpc,
+                    TriggerOrigin = origin
+                });
+            }
+        }
+
+        return model with { Slices = slices };
+    }
+
+    /// <summary>
+    ///     Model-wide derivations that need every slice at once: a slice whose command is an event some
+    ///     other slice emits is an <see cref="SlicePattern.Automation" /> — the "when X, do Y" reaction — not
+    ///     a command slice.
+    /// </summary>
+    public static EventModelDescriptor FinishModel(EventModelDescriptor model)
+    {
+        var emitted = new HashSet<string>(
+            model.Slices.SelectMany(x => x.EmittedEvents).Select(x => x.FullName),
+            StringComparer.Ordinal);
+
+        if (emitted.Count == 0) return model;
+
+        var slices = model.Slices
+            .Select(slice => slice.CommandType is { } command && emitted.Contains(command.FullName) &&
+                             slice.Pattern == SlicePattern.Command
+                ? slice with { Pattern = SlicePattern.Automation }
+                : slice)
+            .ToList();
+
+        return model with { Slices = slices };
+    }
+}

--- a/src/Wolverine/Configuration/IListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/IListenerConfiguration.cs
@@ -15,6 +15,15 @@ public interface IEndpointConfiguration<T>
     T Named(string name);
 
     /// <summary>
+    ///     Name the external system on the other end of this endpoint — "Stripe", "Legacy ERP" — when it
+    ///     listens to, or publishes to, something outside this application (GH-3989). Descriptive only:
+    ///     it flows out through the endpoint's capabilities descriptor and onto the Event Model as an
+    ///     external-system element on the translation slice this endpoint triggers or feeds.
+    /// </summary>
+    /// <param name="name">Display name of the external system.</param>
+    T ExternalSystem(string name);
+
+    /// <summary>
     ///     Override the default serializer for this endpoint
     /// </summary>
     /// <param name="serializer"></param>

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -407,6 +407,12 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         return this.As<TSelf>();
     }
 
+    public TSelf ExternalSystem(string name)
+    {
+        add(e => e.ExternalSystemName = name);
+        return this.As<TSelf>();
+    }
+
     public TSelf DefaultSerializer(IMessageSerializer serializer)
     {
         add(e =>

--- a/src/Wolverine/Configuration/SubscriberConfiguration.cs
+++ b/src/Wolverine/Configuration/SubscriberConfiguration.cs
@@ -149,6 +149,12 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
         return this.As<T>();
     }
 
+    public T ExternalSystem(string name)
+    {
+        add(e => e.ExternalSystemName = name);
+        return this.As<T>();
+    }
+
 
     /// <summary>
     /// For endpoints that send or receive messages in batches, this governs the maximum

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -14,12 +14,14 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.ObjectPool;
 using JasperFx;
+using JasperFx.Events.EventModeling;
 using JasperFx.CodeGeneration.Services;
 using JasperFx.CommandLine;
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Resources;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
+using Wolverine.Configuration.EventModeling;
 using Wolverine.ErrorHandling;
 using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
@@ -184,6 +186,15 @@ public static class HostBuilderExtensions
         });
 
         services.AddSingleton<IWolverineRuntime, WolverineRuntime>();
+
+        // GH-3988: the Wolverine-derived Event Model source. Inserted at the FRONT of the collection
+        // rather than appended, because JasperFx's EventModelDiscovery folds sources in registration
+        // order with the earlier winning on every scalar — and a derived role must never be overwritten
+        // by an overlay the application registered before UseWolverine().
+        if (services.All(x => x.ImplementationType != typeof(WolverineEventModelSource)))
+        {
+            services.Insert(0, ServiceDescriptor.Singleton<IEventModelDefinitionSource, WolverineEventModelSource>());
+        }
 
         services.AddSingleton<IFaultPublisher>(sp =>
         {


### PR DESCRIPTION
Closes #3988, Closes #3990. Part of the Spec Driven Development effort (master: JasperFx/stoat#9; semantic model: jasperfx#687, shipped in JasperFx **2.54.0** — this PR bumps the pin from 2.53.0).

## What

**GH-3988 — every chain derives its own Event Modeling slice.** Message handler chains (core) and HTTP chains (Wolverine.Http) write a JasperFx `EventModelSliceDescriptor` — command, handler, `AggregateTypes` (a list), emitted events, read models, published messages, trigger kind, slice pattern — **derived, never declared** (SDD decision D2):

| role | read from |
|---|---|
| aggregates (write) | `[WriteModel]` / `[WriteAggregate]` / `[ConsistentAggregate]` params, `IEventStream<T>` params, `[DeciderFunction]` / `[AggregateHandler]` (the attribute's `AggregateType`, else the workflow's own inference), and the `AggregateHandling` tag the workflow records on the chain |
| boundary model (DCB) | `[DcbModel]` / `[BoundaryModel]` params, the `BoundaryHandling` tag |
| read models | `[ReadModel]` / `[ReadAggregate]`, `[Entity]`; `IStorageAction<T>` returns as a read model the slice *produces* |
| emitted events | declarative return values on an event-sourced chain (typed events; the store's `Events` / `EventsToAppend` / `IEnumerable<object>` mark the chain event-sourced even though their element types cannot be read) |
| published messages | the same return values on a chain that is not event-sourced (`PublishedTypes()` semantics; sagas, side effects, responses excluded) |
| trigger | `MessageHandler`; `JobScheduler` for a `TimeoutMessage`; `Http` with route + verb; `Grpc` + service/method when an RPC forwards the message to the bus (`IGrpcEndpointManifest`, core) |
| pattern | `Command`; `View` for a GET that writes nothing (reads its resource type as a read model); `Automation` when the command is an event another slice emits (model-wide pass) |

Surfaced three ways, all additive on the wire: `MessageHandlerDescriptor.EventModel` (per handler), `ServiceCapabilities.EventModel` (the assembled model — derived sources first, overlays folded in), and `WolverineEventModelSource` / `HttpEventModelSource : IEventModelDefinitionSource` so JasperFx's `EventModelDiscovery` — and therefore CritterWatch's `ManifestAggregator.MergeAllAsync` (CW#1120) — picks them up with **no CritterWatch change**. `UseWolverine()` / `AddWolverineHttp()` insert the derived sources at the *front* of the service collection, because `EventModelDescriptor.Merge` lets the earlier source win on every scalar and a derived role must never be overwritten by an overlay the app registered before `UseWolverine()`.

The aggregate *elements* (`EventModelDescriptor.Aggregates`) carry kind (write / consistent / read / boundary) and the events the type applies, read off its conventional `Apply` / `Create` / `ShouldDelete` methods.

**GH-3990 — `dotnet run -- event-model [--json <path>] [--name <model>]`.** Builds the host and — **without starting it** — compiles the handler graph by resolving the `ICodeFileCollection`s (the `wolverine-diagnostics describe-handlers` trick), assembles every registered source through `EventModelDiscovery`, and writes one `EventModelDescriptor` camelCase with enums as strings — exactly the shape CritterWatch serialises, so the file round-trips through the wire descriptor and renders in the shared Vue component. **Bootstrap decision:** no transport is opened, no database touched, and no runtime compiler needed — a `TypeLoadMode.Dynamic` app *without* `WolverineFx.RuntimeCompilation` exports (proven on the Quickstart sample, which fails under `host.StartAsync()` for exactly that reason). That is stronger than the "lightweight start" the issue asked to prefer. `--watch` is not implemented.

## Design notes for review

- **Where the descriptor is produced:** core, once, in `EventModelRoles` — the aggregate-handler, read-model and DCB workflows all live in core since GH-3907, so no per-store strategy needed touching. Marten / Polecat / Fisher attributes are recognised through their core bases. `HandWrittenGrpcServiceChain` / `CodeFirstGrpcServiceChain` / `GrpcServiceChain` have no handler calls of their own (they forward to the bus), so gRPC is modelled as the *trigger* of the forwarded message's slice rather than as a separate chain, via the core `IGrpcEndpointManifest` — no change to `Wolverine.Grpc`.
- **Why reflection AND tags:** tags are written when a chain is customised (codegen / static attach); Dynamic mode assembles chains lazily, so a capabilities read on a cold chain would miss them. The signature walk cannot be late; the two agree (the Marten test drives a message through and re-reads).
- **Out of scope by decision of record:** imperative `session.Events.Append(...)` in a handler body — invisible at runtime; the CritterWatch source generator keeps it. Said so in the code where the emitted-events derivation lives.
- **Per-descriptor attachment on `HttpChainDescriptor` / `GrpcRpcDescriptor`:** not done — `HttpChainDescriptor` lives in JasperFx, and the HTTP slices reach CritterWatch through the source + `ServiceCapabilities.EventModel`. Can be a JasperFx follow-up if a per-route attach is wanted.
- **#3989 (`.ExternalSystem(name)` on endpoints):** not touched.
- **Slice naming:** a message handler slice is named for its message type; an HTTP slice for its request type when it has one (so an endpoint and a handler for the same command fold into one slice, as the JasperFx merge intends), else `"{VERB} {route}"`.

## Evidence

- `dotnet build wolverine.slnx -c Release -f net9.0` — green.
- CoreTests `event_model_roles_on_chains_3988` + `event_model_sources_and_capabilities_3988` — 15/15 (reflection path, booted host, source ordering, capabilities, JSON round trip).
- MartenTests `EventModeling.event_model_roles_3988` — 7/7 against a private Postgres 17 (`WOLVERINE_POSTGRES` override): `[WriteAggregate]`, `[AggregateHandler]`, `[ReadAggregate]`, `[BoundaryModel]` handlers on one host, **no source generator present**; capabilities + discovery; roles unchanged after the workflow actually runs.
- Wolverine.Http.Tests `Marten.event_model_roles_3988` — 3/3 (`POST /orders/ship3` aggregate endpoint, `GET /orders/latest/{id}` view slice, discovery + capabilities).
- Existing capability tests in CoreTests — 25/25 still green.
- `dotnet run --project src/Samples/Quickstart -- event-model --json …` — 4 slices written, host never started; the same run is now a `command-line.yml` smoke step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
