### PR TITLE
GH-4012: share one settle budget across the stacked ack retry blocks

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/shared_ack_attempt_budget.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/shared_ack_attempt_budget.cs
@@ -1,0 +1,147 @@
+using JasperFx.Core;
+using NSubstitute;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4012. <c>RetryBlock.MaximumAttempts</c> bounds retries WITHIN one <c>PostAsync</c>, but the
+/// durable completion path stacks two retry blocks -- <c>DurableReceiver._completeBlock</c> ->
+/// <c>Listener.CompleteAsync</c> -> <c>RabbitMqChannelCallback.Complete</c> -- so their budgets
+/// multiplied to nine broker round trips for a single delivery, with neither block able to see the
+/// other's count.
+///
+/// <c>Envelope.AckAttempts</c> rides the envelope so the layers share one budget. The increment
+/// belongs to the innermost layer that actually issues the broker call; outer layers only check.
+/// </summary>
+public class shared_ack_attempt_budget
+{
+    /// <summary>
+    /// Stands in for a transport whose own inner retry block spends the whole budget inside a
+    /// single outer attempt -- which is exactly the RabbitMQ shape, and the case the multiplication
+    /// bug lived in.
+    /// </summary>
+    private class BudgetBurningListener : IListener
+    {
+        private readonly int _burnPerCall;
+
+        public BudgetBurningListener(int burnPerCall)
+        {
+            _burnPerCall = burnPerCall;
+        }
+
+        public int CompleteCallCount { get; private set; }
+
+        public IHandlerPipeline? Pipeline => null;
+
+        public ValueTask CompleteAsync(Envelope envelope)
+        {
+            CompleteCallCount++;
+            envelope.AckAttempts += _burnPerCall;
+            throw new TimeoutException("broker did not respond");
+        }
+
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public Uri Address { get; } = new("stub://one");
+        public ValueTask StopAsync() => ValueTask.CompletedTask;
+    }
+
+    private static Envelope expiredEnvelopeFor(IListener listener)
+    {
+        // An already-expired envelope is the shortest route from ReceivedAsync into _completeBlock
+        var envelope = ObjectMother.Envelope();
+        envelope.DeliverBy = DateTimeOffset.UtcNow.Subtract(1.Minutes());
+        envelope.Listener = listener;
+        return envelope;
+    }
+
+    private static async Task<int> runAsync(int burnPerCall, int maximumAckAttempts)
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.DurabilitySettings.MaximumAckAttempts = maximumAckAttempts;
+
+        var pipeline = Substitute.For<IHandlerPipeline>();
+        var receiver = new DurableReceiver(new StubEndpoint("one", new StubTransport()), runtime, pipeline);
+
+        var listener = new BudgetBurningListener(burnPerCall);
+        var envelope = expiredEnvelopeFor(listener);
+
+        await receiver.ReceivedAsync(listener, envelope);
+        await receiver.DrainAsync();
+
+        return listener.CompleteCallCount;
+    }
+
+    [Fact]
+    public async Task an_inner_layer_that_spends_the_whole_budget_stops_the_outer_retry_loop()
+    {
+        // One outer attempt burns the entire budget (the 3-inner-attempts-per-outer-attempt shape).
+        // Before the shared budget, the outer block would retry its full MaximumAttempts on top,
+        // giving 3 x 3 = 9 broker round trips. Now the second outer attempt sees a spent budget and
+        // gives up.
+        var calls = await runAsync(burnPerCall: 3, maximumAckAttempts: 3);
+
+        calls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_transport_that_does_not_participate_keeps_its_existing_behavior()
+    {
+        // Nothing increments AckAttempts, so the guard never trips and the outer RetryBlock's own
+        // MaximumAttempts governs exactly as it did before GH-4012. This is the compatibility case:
+        // transports that settle directly in Listener.CompleteAsync are untouched.
+        var calls = await runAsync(burnPerCall: 0, maximumAckAttempts: 3);
+
+        calls.ShouldBeGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task the_budget_is_configurable()
+    {
+        // A budget of 1 means the very first outer retry finds it spent
+        var calls = await runAsync(burnPerCall: 1, maximumAckAttempts: 1);
+
+        calls.ShouldBe(1);
+    }
+}
+
+/// <summary>
+/// GH-4012 unit coverage for the counter itself.
+/// </summary>
+public class envelope_ack_attempt_budget
+{
+    [Fact]
+    public void records_attempts_up_to_the_maximum_then_refuses()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        envelope.TryRecordAckAttempt(3).ShouldBeTrue();
+        envelope.AckAttempts.ShouldBe(1);
+
+        envelope.TryRecordAckAttempt(3).ShouldBeTrue();
+        envelope.TryRecordAckAttempt(3).ShouldBeTrue();
+        envelope.AckAttempts.ShouldBe(3);
+
+        envelope.TryRecordAckAttempt(3).ShouldBeFalse();
+
+        // A refused attempt must not keep incrementing -- the counter is also what the log line
+        // reports, and an unbounded value there would be noise
+        envelope.AckAttempts.ShouldBe(3);
+    }
+
+    [Fact]
+    public void a_maximum_of_zero_refuses_immediately()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        envelope.TryRecordAckAttempt(0).ShouldBeFalse();
+        envelope.AckAttempts.ShouldBe(0);
+    }
+}

