### PR TITLE
GH-3997: reject a multi-part schema name, and stop swallowing failed migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,59 @@
   the decline branch and their local retries are unchanged. That is correct: there is no capability-matched
   alternative node to release them to.
 
+### Dependencies
+
+- **Weasel 9.26.0.** Two defects that Wolverine's new fail-fast migrations (below) turned from a logged
+  line into a failed startup: `Table.FetchExisting` filtered the PostgreSQL catalog with
+  `NOT nspname LIKE 'pg%'`, which hid every index in a *user* schema whose name began with "pg", so those
+  schemas re-issued `create index` on every start and answered `42P07`
+  ([weasel#504](https://github.com/JasperFx/weasel/issues/504)); and Sql Server's column drop did not first
+  drop the auto-named default constraint that depends on the column, so a column declared with a default
+  could be added by a migration but never removed by one
+  ([weasel#505](https://github.com/JasperFx/weasel/issues/505)) — reachable from Wolverine configuration by
+  turning `OutboxStaleTime` / `InboxStaleTime` back off.
+
+### WolverineFx.RDBMS (all relational providers)
+
+- **A multi-part schema name is rejected where it is configured.**
+  (closes [#3997](https://github.com/JasperFx/wolverine/issues/3997)) Wolverine renders each of its tables
+  as `{schema}.{table}` with no delimiting, so a "schema name" that is itself multi-part produces a name
+  with more parts than any supported engine accepts:
+
+  ```
+  opts.PersistMessagesWithSqlServer(cnx, "crm.sales.opportunities");
+
+  // The object name 'crm.sales.opportunities.wolverine_node_records' contains more than
+  // the maximum number of prefixes. The maximum is 2.
+  ```
+
+  Weasel's `CREATE SCHEMA` is the one statement that *does* delimit the name, so the schema was created
+  and only the tables failed — and, because those failures were swallowed (below), startup then died a
+  long way from the cause, in `LoadNodeAgentStateAsync`, against `Could not find server 'crm' in
+  sys.servers`: SQL Server reads a four-part name as *server.database.schema.object*. PostgreSQL reaches
+  the same place through `improper qualified name (too many dotted names)`.
+
+  Every schema name Wolverine accepts — `PersistMessagesWithXXX`, the database-backed transports'
+  `TransportSchemaName`, and the `MessageStorageSchemaName` on the Marten, Polecat and Fisher integrations
+  — now throws an `ArgumentOutOfRangeException` naming the offending value the moment it is set. A name you
+  have already delimited (`"[crm.sales]"`) is rejected as well: the schema is created and the first start
+  succeeds, but the `CREATE SCHEMA` guard compares `sys.schemas.name` against the bracketed spelling, so it
+  never matches and every restart re-issues the `CREATE SCHEMA` against a schema that now exists. Schema
+  difference detection cannot match a delimited name against the catalog either, so the store re-applies its
+  whole DDL every start and never picks up a later column-level change.
+
+- **Failed storage migrations are no longer swallowed.**
+  (closes [#3997](https://github.com/JasperFx/wolverine/issues/3997)) Weasel hands a failed DDL statement
+  to the `IMigrationLogger` rather than throwing, on the grounds that a non-default logger means the caller
+  wants to decide — and Wolverine's decision was to log and carry on, so a host could start against storage
+  that had never been created. It now throws a `WolverineSchemaException` carrying the SQL that failed,
+  which is what Marten's equivalent logger has always done.
+
+  Hosts that would rather start up anyway can keep the old behavior with
+  `ResourceMigrationFailureMode.ContinueOnFailures`. Note that Wolverine already serializes migrations
+  across processes with a global advisory lock and retries the whole migration once after a short delay,
+  so a genuine race between two nodes starting at the same instant does not need it.
+
 ### WolverineFx.PostgreSQL / WolverineFx.SqlServer / WolverineFx.Oracle
 
 - **The orphaned-message sweep is now indexable, bounded, and outside the shared recovery transaction.**

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,13 +137,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.25.1" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.25.1" />
-    <PackageVersion Include="Weasel.MySql" Version="9.25.1" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.25.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.25.1" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.25.1" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.25.1" />
+    <PackageVersion Include="Weasel.Core" Version="9.26.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.26.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.26.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.26.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.26.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.26.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.26.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.

--- a/docs/guide/durability/managing.md
+++ b/docs/guide/durability/managing.md
@@ -9,6 +9,54 @@ Wolverine uses the [JasperFx "Stateful Resource"](https://github.com/JasperFx/ja
 infrastructure configuration at development or even deployment time for configured items like the database-backed message storage or
 message broker queues.
 
+## Schema Names
+
+Every `PersistMessagesWithXXX()` overload takes an optional schema name for Wolverine's tables, as do the
+database-backed transports. That name has to be a **single database identifier**. Wolverine renders each of its
+tables as `{schema}.{table}`, so a multi-part value like `crm.sales.opportunities` would produce
+`crm.sales.opportunities.wolverine_incoming_envelopes` — a name with more parts than any supported database engine
+accepts. SQL Server reports *"The object name contains more than the maximum number of prefixes. The maximum is 2"*
+and PostgreSQL reports *"improper qualified name (too many dotted names)"*.
+
+The database itself is chosen by the connection string, never by the schema name:
+
+```csharp
+// ✅ the schema "sales", inside whatever database the connection string names
+opts.PersistMessagesWithSqlServer(connectionString, "sales");
+
+// ❌ throws immediately with an ArgumentOutOfRangeException
+opts.PersistMessagesWithSqlServer(connectionString, "crm.sales.opportunities");
+```
+
+Wolverine rejects a multi-part schema name at the point where it is configured rather than letting it fail later as
+unusable DDL. Delimiting the name yourself — `"[crm.sales]"` on SQL Server — is rejected too, and does not work if
+you route around the check: the schema is created, but the `CREATE SCHEMA` guard compares `sys.schemas.name` against
+the spelling it was handed, brackets and all, so it never matches and every restart after the first re-issues the
+`CREATE SCHEMA` against a schema that now exists. Schema difference detection cannot match a delimited name against
+the catalog either, so such a store re-applies its whole DDL on every start and never picks up a later
+column-level change.
+
+## When a Migration Fails <Badge type="tip" text="6.30" />
+
+If a DDL statement in Wolverine's own storage migration fails, startup fails with a `WolverineSchemaException` that
+carries the exact SQL that could not be applied. Before 6.30 those failures were only logged, so a host could start
+up against storage that had never been created and then die much later against an error that named nothing you had
+configured.
+
+Hosts that would rather start up anyway — a replica in a rolling deploy where another node is mid-migration, for
+instance — can keep the older, tolerant behavior by setting the failure mode:
+
+```csharp
+builder.Host.UseWolverine(opts =>
+{
+    opts.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+});
+```
+
+Note that Wolverine already serializes migrations across processes with a global advisory lock and retries the whole
+migration once after a short delay, so a genuine race between two nodes starting at the same instant is resolved
+without this setting.
+
 ## Disable Automatic Storage Migration
 
 To disable the automatic storage migration, just flip this flag:

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlBackedPersistence.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlBackedPersistence.cs
@@ -136,7 +136,17 @@ internal class MySqlBackedPersistence : IMySqlBackedPersistence, IWolverineExten
     public MySqlDataSource? DataSource { get; set; }
     public string? ConnectionString { get; set; }
 
-    public string EnvelopeStorageSchemaName { get; set; }
+    private string _envelopeStorageSchemaName = null!;
+
+    public string EnvelopeStorageSchemaName
+    {
+        get => _envelopeStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(EnvelopeStorageSchemaName));
+            _envelopeStorageSchemaName = value;
+        }
+    }
 
     public AutoCreate AutoCreate { get; set; } = JasperFx.AutoCreate.CreateOrUpdate;
 

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlConfigurationExtensions.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlConfigurationExtensions.cs
@@ -29,7 +29,7 @@ public static class MySqlConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static IMySqlBackedPersistence PersistMessagesWithMySql(this WolverineOptions options,
         string connectionString,
@@ -57,7 +57,7 @@ public static class MySqlConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="dataSource"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static IMySqlBackedPersistence PersistMessagesWithMySql(this WolverineOptions options,
         MySqlDataSource dataSource,
@@ -86,8 +86,8 @@ public static class MySqlConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schema"></param>
-    /// <param name="transportSchema"></param>
+    /// <param name="schema">Schema name for the Wolverine envelope storage. A single database identifier, not a multi-part name</param>
+    /// <param name="transportSchema">Schema name for the queue tables. A single database identifier, not a multi-part name</param>
     /// <returns></returns>
     public static MySqlPersistenceExpression UseMySqlPersistenceAndTransport(this WolverineOptions options,
         string connectionString,

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlTransport.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlTransport.cs
@@ -4,6 +4,7 @@ using MySqlConnector;
 using Spectre.Console;
 using Weasel.MySql;
 using Wolverine.Configuration;
+using Wolverine.RDBMS;
 using Wolverine.RDBMS.MultiTenancy;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -22,15 +23,35 @@ public class MySqlTransport : BrokerTransport<MySqlQueue>
 
     public override Uri ResourceUri => new Uri("mysql-transport://");
 
+    private string _transportSchemaName = "wolverine_queues";
+
     /// <summary>
     /// Schema name for the queue and scheduled message tables
     /// </summary>
-    public string TransportSchemaName { get; set; } = "wolverine_queues";
+    public string TransportSchemaName
+    {
+        get => _transportSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
+            _transportSchemaName = value;
+        }
+    }
+
+    private string _messageStorageSchemaName = "wolverine";
 
     /// <summary>
     /// Schema name for the message storage tables
     /// </summary>
-    public string MessageStorageSchemaName { get; set; } = "wolverine";
+    public string MessageStorageSchemaName
+    {
+        get => _messageStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value;
+        }
+    }
 
     public LightweightCache<string, MySqlQueue> Queues { get; }
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleBackedPersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleBackedPersistence.cs
@@ -100,7 +100,17 @@ internal class OracleBackedPersistence : IOracleBackedPersistence, IWolverineExt
 
     public string? ConnectionString { get; set; }
 
-    public string EnvelopeStorageSchemaName { get; set; }
+    private string _envelopeStorageSchemaName = null!;
+
+    public string EnvelopeStorageSchemaName
+    {
+        get => _envelopeStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(EnvelopeStorageSchemaName));
+            _envelopeStorageSchemaName = value;
+        }
+    }
 
     public AutoCreate AutoCreate { get; set; } = JasperFx.AutoCreate.CreateOrUpdate;
 

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleConfigurationExtensions.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleConfigurationExtensions.cs
@@ -13,7 +13,7 @@ public static class OracleConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static IOracleBackedPersistence PersistMessagesWithOracle(this WolverineOptions options,
         string connectionString,

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleTransport.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleTransport.cs
@@ -4,6 +4,7 @@ using Oracle.ManagedDataAccess.Client;
 using Spectre.Console;
 using Weasel.Oracle;
 using Wolverine.Configuration;
+using Wolverine.RDBMS;
 using Wolverine.RDBMS.MultiTenancy;
 using Wolverine.Runtime;
 using Wolverine.Transports;
@@ -22,15 +23,35 @@ public class OracleTransport : BrokerTransport<OracleQueue>
 
     public override Uri ResourceUri => new Uri("oracle-transport://");
 
+    private string _transportSchemaName = "WOLVERINE_QUEUES";
+
     /// <summary>
     /// Schema name for the queue and scheduled message tables
     /// </summary>
-    public string TransportSchemaName { get; set; } = "WOLVERINE_QUEUES";
+    public string TransportSchemaName
+    {
+        get => _transportSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
+            _transportSchemaName = value;
+        }
+    }
+
+    private string _messageStorageSchemaName = "WOLVERINE";
 
     /// <summary>
     /// Schema name for the message storage tables
     /// </summary>
-    public string MessageStorageSchemaName { get; set; } = "WOLVERINE";
+    public string MessageStorageSchemaName
+    {
+        get => _messageStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value;
+        }
+    }
 
     public LightweightCache<string, OracleQueue> Queues { get; }
 

--- a/src/Persistence/PersistenceTests/schema_name_validation.cs
+++ b/src/Persistence/PersistenceTests/schema_name_validation.cs
@@ -1,0 +1,96 @@
+using Xunit;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+using Wolverine.SqlServer;
+
+namespace PersistenceTests;
+
+/// <summary>
+/// GH-3997: a multi-part "schema name" makes every Wolverine table a name with more parts than any
+/// engine accepts, and the resulting DDL failures used to be swallowed.
+/// </summary>
+public class schema_name_validation
+{
+    [Theory]
+    [InlineData("crm.sales.opportunities")]
+    [InlineData("crm.sales")]
+    // delimiting does not rescue it: the schema is created, but Weasel's CREATE SCHEMA guard compares
+    // sys.schemas.name against the bracketed spelling, so every restart re-issues the CREATE and fails
+    [InlineData("[crm.sales.opportunities]")]
+    [InlineData("\"crm.sales.opportunities\"")]
+    [InlineData("`crm.sales.opportunities`")]
+    public void reject_a_multi_part_schema_name_on_database_settings(string schemaName)
+    {
+        var settings = new DatabaseSettings();
+
+        Should.Throw<ArgumentOutOfRangeException>(() => settings.SchemaName = schemaName)
+            .Message.ShouldContain(schemaName);
+    }
+
+    [Theory]
+    [InlineData("wolverine")]
+    [InlineData("dbo")]
+    [InlineData(null)]
+    [InlineData("[quoted_but_single_part]")]
+    public void allow_a_usable_schema_name(string? schemaName)
+    {
+        var settings = new DatabaseSettings
+        {
+            SchemaName = schemaName
+        };
+
+        settings.SchemaName.ShouldBe(schemaName);
+    }
+
+    [Fact]
+    public void reject_a_multi_part_schema_name_when_configuring_sql_server()
+    {
+        var options = new WolverineOptions();
+
+        var ex = Should.Throw<ArgumentOutOfRangeException>(() =>
+            options.PersistMessagesWithSqlServer("Server=localhost;Database=fake", "crm.sales.opportunities"));
+
+        // the message has to say what to do about it, not just that it is wrong
+        ex.Message.ShouldContain("crm.sales.opportunities");
+        ex.Message.ShouldContain("'crm'");
+    }
+
+    [Fact]
+    public void reject_a_multi_part_schema_name_when_configuring_postgresql()
+    {
+        var options = new WolverineOptions();
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            options.PersistMessagesWithPostgresql("Host=localhost;Database=fake", "crm.sales"));
+    }
+
+    [Fact]
+    public void reject_a_multi_part_transport_schema_name()
+    {
+        var options = new WolverineOptions();
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            options.UseSqlServerPersistenceAndTransport("Server=localhost;Database=fake", "wolverine",
+                "crm.sales.queues"));
+    }
+
+    [Fact]
+    public void migration_failures_are_not_swallowed()
+    {
+        var logger = new MigrationLogger(NullLogger.Instance);
+
+        using var conn = new SqlConnection("Server=localhost;Database=fake");
+        var command = conn.CreateCommand();
+        command.CommandText = "create table crm.sales.opportunities.wolverine_incoming_envelopes (id int)";
+
+        var ex = Should.Throw<WolverineSchemaException>(() =>
+            logger.OnFailure(command, new DivideByZeroException("boom")));
+
+        ex.Sql.ShouldBe(command.CommandText);
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+    }
+}

--- a/src/Persistence/PostgresqlTests/Agents/control_queue_tests.cs
+++ b/src/Persistence/PostgresqlTests/Agents/control_queue_tests.cs
@@ -32,6 +32,11 @@ public class control_queue_tests : PostgresqlContext, IAsyncLifetime
         _receiver.Dispose();
     }
 
+    // The schema name deliberately starts with "pg". Weasel's index query used to filter the catalog with
+    // `NOT nspname LIKE 'pg%'` to skip pg_catalog/pg_toast, which also hid every index in a *user* schema
+    // whose name began with "pg" -- so the differences never converged and every startup after the first
+    // re-issued `create index` and failed with 42P07. This suite logged that on every run until Wolverine
+    // stopped swallowing failed migrations (GH-3997) made it visible. Fixed in Weasel 9.26 (weasel#504).
     private static async Task dropControlSchema()
     {
         using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);

--- a/src/Persistence/SqlServerTests/bumping_stale_inbox_messages.cs
+++ b/src/Persistence/SqlServerTests/bumping_stale_inbox_messages.cs
@@ -25,7 +25,12 @@ public class bumping_stale_inbox_messages : IAsyncLifetime
         theHost = await Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "stale_outbox");
+                // Deliberately NOT the "stale_outbox" schema that bumping_stale_outbox_messages uses. That test
+                // sets OutboxStaleTime, which adds a `timestamp` column to wolverine_outgoing_envelopes and this
+                // one does not, so sharing a schema had the two classes migrating that column in and out of
+                // existence depending on which ran first. Weasel 9.26 (weasel#505) can finally apply that drop
+                // on Sql Server; keeping the schemas apart keeps the two classes independent of run order.
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "stale_inbox");
                 opts.Durability.InboxStaleTime = 1.Hours();
             }).StartAsync();
 
