### PR TITLE
GH-3509: Wolverine-driven TTL/GC for claim-check payloads

### DIFF
--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -247,7 +247,7 @@ An overload accepting an existing `NpgsqlDataSource` is also available if you wa
 opts.UseClaimCheck(cc => cc.UsePostgresqlClaimCheck(myDataSource));
 ```
 
-The claim check table is created on first use (`create schema/table if not exists`). Token id maps to the row's primary key; the content type and length are stored alongside the `bytea` body. `DeleteAsync` is naturally idempotent — deleting a missing row is a no-op. Because the payloads live in a table you own, database-native cleanup (a scheduled `delete ... where created < ...`) is straightforward.
+The claim check table is created on first use (`create schema/table if not exists`). Token id maps to the row's primary key; the content type and length are stored alongside the `bytea` body. `DeleteAsync` is naturally idempotent — deleting a missing row is a no-op. This backend supports Wolverine-driven expiration — see [Expiring old payloads](#expiring-old-payloads) — and because the payloads live in a table you own, database-native cleanup (a scheduled `delete ... where created < ...`) works too.
 
 ### File system (built in)
 
@@ -259,14 +259,75 @@ opts.UseClaimCheck(cc => cc.UseFileSystem("/var/wolverine/claim-checks"));
 
 Each payload is written as `{id}.bin`, with a sidecar `{id}.meta` file recording the original content type so the round-trip is lossless even if the token were ever reconstructed externally.
 
+## Expiring old payloads
+
+Nothing about a successful send tells Wolverine when the payload behind it stops being needed — the
+message may still be scheduled, retrying, or parked in a dead-letter queue. So by default Wolverine
+does not delete off-loaded payloads at all, and they accumulate until something else removes them.
+
+There are two ways to close that gap, and for object stores the first is usually the better one:
+
+**1. Native lifecycle rules.** Azure Blob Storage, Amazon S3, and Google Cloud Storage all expire
+objects server-side for free. Point a lifecycle policy at the container/bucket (or prefix) your
+claim-check store writes to and you are done — no Wolverine configuration, no LIST charges, and it
+keeps working even while your application is down. These backends deliberately do **not** implement
+Wolverine-driven sweeping for exactly that reason.
+
+**2. A Wolverine-driven sweep.** For backends with no native lifecycle support — the file system
+store and the database-LOB stores — call `DeletePayloadsOlderThan`:
+
+```csharp
+opts.UseClaimCheck(cc =>
+{
+    cc.UsePostgresqlClaimCheck(connectionString);
+
+    // Delete off-loaded payloads more than seven days old
+    cc.DeletePayloadsOlderThan(7.Days());
+
+    // Optional tuning
+    cc.SweepInterval = 10.Minutes();   // default
+    cc.SweepBatchSize = 1000;          // payloads deleted per store, per pass
+});
+```
+
+::: warning Size the TTL against your slowest delivery, not your fastest
+The sweep deletes purely by age, and it has no idea whether a message that references a payload is
+still in flight. The TTL must comfortably exceed the longest window in which a message could still
+need to re-hydrate — scheduled delivery, retry back-offs, and time spent sitting in a dead-letter
+queue awaiting a replay all count. A payload swept out from under a message that is delivered later
+will fail to load.
+:::
+
+A few properties worth knowing:
+
+- **It runs on every node, not just the leader.** Deleting by age is idempotent, so overlapping
+  sweeps are harmless, and each node jitters its own schedule. This is deliberate: leader election
+  requires message persistence, but claim checks do not, so a leader-pinned sweeper would silently
+  never run for apps using claim checks without a durable message store.
+- **Every configured store is swept**, including any per-message or per-endpoint stores registered
+  with `StoreForMessage<T>` / `StoreWhen` — not just the default one.
+- **Backends that cannot be swept are skipped with a warning** naming the store type, so a TTL that
+  is not actually doing anything is visible in the logs rather than silently ignored.
+- **A full batch triggers an immediate follow-up pass**, so a large backlog drains without waiting
+  out `SweepInterval` between every batch.
+
+### Writing a sweepable backend
+
+A custom `IClaimCheckStore` opts into sweeping by implementing `IClaimCheckStoreWithExpiration`:
+
+<<< @/../src/Wolverine/Persistence/ClaimCheck/IClaimCheckStoreWithExpiration.cs
+
+Implementations must tolerate concurrent sweeps from several nodes, and deleting an already-deleted
+payload must not throw.
+
 ## Operational considerations
 
-- **Lifetime of stored payloads.** The pipeline never auto-deletes blobs. If you let large payloads accumulate, they will eat storage. The recommended pattern is to use the storage system's native lifecycle support (S3 lifecycle rules, Azure Blob Storage lifecycle policies, or a periodic cleanup job for the file system backend) keyed off blob age. A future enhancement may add Wolverine-driven TTL; tracked separately.
+- **Lifetime of stored payloads.** By default the pipeline only deletes a payload when the send that created it fails outright. Everything successfully sent accumulates until something removes it — either a Wolverine-driven TTL (see [Expiring old payloads](#expiring-old-payloads)) or your storage system's own lifecycle rules.
 - **Synchronous serializer hot path.** `IMessageSerializer.Write` and `IMessageSerializer.ReadFromData` are synchronous. When the inner serializer is `IAsyncMessageSerializer` (most are), the pipeline preserves async end-to-end. If your inner serializer is sync-only, the upload/download will block on the hot path; pre-uploading payloads outside the serializer is an option for very high-throughput scenarios.
 - **Backend failures.** If the store is unreachable on send, the publish fails and Wolverine's normal retry/dead-letter machinery applies. If the store is unreachable on receive, the handler chain throws and the message is retried per its failure rules — the same behavior as if the original payload were corrupted in transport.
 - **Tokens are opaque.** Don't parse `ClaimCheckToken.Id`. Backends are free to use whatever id format makes sense (`Guid.ToString("N")` for the bundled stores).
 - **Local queues and in-process routing.** A *durable* local queue serializes the envelope when it persists it, so the off-load fires for it exactly as it would for an external transport. A *buffered* (in-memory) local queue never serializes the local hand-off, so no off-load happens there. Either way the handler receives a fully-populated message: the off-loaded properties are restored on the live message after serialization (see [How it works](#how-it-works)).
-- **Off-loading requires an envelope.** The claim-check token is carried in an envelope header, so the off-load only round-trips through Wolverine's normal `Write(envelope)` / `WriteAsync(envelope)` paths. Serializing a `[Blob]` message outside that path — for example a raw `IMessageSerializer.WriteMessage(object)` call with no envelope — cannot carry the token, so the payload would not be recoverable on the other side.
+- **Off-loading requires an envelope.** The claim-check token is carried in an envelope header, so the off-load only round-trips through Wolverine's normal `Write(envelope)` / `WriteAsync(envelope)` paths. Serializing a `[Blob]` message outside that path — for example a raw `IMessageSerializer.WriteMessage(object)` call with no envelope — cannot carry the token, so the payload would not be recoverable on the other side. That path therefore does not upload anything at all; it clears the `[Blob]` properties so the serialized body stays small, then restores them on the live message.
 
 ## Issue tracking
 

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/PostgresqlClaimCheckStoreExpirationTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql.Tests/PostgresqlClaimCheckStoreExpirationTests.cs
@@ -1,0 +1,146 @@
+using IntegrationTests;
+using Npgsql;
+using Shouldly;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Postgresql.Tests;
+
+/// <summary>
+/// GH-3509: <see cref="IClaimCheckStoreWithExpiration"/> support on the PostgreSQL backend.
+/// </summary>
+public class PostgresqlClaimCheckStoreExpirationTests : IAsyncLifetime
+{
+    private readonly string _schema = "claim_check_ttl_" + Guid.NewGuid().ToString("N")[..12];
+    private NpgsqlDataSource _dataSource = null!;
+    private PostgresqlClaimCheckStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        _store = new PostgresqlClaimCheckStore(_dataSource, _schema);
+
+        await _store.DeleteAsync(new ClaimCheckToken("warmup", "text/plain", 0));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"drop schema if exists \"{_schema}\" cascade";
+            await cmd.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    private async Task<ClaimCheckToken> storeAged(TimeSpan age)
+    {
+        var token = await _store.StoreAsync(new byte[] { 1, 2, 3 }, "application/octet-stream",
+            TestContext.Current.CancellationToken);
+
+        await using var conn = await _dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"update \"{_schema}\".\"wolverine_claim_check\" set created = @created where id = @id";
+        cmd.Parameters.AddWithValue("created", DateTime.UtcNow - age);
+        cmd.Parameters.AddWithValue("id", token.Id);
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+
+        return token;
+    }
+
+    private async Task<long> countRows()
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select count(*) from \"{_schema}\".\"wolverine_claim_check\"";
+        return (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    [Fact]
+    public async Task deletes_aged_rows_and_leaves_recent_ones()
+    {
+        var old = await storeAged(TimeSpan.FromHours(2));
+        var recent = await storeAged(TimeSpan.FromMinutes(1));
+
+        var deleted = await _store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow.AddHours(-1), 100,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(1);
+
+        await Should.ThrowAsync<KeyNotFoundException>(() => _store.LoadAsync(old));
+
+        (await _store.LoadAsync(recent, TestContext.Current.CancellationToken)).ToArray()
+            .ShouldBe(new byte[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task honors_the_max_count()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            await storeAged(TimeSpan.FromHours(2));
+        }
+
+        var deleted = await _store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow.AddHours(-1), 2,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(2);
+        (await countRows()).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_repeat_sweep_is_a_no_op()
+    {
+        await storeAged(TimeSpan.FromHours(2));
+
+        var cutoff = DateTimeOffset.UtcNow.AddHours(-1);
+        (await _store.DeleteExpiredPayloadsAsync(cutoff, 100, TestContext.Current.CancellationToken)).ShouldBe(1);
+        (await _store.DeleteExpiredPayloadsAsync(cutoff, 100, TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task created_is_written_as_true_utc_regardless_of_the_session_time_zone()
+    {
+        // The column default was `now() at time zone 'utc'`, which lands local wall clock in a
+        // timestamptz column. The store writes `created` explicitly so the sweep's UTC cutoff is
+        // comparable no matter what time zone the session is running in.
+        await using (var conn = await _dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken))
+        {
+            await using var setTz = conn.CreateCommand();
+            setTz.CommandText = "set time zone 'America/Chicago'";
+            await setTz.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var token = await _store.StoreAsync(new byte[] { 9 }, "text/plain", TestContext.Current.CancellationToken);
+
+        await using var check = await _dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await using var cmd = check.CreateCommand();
+        cmd.CommandText = $"select created from \"{_schema}\".\"wolverine_claim_check\" where id = @id";
+        cmd.Parameters.AddWithValue("id", token.Id);
+
+        var created = (DateTime)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+
+        // Within a couple of minutes of "now" -- an hours-off value means the offset bug is back.
+        (DateTime.UtcNow - created).Duration().ShouldBeLessThan(TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public async Task the_created_index_is_provisioned()
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select count(*) from pg_indexes where schemaname = @schema and indexname = 'wolverine_claim_check_created_idx'";
+        cmd.Parameters.AddWithValue("schema", _schema);
+
+        ((long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!).ShouldBe(1);
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Postgresql/PostgresqlClaimCheckStore.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Postgresql/PostgresqlClaimCheckStore.cs
@@ -11,7 +11,7 @@ namespace Wolverine.ClaimCheck.Postgresql;
 /// PostgreSQL database — the zero-new-infrastructure option for critter-stack users, requiring no
 /// S3 / Azure / GCS account. The <see cref="ClaimCheckToken.Id"/> maps to the row's primary key.
 /// </summary>
-public class PostgresqlClaimCheckStore : IClaimCheckStore
+public class PostgresqlClaimCheckStore : IClaimCheckStoreWithExpiration
 {
     // Postgres identifiers we build DDL/DML for are validated against this so the schema/table
     // names (which come from configuration) can be safely embedded in quoted identifiers.
@@ -21,6 +21,7 @@ public class PostgresqlClaimCheckStore : IClaimCheckStore
     private readonly string _schemaName;
     private readonly string _tableName;
     private readonly string _qualifiedTable;
+    private readonly string _createdIndexName;
 
     private readonly SemaphoreSlim _gate = new(1, 1);
     private bool _provisioned;
@@ -61,6 +62,7 @@ public class PostgresqlClaimCheckStore : IClaimCheckStore
         _schemaName = schemaName;
         _tableName = tableName;
         _qualifiedTable = $"\"{schemaName}\".\"{tableName}\"";
+        _createdIndexName = $"\"{tableName}_created_idx\"";
     }
 
     /// <summary>The schema that owns the claim check table.</summary>
@@ -85,12 +87,21 @@ public class PostgresqlClaimCheckStore : IClaimCheckStore
 
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var cmd = conn.CreateCommand();
+        // created is written explicitly rather than left to the column default. The default is
+        // `now() at time zone 'utc'`, which yields a timestamp WITHOUT time zone holding UTC wall clock
+        // and is then re-interpreted in the session's time zone on the way into the timestamptz column --
+        // so on any non-UTC session the stored value is skewed by the offset. The expiration sweep
+        // (GH-3509) compares against a true UTC cutoff, so it needs a true UTC value here. Setting it on
+        // the insert also fixes tables that were already provisioned with the old default.
         cmd.CommandText =
-            $"insert into {_qualifiedTable} (id, content_type, body, length) values (@id, @ct, @body, @len)";
+            $"insert into {_qualifiedTable} (id, content_type, body, length, created) " +
+            "values (@id, @ct, @body, @len, @created)";
         cmd.Parameters.AddWithValue("id", id);
         cmd.Parameters.AddWithValue("ct", contentType);
         cmd.Parameters.Add(new NpgsqlParameter("body", NpgsqlDbType.Bytea) { Value = payload.ToArray() });
         cmd.Parameters.AddWithValue("len", (long)payload.Length);
+        cmd.Parameters.Add(new NpgsqlParameter("created", NpgsqlDbType.TimestampTz)
+            { Value = DateTime.UtcNow });
 
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -141,6 +152,34 @@ public class PostgresqlClaimCheckStore : IClaimCheckStore
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// GH-3509 sweep support. The <c>ctid</c> sub-select is what lets a plain <c>delete</c> honour a
+    /// <c>limit</c> — PostgreSQL has no <c>delete ... limit</c> — so one pass removes a bounded batch
+    /// rather than locking every expired row at once.
+    /// </summary>
+    public async Task<int> DeleteExpiredPayloadsAsync(
+        DateTimeOffset cutoff,
+        int maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxCount <= 0)
+        {
+            return 0;
+        }
+
+        await ensureProvisionedAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"delete from {_qualifiedTable} where ctid in " +
+            $"(select ctid from {_qualifiedTable} where created < @cutoff limit @max)";
+        cmd.Parameters.AddWithValue("cutoff", cutoff.UtcDateTime);
+        cmd.Parameters.AddWithValue("max", maxCount);
+
+        return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     private async Task ensureProvisionedAsync(CancellationToken cancellationToken)
     {
         if (_provisioned)
@@ -165,7 +204,10 @@ public class PostgresqlClaimCheckStore : IClaimCheckStore
                 "content_type text not null, " +
                 "body bytea not null, " +
                 "length bigint not null, " +
-                "created timestamptz not null default (now() at time zone 'utc'));";
+                "created timestamptz not null default now());" +
+                // GH-3509: the expiration sweep filters on created, and every row here is a large
+                // payload -- without this index the sweep seq-scans the whole table on every pass.
+                $"create index if not exists {_createdIndexName} on {_qualifiedTable} (created);";
 
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Testing/CoreTests/Persistence/ClaimCheck/ExpiringInMemoryClaimCheckStore.cs
+++ b/src/Testing/CoreTests/Persistence/ClaimCheck/ExpiringInMemoryClaimCheckStore.cs
@@ -1,0 +1,116 @@
+using System.Collections.Concurrent;
+using Wolverine.Persistence;
+
+namespace CoreTests.Persistence.ClaimCheck;
+
+/// <summary>
+/// An in-memory <see cref="IClaimCheckStoreWithExpiration"/> whose payload timestamps can be back-dated,
+/// so a test can prove the GH-3509 sweeper deletes aged payloads without waiting out a real TTL.
+/// </summary>
+public sealed class ExpiringInMemoryClaimCheckStore : IClaimCheckStoreWithExpiration
+{
+    private readonly ConcurrentDictionary<string, Entry> _payloads = new();
+
+    public int SweepCount;
+
+    private sealed record Entry(byte[] Payload, DateTimeOffset Created);
+
+    public IReadOnlyCollection<string> Ids => _payloads.Keys.ToList();
+
+    public int Count => _payloads.Count;
+
+    /// <summary>Back-date a stored payload so it looks older than the sweeper's cutoff.</summary>
+    public void Age(string id, TimeSpan by)
+    {
+        if (_payloads.TryGetValue(id, out var entry))
+        {
+            _payloads[id] = entry with { Created = entry.Created - by };
+        }
+    }
+
+    public Task<ClaimCheckToken> StoreAsync(ReadOnlyMemory<byte> payload, string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        var id = Guid.NewGuid().ToString("N");
+        _payloads[id] = new Entry(payload.ToArray(), DateTimeOffset.UtcNow);
+        return Task.FromResult(new ClaimCheckToken(id, contentType, payload.Length));
+    }
+
+    public Task<ReadOnlyMemory<byte>> LoadAsync(ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_payloads.TryGetValue(token.Id, out var entry))
+        {
+            throw new KeyNotFoundException($"No claim-check payload stored under '{token.Id}'.");
+        }
+
+        return Task.FromResult<ReadOnlyMemory<byte>>(entry.Payload);
+    }
+
+    public Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+    {
+        _payloads.TryRemove(token.Id, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<int> DeleteExpiredPayloadsAsync(DateTimeOffset cutoff, int maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref SweepCount);
+
+        var deleted = 0;
+        foreach (var pair in _payloads)
+        {
+            if (deleted >= maxCount)
+            {
+                break;
+            }
+
+            if (pair.Value.Created < cutoff && _payloads.TryRemove(pair.Key, out _))
+            {
+                deleted++;
+            }
+        }
+
+        return Task.FromResult(deleted);
+    }
+}
+
+/// <summary>
+/// A store that succeeds for the first <see cref="FailAfter"/> uploads and then throws, so a test can
+/// assert that a partially-completed off-load cleans up the payloads it already wrote (GH-3509).
+/// </summary>
+public sealed class FailAfterNClaimCheckStore : IClaimCheckStore
+{
+    private readonly ConcurrentDictionary<string, byte[]> _payloads = new();
+    private int _stored;
+
+    public int FailAfter { get; init; } = 1;
+
+    public int Count => _payloads.Count;
+    public int DeleteCount;
+
+    public Task<ClaimCheckToken> StoreAsync(ReadOnlyMemory<byte> payload, string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Increment(ref _stored) > FailAfter)
+        {
+            throw new InvalidOperationException("Simulated claim-check storage failure.");
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+        _payloads[id] = payload.ToArray();
+        return Task.FromResult(new ClaimCheckToken(id, contentType, payload.Length));
+    }
+
+    public Task<ReadOnlyMemory<byte>> LoadAsync(ClaimCheckToken token,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<ReadOnlyMemory<byte>>(_payloads[token.Id]);
+
+    public Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref DeleteCount);
+        _payloads.TryRemove(token.Id, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Testing/CoreTests/Persistence/ClaimCheck/claim_check_sweeper.cs
+++ b/src/Testing/CoreTests/Persistence/ClaimCheck/claim_check_sweeper.cs
@@ -1,0 +1,160 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Persistence.ClaimCheck.Internal;
+using Xunit;
+
+namespace CoreTests.Persistence.ClaimCheck;
+
+/// <summary>
+/// GH-3509: the background sweeper that deletes aged claim-check payloads. It is registered only when
+/// a time to live was configured, and it sweeps every configured store, not just the default one.
+/// </summary>
+public class claim_check_sweeper
+{
+    private static async Task<IHost> hostFor(Action<ClaimCheckConfiguration> configure)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(claim_check_sweeper).Assembly;
+                opts.UseClaimCheck(configure);
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task no_sweeper_is_registered_without_a_configured_ttl()
+    {
+        using var host = await hostFor(c => c.Store = new ExpiringInMemoryClaimCheckStore());
+
+        // Default behavior must be unchanged: Wolverine never deletes a payload unless asked to.
+        host.Services.GetServices<IHostedService>().OfType<ClaimCheckSweeper>().ShouldBeEmpty();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task the_sweeper_is_registered_when_a_ttl_is_configured()
+    {
+        using var host = await hostFor(c =>
+        {
+            c.Store = new ExpiringInMemoryClaimCheckStore();
+            c.DeletePayloadsOlderThan(1.Hours());
+        });
+
+        host.Services.GetServices<IHostedService>().OfType<ClaimCheckSweeper>().ShouldHaveSingleItem();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task calling_use_claim_check_twice_registers_exactly_one_sweeper()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(claim_check_sweeper).Assembly;
+                opts.UseClaimCheck(c =>
+                {
+                    c.Store = new ExpiringInMemoryClaimCheckStore();
+                    c.DeletePayloadsOlderThan(1.Hours());
+                });
+                opts.UseClaimCheck(c =>
+                {
+                    c.Store = new ExpiringInMemoryClaimCheckStore();
+                    c.DeletePayloadsOlderThan(2.Hours());
+                });
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        host.Services.GetServices<IHostedService>().OfType<ClaimCheckSweeper>().ShouldHaveSingleItem();
+        host.Services.GetServices<ClaimCheckSweepSettings>().ShouldHaveSingleItem()
+            .TimeToLive.ShouldBe(2.Hours());
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task sweeps_aged_payloads_out_of_every_configured_store()
+    {
+        var defaultStore = new ExpiringInMemoryClaimCheckStore();
+        var routedStore = new ExpiringInMemoryClaimCheckStore();
+
+        var stale = await defaultStore.StoreAsync(new byte[] { 1 }, "text/plain", TestContext.Current.CancellationToken);
+        var staleRouted = await routedStore.StoreAsync(new byte[] { 2 }, "text/plain", TestContext.Current.CancellationToken);
+        var fresh = await defaultStore.StoreAsync(new byte[] { 3 }, "text/plain", TestContext.Current.CancellationToken);
+
+        defaultStore.Age(stale.Id, 10.Hours());
+        routedStore.Age(staleRouted.Id, 10.Hours());
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(claim_check_sweeper).Assembly;
+                opts.UseClaimCheck(c =>
+                {
+                    c.Store = defaultStore;
+                    c.StoreForMessage<BlobStringMessage>(routedStore);
+                    c.DeletePayloadsOlderThan(1.Hours());
+                    c.SweepInterval = 1.Seconds();
+                });
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            await waitFor(() => defaultStore.Count == 1 && routedStore.Count == 0);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The routed store must be swept too -- a multi-store configuration would otherwise leak
+        // everything that was not sent through the default backend.
+        routedStore.Count.ShouldBe(0);
+
+        defaultStore.Count.ShouldBe(1);
+        defaultStore.Ids.ShouldContain(fresh.Id);
+    }
+
+    [Fact]
+    public async Task a_store_without_expiration_support_is_skipped_without_throwing()
+    {
+        var unsupported = new RecordingInMemoryClaimCheckStore();
+
+        using var host = await hostFor(c =>
+        {
+            c.Store = unsupported;
+            c.DeletePayloadsOlderThan(1.Hours());
+            c.SweepInterval = 1.Seconds();
+        });
+
+        // Give the sweeper time to wake, notice the backend cannot be swept, log, and carry on.
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
+
+        host.Services.GetServices<IHostedService>().OfType<ClaimCheckSweeper>().ShouldHaveSingleItem();
+        unsupported.DeleteCount.ShouldBe(0);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task waitFor(Func<bool> condition)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        throw new TimeoutException("The claim-check sweeper did not reach the expected state in time.");
+    }
+}

--- a/src/Testing/CoreTests/Persistence/ClaimCheck/offload_failure_cleanup.cs
+++ b/src/Testing/CoreTests/Persistence/ClaimCheck/offload_failure_cleanup.cs
@@ -1,0 +1,97 @@
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence;
+using Wolverine.Persistence.ClaimCheck.Internal;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Persistence.ClaimCheck;
+
+/// <summary>
+/// GH-3509: the two places the pipeline used to orphan a payload with no token on the wire that could
+/// ever reference it. <see cref="claim_check_serializer_restore"/> covers restoring the in-memory
+/// message on the same failure path; this covers cleaning up the storage backend.
+/// </summary>
+public class offload_failure_cleanup
+{
+    private static ClaimCheckMessageSerializer sutFor(IClaimCheckStore store)
+    {
+        var inner = new SystemTextJsonSerializer(SystemTextJsonSerializer.DefaultOptions());
+        return new ClaimCheckMessageSerializer(inner, store);
+    }
+
+    [Fact]
+    public void a_partial_offload_deletes_the_payloads_it_already_uploaded()
+    {
+        // The first [Blob] property uploads fine, the second throws. The first payload's token never
+        // reaches the wire, so nothing will ever load or delete it -- the serializer must clean it up.
+        var store = new FailAfterNClaimCheckStore { FailAfter = 1 };
+        var sut = sutFor(store);
+
+        var message = new MultiBlobMessage("multi", new byte[] { 1, 2, 3, 4 }, new string('z', 64));
+
+        Should.Throw<InvalidOperationException>(() => sut.Write(new Envelope(message)));
+
+        store.DeleteCount.ShouldBe(1);
+        store.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_partial_offload_deletes_uploaded_payloads_on_the_async_path_too()
+    {
+        var store = new FailAfterNClaimCheckStore { FailAfter = 1 };
+        var sut = sutFor(store);
+
+        var message = new MultiBlobMessage("multi", new byte[] { 1, 2, 3, 4 }, new string('z', 64));
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await sut.WriteAsync(new Envelope(message)));
+
+        store.DeleteCount.ShouldBe(1);
+        store.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void a_failed_whole_body_offload_deletes_the_property_payloads()
+    {
+        // Both [Blob] properties upload, then the GH-3504 whole-body off-load throws. The property
+        // tokens were stamped onto an envelope that is now never going to be sent.
+        var store = new FailAfterNClaimCheckStore { FailAfter = 2 };
+        var sut = new ClaimCheckMessageSerializer(
+            new SystemTextJsonSerializer(SystemTextJsonSerializer.DefaultOptions()),
+            store,
+            autoOffloadThreshold: 1);
+
+        var message = new MultiBlobMessage("multi", new byte[] { 1, 2, 3, 4 }, new string('z', 64));
+
+        Should.Throw<InvalidOperationException>(() => sut.Write(new Envelope(message)));
+
+        store.DeleteCount.ShouldBe(2);
+        store.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void write_message_without_an_envelope_uploads_nothing()
+    {
+        // There is no envelope here, so a token could never be stamped anywhere -- uploading would
+        // orphan a payload on every single call. The properties are still cleared so the inner
+        // serializer keeps the body small, then restored on the live message.
+        var store = new RecordingInMemoryClaimCheckStore();
+        var sut = sutFor(store);
+
+        var image = new byte[] { 1, 2, 3, 4 };
+        var notes = new string('z', 64);
+        var message = new MultiBlobMessage("multi", image, notes);
+
+        var json = System.Text.Encoding.UTF8.GetString(sut.WriteMessage(message));
+
+        store.StoreCount.ShouldBe(0);
+
+        // The payloads must still be absent from the serialized body...
+        json.ShouldNotContain(notes);
+
+        // ...while the live message is left intact for in-process hand-off.
+        message.Image.ShouldBe(image);
+        message.Notes.ShouldBe(notes);
+    }
+}

--- a/src/Testing/CoreTests/Persistence/ClaimCheck/payload_expiration.cs
+++ b/src/Testing/CoreTests/Persistence/ClaimCheck/payload_expiration.cs
@@ -1,0 +1,116 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace CoreTests.Persistence.ClaimCheck;
+
+/// <summary>
+/// GH-3509: coverage for <see cref="IClaimCheckStoreWithExpiration"/> against the file-system backend.
+/// The database backends run the same shape of assertions in their own suites.
+/// </summary>
+public class payload_expiration : IDisposable
+{
+    private readonly string _directory;
+    private readonly FileSystemClaimCheckStore _store;
+
+    public payload_expiration()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "wolverine-claim-check-ttl-" + Guid.NewGuid().ToString("N"));
+        _store = new FileSystemClaimCheckStore(_directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_directory))
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private async Task<ClaimCheckToken> storeAged(TimeSpan age)
+    {
+        var token = await _store.StoreAsync(new byte[] { 1, 2, 3 }, "application/octet-stream",
+            TestContext.Current.CancellationToken);
+
+        var path = Path.Combine(_directory, token.Id + ".bin");
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow - age);
+
+        return token;
+    }
+
+    [Fact]
+    public async Task deletes_aged_payloads_and_leaves_recent_ones()
+    {
+        var old = await storeAged(2.Hours());
+        var recent = await storeAged(1.Minutes());
+
+        var deleted = await _store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow - 1.Hours(), 100,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(1);
+
+        await Should.ThrowAsync<FileNotFoundException>(() => _store.LoadAsync(old));
+
+        // The recent payload must survive untouched -- an over-eager sweep is worse than no sweep.
+        (await _store.LoadAsync(recent, TestContext.Current.CancellationToken)).ToArray()
+            .ShouldBe(new byte[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task deletes_the_sidecar_metadata_file_too()
+    {
+        var token = await storeAged(2.Hours());
+
+        await _store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow - 1.Hours(), 100,
+            TestContext.Current.CancellationToken);
+
+        File.Exists(Path.Combine(_directory, token.Id + ".bin")).ShouldBeFalse();
+        File.Exists(Path.Combine(_directory, token.Id + ".meta")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task honors_the_max_count()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            await storeAged(2.Hours());
+        }
+
+        var deleted = await _store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow - 1.Hours(), 2,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(2);
+        Directory.GetFiles(_directory, "*.bin").Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task second_sweep_over_an_empty_store_is_a_no_op()
+    {
+        await storeAged(2.Hours());
+
+        var cutoff = DateTimeOffset.UtcNow - 1.Hours();
+        (await _store.DeleteExpiredPayloadsAsync(cutoff, 100, TestContext.Current.CancellationToken)).ShouldBe(1);
+
+        // Idempotence matters because the sweeper runs on every node, so overlapping passes are expected.
+        (await _store.DeleteExpiredPayloadsAsync(cutoff, 100, TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_non_positive_max_count_deletes_nothing()
+    {
+        await storeAged(2.Hours());
+
+        (await _store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow - 1.Hours(), 0,
+            TestContext.Current.CancellationToken)).ShouldBe(0);
+
+        Directory.GetFiles(_directory, "*.bin").Length.ShouldBe(1);
+    }
+}

--- a/src/Wolverine/Persistence/ClaimCheck/ClaimCheckConfiguration.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/ClaimCheckConfiguration.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core;
 using Wolverine.Persistence.ClaimCheck.Internal;
 
 namespace Wolverine.Persistence;
@@ -96,6 +97,52 @@ public class ClaimCheckConfiguration
         }
 
         AutoOffloadThreshold = thresholdInBytes;
+        return this;
+    }
+
+    /// <summary>
+    /// When set, Wolverine periodically deletes off-loaded payloads older than this age from every
+    /// configured store that implements <see cref="IClaimCheckStoreWithExpiration"/>. Null (the default)
+    /// disables sweeping entirely, which is the pre-GH-3509 behavior: nothing in the pipeline ever deletes
+    /// a payload, and the operator is responsible for the storage backend's own lifecycle rules.
+    /// </summary>
+    /// <remarks>
+    /// The TTL must comfortably exceed the longest window in which a message could still need its payload —
+    /// scheduled delivery, retry back-offs, and time spent parked in a dead-letter queue all count. A payload
+    /// swept out from under a message that is later delivered will fail to re-hydrate.
+    /// </remarks>
+    public TimeSpan? PayloadTimeToLive { get; set; }
+
+    /// <summary>
+    /// How often the claim-check sweeper runs when <see cref="PayloadTimeToLive"/> is set. Defaults to
+    /// ten minutes. The sweeper runs on every node rather than electing a leader — deletion by age is
+    /// idempotent, so overlapping sweeps are harmless — and each node applies its own random jitter so
+    /// a large cluster does not stampede the store on a fixed cadence.
+    /// </summary>
+    public TimeSpan SweepInterval { get; set; } = 10.Minutes();
+
+    /// <summary>
+    /// The maximum number of payloads a single sweep pass will delete from one store. Bounding the batch
+    /// keeps a first sweep over a store with a large backlog from turning into one enormous delete. When a
+    /// pass deletes a full batch the sweeper immediately runs again rather than waiting out
+    /// <see cref="SweepInterval"/>, so a backlog still drains promptly. Defaults to 1000.
+    /// </summary>
+    public int SweepBatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Periodically delete off-loaded payloads older than <paramref name="timeToLive"/> from every configured
+    /// store that supports expiration. See <see cref="PayloadTimeToLive"/> for the sizing caveat. See GH-3509.
+    /// </summary>
+    /// <param name="timeToLive">How long a payload is retained after it is stored.</param>
+    public ClaimCheckConfiguration DeletePayloadsOlderThan(TimeSpan timeToLive)
+    {
+        if (timeToLive <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeToLive),
+                "The claim-check payload time to live must be a positive duration.");
+        }
+
+        PayloadTimeToLive = timeToLive;
         return this;
     }
 

--- a/src/Wolverine/Persistence/ClaimCheck/FileSystemClaimCheckStore.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/FileSystemClaimCheckStore.cs
@@ -12,7 +12,7 @@ namespace Wolverine.Persistence;
 /// span multiple machines should use a shared object-store backend (Azure
 /// Blob, S3, etc.).
 /// </remarks>
-public class FileSystemClaimCheckStore : IClaimCheckStore
+public class FileSystemClaimCheckStore : IClaimCheckStoreWithExpiration
 {
     private const string PayloadExtension = ".bin";
     private const string MetadataExtension = ".meta";
@@ -90,6 +90,62 @@ public class FileSystemClaimCheckStore : IClaimCheckStore
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// GH-3509 sweep support: delete the payload/metadata pairs whose payload file was last written
+    /// before <paramref name="cutoff"/>. The <c>.bin</c> file's last-write time is the age of record —
+    /// it is written first and never touched again, so it is a faithful stand-in for "stored at".
+    /// </summary>
+    public Task<int> DeleteExpiredPayloadsAsync(
+        DateTimeOffset cutoff,
+        int maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxCount <= 0)
+        {
+            return Task.FromResult(0);
+        }
+
+        var deleted = 0;
+
+        foreach (var payloadPath in System.IO.Directory.EnumerateFiles(Directory, "*" + PayloadExtension))
+        {
+            if (deleted >= maxCount || cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            // Another node's sweeper can delete the same file between the enumeration and this check,
+            // so every filesystem call here has to tolerate the file already being gone.
+            try
+            {
+                if (File.GetLastWriteTimeUtc(payloadPath) >= cutoff.UtcDateTime)
+                {
+                    continue;
+                }
+
+                File.Delete(payloadPath);
+
+                var metadataPath = Path.ChangeExtension(payloadPath, MetadataExtension);
+                if (File.Exists(metadataPath))
+                {
+                    File.Delete(metadataPath);
+                }
+
+                deleted++;
+            }
+            catch (FileNotFoundException)
+            {
+                // Already swept by someone else; not an error.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                break;
+            }
+        }
+
+        return Task.FromResult(deleted);
     }
 
     private string PayloadPathFor(string id) => Path.Combine(Directory, id + PayloadExtension);

--- a/src/Wolverine/Persistence/ClaimCheck/IClaimCheckStoreWithExpiration.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/IClaimCheckStoreWithExpiration.cs
@@ -1,0 +1,36 @@
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Optional capability for an <see cref="IClaimCheckStore"/> that can find and delete its own aged
+/// payloads. Implementing this interface opts the backend into Wolverine's claim-check sweeper, which
+/// is enabled by <see cref="ClaimCheckConfiguration.DeletePayloadsOlderThan"/>. See GH-3509.
+/// </summary>
+/// <remarks>
+/// This is deliberately a separate interface rather than another method on <see cref="IClaimCheckStore"/>:
+/// adding to the core contract would break every third-party backend, and several first-party backends
+/// legitimately should <i>not</i> implement it. Azure Blob Storage, Amazon S3, and Google Cloud Storage all
+/// support server-side lifecycle rules that expire objects for free, whereas a Wolverine-driven sweep over
+/// those stores would mean paying for LIST operations across the whole bucket on every pass. Those backends
+/// deliberately do not implement this interface; point their native lifecycle policies at the claim-check
+/// prefix instead.
+/// </remarks>
+public interface IClaimCheckStoreWithExpiration : IClaimCheckStore
+{
+    /// <summary>
+    /// Delete at most <paramref name="maxCount"/> payloads that were stored before <paramref name="cutoff"/>,
+    /// and return how many were actually deleted. Returning <paramref name="maxCount"/> tells the sweeper
+    /// there is probably more to do, so it may immediately sweep again rather than waiting out the interval.
+    /// </summary>
+    /// <remarks>
+    /// Implementations must be safe to run concurrently from several nodes — Wolverine's sweeper runs on
+    /// every node rather than electing a leader, so two hosts can issue overlapping sweeps against the same
+    /// backend. Deleting an already-deleted payload is not an error.
+    /// </remarks>
+    /// <param name="cutoff">Payloads stored strictly before this moment are eligible for deletion.</param>
+    /// <param name="maxCount">Upper bound on the number of payloads to delete in this pass.</param>
+    /// <param name="cancellationToken">Token that is cancelled when the host is shutting down.</param>
+    Task<int> DeleteExpiredPayloadsAsync(
+        DateTimeOffset cutoff,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckMessageSerializer.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckMessageSerializer.cs
@@ -61,6 +61,10 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
         // visible to the finally and gets restored. Otherwise a failed off-load would leak cleared
         // properties into subsequent in-process handling of the same Envelope.
         var offloaded = new List<OffloadedBlob>();
+        // Every token written during this serialization, so that a failure at ANY later point — a second
+        // [Blob] property, or the whole-body off-load that runs afterwards — can delete the payloads that
+        // will now never be referenced by anything on the wire. See GH-3509.
+        var uploaded = new List<ClaimCheckToken>();
         try
         {
             if (message is not null)
@@ -69,7 +73,7 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
                 if (info.HasBlobs)
                 {
 #pragma warning disable VSTHRD002 // Documented blocking call, see class remarks
-                    StoreBlobsAsync(envelope, message, info, offloaded, selection).GetAwaiter().GetResult();
+                    StoreBlobsAsync(envelope, message, info, offloaded, uploaded, selection).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
                 }
             }
@@ -77,6 +81,13 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
 #pragma warning disable VSTHRD002 // Documented blocking call, see class remarks
             return maybeOffloadBodyAsync(envelope, _inner.Write(envelope), selection).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
+        }
+        catch
+        {
+#pragma warning disable VSTHRD002 // Documented blocking call, see class remarks
+            deleteQuietlyAsync(selection.Store, uploaded).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+            throw;
         }
         finally
         {
@@ -94,14 +105,22 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
                 var info = BlobTypeInfo.For(message.GetType());
                 if (info.HasBlobs)
                 {
-                    // No envelope is available here so the tokens cannot be smuggled
-                    // back to the consumer. We still upload the payloads for symmetry,
-                    // but nullify the properties so the inner serializer doesn't pull
-                    // bytes through the wire under both paths.
-                    var selection = _router.ResolveForSend(message.GetType(), envelope: null);
-#pragma warning disable VSTHRD002
-                    StoreBlobsAsync(envelope: null, message, info, offloaded, selection).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
+                    // No envelope is available here, so there is nowhere to stamp a claim-check header and
+                    // the token would be unreachable by construction. This path used to upload anyway "for
+                    // symmetry", which orphaned a payload on EVERY call with no way for anything to ever
+                    // read or delete it (GH-3509). Clear the properties so the inner serializer still keeps
+                    // the body small, and skip the pointless upload.
+                    foreach (var accessor in info.Properties)
+                    {
+                        var bytes = accessor.ReadPayload(message);
+                        if (bytes is null || bytes.Length == 0)
+                        {
+                            continue;
+                        }
+
+                        accessor.Clear(message);
+                        offloaded.Add(new OffloadedBlob(accessor, bytes));
+                    }
                 }
             }
 
@@ -118,6 +137,8 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
         var message = envelope.Message;
         var selection = _router.ResolveForSend(message?.GetType(), envelope);
         var offloaded = new List<OffloadedBlob>();
+        // See the note in Write(Envelope) -- tracked so a later failure can delete the orphans. GH-3509.
+        var uploaded = new List<ClaimCheckToken>();
         try
         {
             if (message is not null)
@@ -125,7 +146,8 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
                 var info = BlobTypeInfo.For(message.GetType());
                 if (info.HasBlobs)
                 {
-                    await StoreBlobsAsync(envelope, message, info, offloaded, selection).ConfigureAwait(false);
+                    await StoreBlobsAsync(envelope, message, info, offloaded, uploaded, selection)
+                        .ConfigureAwait(false);
                 }
             }
 
@@ -134,6 +156,11 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
                 : _inner.Write(envelope);
 
             return await maybeOffloadBodyAsync(envelope, body, selection).ConfigureAwait(false);
+        }
+        catch
+        {
+            await deleteQuietlyAsync(selection.Store, uploaded).ConfigureAwait(false);
+            throw;
         }
         finally
         {
@@ -266,7 +293,7 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
     /// of two blobs) the caller's finally still restores every property cleared so far.
     /// </summary>
     private async Task StoreBlobsAsync(Envelope? envelope, object message, BlobTypeInfo info,
-        List<OffloadedBlob> offloaded, ClaimCheckSelection selection)
+        List<OffloadedBlob> offloaded, List<ClaimCheckToken> uploaded, ClaimCheckSelection selection)
     {
         foreach (var accessor in info.Properties)
         {
@@ -277,6 +304,11 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
             }
 
             var token = await selection.Store.StoreAsync(bytes, accessor.ContentType).ConfigureAwait(false);
+
+            // Recorded before the header is stamped so the caller can clean this payload up if any
+            // later step of the same serialization throws. See GH-3509.
+            uploaded.Add(token);
+
             if (envelope is not null)
             {
                 envelope.Headers[accessor.HeaderName] = token.Serialize();
@@ -284,6 +316,26 @@ internal sealed class ClaimCheckMessageSerializer : IMessageSerializer, IAsyncMe
             }
             accessor.Clear(message);
             offloaded.Add(new OffloadedBlob(accessor, bytes));
+        }
+    }
+
+    /// <summary>
+    /// Best-effort cleanup of payloads uploaded for a send that then failed. A delete that itself fails is
+    /// swallowed: the caller is already throwing the real error, and losing that to a secondary storage
+    /// failure would be strictly worse than leaving an orphan behind for the sweeper.
+    /// </summary>
+    private static async Task deleteQuietlyAsync(IClaimCheckStore store, List<ClaimCheckToken> tokens)
+    {
+        foreach (var token in tokens)
+        {
+            try
+            {
+                await store.DeleteAsync(token).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Intentionally ignored -- see the summary above.
+            }
         }
     }
 

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckStoreRouter.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckStoreRouter.cs
@@ -66,6 +66,30 @@ internal sealed class ClaimCheckStoreRouter
     public IClaimCheckStore DefaultStore { get; }
     public long? DefaultThreshold { get; }
 
+    /// <summary>
+    /// Every distinct store this router can hand out — the global default plus each keyed route store.
+    /// The claim-check sweeper (GH-3509) walks this so a multi-store configuration has all of its backends
+    /// swept, not just the default one. Deduplicated by reference, since several routes commonly point at
+    /// the same store instance.
+    /// </summary>
+    public IEnumerable<IClaimCheckStore> AllStores()
+    {
+        var seen = new HashSet<IClaimCheckStore>(ReferenceEqualityComparer.Instance);
+
+        if (seen.Add(DefaultStore))
+        {
+            yield return DefaultStore;
+        }
+
+        foreach (var store in _namedStores.Values)
+        {
+            if (seen.Add(store))
+            {
+                yield return store;
+            }
+        }
+    }
+
     public ClaimCheckSelection ResolveForSend(Type? messageType, Envelope? envelope)
     {
         foreach (var route in _routes)

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckSweepSettings.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckSweepSettings.cs
@@ -1,0 +1,12 @@
+namespace Wolverine.Persistence.ClaimCheck.Internal;
+
+/// <summary>
+/// The resolved sweep configuration handed to <see cref="ClaimCheckSweeper"/> through DI. Registered by
+/// <see cref="WolverineOptionsClaimCheckExtensions.UseClaimCheck"/> only when a payload time to live was
+/// configured, so the presence of this service is itself the "sweeping is on" switch. See GH-3509.
+/// </summary>
+internal sealed record ClaimCheckSweepSettings(
+    ClaimCheckStoreRouter Router,
+    TimeSpan TimeToLive,
+    TimeSpan Interval,
+    int BatchSize);

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckSweeper.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/ClaimCheckSweeper.cs
@@ -1,0 +1,171 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Persistence.ClaimCheck.Internal;
+
+/// <summary>
+/// Periodically deletes off-loaded claim-check payloads older than the configured time to live from every
+/// backend that implements <see cref="IClaimCheckStoreWithExpiration"/>. Registered only when
+/// <see cref="ClaimCheckConfiguration.DeletePayloadsOlderThan"/> was called, so the default behavior is
+/// unchanged. See GH-3509.
+/// </summary>
+/// <remarks>
+/// This runs on <b>every</b> node rather than being pinned to the cluster leader. Agent families — the usual
+/// home for cluster-singleton work — are only instantiated in <see cref="DurabilityMode.Balanced"/>, which
+/// requires message persistence and a node table. Claim checks have no such requirement: UseClaimCheck only
+/// decorates the default serializer, so a perfectly ordinary app can use claim checks with no message store
+/// at all, and a leader-pinned sweeper would silently never run for those users. Deleting by age is
+/// idempotent and safe to run concurrently, so every-node execution costs nothing but a bounded delete per
+/// interval, and each node jitters its own schedule so a large cluster does not stampede the store.
+/// </remarks>
+internal sealed class ClaimCheckSweeper : BackgroundService
+{
+    // Bounds how many back-to-back full batches one wake-up will drain before yielding to the interval
+    // again. Without this, a store holding millions of expired payloads would keep a first sweep running
+    // indefinitely and delay a graceful shutdown.
+    private const int MaxConsecutivePasses = 20;
+
+    private readonly ClaimCheckSweepSettings _settings;
+    private readonly ILogger _logger;
+    private readonly Random _jitter = new();
+
+    private readonly HashSet<Type> _warnedUnsupported = new();
+
+    public ClaimCheckSweeper(ClaimCheckSweepSettings settings, ILogger<ClaimCheckSweeper> logger)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(nextDelay(), stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            foreach (var store in _settings.Router.AllStores())
+            {
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                await sweepAsync(store, stoppingToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Spread each node's sweep across the interval so a rolling deployment does not leave every node
+    /// hitting the store on the same cadence. Jitter is +/- 20% of the configured interval.
+    /// </summary>
+    private TimeSpan nextDelay()
+    {
+        var jitterRange = _settings.Interval.TotalMilliseconds * 0.2;
+        var offset = (_jitter.NextDouble() * 2 - 1) * jitterRange;
+        return TimeSpan.FromMilliseconds(Math.Max(1000, _settings.Interval.TotalMilliseconds + offset));
+    }
+
+    private async Task sweepAsync(IClaimCheckStore store, CancellationToken stoppingToken)
+    {
+        if (!tryResolveExpiringStore(store, out var expiring))
+        {
+            return;
+        }
+
+        var total = 0;
+
+        for (var pass = 0; pass < MaxConsecutivePasses; pass++)
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            int deleted;
+            try
+            {
+                var cutoff = DateTimeOffset.UtcNow - _settings.TimeToLive;
+                deleted = await expiring.DeleteExpiredPayloadsAsync(cutoff, _settings.BatchSize, stoppingToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception e)
+            {
+                // A sweep failure is never fatal — the payloads are still there and the next pass will
+                // retry. Log and move on rather than tearing down the host's background service.
+                _logger.LogError(e,
+                    "Failed to sweep expired claim-check payloads from {Store}. The sweep will be retried in {Interval}.",
+                    expiring.GetType().FullName, _settings.Interval);
+                break;
+            }
+
+            total += deleted;
+
+            // A short batch means the backlog is drained; wait out the interval before looking again.
+            if (deleted < _settings.BatchSize)
+            {
+                break;
+            }
+        }
+
+        if (total > 0)
+        {
+            _logger.LogInformation(
+                "Deleted {Count} claim-check payload(s) older than {TimeToLive} from {Store}.",
+                total, _settings.TimeToLive, expiring.GetType().FullName);
+        }
+    }
+
+    /// <summary>
+    /// Unwrap the deferred DI proxy (GH-3564) before testing for expiration support, and warn exactly once
+    /// per backend type that cannot be swept so the operator knows to configure a native lifecycle rule
+    /// instead of assuming the TTL they set is doing something.
+    /// </summary>
+    private bool tryResolveExpiringStore(IClaimCheckStore store, out IClaimCheckStoreWithExpiration expiring)
+    {
+        expiring = null!;
+
+        var target = store;
+        if (store is DeferredClaimCheckStore deferred)
+        {
+            var resolved = deferred.TryResolve();
+            if (resolved is null)
+            {
+                // The container is not bound yet; try again on the next pass rather than warning.
+                return false;
+            }
+
+            target = resolved;
+        }
+
+        if (target is IClaimCheckStoreWithExpiration supported)
+        {
+            expiring = supported;
+            return true;
+        }
+
+        if (_warnedUnsupported.Add(target.GetType()))
+        {
+            _logger.LogWarning(
+                "Claim-check payload expiration is configured, but the {Store} backend does not support " +
+                "Wolverine-driven sweeping and will be skipped. Object stores such as Azure Blob Storage, " +
+                "Amazon S3, and Google Cloud Storage expire objects far more cheaply through their own " +
+                "server-side lifecycle rules — configure one against the claim-check prefix instead. " +
+                "See https://wolverinefx.io/guide/durability/claim-checks.html",
+                target.GetType().FullName);
+        }
+
+        return false;
+    }
+}

--- a/src/Wolverine/Persistence/ClaimCheck/Internal/DeferredClaimCheckStore.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/Internal/DeferredClaimCheckStore.cs
@@ -62,6 +62,14 @@ internal sealed class DeferredClaimCheckStore : IClaimCheckStore
         }
     }
 
+    /// <summary>
+    /// The concrete store behind this proxy, or null if the service provider has not been attached yet.
+    /// The claim-check sweeper (GH-3509) uses this to unwrap the proxy before testing for
+    /// <see cref="IClaimCheckStoreWithExpiration"/> — a type test against the proxy itself would always say
+    /// "not supported" and silently skip a perfectly sweepable backend.
+    /// </summary>
+    public IClaimCheckStore? TryResolve() => _provider is null ? null : resolve();
+
     public Task<ClaimCheckToken> StoreAsync(ReadOnlyMemory<byte> payload, string contentType,
         CancellationToken cancellationToken = default)
         => resolve().StoreAsync(payload, contentType, cancellationToken);

--- a/src/Wolverine/Persistence/ClaimCheck/WolverineOptionsClaimCheckExtensions.cs
+++ b/src/Wolverine/Persistence/ClaimCheck/WolverineOptionsClaimCheckExtensions.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Wolverine.Persistence.ClaimCheck.Internal;
 
 namespace Wolverine.Persistence;
@@ -66,6 +68,33 @@ public static class WolverineOptionsClaimCheckExtensions
         // per-endpoint routes registered during configuration (GH-3508).
         var router = new ClaimCheckStoreRouter(store, configuration.AutoOffloadThreshold,
             configuration.Routes, configuration.NamedStores);
+
+        // GH-3509: register the background sweeper when a TTL was configured. The settings singleton is
+        // replaced outright so a second UseClaimCheck call sweeps the router that actually won, while
+        // TryAddEnumerable keys on (IHostedService, ClaimCheckSweeper) and therefore never registers a
+        // second sweeper. With no TTL configured nothing is registered at all, so the default behavior —
+        // Wolverine never deletes a payload — is unchanged.
+        options.Services.RemoveAll<ClaimCheckSweepSettings>();
+
+        if (configuration.PayloadTimeToLive.HasValue)
+        {
+            if (configuration.SweepInterval <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(configure),
+                    "ClaimCheckConfiguration.SweepInterval must be a positive duration.");
+            }
+
+            if (configuration.SweepBatchSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(configure),
+                    "ClaimCheckConfiguration.SweepBatchSize must be a positive number of payloads.");
+            }
+
+            options.Services.AddSingleton(new ClaimCheckSweepSettings(router,
+                configuration.PayloadTimeToLive.Value, configuration.SweepInterval, configuration.SweepBatchSize));
+
+            options.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ClaimCheckSweeper>());
+        }
 
         // If UseClaimCheck has already been applied to this options instance,
         // unwrap and re-wrap so the operation is idempotent (new store wins).


### PR DESCRIPTION
Closes #3509. Part of epic #3511.

## The gap

`IClaimCheckStore.DeleteAsync` was **never called by the pipeline**. The only call sites were the `DeferredClaimCheckStore` pass-through proxy and backend unit tests — nothing in `ClaimCheckMessageSerializer`, send path or receive path, ever deleted anything. Every off-loaded payload was permanent unless the operator wired up a native lifecycle rule, and the FileSystem, NATS, and PostgreSQL backends have no native lifecycle at all. The docs already conceded this.

## The expiration contract

New `IClaimCheckStoreWithExpiration` — an **opt-in capability interface**, not a new method on `IClaimCheckStore`, which would have broken every third-party backend.

Implemented by `FileSystemClaimCheckStore` and `PostgresqlClaimCheckStore`. Azure Blob, S3, and GCS deliberately **do not** implement it: their server-side lifecycle rules expire objects for free, keep working while your app is down, and cost nothing, whereas a Wolverine-side sweep over a bucket means paying for LIST operations on every pass. The docs now steer object-store users to native rules explicitly.

## The sweeper

`ClaimCheckSweeper` is a `BackgroundService` registered only when `DeletePayloadsOlderThan(...)` is configured, so **the default behavior is unchanged** — with no TTL set, nothing is registered at all.

```csharp
opts.UseClaimCheck(cc =>
{
    cc.UsePostgresqlClaimCheck(connectionString);
    cc.DeletePayloadsOlderThan(7.Days());
    cc.SweepInterval = 10.Minutes();   // default
    cc.SweepBatchSize = 1000;          // default
});
```

It runs on **every node rather than pinned to the leader**. Agent families — the usual home for cluster-singleton work — are only instantiated in `DurabilityMode.Balanced`, which requires message persistence and a node table. But `UseClaimCheck` only decorates the default serializer and works with no message store at all, so a leader-pinned sweeper would silently never run for that group of users. Deletion by age is idempotent, so overlapping sweeps are harmless; each node jitters its own schedule ±20% and batches are bounded, with a full batch triggering an immediate follow-up pass so a backlog drains.

Every routed store is swept, not just the default — a `StoreForMessage<T>` backend would otherwise leak everything. A backend that can't be swept warns once per type, so a TTL that isn't actually doing anything is visible rather than silently ignored.

Sizing caveat is documented prominently: the sweep deletes purely by age and can't know whether a message referencing a payload is still in flight, so the TTL must exceed the longest scheduled-delivery, retry, and dead-letter window.

## Two guaranteed leaks in the serializer

- **Partial off-load.** The uploaded-token list is now owned by the caller, so a failure in a later `[Blob]` property *or* in the GH-3504 whole-body off-load deletes the earlier uploads. Those tokens never reach the wire, so this is the one place we know for certain the bytes are garbage. Cleanup is best-effort and never masks the original exception.
- **`WriteMessage(object)`** uploaded "for symmetry" with no envelope to stamp a token on — orphaning a payload on *every single call*, unreachable by construction. It now clears and restores the properties without uploading. Minor behavior change, called out here for review.

## Two defects found in the shipped PostgreSQL store

- `created` defaulted to `now() at time zone 'utc'`, which puts a **local wall-clock value into a `timestamptz` column** — skewed by the session offset on any non-UTC server. The sweep compares against a true UTC cutoff, so `created` is now written explicitly on insert, which also corrects tables already provisioned with the old default. New default is plain `now()`. Regression test sets the session to `America/Chicago`.
- **No index on `created`** — the sweep would have seq-scanned a table full of multi-MB rows. Added to lazy provisioning.

## Verification

- `CoreTests` full suite: **2441 passed, 0 failed, 2 skipped**
- `Wolverine.ClaimCheck.Postgresql.Tests`: **10/10** against docker Postgres
- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings

New coverage: expiration-contract compliance (aged vs. recent, `maxCount`, idempotence, sidecar cleanup), sweeper registration/idempotence/multi-store/unsupported-backend, both serializer leak paths sync and async, and the UTC-`created` and index regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3