--- a/src/Testing/CoreTests/Runtime/envelope_pool_tests.cs
+++ b/src/Testing/CoreTests/Runtime/envelope_pool_tests.cs
@@ -1,10 +1,14 @@
 using System.Reflection;
 using JasperFx.Resources;
+using NSubstitute;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
+using Wolverine.Logging;
+using Wolverine.Persistence.Durability;
 using Wolverine.Runtime;
 using Wolverine.Tracking;
+using Wolverine.Transports.Sending;
 using Xunit;
 
 namespace CoreTests.Runtime;
@@ -70,6 +74,23 @@ public class envelope_pool_tests
             KeepUntil = DateTimeOffset.UtcNow,
         };
 
+        // Internal settable properties, stamped separately because they can't ride the object
+        // initializer from outside the assembly's public surface. Without these the widened
+        // reflection guard below would pass vacuously -- every one of them would already be at its
+        // default.
+        envelope.ResponseType = typeof(SomeProbeMessage);
+        envelope.Response = new SomeProbeMessage();
+        envelope.InBatch = true;
+        envelope.BatchGroupId = 11;
+        envelope.FromPool = true;
+        envelope.Sender = Substitute.For<ISendingAgent>();
+        envelope.Batch = [new Envelope()];
+        envelope.BatchPendingSettled = true;
+        envelope.HasBeenAcked = true;
+        envelope.AckAttempts = 2;
+        envelope.WireTap = Substitute.For<IWireTap>();
+        envelope.Store = Substitute.For<IMessageStore>();
+
         // Also stamp the Headers dictionary so Reset's _headers = null path
         // is exercised.
         envelope.Headers["k"] = "v";
@@ -99,7 +120,11 @@ public class envelope_pool_tests
             nameof(Envelope.Data),
         };
 