@@ -44,7 +49,7 @@ public class bumping_stale_inbox_messages : IAsyncLifetime
         using var conn = new SqlConnection(Servers.SqlServerConnectionString);
         await conn.OpenAsync(TestContext.Current.CancellationToken);
 
-        var table = await new Table(new DbObjectName("stale_outbox", DatabaseConstants.IncomingTable)).FetchExistingAsync(conn, TestContext.Current.CancellationToken);
+        var table = await new Table(new DbObjectName("stale_inbox", DatabaseConstants.IncomingTable)).FetchExistingAsync(conn, TestContext.Current.CancellationToken);
         
         table!.HasColumn(DatabaseConstants.Timestamp).ShouldBeTrue();
         
@@ -77,17 +82,17 @@ public class bumping_stale_inbox_messages : IAsyncLifetime
         
         using var conn = new SqlConnection(Servers.SqlServerConnectionString);
         await conn.OpenAsync(TestContext.Current.CancellationToken);
-        await conn.CreateCommand("update stale_outbox.wolverine_incoming_envelopes set timestamp = @time where id = @id")
+        await conn.CreateCommand("update stale_inbox.wolverine_incoming_envelopes set timestamp = @time where id = @id")
             .With("time", DateTimeOffset.UtcNow.Subtract(2.Hours()))
             .With("id", envelope1.Id)
             .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         
