### PR TITLE
GH-3989: `.ExternalSystem(name)` on endpoints, rendered on the Event Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@
 
 ### WolverineFx (core)
 
+- **`.ExternalSystem("Stripe")` names the external system on an endpoint, and the Event Model renders the
+  boundary.** ([#3989](https://github.com/JasperFx/wolverine/issues/3989)) Every listener and subscriber
+  configuration gains `ExternalSystem(string name)` (stored as `Endpoint.ExternalSystemName`, surfaced as the typed
+  `EndpointDescriptor.ExternalSystem` in capabilities). The Wolverine-derived Event Model attaches an inbound
+  external-system element to the slice a named listener triggers — a handler stuck to it, or the handler of its
+  `DefaultIncomingMessage<T>()` — making it a `Translation` slice triggered `External` (a named listener bound to
+  no slice still renders as a trigger-only boundary), and an outbound element to every slice whose published
+  messages or emitted events the named endpoint subscribes to. The edge is derived; only the name is declared,
+  on the endpoint, never in the overlay (jasperfx#687 decision 5).
+
 - **Chains carry their Event Modeling roles, and `event-model` exports them.**
   ([#3988](https://github.com/JasperFx/wolverine/issues/3988), [#3990](https://github.com/JasperFx/wolverine/issues/3990))
   Every message handler chain now derives its Event Modeling slice — command, handler, the aggregate(s) it decides

--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -338,3 +338,28 @@ component with the same output CritterWatch shows for the same host.
 What is deliberately *not* visible here: imperative `session.Events.Append(...)` inside a handler body. That is
 invisible at runtime, so only declarative returns are reported; CritterWatch's source generator covers the
 imperative case.
+
+### Naming the external system on an endpoint
+
+The *edge* of a translation slice is derived — a listener that receives from, or a subscriber that publishes to,
+something outside your application *is* the external-system boundary — but the **name** of that system is the one
+thing code cannot say. Declare it on the endpoint, never in the event-model overlay:
+
+```cs
+opts.ListenToRabbitQueue("stripe-events")
+    .ExternalSystem("Stripe")
+    .DefaultIncomingMessage<StripeChargeSucceeded>();
+
+opts.PublishMessage<IssueStripeRefund>()
+    .ToRabbitQueue("stripe-refunds")
+    .ExternalSystem("Stripe");
+```
+
+`.ExternalSystem("...")` is available on every listener and subscriber configuration. The name flows out through
+the endpoint's `EndpointDescriptor.ExternalSystem` in the capabilities snapshot, and the Event Model attaches a
+**Stripe** external-system element — inbound — to the slice the listener triggers (a handler stuck to that
+listener, or the handler of its `DefaultIncomingMessage<T>()`), which makes that slice a `Translation` slice
+triggered `External`; a named listener bound to no slice still renders as a trigger-only boundary. On the outbound
+side, every slice whose published messages or emitted events the named endpoint subscribes to gets the system on
+its far end (a pure relay becomes a `Translation` slice; a command slice that also notifies Stripe stays a command
+slice).

--- a/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
+++ b/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
@@ -28,10 +28,31 @@ internal sealed class HttpEventModelSource : IEventModelDefinitionSource
         var graph = _options.Endpoints;
         if (graph is null) return Task.FromResult<EventModelDescriptor?>(null);
 
-        return Task.FromResult<EventModelDescriptor?>(Describe(_wolverineOptions.ServiceName, graph.Chains));
+        return Task.FromResult<EventModelDescriptor?>(Describe(_wolverineOptions, graph.Chains));
     }
 
     /// <summary>Describe every routed HTTP chain as an Event Model slice.</summary>
+    public static EventModelDescriptor Describe(WolverineOptions options, IEnumerable<HttpChain> chains)
+    {
+        var chainList = chains.ToList();
+        var model = Describe(options.ServiceName, chainList);
+
+        var knownTypes = new Dictionary<string, Type>(StringComparer.Ordinal);
+        foreach (var chain in chainList)
+        {
+            if (chain.RequestType?.FullName is { } request) knownTypes.TryAdd(request, chain.RequestType);
+            foreach (var variable in chain.Method.Creates)
+            {
+                if (variable.VariableType.FullName is { } fullName) knownTypes.TryAdd(fullName, variable.VariableType);
+            }
+        }
+
+        // GH-3989: an endpoint publishing to a named external system puts that system on the far end
+        // of the HTTP slice too; HTTP chains have no listener, so only outbound edges apply
+        return WolverineEventModelSource.ApplyExternalSystems(model, options, knownTypes: knownTypes, includeInbound: false);
+    }
+
+    /// <summary>Describe every routed HTTP chain as an Event Model slice, without endpoint-derived external systems.</summary>
     public static EventModelDescriptor Describe(string serviceName, IEnumerable<HttpChain> chains)
     {
         var slices = new List<EventModelSliceDescriptor>();

--- a/src/Testing/CoreTests/Acceptance/external_system_3989.cs
+++ b/src/Testing/CoreTests/Acceptance/external_system_3989.cs
@@ -1,0 +1,191 @@
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Tracking;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Acceptance.ExternalSystem3989;
+
+// GH-3989: the *edge* of a translation slice is derived — a listening or sending endpoint to something
+// outside the application IS the external-system boundary — but the *name* ("Stripe") is the one thing
+// code cannot say, so it is declared on the endpoint with .ExternalSystem("Stripe"), never in the event
+// model overlay. It flows out through EndpointDescriptor and lands on the slice as an external-system
+// element. TCP endpoints here so no broker is needed; the RabbitMQ-flavoured twin lives in
+// Wolverine.RabbitMQ.Tests.
+public class external_system_3989 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private int _stripeInboundPort;
+    private int _stripeOutboundPort;
+    private int _erpInboundPort;
+    private int _ledgerPort;
+
+    public async ValueTask InitializeAsync()
+    {
+        _stripeInboundPort = PortFinder.GetAvailablePort();
+        _stripeOutboundPort = PortFinder.GetAvailablePort();
+        _erpInboundPort = PortFinder.GetAvailablePort();
+        _ledgerPort = PortFinder.GetAvailablePort();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "external-system-3989";
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StripeChargeSucceededHandler))
+                    .IncludeType(typeof(RefundOrderHandler))
+                    .IncludeType(typeof(PlaceOrderHandler));
+
+                // inbound: Stripe pushes charge events onto this listener; DefaultIncomingMessage<T> is what
+                // binds the listener to the slice (the other binding is a handler stuck to the listener). The
+                // TCP helper returns the interface, so reach the generic base for DefaultIncomingMessage<T>;
+                // the broker configurations (RabbitMqListenerConfiguration etc.) expose it directly.
+                ((ListenerConfiguration)opts.ListenAtPort(_stripeInboundPort))
+                    .DefaultIncomingMessage<StripeChargeSucceeded>()
+                    .ExternalSystem("Stripe");
+
+                // inbound, bound to nothing: still a boundary to render
+                opts.ListenAtPort(_erpInboundPort).ExternalSystem("Legacy ERP").Named("erp-feed");
+
+                // outbound: refund requests go to Stripe
+                opts.PublishMessage<IssueStripeRefund>().ToPort(_stripeOutboundPort).ExternalSystem("Stripe");
+
+                // outbound: a plain internal subscriber, no external system
+                opts.PublishMessage<OrderPlacedNotification>().ToPort(_ledgerPort);
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void the_endpoint_descriptor_reports_the_external_system_name()
+    {
+        var endpoint = _host.GetRuntime().Options.Transports.AllEndpoints()
+            .Single(x => x.Uri.Port == _stripeInboundPort);
+
+        endpoint.ExternalSystemName.ShouldBe("Stripe");
+        new EndpointDescriptor(endpoint).ExternalSystem.ShouldBe("Stripe");
+
+        var ledger = _host.GetRuntime().Options.Transports.AllEndpoints().Single(x => x.Uri.Port == _ledgerPort);
+        new EndpointDescriptor(ledger).ExternalSystem.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task the_capabilities_snapshot_carries_the_name_on_the_messaging_endpoint()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+
+        capabilities.MessagingEndpoints.Single(x => x.Uri.Port == _stripeInboundPort).ExternalSystem.ShouldBe("Stripe");
+        capabilities.MessagingEndpoints.Single(x => x.Uri.Port == _stripeOutboundPort).ExternalSystem.ShouldBe("Stripe");
+        capabilities.MessagingEndpoints.Single(x => x.Uri.Port == _ledgerPort).ExternalSystem.ShouldBeNull();
+    }
+
+    [Fact]
+    public void an_inbound_listener_is_the_trigger_of_the_slice_for_its_message_type()
+    {
+        var model = WolverineEventModelSource.Describe(_host.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded));
+
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Stripe");
+        system.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+        system.EndpointUri.ShouldBe($"tcp://localhost:{_stripeInboundPort}/");
+
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+        slice.TriggerLabel.ShouldNotBeNull();
+
+        // and the handler roles are untouched
+        slice.CommandType!.Name.ShouldBe(nameof(StripeChargeSucceeded));
+        slice.HandlerType!.Name.ShouldBe(nameof(StripeChargeSucceededHandler));
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(RecordPayment) });
+
+        // the external system renders as an element on the wireframe lane
+        slice.Elements.ShouldContain(x => x.Kind == EventModelElementKind.ExternalSystem && x.Label == "Stripe");
+    }
+
+    [Fact]
+    public void an_outbound_subscriber_puts_the_external_system_on_the_publishing_slice()
+    {
+        var model = WolverineEventModelSource.Describe(_host.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == nameof(RefundOrder));
+
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Stripe");
+        system.Direction.ShouldBe(ExternalSystemDirection.Outbound);
+        system.EndpointUri.ShouldBe($"tcp://localhost:{_stripeOutboundPort}/");
+
+        // a pure relay — no aggregate, no events of its own — is a translation slice
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+
+        // an internal subscriber is not an external system
+        model.Slices.Single(x => x.Name == nameof(PlaceOrder)).ExternalSystems.ShouldBeEmpty();
+        model.Slices.Single(x => x.Name == nameof(PlaceOrder)).Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void a_named_listener_bound_to_no_slice_still_renders_as_a_boundary()
+    {
+        var model = WolverineEventModelSource.Describe(_host.GetRuntime());
+        var slice = model.Slices.Single(x => x.Name == "erp-feed");
+
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+        slice.CommandType.ShouldBeNull();
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Legacy ERP");
+        system.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+    }
+
+    [Fact]
+    public async Task the_external_systems_survive_assembly_and_the_wire()
+    {
+        var assembled = await WolverineEventModelExport.AssembleAsync(_host.Services, token: TestContext.Current.CancellationToken);
+        assembled.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded)).ExternalSystems.Single().Name.ShouldBe("Stripe");
+
+        var json = WolverineEventModelExport.ToJson(assembled);
+        json.ShouldContain("\"externalSystems\"");
+        json.ShouldContain("\"direction\": \"Inbound\"");
+        json.ShouldContain("\"direction\": \"Outbound\"");
+        json.ShouldContain("\"pattern\": \"Translation\"");
+
+        var back = WolverineEventModelExport.FromJson(json)!;
+        var slice = back.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded));
+        var system = slice.ExternalSystems.ShouldHaveSingleItem();
+        system.Name.ShouldBe("Stripe");
+        system.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+        system.EndpointUri.ShouldBe($"tcp://localhost:{_stripeInboundPort}/");
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+    }
+}
+
+public record StripeChargeSucceeded(string ChargeId);
+public record RecordPayment(string ChargeId);
+public record RefundOrder(string OrderId);
+public record IssueStripeRefund(string OrderId);
+public record PlaceOrder(string OrderId);
+public record OrderPlacedNotification(string OrderId);
+
+public class StripeChargeSucceededHandler
+{
+    public static RecordPayment Handle(StripeChargeSucceeded charge) => new(charge.ChargeId);
+}
+
+public class RefundOrderHandler
+{
+    public static IssueStripeRefund Handle(RefundOrder command) => new(command.OrderId);
+}
+
+public class PlaceOrderHandler
+{
+    public static OrderPlacedNotification Handle(PlaceOrder command) => new(command.OrderId);
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/external_system_3989.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/external_system_3989.cs
@@ -1,0 +1,91 @@
+using JasperFx.Events.EventModeling;
+using JasperFx.Resources;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// GH-3989 acceptance: a host with ListenToRabbitQueue("stripe-events").ExternalSystem("Stripe") reports
+// the name on that endpoint's descriptor, and the merged EventModelDescriptor carries an external-system
+// element named "Stripe" attached to the slice whose trigger is that endpoint.
+public class external_system_3989 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "external-system-3989";
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StripeChargeSucceededHandler))
+                    .IncludeType(typeof(RefundOrderHandler));
+
+                opts.ListenToRabbitQueue("stripe-events")
+                    .ExternalSystem("Stripe")
+                    .DefaultIncomingMessage<StripeChargeSucceeded>();
+
+                opts.PublishMessage<IssueStripeRefund>().ToRabbitQueue("stripe-refunds").ExternalSystem("Stripe");
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_rabbit_endpoints_report_the_external_system()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null, CancellationToken.None);
+
+        capabilities.MessagingEndpoints.Single(x => x.Uri == new Uri("rabbitmq://queue/stripe-events")).ExternalSystem.ShouldBe("Stripe");
+        capabilities.MessagingEndpoints.Single(x => x.Uri == new Uri("rabbitmq://queue/stripe-refunds")).ExternalSystem.ShouldBe("Stripe");
+    }
+
+    [Fact]
+    public async Task the_merged_event_model_attaches_stripe_to_the_slices_the_queues_trigger_and_feed()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services, token: TestContext.Current.CancellationToken);
+
+        var inbound = model.Slices.Single(x => x.Name == nameof(StripeChargeSucceeded));
+        var trigger = inbound.ExternalSystems.ShouldHaveSingleItem();
+        trigger.Name.ShouldBe("Stripe");
+        trigger.Direction.ShouldBe(ExternalSystemDirection.Inbound);
+        trigger.EndpointUri.ShouldBe("rabbitmq://queue/stripe-events");
+        inbound.Pattern.ShouldBe(SlicePattern.Translation);
+        inbound.TriggerKind.ShouldBe(TriggerKind.External);
+        inbound.Elements.ShouldContain(x => x.Kind == EventModelElementKind.ExternalSystem && x.Label == "Stripe");
+
+        var outbound = model.Slices.Single(x => x.Name == nameof(RefundOrder));
+        var target = outbound.ExternalSystems.ShouldHaveSingleItem();
+        target.Name.ShouldBe("Stripe");
+        target.Direction.ShouldBe(ExternalSystemDirection.Outbound);
+        target.EndpointUri.ShouldBe("rabbitmq://queue/stripe-refunds");
+    }
+}
+
+public record StripeChargeSucceeded(string ChargeId);
+public record RecordPayment(string ChargeId);
+public record RefundOrder(string OrderId);
+public record IssueStripeRefund(string OrderId);
+
+public class StripeChargeSucceededHandler
+{
+    public static RecordPayment Handle(StripeChargeSucceeded charge) => new(charge.ChargeId);
+}
+
+public class RefundOrderHandler
+{
+    public static IssueStripeRefund Handle(RefundOrder command) => new(command.OrderId);
+}

