### PR TITLE
GH-4010: resolve the deserialize stage's channel callback per envelope

### DIFF
--- a/src/Testing/CoreTests/Runtime/Partitioning/sharded_execution_parallel_deserialization.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/sharded_execution_parallel_deserialization.cs
@@ -108,10 +108,11 @@ public class sharded_execution_parallel_deserialization
         });
 
         // runtime/channel are only touched on the non-NullContinuation path, which these
-        // stubbed deserializations never take
+        // stubbed deserializations never take. The cast disambiguates the single-channel
+        // overload from the GH-4010 per-envelope resolver -- a bare null fits both
         var block = parallelism.HasValue
-            ? sharded.DeserializeFirst(pipeline, null!, null!, parallelism.Value)
-            : sharded.DeserializeFirst(pipeline, null!, null!);
+            ? sharded.DeserializeFirst(pipeline, null!, (Wolverine.Transports.IChannelCallback)null!, parallelism.Value)
+            : sharded.DeserializeFirst(pipeline, null!, (Wolverine.Transports.IChannelCallback)null!);
 
         // Posting sequentially from one thread is what DEFINES the arrival order the
         // sharded structure promises to preserve per group
@@ -343,7 +344,7 @@ public class sharded_execution_parallel_deserialization
             received.GetOrAdd(coffee.Name, _ => new List<int>()).Add(coffee.Sequence);
         });
 