-        await conn.CreateCommand("update stale_outbox.wolverine_incoming_envelopes set timestamp = @time where id = @id")
+        await conn.CreateCommand("update stale_inbox.wolverine_incoming_envelopes set timestamp = @time where id = @id")
             .With("time", DateTimeOffset.UtcNow.Subtract(2.Hours()))
             .With("id", envelope3.Id)
             .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
         
-        await conn.CreateCommand("update stale_outbox.wolverine_incoming_envelopes set timestamp = @time where id = @id")
+        await conn.CreateCommand("update stale_inbox.wolverine_incoming_envelopes set timestamp = @time where id = @id")
             .With("time", DateTimeOffset.UtcNow.Subtract(2.Hours()))
             .With("id", envelope5.Id)
             .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
@@ -96,7 +101,7 @@ public class bumping_stale_inbox_messages : IAsyncLifetime
         envelopesBefore.Count(x => x.OwnerId == 0).ShouldBe(0);
 
         var operation = new BumpStaleIncomingEnvelopesOperation(
-            new DbObjectName("stale_outbox", DatabaseConstants.IncomingTable), theHost.GetRuntime().Options.Durability, DateTimeOffset.UtcNow);
+            new DbObjectName("stale_inbox", DatabaseConstants.IncomingTable), theHost.GetRuntime().Options.Durability, DateTimeOffset.UtcNow);
         
         var batch = new DatabaseOperationBatch((IMessageDatabase)messageStore, [operation]);
         await theHost.InvokeAsync(batch);

