### PR TITLE
GH-4007: run the object-store claim-check suites in CI, and fix the Azure Blob suite

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -445,29 +445,39 @@ partial class Build
         });
 
     /// <summary>
-    /// GH-3566: the claim-check backend suites had no CI target at all -- every backend shipped with tests
-    /// that only ever ran on a developer machine. This covers the three database-backed stores, which need
-    /// nothing beyond the Postgres and SQL Server containers already in the compose file. The object-store
-    /// backends (S3, Azure, GCS, NATS) still need their emulators and carry their own skip guards.
+    /// GH-3566 / GH-4007: the claim-check backend suites had no CI target at all -- every backend shipped
+    /// with tests that only ever ran on a developer machine, and were merely *compiled* by the
+    /// full-solution build. This runs all seven, database-backed and object-store alike.
     /// </summary>
+    /// <remarks>
+    /// The object-store suites keep their own per-emulator skip guards so a developer without, say,
+    /// Azurite running still gets a clean local run. The point of this target is that CI has every
+    /// emulator, so nothing skips there. Azurite in particular was missing from the compose file
+    /// entirely, which meant the Azure Blob suite skipped everywhere -- see GH-4007.
+    /// </remarks>
     Target CIClaimCheck => _ => _
         .ProceedAfterFailure()
         .Executes(() =>
         {
-            var claimCheck = RootDirectory / "src" / "Persistence";
-            var postgresql = claimCheck / "Wolverine.ClaimCheck.Postgresql.Tests" /
-                             "Wolverine.ClaimCheck.Postgresql.Tests.csproj";
-            var sqlServer = claimCheck / "Wolverine.ClaimCheck.SqlServer.Tests" /
-                            "Wolverine.ClaimCheck.SqlServer.Tests.csproj";
-            var marten = claimCheck / "Wolverine.ClaimCheck.Marten.Tests" /
-                         "Wolverine.ClaimCheck.Marten.Tests.csproj";
+            AbsolutePath suite(string name) =>
+                RootDirectory / "src" / "Persistence" / $"Wolverine.ClaimCheck.{name}.Tests" /
+                $"Wolverine.ClaimCheck.{name}.Tests.csproj";
 
-            BuildTestProjects(postgresql, sqlServer, marten);
-            StartDockerServices("postgresql", "sqlserver");
+            var databaseSuites = new[] { suite("Postgresql"), suite("SqlServer"), suite("Marten") };
+            var objectStoreSuites = new[]
+            {
+                suite("AmazonS3"), suite("AzureBlobStorage"), suite("GoogleCloudStorage"), suite("Nats")
+            };
 
-            RunTestProject(postgresql);
-            RunTestProject(sqlServer);
-            RunTestProject(marten);
+            var all = databaseSuites.Concat(objectStoreSuites).ToArray();
+
+            BuildTestProjects(all);
+            StartDockerServices("postgresql", "sqlserver", "localstack", "azurite", "fake-gcs-server", "nats");
+
+            foreach (var project in all)
+            {
+                RunTestProject(project);
+            }
         });
 
     Target CISqlite => _ => _

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,18 @@ services:
       - "4443:4443"
     command: ["-scheme", "http", "-host", "0.0.0.0", "-port", "4443", "-public-host", "localhost:4443"]
 
+  # Azure Storage emulator used by the WolverineFx.ClaimCheck.AzureBlobStorage backend tests.
+  # Without this service AzuriteFactAttribute skips EVERY test in that suite -- including on a dev
+  # machine -- so the Azure Blob claim-check backend had no executed coverage anywhere. See GH-4007.
+  # Pinned rather than :latest, for the same reason called out on fake-gcs-server above.
+  azurite:
+    image: "mcr.microsoft.com/azure-storage/azurite:3.36.0"
+    ports:
+      - "10000:10000"
+    # Blob only -- the claim-check store never touches queues or tables. --blobHost 0.0.0.0 is
+    # required for the port publish to be reachable from outside the container.
+    command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000"]
+
   rabbitmq:
     image: "rabbitmq:4-management"
     ports:

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/AzureBlobClaimCheckStoreTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/AzureBlobClaimCheckStoreTests.cs
@@ -20,7 +20,7 @@ public class AzureBlobClaimCheckStoreTests : IAsyncLifetime
             return;
         }
 
-        _container = new BlobContainerClient(Azurite.ConnectionString, _containerName);
+        _container = Azurite.ContainerClient(_containerName);
         await _container.CreateIfNotExistsAsync();
         _store = new AzureBlobClaimCheckStore(_container);
     }
