### PR TITLE
GH-3510: read MassTransit MessageData claim-check references

### DIFF
--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -259,6 +259,64 @@ opts.UseClaimCheck(cc => cc.UseFileSystem("/var/wolverine/claim-checks"));
 
 Each payload is written as `{id}.bin`, with a sidecar `{id}.meta` file recording the original content type so the round-trip is lossless even if the token were ever reconstructed externally.
 
+## Consuming MassTransit MessageData
+
+If you are migrating off MassTransit, or running Wolverine and MassTransit services side by side, Wolverine
+can read MassTransit's [`MessageData<T>`](https://masstransit.io/documentation/patterns/claim-check)
+claim-check references directly:
+
+```csharp
+opts.UseRabbitMq(/* ... */)
+    .UseConventionalRouting();
+
+opts.PublishAllMessages().ToRabbitQueue("large-docs")
+    .UseMassTransitInterop(mt =>
+    {
+        // Point Wolverine's store at the SAME bucket MassTransit's repository writes to
+        mt.ReadMessageDataFrom(new AmazonS3ClaimCheckStore(s3Client, "mt-message-data"));
+    });
+```
+
+Any property marked with `[Blob]` on the incoming message is then hydrated from that store. `[Blob]` is
+reused as the opt-in marker deliberately — a property big enough for MassTransit to have off-loaded is the
+same property Wolverine would off-load, so a contract shared across the migration needs no extra
+annotation. It also matters for correctness: a blanket rule over every `byte[]` or `string` property would
+try to read ordinary values as claim-check references.
+
+::: warning MassTransit's reference is in the body, not a header
+Wolverine carries its own claim-check token in an envelope header. MassTransit does not — it writes a JSON
+object *inside the message body*, of the form `{ "data-ref": "…", "text": "…", "data": "…" }`. `text` and
+`data` are the inline forms MassTransit uses for payloads under its 4&nbsp;KB threshold; when either is
+present Wolverine uses it directly and never calls the store.
+:::
+
+Wolverine understands the address formats produced by MassTransit's file-system, Amazon S3, and Azure
+Storage repositories:
+
+| MassTransit repository | Address | Payload id |
+| --- | --- | --- |
+| File system / Amazon S3 | `urn:file:{key}` (colons for separators) | segments rejoined with `/` |
+| Azure Storage | `https://…/{container}/{blob}` | everything after the container segment |
+| In-memory | `urn:msgdata:{id}` | rejected — see below |
+
+An Azure blob name ending in `.gz` is gunzipped automatically, matching that repository's compression
+option. For a custom `IMessageDataRepository` with its own address format, pass a mapper:
+
+```csharp
+mt.ReadMessageDataFrom(store, address => address.Segments.Last());
+```
+
+Two limits worth knowing up front:
+
+- **The address carries the key, not the bucket.** MassTransit's repository configuration owns the
+  bucket/container, so it never appears in the address. The store you pass to `ReadMessageDataFrom` must be
+  pointed at the same one, or every lookup will miss.
+- **MassTransit's in-memory repository cannot be read at all.** Its payloads never leave the producing
+  process. Wolverine fails with an explicit message saying so rather than a confusing lookup failure.
+
+This is a **read/consume path only** — Wolverine does not produce MassTransit-compatible references, and
+the outbound path is unchanged by enabling it.
+
 ## Operational considerations
 
 - **Lifetime of stored payloads.** The pipeline never auto-deletes blobs. If you let large payloads accumulate, they will eat storage. The recommended pattern is to use the storage system's native lifecycle support (S3 lifecycle rules, Azure Blob Storage lifecycle policies, or a periodic cleanup job for the file system backend) keyed off blob age. A future enhancement may add Wolverine-driven TTL; tracked separately.