--- a/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
@@ -109,6 +109,7 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
         get => _transportSchemaName;
         set
         {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
             _transportSchemaName = value.ToLowerInvariant();
         }
     }
@@ -130,7 +131,11 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
     public string? MessageStorageSchemaName
     {
         get => _messageStorageSchemaName;
-        set => _messageStorageSchemaName = value?.ToLowerInvariant();
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value?.ToLowerInvariant();
+        }
     }
 
     public EventForwardingTransform<T> SubscribeToEvent<T>() where T : notnull

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -159,6 +159,7 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
         get => _transportSchemaName;
         set
         {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
             _transportSchemaName = value.ToLowerInvariant();
             _transportSchemaNameIsExplicit = true;
         }
@@ -173,7 +174,11 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
     public string? MessageStorageSchemaName
     {
         get => _messageStorageSchemaName;
-        set => _messageStorageSchemaName = value?.ToLowerInvariant();
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value?.ToLowerInvariant();
+        }
     }
     
     /// <summary>

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -136,6 +136,7 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
         get => _transportSchemaName;
         set
         {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
             _transportSchemaName = value.ToLowerInvariant();
             _transportSchemaNameIsExplicit = true;
         }
@@ -150,7 +151,11 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
     public string? MessageStorageSchemaName
     {
         get => _messageStorageSchemaName;
-        set => _messageStorageSchemaName = value?.ToLowerInvariant();
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value?.ToLowerInvariant();
+        }
     }
 
     public EventForwardingTransform<T> SubscribeToEvent<T>() where T : notnull

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlBackedPersistence.cs
@@ -154,7 +154,17 @@ internal class PostgresqlBackedPersistence : IPostgresqlBackedPersistence, IWolv
     public NpgsqlDataSource? DataSource { get; set; }
     public string? ConnectionString { get; set; }
     