@@ -80,7 +80,8 @@ public class AzureBlobClaimCheckStoreTests : IAsyncLifetime
     public async Task connection_string_constructor_works()
     {
         await using var _ = new DisposableContainer(_containerName + "-cs");
-        var altStore = new AzureBlobClaimCheckStore(Azurite.ConnectionString, _containerName + "-cs");
+        var altStore = new AzureBlobClaimCheckStore(Azurite.ConnectionString, _containerName + "-cs",
+            new BlobClientOptions(Azurite.MaxSupportedServiceVersion));
         await altStore.ContainerClient.CreateIfNotExistsAsync();
 
         var token = await altStore.StoreAsync(new byte[] { 9, 8, 7 }, "application/octet-stream");
@@ -94,7 +95,7 @@ public class AzureBlobClaimCheckStoreTests : IAsyncLifetime
         private readonly BlobContainerClient _client;
         public DisposableContainer(string name)
         {
-            _client = new BlobContainerClient(Azurite.ConnectionString, name);
+            _client = Azurite.ContainerClient(name);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/AzuriteFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/AzuriteFact.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Net.Sockets;
+using Azure.Storage.Blobs;
 
 namespace Wolverine.ClaimCheck.AzureBlobStorage.Tests;
 
@@ -15,6 +16,20 @@ internal static class Azurite
         "AccountName=devstoreaccount1;" +
         "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
         "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+
+    /// <summary>
+    /// The newest blob service version Azurite understands. The Azure SDK defaults to the newest version
+    /// it knows about, which runs ahead of the emulator — sending it makes Azurite reject every request
+    /// with <c>InvalidHeaderValue</c>, and because this suite skipped everywhere before GH-4007 nobody
+    /// ever saw it. Pin the emulator client to a version Azurite supports; production clients keep the
+    /// SDK default against real Azure Storage.
+    /// </summary>
+    public const BlobClientOptions.ServiceVersion MaxSupportedServiceVersion =
+        BlobClientOptions.ServiceVersion.V2025_11_05;
+
+    /// <summary>A <see cref="BlobContainerClient"/> pinned to a service version Azurite accepts.</summary>
+    public static BlobContainerClient ContainerClient(string containerName)
+        => new(ConnectionString, containerName, new BlobClientOptions(MaxSupportedServiceVersion));
 
     public const string Host = "127.0.0.1";
     public const int Port = 10000;

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/AzureBlobClaimCheckStore.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage/AzureBlobClaimCheckStore.cs
@@ -19,8 +19,16 @@ public class AzureBlobClaimCheckStore : IClaimCheckStore
         _containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
     }
 
-    public AzureBlobClaimCheckStore(string connectionString, string containerName)
-        : this(new BlobContainerClient(connectionString, containerName))
+    /// <param name="connectionString">Connection string for the target storage account.</param>
+    /// <param name="containerName">Blob container that holds the off-loaded payloads.</param>
+    /// <param name="options">
+    /// Optional client options. Chiefly useful for pinning
+    /// <see cref="BlobClientOptions.ServiceVersion"/> when the endpoint is an emulator or an older
+    /// storage service that does not yet accept the version the SDK sends by default.
+    /// </param>
+    public AzureBlobClaimCheckStore(string connectionString, string containerName,
+        BlobClientOptions? options = null)
+        : this(new BlobContainerClient(connectionString, containerName, options))
     {
     }
 


### PR DESCRIPTION
Closes #4007.

Before #4005, **no CI target ran any claim-check backend tests at all** — all five shipped backends had test projects that only ever executed on a developer machine and were merely *compiled* by the full-solution build. #4005 added `CIClaimCheck` for the three database-backed stores; this extends it to the remaining four.

## Adding Azurite proved the Azure Blob suite was broken

Azurite was missing from `docker-compose.yml` entirely, even though `AzuriteFactAttribute` exists and guards every test in the Azure Blob suite. So those tests skipped **everywhere**, including locally — which is exactly how the following went unnoticed. Adding the service and running the suite: **4 failed, 0 succeeded.**

Two separate causes:

1. **Every test failed with `InvalidHeaderValue`.** The Azure SDK defaults to the newest service version it knows about (`V2026_02_06`); Azurite 3.36.0 — the newest published tag — accepts at most `2025-11-05`. Emulator clients are now pinned to a supported version through a single `Azurite.ContainerClient(...)` helper, with the reasoning documented in one place. Production clients keep the SDK default against real Azure Storage.

2. **`connection_string_constructor_works`** exercises the store's own connection-string constructor, which built its `BlobContainerClient` internally with no way to influence it. That constructor now takes an optional `BlobClientOptions` — useful in its own right for retry policy or an older storage service, not only for the emulator.

With both fixed, all four object-store suites run green with **zero skips**, and the Azure Blob backend has executed test coverage for the first time.

## Result

`CIClaimCheck` now runs all seven suites. Verified by running the actual Nuke target locally:

```
Wolverine.ClaimCheck.Postgresql.Tests:        10 passed
Wolverine.ClaimCheck.SqlServer.Tests:         12 passed
Wolverine.ClaimCheck.Marten.Tests:             5 passed
Wolverine.ClaimCheck.AmazonS3.Tests:           4 passed
Wolverine.ClaimCheck.AzureBlobStorage.Tests:   4 passed
Wolverine.ClaimCheck.GoogleCloudStorage.Tests: 4 passed
Wolverine.ClaimCheck.Nats.Tests:               4 passed

CIClaimCheck       Succeeded       0:18
```

43 tests, 0 skips, 0 retries, 18 seconds — far inside the 20-minute job cap.

`dotnet build wolverine.slnx -c Release -f net9.0` is clean. The per-suite skip guards are unchanged, so a developer without a given emulator running still gets a clean local run; the point is that **CI** has them all.

The `azurite` image is pinned rather than `:latest`, matching the reasoning already documented on `fake-gcs-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3