--- a/src/Testing/CoreTests/Runtime/Interop/MassTransitMessageDataAddressTests.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/MassTransitMessageDataAddressTests.cs
@@ -1,0 +1,75 @@
+using Shouldly;
+using Wolverine.Runtime.Interop.MassTransit;
+using Xunit;
+
+namespace CoreTests.Runtime.Interop;
+
+/// <summary>
+/// GH-3510: address shapes transcribed from MassTransit's own repository implementations. MassTransit is
+/// deliberately not a package reference here, so these are hand-built fixtures in the same spirit as
+/// <c>MassTransitHeaders</c>.
+/// </summary>
+public class MassTransitMessageDataAddressTests
+{
+    private static string idFor(string address, out bool compressed)
+        => MassTransitMessageDataAddress.ToPayloadId(new Uri(address), out compressed);
+
+    [Fact]
+    public void amazon_s3_and_file_system_urn_maps_colons_back_to_a_key()
+    {
+        // MassTransit's S3 + file-system repositories both return urn:file:{key} with path separators
+        // replaced by colons.
+        idFor("urn:file:2026-08-22-14:PW5rd0vBQZmpmxvA", out var compressed)
+            .ShouldBe("2026-08-22-14/PW5rd0vBQZmpmxvA");
+
+        compressed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_flat_s3_key_has_no_separators_at_all()
+    {
+        idFor("urn:file:PW5rd0vBQZmpmxvA", out _).ShouldBe("PW5rd0vBQZmpmxvA");
+    }
+
+    [Fact]
+    public void azure_blob_uri_drops_the_container_segment()
+    {
+        idFor("https://myaccount.blob.core.windows.net/message-data/2026-08-22/abc123", out var compressed)
+            .ShouldBe("2026-08-22/abc123");
+
+        compressed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_gz_suffix_marks_the_payload_as_compressed()
+    {
+        idFor("https://myaccount.blob.core.windows.net/message-data/abc123.gz", out var compressed)
+            .ShouldBe("abc123.gz");
+
+        compressed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_in_memory_repository_is_rejected_with_an_explanation()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => idFor("urn:msgdata:PW5rd0vBQZmpmxvA", out _));
+
+        // The failure has to name the actual problem -- a bare "not found" from the store would send
+        // someone hunting through bucket permissions.
+        ex.Message.ShouldContain("in-memory repository");
+    }
+
+    [Fact]
+    public void an_unrecognised_urn_points_at_the_address_mapper_hook()
+    {
+        Should.Throw<NotSupportedException>(() => idFor("urn:something:else", out _))
+            .Message.ShouldContain("ReadMessageDataFrom");
+    }
+
+    [Fact]
+    public void a_blob_uri_with_no_blob_name_is_rejected()
+    {
+        Should.Throw<NotSupportedException>(() =>
+            idFor("https://myaccount.blob.core.windows.net/message-data", out _));
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Interop/MassTransitMessageDataTests.cs
+++ b/src/Testing/CoreTests/Runtime/Interop/MassTransitMessageDataTests.cs
@@ -1,0 +1,211 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Runtime.Interop.MassTransit;
+using Xunit;
+
+namespace CoreTests.Runtime.Interop;
+
+public record MtDocumentMessage(string Name, [property: Blob("application/pdf")] byte[]? Document);
+
+public record MtNotesMessage(string Name, [property: Blob("text/plain")] string? Notes);
+
+public record MtPlainMessage(string Name, byte[]? NotABlob);
+
+/// <summary>
+/// GH-3510: consuming MassTransit's MessageData claim-check references. The wire format is transcribed
+/// from MassTransit's SystemTextMessageDataReference / SystemTextJsonMessageDataConverter — a JSON object
+/// nested in the message body, NOT a header the way Wolverine's own claim checks work. MassTransit is
+/// deliberately not referenced as a package, so the envelopes here are hand-built.
+/// </summary>
+public class MassTransitMessageDataTests
+{
+    private readonly IMassTransitInteropEndpoint theEndpoint = Substitute.For<IMassTransitInteropEndpoint>();
+    private readonly RecordingInMemoryStore theStore = new();
+
+    public MassTransitMessageDataTests()
+    {
+        theEndpoint.MassTransitReplyUri().Returns(new Uri("rabbitmq://localhost/responses"));
+    }
+
+    private MassTransitJsonSerializer serializer(Func<Uri, string>? addressToId = null)
+    {
+        var sut = new MassTransitJsonSerializer(theEndpoint);
+        sut.ReadMessageDataFrom(theStore, addressToId);
+        return sut;
+    }
+
+    /// <summary>Hand-build the MassTransit envelope wrapper around a message body.</summary>
+    private static Envelope incoming(string bodyJson)
+    {
+        var envelope = new
+        {
+            messageId = Guid.NewGuid().ToString(),
+            messageType = new[] { "urn:message:CoreTests.Runtime.Interop:MtDocumentMessage" },
+            message = JsonDocument.Parse(bodyJson).RootElement
+        };
+
+        return new Envelope { Data = JsonSerializer.SerializeToUtf8Bytes(envelope) };
+    }
+
+    private T read<T>(MassTransitJsonSerializer sut, string bodyJson)
+        => (T)sut.ReadFromData(typeof(T), incoming(bodyJson));
+
+    [Fact]
+    public void hydrates_a_byte_array_property_from_a_urn_file_reference()
+    {
+        var payload = "the actual pdf bytes"u8.ToArray();
+        theStore.Seed("2026-08-22/abc123", payload);
+
+        var message = read<MtDocumentMessage>(serializer(),
+            """{"name":"invoice","document":{"data-ref":"urn:file:2026-08-22:abc123"}}""");
+
+        message.Document.ShouldBe(payload);
+        message.Name.ShouldBe("invoice");
+    }
+
+    [Fact]
+    public void hydrates_a_string_property_from_an_azure_blob_reference()
+    {
+        theStore.Seed("2026-08-22/notes", "some very long notes"u8.ToArray());
+
+        var message = read<MtNotesMessage>(serializer(),
+            """{"name":"n","notes":{"data-ref":"https://acct.blob.core.windows.net/message-data/2026-08-22/notes"}}""");
+
+        message.Notes.ShouldBe("some very long notes");
+    }
+
+    [Fact]
+    public void gunzips_a_payload_whose_blob_name_ends_in_gz()
+    {
+        var payload = "compressed contents"u8.ToArray();
+
+        using var buffer = new MemoryStream();
+        using (var gzip = new GZipStream(buffer, CompressionMode.Compress, leaveOpen: true))
+        {
+            gzip.Write(payload);
+        }
+
+        theStore.Seed("abc123.gz", buffer.ToArray());
+
+        var message = read<MtDocumentMessage>(serializer(),
+            """{"name":"z","document":{"data-ref":"https://acct.blob.core.windows.net/message-data/abc123.gz"}}""");
+
+        message.Document.ShouldBe(payload);
+    }
+
+    [Fact]
+    public void an_inline_text_payload_never_touches_the_store()
+    {
+        // MassTransit carries payloads below its 4KB threshold inline, and in that case the repository
+        // may hold nothing at all under the address.
+        var message = read<MtNotesMessage>(serializer(),
+            """{"name":"n","notes":{"data-ref":"urn:file:abc","text":"carried inline"}}""");
+
+        message.Notes.ShouldBe("carried inline");
+        theStore.LoadCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void an_inline_base64_payload_never_touches_the_store()
+    {
+        var payload = "inline bytes"u8.ToArray();
+
+        var body = """{"name":"n","document":{"data-ref":"urn:file:abc","data":"""
+                   + $"\"{Convert.ToBase64String(payload)}\"}}}}";
+
+        var message = read<MtDocumentMessage>(serializer(), body);
+
+        message.Document.ShouldBe(payload);
+        theStore.LoadCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void a_reference_with_no_address_reads_as_empty()
+    {
+        // Matches MassTransit's own converter, which returns EmptyMessageData for this shape.
+        read<MtDocumentMessage>(serializer(), """{"name":"n","document":{}}""")
+            .Document.ShouldBeNull();
+
+        theStore.LoadCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void a_plain_value_is_still_readable_on_a_blob_property()
+    {
+        // A Wolverine peer sending the same contract writes the property normally. The converter has to
+        // tolerate that, otherwise enabling interop would break messages from your own services.
+        var payload = "plain"u8.ToArray();
+
+        read<MtDocumentMessage>(serializer(),
+            $$"""{"name":"n","document":"{{Convert.ToBase64String(payload)}}"}""")
+            .Document.ShouldBe(payload);
+
+        theStore.LoadCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void a_property_without_blob_is_left_completely_alone()
+    {
+        var payload = "not a claim check"u8.ToArray();
+
+        read<MtPlainMessage>(serializer(),
+            $$"""{"name":"n","notABlob":"{{Convert.ToBase64String(payload)}}"}""")
+            .NotABlob.ShouldBe(payload);
+    }
+
+    [Fact]
+    public void a_custom_address_mapper_overrides_the_built_in_translation()
+    {
+        theStore.Seed("mapped-id", "custom"u8.ToArray());
+
+        var message = read<MtNotesMessage>(serializer(_ => "mapped-id"),
+            """{"name":"n","notes":{"data-ref":"acme://whatever/we/like"}}""");
+
+        message.Notes.ShouldBe("custom");
+    }
+
+    [Fact]
+    public void message_data_interop_composes_with_UseSystemTextJsonForSerialization_in_either_order()
+    {
+        theStore.Seed("abc", "composed"u8.ToArray());
+
+        var sut = new MassTransitJsonSerializer(theEndpoint);
+        sut.ReadMessageDataFrom(theStore);
+        sut.UseSystemTextJsonForSerialization(o => o.WriteIndented = true);
+
+        read<MtNotesMessage>(sut, """{"name":"n","notes":{"data-ref":"urn:file:abc"}}""")
+            .Notes.ShouldBe("composed");
+    }
+
+    private sealed class RecordingInMemoryStore : IClaimCheckStore
+    {
+        private readonly Dictionary<string, byte[]> _payloads = new();
+
+        public int LoadCount;
+
+        public void Seed(string id, byte[] payload) => _payloads[id] = payload;
+
+        public Task<ClaimCheckToken> StoreAsync(ReadOnlyMemory<byte> payload, string contentType,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<ReadOnlyMemory<byte>> LoadAsync(ClaimCheckToken token,
+            CancellationToken cancellationToken = default)
+        {
+            LoadCount++;
+            if (!_payloads.TryGetValue(token.Id, out var bytes))
+            {
+                throw new KeyNotFoundException($"No payload seeded under '{token.Id}'.");
+            }
+
+            return Task.FromResult<ReadOnlyMemory<byte>>(bytes);
+        }
+
+        public Task DeleteAsync(ClaimCheckToken token, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/src/Wolverine/Runtime/Interop/MassTransit/IMassTransitInterop.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/IMassTransitInterop.cs
@@ -27,6 +27,31 @@ public interface IMassTransitInterop
     /// <typeparam name="T">The Wolverine message type to extract the tenant id from.</typeparam>
     IMassTransitInterop MapTenantIdFrom<T>(Func<MassTransitEnvelope<T>, string?> tenantIdSource) where T : class;
 
+    /// <summary>
+    ///     Read MassTransit's <c>MessageData&lt;T&gt;</c> claim-check references on incoming messages,
+    ///     hydrating each <c>[Blob]</c>-marked property from <paramref name="store"/>. This lets a Wolverine
+    ///     service consume large-message envelopes produced by a MassTransit service that shares the same
+    ///     blob/object store. Read side only — Wolverine does not produce MassTransit-compatible references.
+    ///     See GH-3510.
+    /// </summary>
+    /// <remarks>
+    ///     MassTransit's address carries the object key but <b>not</b> the bucket or container, which come
+    ///     from the MassTransit repository's own configuration. <paramref name="store"/> must therefore be
+    ///     pointed at the same bucket/container the MassTransit side writes to.
+    /// </remarks>
+    /// <param name="store">
+    ///     The claim-check store to load payloads from, pointed at MassTransit's own bucket/container.
+    /// </param>
+    /// <param name="addressToId">
+    ///     Optional override translating a MassTransit repository address into a payload id. Wolverine
+    ///     understands the addresses produced by MassTransit's file-system, Amazon S3, and Azure Storage
+    ///     repositories out of the box; supply this only for a custom <c>IMessageDataRepository</c> whose
+    ///     address format differs.
+    /// </param>
+    IMassTransitInterop ReadMessageDataFrom(
+        Wolverine.Persistence.IClaimCheckStore store,
+        Func<Uri, string>? addressToId = null);
+
     // Newtonsoft.Json variant moved to WolverineFx.Newtonsoft as the
     // UseNewtonsoftForSerialization(this IMassTransitInterop, ...)
     // extension method. Install WolverineFx.Newtonsoft to opt in.

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitJsonSerializer.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitJsonSerializer.cs
@@ -1,4 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Wolverine.Persistence;
 using ImTools;
 using JasperFx.Core;
 using Wolverine.Runtime.Serialization;
@@ -19,6 +22,10 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
 
     private Func<MassTransitEnvelope, string?>? _tenantIdSource;
 
+    private IClaimCheckStore? _messageDataStore;
+    private Func<Uri, string>? _messageDataAddressToId;
+    private Action<JsonSerializerOptions>? _jsonConfiguration;
+
     public MassTransitJsonSerializer(IMassTransitInteropEndpoint endpoint)
     {
         _endpoint = endpoint;
@@ -32,11 +39,17 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
     /// <param name="configuration"></param>
     public void UseSystemTextJsonForSerialization(Action<JsonSerializerOptions>? configuration = null)
     {
+        _jsonConfiguration = configuration;
+
         var options = SystemTextJsonSerializer.DefaultOptions();
 
         configuration?.Invoke(options);
 
         _inner = new SystemTextJsonSerializer(options);
+
+        // GH-3510: re-attach the MessageData modifier if it was configured first, so the two opt-ins
+        // compose regardless of the order the user calls them in.
+        applyMessageDataOptions();
     }
 
     public IMassTransitInterop MapTenantIdFrom<T>(Func<MassTransitEnvelope<T>, string?> tenantIdSource)
@@ -51,6 +64,45 @@ public class MassTransitJsonSerializer : IMessageSerializer, IMassTransitInterop
             mtEnvelope is MassTransitEnvelope<T> typed ? tenantIdSource(typed) : previous?.Invoke(mtEnvelope);
 
         return this;
+    }
+
+    public IMassTransitInterop ReadMessageDataFrom(IClaimCheckStore store, Func<Uri, string>? addressToId = null)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        _messageDataStore = store;
+        _messageDataAddressToId = addressToId;
+
+        // Rebuild the inner serializer so the modifier is attached. Any options the caller already applied
+        // through UseSystemTextJsonForSerialization are re-applied on top, so call order does not matter.
+        applyMessageDataOptions();
+
+        return this;
+    }
+
+    // The MassTransit interop path is reflection-based JSON by construction -- it deserializes into
+    // MassTransitEnvelope<T> closed over the runtime message type -- so it is already outside the
+    // trim/AOT-safe subset that a source-generated context would provide. Attaching a type-info modifier
+    // adds no new reflection beyond what this serializer already performs.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "MassTransit interop already requires reflection-based JSON; see the AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "MassTransit interop already requires reflection-based JSON; see the AOT guide.")]
+    private void applyMessageDataOptions()
+    {
+        if (_messageDataStore is null)
+        {
+            return;
+        }
+
+        var options = SystemTextJsonSerializer.DefaultOptions();
+        _jsonConfiguration?.Invoke(options);
+
+        var resolver = options.TypeInfoResolver as DefaultJsonTypeInfoResolver ?? new DefaultJsonTypeInfoResolver();
+        resolver.Modifiers.Add(MassTransitMessageDataResolver.ModifierFor(_messageDataStore, _messageDataAddressToId));
+        options.TypeInfoResolver = resolver;
+
+        _inner = new SystemTextJsonSerializer(options);
     }
 
     /// <summary>

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitMessageDataAddress.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitMessageDataAddress.cs
@@ -1,0 +1,88 @@
+namespace Wolverine.Runtime.Interop.MassTransit;
+
+/// <summary>
+/// Translates a MassTransit <c>MessageData</c> repository address into the id Wolverine's
+/// <see cref="Wolverine.Persistence.IClaimCheckStore"/> uses to look a payload up. See GH-3510.
+/// </summary>
+/// <remarks>
+/// MassTransit's address format is owned by the repository implementation, not by MassTransit itself,
+/// so there are several shapes in the wild. These are transcribed from MassTransit's own source the same
+/// way <see cref="MassTransitHeaders"/> is:
+/// <list type="bullet">
+/// <item><c>urn:file:{key}</c> — used by both the file-system and Amazon S3 repositories, which replace
+/// path separators with colons. The bucket/container is <b>not</b> part of the address; it comes from the
+/// repository's own configuration, which is why the Wolverine store must be pointed at the same
+/// bucket.</item>
+/// <item>An absolute <c>https://…/{container}/{blob}</c> URI — used by the Azure Storage repository,
+/// which returns the blob's own URI. The container is the first path segment and is dropped, matching
+/// what Azure's <c>BlobUriBuilder.BlobName</c> yields for a standard account URI.</item>
+/// <item><c>urn:msgdata:{id}</c> — the in-memory repository. Nothing outside the producing process can
+/// resolve it, so this is rejected with an explanatory error rather than a lookup failure.</item>
+/// </list>
+/// </remarks>
+internal static class MassTransitMessageDataAddress
+{
+    private const string GzipSuffix = ".gz";
+
+    /// <summary>
+    /// Resolve <paramref name="address"/> to a claim-check payload id, and report whether the payload is
+    /// gzip-compressed (the Azure repository appends <c>.gz</c> to the blob name when compression is on).
+    /// </summary>
+    public static string ToPayloadId(Uri address, out bool compressed)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        var id = resolve(address);
+
+        compressed = id.EndsWith(GzipSuffix, StringComparison.OrdinalIgnoreCase);
+        return id;
+    }
+
+    private static string resolve(Uri address)
+    {
+        if (!address.IsAbsoluteUri)
+        {
+            throw new NotSupportedException(
+                $"'{address}' is not an absolute MassTransit MessageData address and cannot be resolved.");
+        }
+
+        if (address.Scheme.Equals("urn", StringComparison.OrdinalIgnoreCase))
+        {
+            // A urn has no path structure, so the whole body arrives as a single segment: "file:a:b:c".
+            var parts = address.Segments[0].Split(':');
+
+            if (parts.Length >= 2 && parts[0].Equals("file", StringComparison.OrdinalIgnoreCase))
+            {
+                // MassTransit substitutes colons for path separators on the way out. Object-store keys
+                // always use '/', so rejoin that way rather than with the local separator.
+                return string.Join('/', parts.Skip(1));
+            }
+
+            if (parts.Length >= 2 && parts[0].Equals("msgdata", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new NotSupportedException(
+                    $"MassTransit MessageData address '{address}' refers to MassTransit's in-memory repository, " +
+                    "whose payloads never leave the producing process and cannot be read by Wolverine. Configure " +
+                    "the MassTransit side with a shared repository (file system, Amazon S3, Azure Storage) and " +
+                    "point Wolverine's claim-check store at the same location.");
+            }
+
+            throw new NotSupportedException(
+                $"'{address}' is not a recognised MassTransit MessageData address. Supply an address mapper to " +
+                "ReadMessageDataFrom(...) if your MassTransit repository uses a custom address format.");
+        }
+
+        // Azure Storage returns the blob's own URI; the first path segment is the container, which the
+        // Wolverine store already knows about, so everything after it is the payload id.
+        var path = address.AbsolutePath.TrimStart('/');
+        var slash = path.IndexOf('/');
+
+        if (slash < 0 || slash == path.Length - 1)
+        {
+            throw new NotSupportedException(
+                $"MassTransit MessageData address '{address}' has no blob name after its container segment.");
+        }
+
+        return Uri.UnescapeDataString(path[(slash + 1)..]);
+    }
+}

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitMessageDataConverter.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitMessageDataConverter.cs
@@ -1,0 +1,219 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Wolverine.Persistence;
+
+namespace Wolverine.Runtime.Interop.MassTransit;
+
+/// <summary>
+/// Reads MassTransit's <c>MessageData&lt;T&gt;</c> wire format on the way in and hydrates the value onto a
+/// plain Wolverine property. See GH-3510.
+/// </summary>
+/// <remarks>
+/// MassTransit does not put its claim-check reference in a header the way Wolverine does — it is a JSON
+/// object nested in the message body, written by MassTransit's <c>SystemTextJsonMessageDataConverter</c>:
+/// <code>
+/// { "data-ref": "&lt;address&gt;", "text": "&lt;inline string&gt;", "data": "&lt;inline base64&gt;" }
+/// </code>
+/// <c>text</c> and <c>data</c> are the inline forms MassTransit uses for payloads under its 4 KB threshold;
+/// when either is present the payload never went to the repository and no store lookup is needed.
+///
+/// This is the read side only. On write the value is emitted as ordinary JSON, exactly as it was before
+/// this converter existed — producing MassTransit-compatible references is explicitly out of scope.
+/// </remarks>
+internal sealed class MassTransitMessageDataConverter<T> : JsonConverter<T>
+{
+    private const string ReferenceProperty = "data-ref";
+    private const string TextProperty = "text";
+    private const string DataProperty = "data";
+
+    private readonly IClaimCheckStore _store;
+    private readonly Func<Uri, string>? _addressToId;
+
+    public MassTransitMessageDataConverter(IClaimCheckStore store, Func<Uri, string>? addressToId)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _addressToId = addressToId;
+    }
+
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+                return default!;
+
+            // Not a MassTransit reference at all -- a plain value written by a Wolverine peer, or an
+            // ordinary base64 byte[]. Fall through to the normal representation so a single property can
+            // be read from either kind of producer.
+            case JsonTokenType.String:
+                return fromBytes(readPlainString(ref reader));
+
+            case JsonTokenType.StartObject:
+                break;
+
+            default:
+                throw new JsonException(
+                    $"Unexpected token '{reader.TokenType}' while reading a MassTransit MessageData reference.");
+        }
+
+        string? text = null;
+        byte[]? inline = null;
+        string? address = null;
+
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                continue;
+            }
+
+            var name = reader.GetString();
+            if (!reader.Read())
+            {
+                break;
+            }
+
+            if (ReferenceProperty.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                address = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+            }
+            else if (TextProperty.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                text = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+            }
+            else if (DataProperty.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                inline = reader.TokenType == JsonTokenType.Null ? null : reader.GetBytesFromBase64();
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+
+        // Inline forms win: MassTransit writes them when the payload was small enough to travel in-band,
+        // and in that case the repository may hold nothing at all under the address.
+        if (text is not null)
+        {
+            return fromBytes(Encoding.UTF8.GetBytes(text));
+        }
+
+        if (inline is not null)
+        {
+            return fromBytes(inline);
+        }
+
+        if (address is null)
+        {
+            // MassTransit's own converter treats a reference with no address as empty message data.
+            return default!;
+        }
+
+        return fromBytes(load(new Uri(address, UriKind.RelativeOrAbsolute)));
+    }
+
+    private static byte[] readPlainString(ref Utf8JsonReader reader)
+    {
+        if (typeof(T) == typeof(string))
+        {
+            return Encoding.UTF8.GetBytes(reader.GetString() ?? string.Empty);
+        }
+
+        return reader.GetBytesFromBase64();
+    }
+
+    private byte[] load(Uri address)
+    {
+        bool compressed;
+        string id;
+
+        if (_addressToId is not null)
+        {
+            id = _addressToId(address);
+            compressed = id.EndsWith(".gz", StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            id = MassTransitMessageDataAddress.ToPayloadId(address, out compressed);
+        }
+
+        // JsonConverter.Read is synchronous, so the store call has to block here. This mirrors the
+        // documented blocking calls in ClaimCheckMessageSerializer's sync paths.
+#pragma warning disable VSTHRD002
+        var bytes = _store
+            .LoadAsync(new ClaimCheckToken(id, "application/octet-stream", 0))
+            .GetAwaiter().GetResult()
+            .ToArray();
+#pragma warning restore VSTHRD002
+
+        if (!compressed)
+        {
+            return bytes;
+        }
+
+        // The Azure Storage repository gzips the payload and marks it by appending .gz to the blob name.
+        using var source = new MemoryStream(bytes);
+        using var gzip = new GZipStream(source, CompressionMode.Decompress);
+        using var target = new MemoryStream();
+        gzip.CopyTo(target);
+        return target.ToArray();
+    }
+
+    private static T fromBytes(byte[] bytes)
+    {
+        if (typeof(T) == typeof(byte[]))
+        {
+            return (T)(object)bytes;
+        }
+
+        if (typeof(T) == typeof(string))
+        {
+            return (T)(object)Encoding.UTF8.GetString(bytes);
+        }
+
+        if (typeof(T) == typeof(ReadOnlyMemory<byte>))
+        {
+            return (T)(object)new ReadOnlyMemory<byte>(bytes);
+        }
+
+        if (typeof(T) == typeof(Stream) || typeof(T) == typeof(MemoryStream))
+        {
+            return (T)(object)new MemoryStream(bytes, writable: false);
+        }
+
+        throw new NotSupportedException(
+            $"MassTransit MessageData interop does not support the property type {typeof(T).FullName}. " +
+            "Supported types are byte[], string, and Stream.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        // Read-side interop only (GH-3510). Emit the value the way it would have been written before this
+        // converter was attached so the outbound path is untouched.
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+
+            case byte[] bytes:
+                writer.WriteBase64StringValue(bytes);
+                break;
+
+            case string text:
+                writer.WriteStringValue(text);
+                break;
+
+            case ReadOnlyMemory<byte> memory:
+                writer.WriteBase64StringValue(memory.Span);
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    $"Writing a {typeof(T).FullName} property in MassTransit MessageData format is not supported. " +
+                    "Wolverine's MassTransit MessageData interop is a read/consume path only.");
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Interop/MassTransit/MassTransitMessageDataResolver.cs
+++ b/src/Wolverine/Runtime/Interop/MassTransit/MassTransitMessageDataResolver.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using System.Text.Json.Serialization.Metadata;
+using Wolverine.Persistence;
+
+namespace Wolverine.Runtime.Interop.MassTransit;
+
+/// <summary>
+/// Attaches <see cref="MassTransitMessageDataConverter{T}"/> to every message property marked with
+/// <see cref="BlobAttribute"/>, so those properties — and only those — are read as MassTransit
+/// <c>MessageData</c> references. See GH-3510.
+/// </summary>
+/// <remarks>
+/// The opt-in marker is deliberately the existing <c>[Blob]</c> attribute rather than a new
+/// MassTransit-specific one: a property that is large enough for MassTransit to have off-loaded is the
+/// same property Wolverine would off-load, so a message contract shared across a migration needs no extra
+/// annotation. Scoping by attribute also matters for correctness — a blanket converter over every
+/// <c>byte[]</c> / <c>string</c> property would try to interpret ordinary strings as claim-check
+/// references.
+///
+/// This runs as a <see cref="DefaultJsonTypeInfoResolver"/> modifier on the MassTransit serializer's own
+/// <c>JsonSerializerOptions</c>, so it never affects Wolverine's normal serialization path.
+/// </remarks>
+internal static class MassTransitMessageDataResolver
+{
+    public static Action<JsonTypeInfo> ModifierFor(IClaimCheckStore store, Func<Uri, string>? addressToId)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        return typeInfo =>
+        {
+            if (typeInfo.Kind != JsonTypeInfoKind.Object)
+            {
+                return;
+            }
+
+            foreach (var property in typeInfo.Properties)
+            {
+                if (property.AttributeProvider?.IsDefined(typeof(BlobAttribute), inherit: true) != true)
+                {
+                    continue;
+                }
+
+                property.CustomConverter = converterFor(property.PropertyType, store, addressToId);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Instantiated by an explicit type switch rather than <c>MakeGenericType</c>: core Wolverine is
+    /// analyzed for AOT/trim compatibility, and a reflective generic instantiation trips IL3050. The
+    /// closed set here is exactly the set of property types <see cref="BlobAttribute"/> supports.
+    /// </summary>
+    private static System.Text.Json.Serialization.JsonConverter converterFor(Type propertyType,
+        IClaimCheckStore store, Func<Uri, string>? addressToId)
+    {
+        if (propertyType == typeof(byte[]))
+        {
+            return new MassTransitMessageDataConverter<byte[]>(store, addressToId);
+        }
+
+        if (propertyType == typeof(string))
+        {
+            return new MassTransitMessageDataConverter<string>(store, addressToId);
+        }
+
+        if (propertyType == typeof(ReadOnlyMemory<byte>))
+        {
+            return new MassTransitMessageDataConverter<ReadOnlyMemory<byte>>(store, addressToId);
+        }
+
+        if (propertyType == typeof(Stream))
+        {
+            return new MassTransitMessageDataConverter<Stream>(store, addressToId);
+        }
+
+        if (propertyType == typeof(MemoryStream))
+        {
+            return new MassTransitMessageDataConverter<MemoryStream>(store, addressToId);
+        }
+
+        throw new NotSupportedException(
+            $"A [Blob] property of type {propertyType.FullName} cannot be read as MassTransit MessageData. " +
+            "Supported types are byte[], ReadOnlyMemory<byte>, string, and Stream.");
+    }
+}


### PR DESCRIPTION
Closes #3510. Part of epic #3511.

Lets a Wolverine service consume large-message envelopes produced by a MassTransit service sharing the same blob/object store — the instant-migration story off MT's `MessageData<T>` repositories.

## The issue's premise was wrong, and the fix is in a different place

#3510 asked to "recognize MT's reference **headers**". MassTransit's reference is not a header at all — it's a JSON object nested in the message **body**. Verified against MassTransit source ([`SystemTextMessageDataReference`](https://github.com/MassTransit/MassTransit/blob/master/src/MassTransit/Serialization/JsonConverters/SystemTextMessageDataReference.cs), [`SystemTextJsonMessageDataConverter`](https://github.com/MassTransit/MassTransit/blob/master/src/MassTransit/Serialization/JsonConverters/SystemTextJsonMessageDataConverter.cs)), since MT's published docs omit the format entirely:

```json
{ "data-ref": "<address>", "text": "<inline string>", "data": "<inline base64>" }
```

`text`/`data` are the inline forms MT uses below its 4 KB `MessageDataDefaults.Threshold` — when either is present the payload never reached the repository, so no store lookup happens.

So the seam is `MassTransitJsonSerializer`, **not** `ClaimCheckMessageSerializer`, and it needs no new package.

## Usage

```csharp
.UseMassTransitInterop(mt =>
    mt.ReadMessageDataFrom(new AmazonS3ClaimCheckStore(s3Client, "mt-message-data")));
```

Properties marked `[Blob]` are hydrated from that store. Reusing `[Blob]` as the opt-in marker means a contract shared across the migration needs no extra annotation — and it's what stops the converter interpreting every ordinary `byte[]`/`string` property as a claim-check reference. It's attached via a `DefaultJsonTypeInfoResolver` modifier on the MassTransit serializer's own `JsonSerializerOptions`, so Wolverine's normal serialization path is untouched.

## Address translation

Transcribed from MT's repository implementations, the same way `MassTransitHeaders` was — **MassTransit is deliberately not a package reference**, and the tests use hand-built fixtures.

| MT repository | Address | Payload id |
| --- | --- | --- |
| File system / Amazon S3 | `urn:file:{key}` (colons for separators) | segments rejoined with `/` |
| Azure Storage | `https://…/{container}/{blob}` (the blob's own Uri) | everything after the container segment |
| In-memory | `urn:msgdata:{id}` | rejected with an explicit message |

A trailing `.gz` is gunzipped automatically, matching the Azure repository's compression option. A custom `IMessageDataRepository` can supply its own mapper: `ReadMessageDataFrom(store, address => ...)`.

Two limits, both documented:

- **The address carries the key, not the bucket** — MT's repository config owns that, so the store passed in must point at the same bucket or every lookup misses.
- **MT's in-memory repository can't be read**; its payloads never leave the producing process. Wolverine says exactly that rather than surfacing a confusing lookup failure.

## Notes for review

- The converter tolerates a **plain JSON value** on a `[Blob]` property, so enabling interop doesn't break the same contract arriving from a Wolverine peer.
- Read/consume side only — producing MT-compatible references is explicitly out of scope per the issue, and the outbound path is byte-for-byte unchanged.
- Converters are instantiated by an **explicit type switch rather than `MakeGenericType`**: core Wolverine's trim/AOT analysis rejects the reflective form with IL3050.
- `ReadMessageDataFrom` and `UseSystemTextJsonForSerialization` compose in either call order (covered by a test).

## Verification

- `CoreTests` full suite: **2444 passed, 0 failed, 2 skipped**
- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings

New coverage: all four address forms plus the failure cases, both inline forms, the gzip path, an empty reference, plain-value tolerance, a non-`[Blob]` property left alone, a custom address mapper, and configuration-order composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3