-    public string EnvelopeStorageSchemaName { get; set; }
+    private string _envelopeStorageSchemaName = null!;
+
+    public string EnvelopeStorageSchemaName
+    {
+        get => _envelopeStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(EnvelopeStorageSchemaName));
+            _envelopeStorageSchemaName = value;
+        }
+    }
     
     // This needs to be an override, and we use JasperFxOptions first!
     public AutoCreate AutoCreate { get; set; } = JasperFx.AutoCreate.CreateOrUpdate;

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlConfigurationExtensions.cs
@@ -42,7 +42,7 @@ public static class PostgresqlConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static IPostgresqlBackedPersistence PersistMessagesWithPostgresql(this WolverineOptions options, string connectionString,
         string? schemaName = null, MessageStoreRole role = MessageStoreRole.Main)
@@ -70,7 +70,7 @@ public static class PostgresqlConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="dataSource"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static IPostgresqlBackedPersistence PersistMessagesWithPostgresql(this WolverineOptions options, NpgsqlDataSource dataSource,
         string? schemaName = null, MessageStoreRole role = MessageStoreRole.Main)
@@ -99,7 +99,7 @@ public static class PostgresqlConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schema"></param>
+    /// <param name="schema">Schema name for the Wolverine envelope storage. A single database identifier, not a multi-part name</param>
     /// <returns></returns>
     public static PostgresqlPersistenceExpression UsePostgresqlPersistenceAndTransport(this WolverineOptions options,
         string connectionString,

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -4,6 +4,7 @@ using Npgsql;
 using Spectre.Console;
 using Weasel.Postgresql;
 using Wolverine.Configuration;
+using Wolverine.RDBMS;
 using Wolverine.RDBMS.MultiTenancy;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
@@ -23,15 +24,35 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
 
     public override Uri ResourceUri => new Uri("postgresql-transport://");
 
+    private string _transportSchemaName = "wolverine_queues";
+
     /// <summary>
     /// Schema name for the queue and scheduled message tables
     /// </summary>
-    public string TransportSchemaName { get; set; } = "wolverine_queues";
+    public string TransportSchemaName
+    {
+        get => _transportSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
+            _transportSchemaName = value;
+        }
+    }
     
+    private string _messageStorageSchemaName = "public";
+
     /// <summary>
     /// Schema name for the message storage tables
     /// </summary>
-    public string MessageStorageSchemaName { get; set; } = "public";
+    public string MessageStorageSchemaName
+    {
+        get => _messageStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value;
+        }
+    }
 
     public async ValueTask ConfigureAsync(IWolverineRuntime runtime)
     {

--- a/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseSettings.cs
@@ -10,8 +10,24 @@ public class DatabaseSettings
 {
     public DbDataSource? DataSource { get; set; }
 
+    private string? _schemaName;
+
     public string? ConnectionString { get; set; }
-    public string? SchemaName { get; set; }
+
+    /// <summary>
+    /// The database schema holding Wolverine's tables. This has to be a single database identifier;
+    /// a multi-part name is rejected here rather than at the point where it produces unusable DDL.
+    /// See <see cref="SchemaNameValidation"/> and GH-3997.
+    /// </summary>
+    public string? SchemaName
+    {
+        get => _schemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(SchemaName));
+            _schemaName = value;
+        }
+    }
 
     /// <summary>
     /// Returns the schema name properly quoted for use in SQL statements.

