### PR TITLE
GH-4006: payload expiration for the NATS Object Store claim-check backend

### DIFF
--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -221,6 +221,28 @@ builder.Host.UseWolverine(opts =>
 
 The server must have JetStream enabled. The object-store bucket is created on first use if it does not already exist. Token id maps to the object name; the content type travels with the token. `DeleteAsync` is idempotent — a missing object is treated as already deleted. An overload accepting an existing `INatsObjContext` is also available if you manage the object-store context yourself.
 
+#### Expiring NATS payloads <Badge type="tip" text="6.30" />
+
+Pass a `maxAge` and Wolverine configures the bucket it creates with a native TTL — the NATS server then
+expires off-loaded payloads itself:
+
+```csharp
+opts.UseClaimCheck(cc => cc.UseNatsObjectStore(
+    connection,
+    bucketName: "wolverine-claim-checks",
+    maxAge: 7.Days()));
+```
+
+This is the option to prefer: expiry is server-side, costs nothing, and keeps working while your
+application is down. Note that it only applies to a bucket **Wolverine creates** — an existing bucket keeps
+whatever max age it was already configured with.
+
+For a bucket you did not let Wolverine create, this backend also implements
+`IClaimCheckStoreWithExpiration`, so [`DeletePayloadsOlderThan(...)`](#expiring-old-payloads) works here
+too. Unlike the cloud object stores — where enumerating a bucket means a billed LIST request on every pass,
+which is why they deliberately opt out — a NATS listing reads the bucket's local metadata stream, so
+sweeping is cheap.
+
 ### PostgreSQL (database LOB)
 
 The zero-new-infrastructure option for critter-stack users: off-loaded payloads are stored as `bytea` rows in your existing PostgreSQL database — no S3 / Azure / GCS account required.
@@ -409,8 +431,8 @@ claim-check store writes to and you are done — no Wolverine configuration, no 
 keeps working even while your application is down. These backends deliberately do **not** implement
 Wolverine-driven sweeping for exactly that reason.
 
-**2. A Wolverine-driven sweep.** For backends with no native lifecycle support — the file system
-store and the database-LOB stores — call `DeletePayloadsOlderThan`:
+**2. A Wolverine-driven sweep.** For backends where enumeration is cheap — the file system store, the
+database-LOB stores, and [NATS](#nats-jetstream-object-store) — call `DeletePayloadsOlderThan`:
 
 ```csharp
 opts.UseClaimCheck(cc =>

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsObjectStoreClaimCheckStoreExpirationTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsObjectStoreClaimCheckStoreExpirationTests.cs
@@ -1,0 +1,170 @@
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.ObjectStore;
+using NATS.Net;
+using Shouldly;
+using Wolverine.Persistence;
+
+namespace Wolverine.ClaimCheck.Nats.Tests;
+
+/// <summary>
+/// GH-4006: NATS was the one claim-check backend with no expiration path at all — no native lifecycle
+/// and no <see cref="IClaimCheckStoreWithExpiration"/>. Both halves are covered here.
+/// </summary>
+public class NatsObjectStoreClaimCheckStoreExpirationTests : IAsyncLifetime
+{
+    private readonly string _bucketName = "claimcheckttl" + Guid.NewGuid().ToString("N");
+    private NatsConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        if (!NatsServer.IsRunning)
+        {
+            return;
+        }
+
+        _connection = new NatsConnection(new NatsOpts { Url = NatsServer.Url });
+        await _connection.ConnectAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var context = new NatsObjContext(_connection.CreateJetStreamContext());
+            await context.DeleteObjectStore(_bucketName, CancellationToken.None);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        finally
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+
+    private NatsObjectStoreClaimCheckStore storeFor(TimeSpan? maxAge = null)
+        => new(_connection, _bucketName, maxAge);
+
+    [NatsFact]
+    public async Task deletes_aged_payloads_and_leaves_recent_ones()
+    {
+        var store = storeFor();
+
+        var old = await store.StoreAsync(new byte[] { 1, 2, 3 }, "text/plain",
+            TestContext.Current.CancellationToken);
+
+        // The object's MTime is server-assigned, so age the CUTOFF rather than the object: everything
+        // written before "now" is expired, and anything written after it is not.
+        await Task.Delay(1200, TestContext.Current.CancellationToken);
+        var cutoff = DateTimeOffset.UtcNow;
+        await Task.Delay(1200, TestContext.Current.CancellationToken);
+
+        var recent = await store.StoreAsync(new byte[] { 4, 5, 6 }, "text/plain",
+            TestContext.Current.CancellationToken);
+
+        var deleted = await store.DeleteExpiredPayloadsAsync(cutoff, 100,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(1);
+
+        await Should.ThrowAsync<NatsObjNotFoundException>(() => store.LoadAsync(old));
+
+        (await store.LoadAsync(recent, TestContext.Current.CancellationToken)).ToArray()
+            .ShouldBe(new byte[] { 4, 5, 6 });
+    }
+
+    [NatsFact]
+    public async Task honors_the_max_count()
+    {
+        var store = storeFor();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await store.StoreAsync(new byte[] { (byte)i }, "text/plain", TestContext.Current.CancellationToken);
+        }
+
+        await Task.Delay(1200, TestContext.Current.CancellationToken);
+
+        var deleted = await store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow, 2,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBe(2);
+    }
+
+    [NatsFact]
+    public async Task a_sweep_over_an_empty_bucket_terminates_and_deletes_nothing()
+    {
+        // Regression guard: without NatsObjListOpts.OnNoData the list enumerator parks waiting for more
+        // data once it drains the bucket, which would hang the sweeper forever on an empty bucket.
+        var store = storeFor();
+
+        // Force the bucket into existence without storing anything that should be swept.
+        await store.DeleteAsync(new ClaimCheckToken("never-written", "text/plain", 0),
+            TestContext.Current.CancellationToken);
+
+        var sweep = store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow, 100,
+            TestContext.Current.CancellationToken);
+
+        var finished = await Task.WhenAny(sweep, Task.Delay(TimeSpan.FromSeconds(15),
+            TestContext.Current.CancellationToken));
+
+        finished.ShouldBeSameAs(sweep, "the sweep hung on an empty bucket");
+        (await sweep).ShouldBe(0);
+    }
+
+    [NatsFact]
+    public async Task a_repeat_sweep_is_a_no_op()
+    {
+        var store = storeFor();
+
+        await store.StoreAsync(new byte[] { 1 }, "text/plain", TestContext.Current.CancellationToken);
+        await Task.Delay(1200, TestContext.Current.CancellationToken);
+
+        var cutoff = DateTimeOffset.UtcNow;
+        (await store.DeleteExpiredPayloadsAsync(cutoff, 100, TestContext.Current.CancellationToken)).ShouldBe(1);
+        (await store.DeleteExpiredPayloadsAsync(cutoff, 100, TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    [NatsFact]
+    public async Task a_non_positive_max_count_deletes_nothing()
+    {
+        var store = storeFor();
+
+        await store.StoreAsync(new byte[] { 1 }, "text/plain", TestContext.Current.CancellationToken);
+        await Task.Delay(1200, TestContext.Current.CancellationToken);
+
+        (await store.DeleteExpiredPayloadsAsync(DateTimeOffset.UtcNow, 0,
+            TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    [NatsFact]
+    public async Task a_configured_max_age_is_applied_to_the_bucket_wolverine_creates()
+    {
+        var store = storeFor(TimeSpan.FromMinutes(30));
+
+        // Touch the store so the bucket is provisioned with the configured max age.
+        await store.StoreAsync(new byte[] { 1 }, "text/plain", TestContext.Current.CancellationToken);
+
+        var js = new NatsJSContext(_connection);
+        var stream = await js.GetStreamAsync("OBJ_" + _bucketName, cancellationToken: TestContext.Current.CancellationToken);
+
+        // The object-store bucket's TTL is the underlying JetStream stream's MaxAge.
+        stream.Info.Config.MaxAge.ShouldBe(TimeSpan.FromMinutes(30));
+    }
+
+    [Fact]
+    public void rejects_a_non_positive_max_age()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new NatsObjectStoreClaimCheckStore(new NatsObjContext(
+                new NatsConnection(new NatsOpts { Url = "nats://127.0.0.1:4222" }).CreateJetStreamContext()),
+                "bucket", TimeSpan.Zero));
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckExtensions.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckExtensions.cs
@@ -17,10 +17,17 @@ public static class NatsObjectStoreClaimCheckExtensions
     /// <param name="config">The claim check configuration to attach to.</param>
     /// <param name="connection">An already-connected <see cref="INatsConnection"/>.</param>
     /// <param name="bucketName">Name of the object-store bucket used to hold payloads. Created on first use if it does not exist.</param>
+    /// <param name="maxAge">
+    /// Optional native bucket TTL. When Wolverine creates the bucket it is configured with this max age,
+    /// so the NATS server expires off-loaded payloads itself. This is the cheapest way to keep the bucket
+    /// from growing without bound and it keeps working while the application is down — prefer it over
+    /// <c>DeletePayloadsOlderThan(...)</c> where you control bucket creation. See GH-4006.
+    /// </param>
     public static ClaimCheckConfiguration UseNatsObjectStore(
         this ClaimCheckConfiguration config,
         INatsConnection connection,
-        string bucketName)
+        string bucketName,
+        TimeSpan? maxAge = null)
     {
         if (config is null) throw new ArgumentNullException(nameof(config));
         if (connection is null) throw new ArgumentNullException(nameof(connection));
@@ -29,7 +36,7 @@ public static class NatsObjectStoreClaimCheckExtensions
             throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
         }
 
-        config.Store = new NatsObjectStoreClaimCheckStore(connection, bucketName);
+        config.Store = new NatsObjectStoreClaimCheckStore(connection, bucketName, maxAge);
         return config;
     }
 
@@ -40,7 +47,8 @@ public static class NatsObjectStoreClaimCheckExtensions
     public static ClaimCheckConfiguration UseNatsObjectStore(
         this ClaimCheckConfiguration config,
         INatsObjContext context,
-        string bucketName)
+        string bucketName,
+        TimeSpan? maxAge = null)
     {
         if (config is null) throw new ArgumentNullException(nameof(config));
         if (context is null) throw new ArgumentNullException(nameof(context));
@@ -49,7 +57,7 @@ public static class NatsObjectStoreClaimCheckExtensions
             throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
         }
 
-        config.Store = new NatsObjectStoreClaimCheckStore(context, bucketName);
+        config.Store = new NatsObjectStoreClaimCheckStore(context, bucketName, maxAge);
         return config;
     }
 }

--- a/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckStore.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats/NatsObjectStoreClaimCheckStore.cs
@@ -12,10 +12,11 @@ namespace Wolverine.ClaimCheck.Nats;
 /// <see cref="ClaimCheckToken.Id"/> maps directly to the object name; the content type
 /// travels with the token, so it does not need to be persisted alongside the bytes.
 /// </summary>
-public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
+public class NatsObjectStoreClaimCheckStore : IClaimCheckStoreWithExpiration
 {
     private readonly INatsObjContext _context;
     private readonly string _bucketName;
+    private readonly TimeSpan? _maxAge;
 
     // The bucket is resolved (created-or-fetched) lazily on first use and cached. Guarded by a
     // gate so concurrent StoreAsync/LoadAsync calls don't race on the create-or-get.
@@ -28,8 +29,14 @@ public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
     /// </summary>
     /// <param name="connection">A connected <see cref="INatsConnection"/> (JetStream must be enabled on the server).</param>
     /// <param name="bucketName">Name of the object-store bucket used to hold claim check payloads. Created on first use if it does not exist.</param>
-    public NatsObjectStoreClaimCheckStore(INatsConnection connection, string bucketName)
-        : this(new NatsObjContext(connection.CreateJetStreamContext()), bucketName)
+    /// <param name="maxAge">
+    /// Optional native bucket TTL. When Wolverine creates the bucket it is configured with this
+    /// <see cref="NatsObjConfig.MaxAge"/>, so the NATS server expires payloads itself — the cheapest
+    /// option, and it keeps working while the application is down. See GH-4006.
+    /// </param>
+    public NatsObjectStoreClaimCheckStore(INatsConnection connection, string bucketName,
+        TimeSpan? maxAge = null)
+        : this(new NatsObjContext(connection.CreateJetStreamContext()), bucketName, maxAge)
     {
     }
 
@@ -37,9 +44,18 @@ public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
     /// Create a new claim check store backed by a NATS JetStream Object Store bucket, using an
     /// already-constructed object-store context.
     /// </summary>
-    public NatsObjectStoreClaimCheckStore(INatsObjContext context, string bucketName)
+    public NatsObjectStoreClaimCheckStore(INatsObjContext context, string bucketName,
+        TimeSpan? maxAge = null)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+
+        if (maxAge is { } age && age <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxAge),
+                "The object-store bucket max age must be a positive duration.");
+        }
+
+        _maxAge = maxAge;
         if (string.IsNullOrWhiteSpace(bucketName))
         {
             throw new ArgumentException("Bucket name must be provided", nameof(bucketName));
@@ -50,6 +66,11 @@ public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
 
     /// <summary>The configured object-store bucket name.</summary>
     public string BucketName => _bucketName;
+
+    /// <summary>
+    /// The native bucket TTL applied when Wolverine creates the bucket, or null when none was configured.
+    /// </summary>
+    public TimeSpan? MaxAge => _maxAge;
 
     public async Task<ClaimCheckToken> StoreAsync(
         ReadOnlyMemory<byte> payload,
@@ -104,6 +125,105 @@ public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
         }
     }
 
+    /// <summary>
+    /// How long the metadata enumeration will sit quiet before the sweep concludes the bucket is drained.
+    /// Only actually waited out when the bucket has no objects at all — see the remarks on
+    /// <see cref="DeleteExpiredPayloadsAsync"/>.
+    /// </summary>
+    private static readonly TimeSpan _drainTimeout = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// GH-4006 sweep support. Unlike the S3 / Azure / GCS backends — which deliberately do not implement
+    /// this, because enumerating a cloud bucket costs a billed LIST request per pass — a NATS object-store
+    /// listing reads the bucket's local metadata stream, so a Wolverine-driven sweep is cheap here.
+    /// </summary>
+    /// <remarks>
+    /// Prefer configuring a native bucket <c>maxAge</c> when Wolverine creates the bucket; that expires
+    /// payloads server-side and keeps working while the application is down. This sweep exists for buckets
+    /// Wolverine did not create (and therefore cannot configure), and so that
+    /// <c>DeletePayloadsOlderThan(...)</c> behaves uniformly across every backend.
+    ///
+    /// <para>Three behaviours of the NATS client shape this method, all confirmed against a live server:</para>
+    /// <list type="bullet">
+    /// <item><b>The first <c>OnNoData</c> callback fires before the initial fetch has landed</b>, so
+    /// returning <c>true</c> from it aborts the enumeration with zero results even when the bucket is full.
+    /// It has to return <c>false</c> once to let the data arrive, and <c>true</c> thereafter.</item>
+    /// <item><b>On a genuinely empty bucket <c>OnNoData</c> is never called a second time</b>, so the
+    /// enumeration would park forever. The linked idle deadline below is what bounds that case; it is the
+    /// only case that actually waits.</item>
+    /// <item><b>Breaking out of the enumeration early hangs on disposal.</b> So this always drains the
+    /// whole metadata stream and applies <paramref name="maxCount"/> to the delete step instead. That is
+    /// cheap — the stream is local metadata, not payload bytes.</item>
+    /// </list>
+    /// </remarks>
+    public async Task<int> DeleteExpiredPayloadsAsync(
+        DateTimeOffset cutoff,
+        int maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxCount <= 0)
+        {
+            return 0;
+        }
+
+        var store = await resolveStoreAsync(cancellationToken).ConfigureAwait(false);
+
+        var expired = new List<string>();
+
+        using var idle = new CancellationTokenSource(_drainTimeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, idle.Token);
+
+        var noDataCalls = 0;
+        var options = new NatsObjListOpts
+        {
+            OnNoData = _ => new ValueTask<bool>(++noDataCalls > 1)
+        };
+
+        try
+        {
+            await foreach (var metadata in store.ListAsync(options, linked.Token).ConfigureAwait(false))
+            {
+                // Every delivered item pushes the quiet deadline out, so a large bucket is never cut off
+                // mid-scan; the deadline only expires once the stream really has gone silent.
+                idle.CancelAfter(_drainTimeout);
+
+                if (metadata.Deleted || metadata.Name is null)
+                {
+                    // Tombstones stay in the metadata stream after a delete, so they must be filtered or
+                    // the sweep would try to delete the same object forever.
+                    continue;
+                }
+
+                if (metadata.MTime < cutoff && expired.Count < maxCount)
+                {
+                    expired.Add(metadata.Name);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Our own idle deadline, not the caller's token: the bucket is drained (or empty). Whatever
+            // was collected before it fired is a complete-enough batch — the sweep is idempotent and runs
+            // again on the next interval.
+        }
+
+        var deleted = 0;
+        foreach (var name in expired)
+        {
+            try
+            {
+                await store.DeleteAsync(name, cancellationToken).ConfigureAwait(false);
+                deleted++;
+            }
+            catch (NatsObjNotFoundException)
+            {
+                // Another node's sweeper got there first; not an error.
+            }
+        }
+
+        return deleted;
+    }
+
     private async ValueTask<INatsObjStore> resolveStoreAsync(CancellationToken cancellationToken)
     {
         if (_store is not null)
@@ -129,8 +249,16 @@ public class NatsObjectStoreClaimCheckStore : IClaimCheckStore
                 // "stream not found" error). Create it; if another caller won the race, fall back to get.
                 try
                 {
+                    // MaxAge is init-only, so it has to be set in the initializer. It is native,
+                    // server-side expiry on the bucket's underlying JetStream stream, and only applies
+                    // to a bucket Wolverine creates -- an existing bucket keeps whatever max age it was
+                    // already configured with. See GH-4006.
+                    var config = _maxAge.HasValue
+                        ? new NatsObjConfig(_bucketName) { MaxAge = _maxAge.Value }
+                        : new NatsObjConfig(_bucketName);
+
                     _store = await _context
-                        .CreateObjectStoreAsync(new NatsObjConfig(_bucketName), cancellationToken)
+                        .CreateObjectStoreAsync(config, cancellationToken)
                         .ConfigureAwait(false);
                 }
                 catch (NatsJSApiException)


### PR DESCRIPTION
Closes #4006.

NATS was the only claim-check backend with **no expiration path at all**. The file system and the three database backends implement `IClaimCheckStoreWithExpiration`; Azure Blob / S3 / GCS deliberately opt out in favour of their free server-side lifecycle rules. NATS had neither — `DeletePayloadsOlderThan(...)` skipped it with a warning and there was no documented alternative to point users at.

## NATS did have a native lifecycle — we just never exposed it

`NatsObjConfig.MaxAge` sets a TTL on the bucket's underlying JetStream stream. Wolverine created buckets with a bare `new NatsObjConfig(bucket)` and never touched it. So NATS wasn't missing a mechanism; it was missing *access* to one. Both halves ship here, because they serve different deployments:

```csharp
// Native, server-side, free, and keeps working while your app is down. The docs lead with this.
opts.UseClaimCheck(cc => cc.UseNatsObjectStore(connection, "wolverine-claim-checks", maxAge: 7.Days()));
```

`maxAge` only applies to a bucket **Wolverine creates** — an existing bucket keeps whatever max age it already had, which is documented.

The backend now also implements `IClaimCheckStoreWithExpiration`, so `DeletePayloadsOlderThan(...)` is uniform across every backend and covers a pre-existing bucket Wolverine can't reconfigure. Sweeping is defensible here where it isn't for the cloud object stores: a NATS listing reads a **local metadata stream** rather than costing a billed LIST request per pass.

## Three client behaviours the docs don't mention

All three were confirmed against a live server with a throwaway probe, not inferred — and each one produced a real failure first:

1. **The first `OnNoData` callback fires *before* the initial fetch lands.** Returning `true` from it — the obvious reading of *"return True to break the async enumeration"* — aborts with **zero results against a full bucket**. My first implementation did exactly that and the sweep silently deleted nothing. It has to return `false` once to let data arrive, then `true`.
2. **On a genuinely empty bucket, `OnNoData` is never called a second time**, so the enumeration parks forever. A linked idle deadline bounds that, and it's the only case that actually waits.
3. **Breaking out of the enumeration early hangs on disposal** — measured at 8s, i.e. it blocked until the cancellation token fired. That was a real hang in `honors_the_max_count`. The sweep now always drains the whole metadata stream and applies `maxCount` to the *delete* step instead. That's cheap: metadata, not payload bytes.

Also: **delete tombstones stay in the metadata stream**, so they're filtered explicitly. Without that the sweep would retry the same object forever.

## Verification

- `Wolverine.ClaimCheck.Nats.Tests` — **11/11** (4 pre-existing + 7 new) in 9.3s against docker NATS with JetStream
- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings

New coverage includes a regression guard that **fails if the empty-bucket sweep doesn't complete**, plus `maxCount`, idempotence, tombstone filtering, and an assertion that a configured `maxAge` actually lands on the underlying JetStream stream's config.

Note these tests only run in CI once #4007 lands — `CIClaimCheck` currently covers just the three database backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3