-        foreach (var prop in typeof(Envelope).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        // GH-4012: NonPublic included. The default binding is public-only, which left every
+        // `internal { get; set; }` property on Envelope outside the guard -- and that blind spot was
+        // real, not theoretical: BatchPendingSettled had been missing from Reset since CritterWatch#942.
+        foreach (var prop in typeof(Envelope)
+                     .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
         {
             if (!prop.CanWrite) continue;
             if (setterValidated.Contains(prop.Name)) continue;

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
@@ -25,11 +25,26 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
         return exception.Message.Contains(UnknownDeliveryTag);
     }
 
-    internal RabbitMqChannelCallback(ILogger logger, CancellationToken cancellationToken)
+    internal RabbitMqChannelCallback(ILogger logger, CancellationToken cancellationToken, int maximumAckAttempts)
     {
         Logger = logger;
         Complete = new RetryBlock<RabbitMqEnvelope>(async (e, _) =>
         {
+            // GH-4012: this is the innermost layer -- e.CompleteAsync() is what reaches
+            // BasicAckAsync -- so it owns the increment. Without a budget riding the envelope, this
+            // block's three attempts nested inside DurableReceiver._completeBlock's three meant nine
+            // broker round trips for one delivery, with neither block able to see the other's count.
+            if (!e.TryRecordAckAttempt(maximumAckAttempts))
+            {
+                // Swallowing stops the retry loop. The delivery stays unsettled, the broker
+                // redelivers it, and the durable inbox deduplicates -- the same recovery the
+                // unknown-delivery-tag branch below relies on.
+                logger.LogWarning(
+                    "Giving up on acking Rabbit MQ delivery for envelope {EnvelopeId} after {AckAttempts} attempts; leaving it for broker redelivery",
+                    e.Id, e.AckAttempts);
+                return;
+            }
+
             try
             {
                 await e.CompleteAsync();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransport.cs
@@ -205,7 +205,8 @@ public partial class RabbitMqTransport : BrokerTransport<RabbitMqEndpoint>, IAsy
     public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
     {
         Logger = runtime.LoggerFactory.CreateLogger<RabbitMqTransport>();
-        Callback = new RabbitMqChannelCallback(Logger, runtime.DurabilitySettings.Cancellation);
+        Callback = new RabbitMqChannelCallback(Logger, runtime.DurabilitySettings.Cancellation,
+            runtime.DurabilitySettings.MaximumAckAttempts);
 
         ConnectionFactory ??= runtime.Services.GetService<IConnectionFactory>() as ConnectionFactory ??
                               new ConnectionFactory { HostName = "localhost" };

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -115,6 +115,23 @@ public class DurabilitySettings : IDescribeMyself
     public MessageIdentity MessageIdentity { get; set; } = MessageIdentity.IdOnly;
 
     /// <summary>
+    /// GH-4012. The maximum number of times Wolverine will try to settle (ack/nack) a single broker
+    /// delivery before giving up and letting the broker redeliver it.
+    ///
+    /// This is a budget shared across the whole completion path via <c>Envelope.AckAttempts</c>,
+    /// which is the point: <c>RetryBlock.MaximumAttempts</c> bounds retries within a single
+    /// <c>PostAsync</c>, but the durable path stacks two of them
+    /// (<c>DurableReceiver._completeBlock</c> -> <c>Listener.CompleteAsync</c> ->
+    /// <c>RabbitMqChannelCallback.Complete</c>), so their budgets multiplied to nine broker round
+    /// trips with neither block able to see the other's count.
+    ///
+    /// Note this cannot bound a redeliver -> dedupe -> re-ack loop: every redelivery constructs a
+    /// brand new envelope, so the counter starts over. Only a broker-side delivery count can do
+    /// that.
+    /// </summary>
+    public int MaximumAckAttempts { get; set; } = 3;
+
+    /// <summary>
     /// If non-null, this directs Wolverine to "push" any message in the durable outbox that is older
     /// than the configured time even if the message is marked as owned by an active node
     /// </summary>

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -145,6 +145,36 @@ public partial class Envelope
     internal bool HasBeenAcked { get; set; }
 
     /// <summary>
+    /// GH-4012. Counts real attempts to settle (ack/nack) this delivery with its broker, shared by
+    /// every retry layer on the completion path so their budgets add rather than multiply. See
+    /// <see cref="DurabilitySettings.MaximumAckAttempts"/>.
+    ///
+    /// Deliberately runtime-only and never persisted: each broker redelivery constructs a brand new
+    /// envelope, so this cannot bound a redeliver -> dedupe -> re-ack loop.
+    /// </summary>
+    [JsonIgnore]
+    internal int AckAttempts { get; set; }
+
+    /// <summary>
+    /// GH-4012. Records one settle attempt against this delivery's shared budget, returning false
+    /// when the budget is already spent.
+    ///
+    /// A false return means "stop trying", NOT "fail": callers swallow rather than throw, because an
+    /// unsettled delivery is the recoverable outcome -- the broker redelivers it and the durable
+    /// inbox deduplicates. Throwing would just feed the enclosing RetryBlock.
+    /// </summary>
+    internal bool TryRecordAckAttempt(int maximumAttempts)
+    {
+        if (AckAttempts >= maximumAttempts)
+        {
+            return false;
+        }
+
+        AckAttempts++;
+        return true;
+    }
+
+    /// <summary>
     /// The active wire tap for this envelope, set from the endpoint configuration
     /// during message receive or send. Used by the message tracker to record
     /// success/failure without coupling the tracking infrastructure to endpoint config.
@@ -552,7 +582,9 @@ public partial class Envelope
         IsResponse = false;
         Failure = null;
         Batch = null;
+        BatchPendingSettled = false;
         HasBeenAcked = false;
+        AckAttempts = 0;
         WireTap = null;
         Store = null;
     }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -154,8 +154,27 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         
         _deferBlock = new RetryBlock<Envelope>((env, _) => env.Listener!.DeferAsync(env).AsTask(), runtime.Logger,
             runtime.Cancellation);
-        _completeBlock = new RetryBlock<Envelope>((env, _) => env.Listener!.CompleteAsync(env).AsTask(), runtime.Logger,
-            runtime.Cancellation);
+        // GH-4012: the outer half of the shared settle budget. This block only CHECKS -- the
+        // increment happens at the innermost site that actually issues the broker call, because
+        // that is the only layer that knows a round trip really occurred. For a transport whose
+        // listener settles directly (no inner retry block), nothing increments and this guard never
+        // trips, leaving that transport's behavior exactly as it was.
+        var maximumAckAttempts = runtime.DurabilitySettings.MaximumAckAttempts;
+        _completeBlock = new RetryBlock<Envelope>(async (env, _) =>
+        {
+            if (env.AckAttempts >= maximumAckAttempts)
+            {
+                // Swallow rather than throw: retrying here would only re-enter the inner block,
+                // which has already spent the budget. Leaving the delivery unsettled is the
+                // recoverable outcome -- the broker redelivers and the inbox deduplicates.
+                _logger.LogWarning(
+                    "Giving up on settling envelope {EnvelopeId} at {Uri} after {AckAttempts} attempts; leaving it for broker redelivery",
+                    env.Id, Uri, env.AckAttempts);
+                return;
+            }
+
+            await env.Listener!.CompleteAsync(env).ConfigureAwait(false);
+        }, runtime.Logger, runtime.Cancellation);
 
 
         _markAsHandled = new RetryBlock<Envelope>(async (e, _) =>


### PR DESCRIPTION
Addresses items 1 and 2 of #4012. Items 3-5 (per-transport terminal classification, broker-side redelivery-count bounding, JasperFx `RetryBlock.ShouldRetry`) stay open on that issue.

## The multiplication bug

`RetryBlock.MaximumAttempts` bounds retries *within* one `PostAsync`. The durable completion path stacks two of them. Traced end to end rather than taken from the analysis doc:

```
DurableReceiver._completeBlock                              (RetryBlock, max 3)
  -> RabbitMqListener.CompleteAsync(Envelope)          :222
  -> RabbitMqChannelCallback.CompleteAsync             :63
  -> RabbitMqChannelCallback.Complete                        (RetryBlock, max 3)
  -> RabbitMqEnvelope.CompleteAsync                    :37
  -> RabbitMqListener.CompleteAsync(RabbitMqEnvelope)  :512  -> BasicAckAsync
```

Three by three is **nine** broker round trips for a single delivery, and neither block can see the other's count.

## The fix

`Envelope.AckAttempts` rides the envelope so the layers share a budget — `DurabilitySettings.MaximumAckAttempts`, default 3.

**Where the increment lives matters.** It belongs to the innermost layer that actually issues the broker call, because that is the only layer that knows a round trip really happened. Outer layers only check. That has a deliberate consequence worth a reviewer's eye:

> A transport that settles directly in `Listener.CompleteAsync` — no inner retry block — never increments, so the outer guard never trips and its behavior is **byte-for-byte what it was**. RabbitMQ gets the fix; every other transport is untouched until item 3 extends it per transport.

**Exhausting the budget swallows rather than throws.** An unsettled delivery is the recoverable outcome — the broker redelivers and the durable inbox deduplicates — and it is the same recovery the existing unknown-delivery-tag branch already relies on. Throwing would just feed the enclosing `RetryBlock`.

**Honest scope:** this cannot bound a redeliver → dedupe → re-ack loop. Every redelivery constructs a brand new envelope, so the counter starts over. Only a broker-side delivery count (`redelivered`/`x-death`, `ApproximateReceiveCount`, `DeliveryCount`) can do that — item 4, and it is called out in the xml-docs so the next reader doesn't over-trust the counter.

## The pooling guard blind spot

`envelope_pool_tests.Reset_zeroes_every_settable_property` reflected with default binding — **public only** — which left every `internal { get; set; }` property on `Envelope` outside the guard. Widened to `NonPublic`, and the internal properties are now stamped in the arrange block so the assertions aren't vacuous.

That blind spot was not theoretical. It immediately caught **`BatchPendingSettled` missing from `Envelope.Reset()`** since CritterWatch#942.

**Reachability, checked before claiming anything:** `Batch` is only ever assigned in the `new Envelope(IEnumerable<Envelope>)` constructor, never on a pooled envelope, and `SettleBatch` early-returns when `Batch == null`. So a stale flag cannot bite today — this is a **latent gap, not a live bug**. Fixed anyway, because it is exactly the drift the guard exists to catch and the next batching change could make it reachable.

## Tests

- `shared_ack_attempt_budget` — a listener that spends the whole budget in one call (the Rabbit shape) is called **once**, not three times; a non-participating transport keeps its existing retry behavior; the budget is configurable.
- `envelope_ack_attempt_budget` — the counter refuses past the maximum and does not keep incrementing after refusal.
- The widened pooling guard covers `AckAttempts` and `BatchPendingSettled`.

**Red-checks performed on both halves:**
- Setting `maximumAckAttempts = int.MaxValue` (guard disabled) fails 2 of 3 budget tests.
- Removing the `BatchPendingSettled = false;` line produces `Envelope.BatchPendingSettled not reset: expected False, got True`.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean
- Full `CoreTests`: **2487 passed, 0 failed**, 2 skipped
- Full `Wolverine.RabbitMQ.Tests` against docker-compose Rabbit: **506 passed, 0 failed** (11m14s). Worth noting both of the failures I'd expected from prior runs — `multi_tenancy_through_virtual_hosts` and `end_to_end.use_direct_exchange_with_binding_key` — passed here too.

## Not covered

No Rabbit *integration* test of the budget: forcing repeated real ack failures needs broker-side channel manipulation beyond what the existing harness offers. The arithmetic is pinned at the `DurableReceiver` seam instead, which is where the multiplication actually happened.