--- a/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/EndpointDescriptor.cs
@@ -43,16 +43,27 @@ public class EndpointDescriptor : OptionsDescription
         Mode = endpoint.Mode;
         IsListener = endpoint.IsListener;
         DeadLetterStorage = endpoint.DeadLetterStorage;
+        ExternalSystem = endpoint.ExternalSystemName;
 
         // Mode and IsListener are now first-class typed fields (GH-3009); DeadLetterStorage is
         // likewise a typed field (GH-3104). Drop the generic OptionsDescription rows the base ctor
         // reflected off the Endpoint so we don't ship them twice — CritterWatch reads the typed
         // fields at the service-overview level, and Properties is becoming lazy-fetchable downstream.
         Properties.RemoveAll(x =>
-            x.Name is nameof(Endpoint.Mode) or nameof(Endpoint.IsListener) or nameof(Endpoint.DeadLetterStorage));
+            x.Name is nameof(Endpoint.Mode) or nameof(Endpoint.IsListener) or nameof(Endpoint.DeadLetterStorage)
+                or nameof(Endpoint.ExternalSystemName));
     }
 
     public Uri Uri { get; set; } = null!;
+
+    /// <summary>
+    /// The name of the external system on the other end of this endpoint — "Stripe", "Legacy ERP" —
+    /// when the application declared one with <c>.ExternalSystem("...")</c> on the listener or subscriber
+    /// configuration (GH-3989). Null when none was declared. Lifted from
+    /// <see cref="Endpoint.ExternalSystemName"/> into a first-class typed field so the Event Model can attach
+    /// the external-system element to the slice this endpoint triggers or feeds.
+    /// </summary>
+    public string? ExternalSystem { get; init; }
 
     /// <summary>
     /// Human-readable description of the transport type (e.g., "RabbitMQ Queue", "Local Queue", "Kafka Topic")

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -401,6 +401,17 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// tenant id
     /// </summary>
     public virtual string? TenantId { get; set; }