--- a/src/Persistence/Wolverine.RDBMS/MigrationLogger.cs
+++ b/src/Persistence/Wolverine.RDBMS/MigrationLogger.cs
@@ -18,9 +18,28 @@ public class MigrationLogger : IMigrationLogger
         _logger.LogInformation("Applied database migration for Wolverine Envelope Storage: {Sql}", sql);
     }
 
+    /// <summary>
+    /// Weasel hands a failed DDL statement here instead of throwing, because a non-default
+    /// <see cref="IMigrationLogger"/> is taken to mean the caller wants to decide. Wolverine's decision is
+    /// to fail — matching Marten, whose logger throws a <c>MartenSchemaException</c>.
+    /// </summary>
+    /// <remarks>
+    /// GH-3997: this used to only log. A misconfigured schema name meant every CREATE failed, each one
+    /// logged as an error, and startup carried on regardless — dying later inside
+    /// <c>LoadNodeAgentStateAsync</c> against an error that named nothing the user had configured.
+    /// <para>
+    /// The two paths that could legitimately see a failure here are both already covered:
+    /// <see cref="MessageDatabase{T}.MigrateAsync(JasperFx.AutoCreate?)" /> retries the whole migration once
+    /// after a short delay, which absorbs a DDL race with another node starting at the same instant, and
+    /// <c>ResourceMigrationFailureMode.ContinueOnFailures</c> lets a host that would rather start against
+    /// not-yet-migrated storage keep the old behavior.
+    /// </para>
+    /// </remarks>
     public void OnFailure(DbCommand command, Exception ex)
     {
         _logger.LogError(ex, "Error executing Wolverine Envelope Storage database migration: {Sql}",
             command.CommandText);
+
+        throw new WolverineSchemaException(command.CommandText, ex);
     }
 }

--- a/src/Persistence/Wolverine.RDBMS/SchemaNameValidation.cs
+++ b/src/Persistence/Wolverine.RDBMS/SchemaNameValidation.cs
@@ -1,0 +1,41 @@
+namespace Wolverine.RDBMS;
+
+/// <summary>
+/// Guards the schema names Wolverine is given for its message storage and database backed transports.
+/// See GH-3997.
+/// </summary>
+/// <remarks>
+/// Wolverine renders every one of its tables as <c>{schema}.{table}</c> with no delimiting -- both in the
+/// hand written SQL (<see cref="DatabaseSettings.TableNameFor"/>) and in the Weasel generated DDL, where
+/// <c>IDatabaseProvider.ToQualifiedName</c> is a plain concatenation. A "schema name" that is itself
+/// multi-part therefore produces a name with more parts than any of these engines accept -- SQL Server
+/// reports <c>The object name '...' contains more than the maximum number of prefixes. The maximum is 2</c>,
+/// and PostgreSQL reports <c>improper qualified name (too many dotted names)</c>. Weasel's
+/// <c>CREATE SCHEMA</c> is the one statement that delimits the name, so the schema itself is created and
+/// only the tables fail, which is exactly as confusing as it sounds. Catching this where the name is
+/// configured is far kinder than the failure it produces otherwise.
+/// </remarks>
+public static class SchemaNameValidation
+{
+    /// <summary>
+    /// Throws if <paramref name="schemaName"/> is a multi-part name rather than a single database
+    /// identifier.
+    /// </summary>
+    /// <remarks>
+    /// A name the caller has already delimited -- <c>[crm.sales]</c> -- is rejected along with the bare
+    /// form, even though Weasel passes a pre-delimited identifier through to the table DDL untouched.
+    /// Delimiting gets you a host that starts exactly once: Weasel's <c>CREATE SCHEMA</c> guard compares
+    /// <c>sys.schemas.name</c> against the spelling it was handed, brackets and all, so the guard never
+    /// matches and every subsequent start re-issues the <c>CREATE SCHEMA</c> against a schema that now
+    /// exists. Schema difference detection cannot match a delimited name against the catalog either, so
+    /// the store re-applies its whole DDL every time and never picks up a later column-level change.
+    /// </remarks>
+    public static void AssertValid(string? schemaName, string parameterName)
+    {
+        if (schemaName == null) return;
+        if (!schemaName.Contains('.')) return;
+
+        throw new ArgumentOutOfRangeException(parameterName, schemaName,
+            $"'{schemaName}' is not a usable database schema name for Wolverine. A schema name has to be a single database identifier, but this one is multi-part -- Wolverine would emit '{schemaName}.wolverine_incoming_envelopes', and no supported database engine accepts a name with that many parts. Did you mean '{schemaName.Split('.')[0]}', with the database itself chosen by the connection string? Delimiting the name does not help: the schema would be created, but every restart afterwards fails.");
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/WolverineSchemaException.cs
+++ b/src/Persistence/Wolverine.RDBMS/WolverineSchemaException.cs
@@ -1,0 +1,20 @@
+namespace Wolverine.RDBMS;
+
+/// <summary>
+/// Thrown when a DDL statement in Wolverine's own database migration fails. See GH-3997: these failures
+/// used to be logged and swallowed, so the host started up against storage that had never been created
+/// and died much later against an error that named nothing recognizable.
+/// </summary>
+public class WolverineSchemaException : Exception
+{
+    public WolverineSchemaException(string sql, Exception innerException) : base(
+        $"Error while applying a Wolverine database migration:\n\n{sql}\n\n{innerException.Message}", innerException)
+    {
+        Sql = sql;
+    }
+
+    /// <summary>
+    /// The DDL that failed
+    /// </summary>
+    public string Sql { get; }
+}

--- a/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerBackedPersistence.cs
@@ -131,7 +131,17 @@ internal class SqlServerBackedPersistence : IWolverineExtension, ISqlServerBacke
 
     public string? ConnectionString { get; set; }
     
-    public string EnvelopeStorageSchemaName { get; set; } = "wolverine";
+    private string _envelopeStorageSchemaName = "wolverine";
+
+    public string EnvelopeStorageSchemaName
+    {
+        get => _envelopeStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(EnvelopeStorageSchemaName));
+            _envelopeStorageSchemaName = value;
+        }
+    }
     
     // This needs to be an override, and we use JasperFxOptions first!
     public AutoCreate AutoCreate { get; set; } = JasperFx.AutoCreate.CreateOrUpdate;