-        var block = sharded.DeserializeFirst(pipeline, null!, null!, 8);
+        var block = sharded.DeserializeFirst(pipeline, null!, (Wolverine.Transports.IChannelCallback)null!, 8);
 
         foreach (var envelope in envelopes)
         {

--- a/src/Testing/CoreTests/Runtime/Partitioning/sharded_execution_per_envelope_channel.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/sharded_execution_per_envelope_channel.cs
@@ -1,0 +1,194 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Runtime.Partitioning;
+
+/// <summary>
+/// GH-4010: the deserialize stage in front of the sharded slots resolves its
+/// <see cref="IChannelCallback"/> per envelope rather than capturing a single one for the
+/// lifetime of the block.
+///
+/// The channel is only consulted on the deserialization-FAILURE path -- the envelope never
+/// reaches the handler pipeline, so the continuation (dead-letter, discard) has to settle the
+/// delivery itself. For receivers that ack at receipt or against an inbox row, one captured
+/// channel is correct and these overloads are unchanged. For a receiver whose settlement rides
+/// the delivery's own transport channel it is not: a poison payload would be dead-lettered and
+/// then never settled, which is a silent stall rather than an exception. With
+/// <c>ListenerCount > 1</c> there isn't even a single correct channel to capture.
+/// </summary>
+public class sharded_execution_per_envelope_channel
+{
+    public record Poison(string Name);
+
+    /// <summary>
+    /// Records which envelopes were settled against it, standing in for one listener's channel.
+    /// </summary>
+    private class RecordingChannel : IChannelCallback
+    {
+        public ConcurrentBag<Guid> Completed { get; } = new();
+
+        public IHandlerPipeline? Pipeline => null;
+
+        public ValueTask CompleteAsync(Envelope envelope)
+        {
+            Completed.Add(envelope.Id);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Settles through the lifecycle, the way the real dead-letter and discard continuations do.
+    /// That routes to whichever channel <c>ReadEnvelope</c> installed -- which is the thing
+    /// under test.
+    /// </summary>
+    private class SettlingContinuation : IContinuation
+    {
+        public async ValueTask ExecuteAsync(IEnvelopeLifecycle lifecycle, IWolverineRuntime runtime,
+            DateTimeOffset now, Activity? activity)
+        {
+            await lifecycle.CompleteAsync();
+        }
+    }
+
+    /// <summary>
+    /// Every envelope "fails" deserialization by returning a non-null continuation, which is the
+    /// branch that consults the channel.
+    /// </summary>
+    private class AlwaysFailsDeserializationPipeline : IHandlerPipeline
+    {
+        public Task InvokeAsync(Envelope envelope, IChannelCallback channel)
+            => throw new NotSupportedException();
+
+        public Task InvokeAsync(Envelope envelope, IChannelCallback channel, Activity activity)
+            => throw new NotSupportedException();
+
+        public async ValueTask<IContinuation> TryDeserializeEnvelope(Envelope envelope)
+        {
+            await Task.Yield();
+            return new SettlingContinuation();
+        }
+    }
+
+    [Fact]
+    public async Task failed_deserialization_settles_on_the_envelopes_own_channel()
+    {
+        // Two channels standing in for two listeners behind one receiver -- the ListenerCount > 1
+        // shape, where no single captured channel could be correct for both
+        var first = new RecordingChannel();
+        var second = new RecordingChannel();
+
+        var pipeline = new AlwaysFailsDeserializationPipeline();
+        var rules = new MessagePartitioningRules(new());
+
+        var sharded = new ShardedExecutionBlock(3, rules, (_, _) => Task.CompletedTask);
+
+        var expectedFirst = new List<Guid>();
+        var expectedSecond = new List<Guid>();
+        var envelopes = new List<Envelope>();
+        var channelFor = new Dictionary<Guid, RecordingChannel>();
+
+        for (var i = 0; i < 40; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.GroupId = $"group-{i % 4}";
+            envelope.Message = new Poison($"poison-{i}");
+
+            var channel = i % 2 == 0 ? first : second;
+            channelFor[envelope.Id] = channel;
+            (i % 2 == 0 ? expectedFirst : expectedSecond).Add(envelope.Id);
+
+            envelopes.Add(envelope);
+        }
+
+        var block = sharded.DeserializeFirst(pipeline, new MockWolverineRuntime(),
+            e => channelFor[e.Id], 8);
+
+        foreach (var envelope in envelopes)
+        {
+            await block.PostAsync(envelope);
+        }
+
+        await block.WaitForCompletionAsync();
+
+        // Each envelope settled exactly once, and on ITS channel -- not on a single captured one
+        first.Completed.OrderBy(x => x).ShouldBe(expectedFirst.OrderBy(x => x));
+        second.Completed.OrderBy(x => x).ShouldBe(expectedSecond.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task single_channel_overload_still_settles_every_envelope_on_that_channel()
+    {
+        // The delegating overload both existing receivers use. Behavior must be identical to
+        // before GH-4010: one channel, every envelope
+        var only = new RecordingChannel();
+
+        var pipeline = new AlwaysFailsDeserializationPipeline();
+        var rules = new MessagePartitioningRules(new());
+
+        var sharded = new ShardedExecutionBlock(3, rules, (_, _) => Task.CompletedTask);
+
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < 25; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.GroupId = $"group-{i % 3}";
+            envelope.Message = new Poison($"poison-{i}");
+            envelopes.Add(envelope);
+        }
+
+        var block = sharded.DeserializeFirst(pipeline, new MockWolverineRuntime(), only, 4);
+
+        foreach (var envelope in envelopes)
+        {
+            await block.PostAsync(envelope);
+        }
+
+        await block.WaitForCompletionAsync();
+
+        only.Completed.OrderBy(x => x).ShouldBe(envelopes.Select(x => x.Id).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task resolver_is_consulted_once_per_envelope_not_once_per_block()
+    {
+        var pipeline = new AlwaysFailsDeserializationPipeline();
+        var rules = new MessagePartitioningRules(new());
+
+        var sharded = new ShardedExecutionBlock(2, rules, (_, _) => Task.CompletedTask);
+
+        var asked = new ConcurrentBag<Guid>();
+        var channel = new RecordingChannel();
+
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < 30; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.GroupId = "solo";
+            envelope.Message = new Poison($"poison-{i}");
+            envelopes.Add(envelope);
+        }
+
+        var block = sharded.DeserializeFirst(pipeline, new MockWolverineRuntime(), e =>
+        {
+            asked.Add(e.Id);
+            return channel;
+        }, 4);
+
+        foreach (var envelope in envelopes)
+        {
+            await block.PostAsync(envelope);
+        }
+
+        await block.WaitForCompletionAsync();
+
+        asked.OrderBy(x => x).ShouldBe(envelopes.Select(x => x.Id).OrderBy(x => x));
+    }
+}

--- a/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
+++ b/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
@@ -58,9 +58,34 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
 
     public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime, IChannelCallback channel)
     {
+        return DeserializeFirst(pipeline, runtime, _ => channel);
+    }
+
+    /// <summary>
+    /// GH-4010. Resolves the <see cref="IChannelCallback"/> to settle against <em>per envelope</em>
+    /// rather than capturing a single one for the lifetime of the block.
+    ///
+    /// The channel is only consulted on the deserialization-FAILURE path, where the envelope never
+    /// reaches the handler pipeline and the continuation (dead-letter, discard) has to settle the
+    /// delivery itself. Receivers that ack at receipt (<c>BufferedReceiver</c>) or against an inbox
+    /// row (<c>DurableReceiver</c>) pass themselves and are unaffected -- the single-channel overload
+    /// above delegates here. A receiver whose settlement rides the delivery's own transport channel
+    /// passes <c>e =&gt; e.Listener!</c> instead: capturing one channel would leave a poison payload
+    /// dead-lettered but never settled (a silent stall until the connection drops, then an infinite
+    /// redelivery loop), and with <c>ListenerCount &gt; 1</c> there is no single correct listener to
+    /// capture in the first place.
+    /// </summary>
+    public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime,
+        Func<Envelope, IChannelCallback> channelSource)
+    {
         // Deserialize parallelism beyond the slot count buys nothing (the slots become the
         // bottleneck again), and going wider than the machine can't help CPU-bound decompression
-        return DeserializeFirst(pipeline, runtime, channel, Math.Min(_numberOfSlots, Environment.ProcessorCount));
+        return DeserializeFirst(pipeline, runtime, channelSource, Math.Min(_numberOfSlots, Environment.ProcessorCount));
+    }
+
+    public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime, IChannelCallback channel, int parallelism)
+    {
+        return DeserializeFirst(pipeline, runtime, _ => channel, parallelism);
     }
 
     /// <summary>
@@ -88,7 +113,8 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
     /// ordered emission; posting to the multi-worker exempt lane never blocks emission any harder
     /// than posting to a slot does (same bounded-channel back pressure).
     /// </summary>
-    public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime, IChannelCallback channel, int parallelism)
+    public IBlock<Envelope> DeserializeFirst(IHandlerPipeline pipeline, IWolverineRuntime runtime,
+        Func<Envelope, IChannelCallback> channelSource, int parallelism)
     {
         async Task<Envelope?> deserializeAsync(Envelope e)
         {
@@ -99,7 +125,7 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
             }
 
             var envelopeLifecycle = new MessageContext(runtime);
-            envelopeLifecycle.ReadEnvelope(e, channel);
+            envelopeLifecycle.ReadEnvelope(e, channelSource(e));
             await continuation.ExecuteAsync(envelopeLifecycle, runtime, DateTimeOffset.UtcNow, Activity.Current);
 
             return null;


### PR DESCRIPTION
Closes #4010.

## What

`ShardedExecutionBlock.DeserializeFirst` captured a single `IChannelCallback` at construction and used it for the deserialization-failure continuation. This adds `Func<Envelope, IChannelCallback>` overloads that resolve the channel **per envelope**, and makes them the real implementation — the existing `IChannelCallback` overloads now delegate as `_ => channel`, so there is one code path rather than two.

## Why this is a prerequisite, not a bug fix

Nothing is broken on `main`. Both existing callers pass `this` and are correct doing so:

- `BufferedReceiver` (`:75`) has already acked the delivery at receipt, so its `CompleteAsync` is a deliberate no-op
- `DurableReceiver` (`:145`) settles against the inbox row, not the broker

The capture stops being correct for a receiver whose settlement rides the delivery's own transport channel — `EndpointMode.NativeAck` (#3708). The deserialization-failure path is the one place an envelope never reaches the handler pipeline, so the continuation (dead-letter, discard) has to settle the delivery itself. With one captured channel a poison payload would be dead-lettered and then **never settled**: a silent stall until the connection drops, then an endless redeliver → fail-to-deserialize → redeliver loop. And with `ListenerCount > 1` building a `ParallelListener` over N listeners behind one receiver, there is no single correct channel to capture even in principle.

## Behavior change

None. The delegating overloads make the existing paths byte-for-byte what they were.

## Tests

New `sharded_execution_per_envelope_channel`:

- **`failed_deserialization_settles_on_the_envelopes_own_channel`** — 40 envelopes split across two channels (the `ListenerCount > 1` shape), each failing deserialization; asserts every envelope settled exactly once and on *its* channel. The continuation stub settles through `lifecycle.CompleteAsync()`, the way the real dead-letter and discard continuations do, so this exercises the actual `ReadEnvelope` → `_channel` routing rather than just the resolver call.
- **`single_channel_overload_still_settles_every_envelope_on_that_channel`** — pins the delegating overload's behavior.
- **`resolver_is_consulted_once_per_envelope_not_once_per_block`**.

**Red-check performed:** temporarily reverting the implementation to capture-once (`capturedForRedCheck ??= channelSource(e)`) fails tests 1 and 3 and passes test 2, which is exactly the expected signature. These assertions are not vacuous.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean (the one `MSB3101` warning is a pre-existing sample-project cache race, present on `main`)
- Full `CoreTests`: **2485 passed, 0 failed, 2 skipped**
- `Runtime.Partitioning` suite: 106 passed

## Note for review

The three existing test call sites passing a bare `null!` needed an explicit `(IChannelCallback)` cast — a null literal converts to both overloads with no better-conversion between them, so it became ambiguous. Production call sites pass `this` and were unaffected.