+
+    /// <summary>
+    ///     The name of the external system on the other end of this endpoint — "Stripe", "Legacy ERP" —
+    ///     when a listener receives from, or a sender publishes to, something outside this application.
+    ///     Optional and purely descriptive (GH-3989): the <em>edge</em> of an Event Modeling translation
+    ///     slice is derived from the endpoint itself, but the name is the one thing code cannot say, so it
+    ///     is declared here and flows out through <c>EndpointDescriptor.ExternalSystem</c> and onto the
+    ///     slice as an external-system element. Set with <c>.ExternalSystem("Stripe")</c> on the listener
+    ///     or subscriber configuration.
+    /// </summary>
+    public string? ExternalSystemName { get; set; }
     
     internal IEnumerable<IEnvelopeRule> RulesForIncoming()
     {

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -54,19 +54,45 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         var slices = new List<EventModelSliceDescriptor>();
         var aggregates = new List<AggregateDescriptor>();
         var aggregateNames = new HashSet<string>(StringComparer.Ordinal);
+        var stickyEndpoints = new Dictionary<string, HashSet<Uri>>(StringComparer.Ordinal);
+        var knownTypes = new Dictionary<string, Type>(StringComparer.Ordinal);
 
         void describe(HandlerChain chain)
         {
-            if (chain.Handlers.Count == 0) return;
             if (chain.MessageType.IsSystemMessageType()) return;
 
-            slices.Add(EventModelRoles.ForHandlerChain(chain));
+            // sticky handlers live on per-endpoint sub-chains, so walk those whether or not the
+            // parent chain has a default handler of its own
+            foreach (var sticky in chain.ByEndpoint) describe(sticky);
+
+            if (chain.Handlers.Count == 0) return;
+
+            var slice = EventModelRoles.ForHandlerChain(chain);
+            slices.Add(slice);
+
+            knownTypes.TryAdd(chain.MessageType.FullName!, chain.MessageType);
+            foreach (var call in chain.Handlers)
+            foreach (var variable in call.Creates)
+            {
+                if (variable.VariableType.FullName is { } fullName) knownTypes.TryAdd(fullName, variable.VariableType);
+            }
+
+            // a sticky handler chain is bound to these listeners — that is what makes a listener the
+            // trigger of this slice (GH-3989)
+            if (chain.Endpoints.Count > 0)
+            {
+                if (!stickyEndpoints.TryGetValue(slice.Name, out var uris))
+                {
+                    uris = new HashSet<Uri>();
+                    stickyEndpoints[slice.Name] = uris;
+                }
+
+                foreach (var endpoint in chain.Endpoints) uris.Add(endpoint.Uri);
+            }
             foreach (var aggregate in EventModelRoles.AggregatesFor(chain))
             {
                 if (aggregateNames.Add(aggregate.Type.FullName)) aggregates.Add(aggregate);
             }
-
-            foreach (var sticky in chain.ByEndpoint) describe(sticky);
         }
 
         foreach (var chain in options.HandlerGraph.Chains.OrderBy(x => x.MessageType.FullName, StringComparer.Ordinal))
@@ -76,7 +102,140 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
 
         var model = new EventModelDescriptor(options.ServiceName, slices) { Aggregates = aggregates };
         model = ApplyGrpcTriggers(model, grpc);
+        model = ApplyExternalSystems(model, options, stickyEndpoints, knownTypes, includeInbound: true);
         return FinishModel(model);
+    }
+
+    /// <summary>
+    ///     GH-3989: the <em>edge</em> of a translation slice is the endpoint — a listener receiving from, or a
+    ///     sender publishing to, something outside this application — and the external system's
+    ///     <em>name</em> is what the application declared on that endpoint with <c>.ExternalSystem("...")</c>.
+    ///     Inbound: the named listener is the trigger of every slice stuck to it, or whose command is its
+    ///     <see cref="Endpoint.MessageType"/>; a listener bound to no slice still renders, as a trigger-only
+    ///     translation slice. Outbound: every slice whose published messages or emitted events the named
+    ///     endpoint subscribes to gets the external system on its far end.
+    /// </summary>
+    /// <param name="model">The model to annotate.</param>
+    /// <param name="options">The Wolverine options — the endpoints come from <c>Transports.AllEndpoints()</c>.</param>
+    /// <param name="stickyEndpointsBySlice">Listener URIs each slice's chain is stuck to, by slice name. May be empty.</param>
+    /// <param name="knownTypes">The CLR types behind the slices' message / event descriptors, by full name, so a subscription's own matching rules decide the outbound edge. Descriptors with no known type fall back to a name match.</param>
+    /// <param name="includeInbound">False for a source whose slices have no listener (Wolverine.HTTP): only outbound edges apply.</param>
+    public static EventModelDescriptor ApplyExternalSystems(
+        EventModelDescriptor model,
+        WolverineOptions options,
+        IReadOnlyDictionary<string, HashSet<Uri>>? stickyEndpointsBySlice = null,
+        IReadOnlyDictionary<string, Type>? knownTypes = null,
+        bool includeInbound = true)
+    {
+        var named = options.Transports.AllEndpoints()
+            .Where(x => !string.IsNullOrWhiteSpace(x.ExternalSystemName))
+            .OrderBy(x => x.Uri.ToString(), StringComparer.Ordinal)
+            .ToArray();
+        if (named.Length == 0) return model;
+
+        var slices = model.Slices.ToList();
+
+        foreach (var endpoint in named)
+        {
+            var name = endpoint.ExternalSystemName!;
+            var uri = endpoint.Uri.ToString();
+
+            // Outbound: the endpoint subscribes to a message this slice publishes or an event it emits
+            for (var i = 0; i < slices.Count; i++)
+            {
+                var slice = slices[i];
+                var outgoing = slice.PublishedMessages.Concat(slice.EmittedEvents).ToArray();
+                if (outgoing.Length == 0) continue;
+
+                if (endpoint.Subscriptions.Any(subscription => outgoing.Any(type => matches(subscription, type, knownTypes))))
+                {
+                    slices[i] = withExternalSystem(slice, new ExternalSystemDescriptor(name, ExternalSystemDirection.Outbound, uri), flipPattern: false);
+                }
+            }
+
+            if (!includeInbound || !endpoint.IsListener) continue;
+
+            // Inbound: the listener is the trigger of a slice stuck to it, or whose command is its message type
+            var matched = false;
+            for (var i = 0; i < slices.Count; i++)
+            {
+                var slice = slices[i];
+                var stuck = stickyEndpointsBySlice != null &&
+                            stickyEndpointsBySlice.TryGetValue(slice.Name, out var uris) && uris.Contains(endpoint.Uri);
+                var byType = endpoint.MessageType != null && slice.CommandType?.FullName == endpoint.MessageType.FullName;
+                if (!stuck && !byType) continue;
+
+                matched = true;
+                var label = $"{name} → {endpoint.EndpointName}";
+                slices[i] = withExternalSystem(slice, new ExternalSystemDescriptor(name, ExternalSystemDirection.Inbound, uri), flipPattern: true)
+                    with
+                    {
+                        TriggerLabel = slice.TriggerLabel ?? label,
+                        TriggerKind = TriggerKind.External,
+                        TriggerOrigin = slice.TriggerOrigin ?? new PublisherOrigin { Label = label }
+                    };
+            }
+
+            if (!matched)
+            {
+                // Nothing binds the listener to a slice — there is still a boundary to render
+                slices.Add(new EventModelSliceDescriptor(
+                    endpoint.EndpointName,
+                    $"{name} → {endpoint.EndpointName}",
+                    null,
+                    endpoint.MessageType is null ? null : JasperFx.Descriptors.TypeDescriptor.For(endpoint.MessageType),
+                    null,
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>())
+                {
+                    Pattern = SlicePattern.Translation,
+                    TriggerKind = TriggerKind.External,
+                    TriggerOrigin = new PublisherOrigin { Label = $"{name} → {endpoint.EndpointName}" },
+                    ExternalSystems = new[] { new ExternalSystemDescriptor(name, ExternalSystemDirection.Inbound, uri) }
+                });
+            }
+        }
+
+        return model with { Slices = slices };
+
+        static bool matches(Wolverine.Runtime.Routing.Subscription subscription, JasperFx.Descriptors.TypeDescriptor descriptor,
+            IReadOnlyDictionary<string, Type>? knownTypes)
+        {
+            // Subscriptions match on Type; the slice carries TypeDescriptors. The source that derived the
+            // slice knows the types, so the subscription's own rules decide; a descriptor nobody resolved
+            // (an overlay's, say) gets the name-only approximation of the same rules.
+            if (knownTypes != null && knownTypes.TryGetValue(descriptor.FullName, out var type))
+            {
+                return subscription.Matches(type);
+            }
+
+            return subscription.Scope switch
+            {
+                Wolverine.Runtime.Routing.RoutingScope.Type => descriptor.Name.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase) ||
+                                                               descriptor.FullName.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.TypeName => descriptor.FullName.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.Namespace => descriptor.FullName.StartsWith(subscription.Match + ".", StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.Assembly => descriptor.AssemblyName.Equals(subscription.Match, StringComparison.OrdinalIgnoreCase),
+                Wolverine.Runtime.Routing.RoutingScope.Implements => false,
+                _ => true,
+            };
+        }
+
+        static EventModelSliceDescriptor withExternalSystem(EventModelSliceDescriptor slice, ExternalSystemDescriptor system, bool flipPattern)
+        {
+            if (slice.ExternalSystems.Any(x => x.Name == system.Name && x.Direction == system.Direction)) return slice;
+
+            var systems = slice.ExternalSystems.Concat(new[] { system }).ToList();
+            // An external system on the inbound side makes this a translation slice. On the outbound side
+            // a slice keeps its own pattern (a command slice that also notifies Stripe is still a command
+            // slice) unless it is a pure relay — no aggregate, no events of its own.
+            var pattern = flipPattern || (slice.AggregateTypes.Count == 0 && slice.EmittedEvents.Count == 0 && slice.Pattern == SlicePattern.Command)
+                ? SlicePattern.Translation
+                : slice.Pattern;
+
+            return slice with { ExternalSystems = systems, Pattern = pattern };
+        }
     }
 
     /// <summary>