--- a/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.SqlServer/SqlServerConfigurationExtensions.cs
@@ -23,7 +23,7 @@ public static class SqlServerConfigurationExtensions
     /// </summary>
     /// <param name="settings"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schema">Potentially override the schema name for Wolverine envelope storage. Default is to use WolverineOptions.Durability.MessageStorageSchemaName ?? "dbo"</param>
+    /// <param name="schema">Potentially override the schema name for Wolverine envelope storage. Default is to use WolverineOptions.Durability.MessageStorageSchemaName ?? "dbo". This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     public static ISqlServerBackedPersistence PersistMessagesWithSqlServer(this WolverineOptions options, string connectionString,
         string? schema = null, MessageStoreRole role = MessageStoreRole.Main)
     {
@@ -79,7 +79,7 @@ public static class SqlServerConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schema"></param>
+    /// <param name="schema">Schema name for the Wolverine envelope storage. A single database identifier, not a multi-part name</param>
     /// <returns></returns>
     public static SqlServerPersistenceExpression UseSqlServerPersistenceAndTransport(this WolverineOptions options,
         string connectionString,

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -41,6 +41,8 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
 
     public LightweightCache<string, SqlServerQueue> Queues { get; }
 
+    private string _transportSchemaName = "dbo";
+
     /// <summary>
     /// Schema name for the queue and scheduled message tables
     /// </summary>
@@ -51,12 +53,30 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
     /// The queue/scheduled tables are built lazily per queue, so reassignment before the
     /// runtime initializes the transport is safe.
     /// </remarks>
-    public string TransportSchemaName { get; set; } = "dbo";
+    public string TransportSchemaName
+    {
+        get => _transportSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(TransportSchemaName));
+            _transportSchemaName = value;
+        }
+    }
+
+    private string _messageStorageSchemaName = "dbo";
 
     /// <summary>
     /// Schema name for the message storage tables
     /// </summary>
-    public string MessageStorageSchemaName { get; set; } = "dbo";
+    public string MessageStorageSchemaName
+    {
+        get => _messageStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(MessageStorageSchemaName));
+            _messageStorageSchemaName = value;
+        }
+    }
 
     /// <summary>
     /// Opt into the higher-throughput queue table storage layout: queue and scheduled tables are

--- a/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteBackedPersistence.cs
@@ -120,7 +120,17 @@ internal class SqliteBackedPersistence : ISqliteBackedPersistence, IWolverineExt
     public DbDataSource? DataSource { get; set; }
     public string? ConnectionString { get; set; }
 
-    public string EnvelopeStorageSchemaName { get; set; }
+    private string _envelopeStorageSchemaName = null!;
+
+    public string EnvelopeStorageSchemaName
+    {
+        get => _envelopeStorageSchemaName;
+        set
+        {
+            SchemaNameValidation.AssertValid(value, nameof(EnvelopeStorageSchemaName));
+            _envelopeStorageSchemaName = value;
+        }
+    }
 
     public AutoCreate AutoCreate { get; set; } = JasperFx.AutoCreate.CreateOrUpdate;
 

--- a/src/Persistence/Wolverine.Sqlite/SqliteConfigurationExtensions.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteConfigurationExtensions.cs
@@ -15,7 +15,7 @@ public static class SqliteConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="connectionString"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static ISqliteBackedPersistence PersistMessagesWithSqlite(this WolverineOptions options, string connectionString,
         string? schemaName = null, MessageStoreRole role = MessageStoreRole.Main)
@@ -44,7 +44,7 @@ public static class SqliteConfigurationExtensions
     /// </summary>
     /// <param name="options"></param>
     /// <param name="dataSource"></param>