--- a/src/Wolverine/Configuration/IListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/IListenerConfiguration.cs
@@ -15,6 +15,15 @@ public interface IEndpointConfiguration<T>
     T Named(string name);
 
     /// <summary>
+    ///     Name the external system on the other end of this endpoint — "Stripe", "Legacy ERP" — when it
+    ///     listens to, or publishes to, something outside this application (GH-3989). Descriptive only:
+    ///     it flows out through the endpoint's capabilities descriptor and onto the Event Model as an
+    ///     external-system element on the translation slice this endpoint triggers or feeds.
+    /// </summary>
+    /// <param name="name">Display name of the external system.</param>
+    T ExternalSystem(string name);
+
+    /// <summary>
     ///     Override the default serializer for this endpoint
     /// </summary>
     /// <param name="serializer"></param>

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -407,6 +407,12 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         return this.As<TSelf>();
     }
 
+    public TSelf ExternalSystem(string name)
+    {
+        add(e => e.ExternalSystemName = name);
+        return this.As<TSelf>();
+    }
+
     public TSelf DefaultSerializer(IMessageSerializer serializer)
     {
         add(e =>

--- a/src/Wolverine/Configuration/SubscriberConfiguration.cs
+++ b/src/Wolverine/Configuration/SubscriberConfiguration.cs
@@ -149,6 +149,12 @@ public class SubscriberConfiguration<T, TEndpoint> : DelayedEndpointConfiguratio
         return this.As<T>();
     }
 
+    public T ExternalSystem(string name)
+    {
+        add(e => e.ExternalSystemName = name);
+        return this.As<T>();
+    }
+
 
     /// <summary>
     /// For endpoints that send or receive messages in batches, this governs the maximum


### PR DESCRIPTION
Closes #3989. Part of the Spec Driven Development effort (master: JasperFx/stoat#9; jasperfx#687 decision 5).

> **Stacked on #3999** (`gh-3988-3990-event-model-roles`) — the external-system element attaches to the slices `WolverineEventModelSource` derives there. Review the single commit on top of #3999; after #3999 merges, retarget this PR to `main` (or rebase) before merging.

## What

The translation-slice **edge** is derived — a listener that receives from, or a subscriber that publishes to, something outside the application *is* the external-system boundary — but the **name** ("Stripe", "Legacy ERP") is the one thing code cannot say. It is declared on the endpoint, never in the event-model overlay.

**Configuration API**
```cs
opts.ListenToRabbitQueue("stripe-events")
    .ExternalSystem("Stripe")
    .DefaultIncomingMessage<StripeChargeSucceeded>();

opts.PublishMessage<IssueStripeRefund>()
    .ToRabbitQueue("stripe-refunds")
    .ExternalSystem("Stripe");
```
- `IEndpointConfiguration<T>.ExternalSystem(string name)` → available on **every** listener and subscriber configuration (implemented once on `ListenerConfiguration<,>` and `SubscriberConfiguration<,>`); stored as `Endpoint.ExternalSystemName` (`string?`).
- Capabilities: `EndpointDescriptor.ExternalSystem` (`string?`, typed, additive); the reflected `ExternalSystemName` row is dropped from `Properties` the same way `Mode` / `IsListener` / `DeadLetterStorage` are.

**Event Model** (`WolverineEventModelSource.ApplyExternalSystems`, also applied — outbound half only — by `HttpEventModelSource`):
- **Inbound:** a named listener is the trigger of every slice whose handler is stuck to it, or whose command is its `DefaultIncomingMessage<T>`. The slice gets an inbound `ExternalSystemDescriptor(name, Inbound, endpointUri)`, flips to `SlicePattern.Translation`, `TriggerKind.External`, trigger label `"Stripe → stripe-events"`. A named listener bound to no slice still renders as a trigger-only translation slice (named for the endpoint) so the boundary is visible.
- **Outbound:** every slice whose published messages or emitted events the named endpoint **subscribes to** gets `ExternalSystemDescriptor(name, Outbound, endpointUri)` — decided by the subscription's own `Matches(Type)` over the types the source derived (name-only approximation of the same rules for a descriptor nobody resolved, e.g. an overlay's). A pure relay (no aggregate, no events) becomes `Translation`; a command slice that also notifies Stripe stays a command slice.
- Pattern logic in `EventModelRoles` itself is unchanged; the flip happens where the edge is known (model level), which is also where the gRPC trigger and the Automation pass live.
- One side fix surfaced by the sticky path: `Describe` now walks `ByEndpoint` sub-chains whether or not the parent chain has a default handler (it previously returned early).

## Evidence
- `dotnet build wolverine.slnx -c Release -f net9.0` green.
- CoreTests `ExternalSystem3989.external_system_3989` — 6/6 over TCP endpoints (no broker): endpoint + capabilities descriptor, inbound by message type, outbound, internal subscriber stays clean, unbound named listener, assembly + JSON round trip; the #3988 CoreTests (15) and capability tests still green.
- Wolverine.RabbitMQ.Tests `external_system_3989` — 2/2 on a real RabbitMQ 4: the issue's acceptance case (`ListenToRabbitQueue("stripe-events").ExternalSystem("Stripe")` → descriptor carries the name; merged model carries an external-system element "Stripe" on the slice that queue triggers, and on the slice `stripe-refunds` feeds).
- Docs: "Naming the external system on an endpoint" under the event-model section of the command-line page; CHANGELOG entry under `### WolverineFx (core)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