-    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage</param>
+    /// <param name="schemaName">Optional schema name for the Wolverine envelope storage. This has to be a single database identifier; a multi-part name like "crm.sales" is rejected. See GH-3997</param>
     /// <param name="role">Default is Main. Use this to mark some stores as Ancillary to disambiguate the main storage for Wolverine</param>
     public static ISqliteBackedPersistence PersistMessagesWithSqlite(this WolverineOptions options, DbDataSource dataSource,
         string? schemaName = null, MessageStoreRole role = MessageStoreRole.Main)


### PR DESCRIPTION
Closes #3997.

## What was reported

```csharp
opts.PersistMessagesWithSqlServer(cnxString, "crm.sales.opportunities");
```

```
The object name 'crm.sales.opportunities.wolverine_node_records' contains more than
the maximum number of prefixes. The maximum is 2.
```

## What actually happens

Wolverine renders every one of its tables as `{schema}.{table}` with no delimiting — in the hand-written SQL (`DatabaseSettings.TableNameFor`) and in the Weasel DDL, where `IDatabaseProvider.ToQualifiedName` is a plain concatenation. A multi-part schema name therefore produces a four-part name. Not SQL Server-specific: PostgreSQL answers `improper qualified name (too many dotted names)`.

Weasel's `CREATE SCHEMA` is the one statement that *does* delimit the name, which is why the reporter ends up with the schema created and no tables.

And the failures were swallowed. Wolverine hands Weasel a `MigrationLogger` whose `OnFailure` only logged, and Weasel rethrows only for a `DefaultMigrationLogger`, so startup carried on and died a long way from the cause — in `LoadNodeAgentStateAsync`, against `Could not find server 'crm' in sys.servers` (SQL Server reads a four-part name as *server.database.schema.object*).

## What this changes

**Multi-part schema names are rejected where they are configured.** `SchemaNameValidation.AssertValid` throws an `ArgumentOutOfRangeException` naming the value and suggesting the first segment. It is wired into `DatabaseSettings.SchemaName` (the catch-all every provider, transport and tenanted store funnels through), each provider's `EnvelopeStorageSchemaName`, the four database-backed transports' `TransportSchemaName` / `MessageStorageSchemaName`, and the same two on the Marten, Polecat and Fisher integrations.

A pre-delimited name (`"[crm.sales]"`) is rejected as well. It reaches steady state exactly once: Weasel's `CREATE SCHEMA` guard compares `sys.schemas.name` against the spelling it was handed, brackets and all, so every restart re-issues the `CREATE SCHEMA` against a schema that now exists. Schema difference detection cannot match a delimited name against the catalog either, so the store re-applies its whole DDL every start and never picks up a later column-level change.

**Failed migrations now fail startup.** `MigrationLogger.OnFailure` throws a `WolverineSchemaException` carrying the SQL, which is what Marten's logger has always done. The tolerant path is unchanged and already wired: `WolverineRuntime.tryMigrateStorage` honors `ResourceMigrationFailureMode.ContinueOnFailures`, and `MessageDatabase.MigrateAsync` already retries the whole migration once after a random delay, which absorbs a real race between two nodes starting at the same instant.

## Two Weasel defects this exposed — fixed in 9.26.0, bumped here

Both were failing on every run before this, logged and ignored. Each was confirmed against `origin/main` with these changes stashed, so neither is caused by the fail-fast.

- **[weasel#504](https://github.com/JasperFx/weasel/issues/504)** — the PostgreSQL index query filtered `NOT nspname LIKE 'pg%'` to skip `pg_catalog`/`pg_toast`, which also hid every index in a *user* schema whose name began with "pg". Those indexes came back Missing rather than Different, so each start re-issued `create index` and answered `42P07` — and since a delta runs as one command, everything after the first failure was skipped. Bisected on the schema name alone: `pg3997` failed, `wolv3997` was clean. `control_queue_tests` had been logging this on every run; it stays on the `pgcontrol` schema deliberately now, as a regression canary.
- **[weasel#505](https://github.com/JasperFx/weasel/issues/505)** — Sql Server's column drop did not first drop the auto-named default constraint that depends on the column, so a column declared with a default could be added by a migration but never removed by one. Reachable from configuration: `OutboxStaleTime` / `InboxStaleTime` add a `timestamp` column with a `GETUTCDATE()` default, so turning either back off left a database that could not migrate forward. `bumping_stale_inbox_messages` and `bumping_stale_outbox_messages` shared the `stale_outbox` schema and disagreed about that column, so whichever ran second had been failing silently; they now use separate schemas and no longer depend on run order.

## Verification

`dotnet build wolverine.slnx -c Release -f net9.0` clean, and locally green on Weasel 9.26.0: PostgreSQL 493, Sql Server 405, Marten 610, Persistence 105, SQLite 170, Fisher 27.

New coverage in `PersistenceTests/schema_name_validation.cs`: rejection for bare and delimited multi-part names, the usable names that must still pass, the provider entry points, and that `OnFailure` throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3
