### PR TITLE
docs(sqs, asb): describe per-mode settlement points in the visibility-timeout and lock-duration sections (GH-3493, GH-3494)

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/performance.md
+++ b/docs/guide/messaging/transports/azureservicebus/performance.md
@@ -55,19 +55,25 @@ more sessions at once, use `RequireSessions(n)`.
 
 ## Lock duration vs. processing window
 
-For Buffered/Durable endpoints, Wolverine does not renew message locks while messages wait in
-the local worker queue. If (buffered backlog × handler time ÷ `MaximumParallelMessages`) can
-exceed the queue's lock duration, locks expire silently and the broker redelivers:
+Wolverine never renews a message lock on the Buffered/Durable (batched receiver) paths. How
+much of your processing the lock has to cover depends on the endpoint mode, because each mode
+settles the message at a different point:
 
-- **Durable** endpoints deduplicate redelivery through the inbox (wasted work, no duplicate
-  side effects).
+- **Durable** endpoints complete the message as soon as it has been written to the durable
+  inbox — *before* the handler runs. The local backlog lives in your database, not under a
+  broker lock, so the lock only has to cover the receive-to-insert round trip. If that insert
+  is ever slower than the lock duration (an overloaded database), the lock expires, the broker
+  redelivers, and the inbox deduplicates the copy — wasted work, not duplicate side effects.
 - **Buffered** endpoints settle messages as soon as they are buffered — so lock expiry is moot
   for them, but an ungraceful crash loses the buffered backlog (at-most-once on crash).
-- **Inline** endpoints can rely on the processor's automatic lock renewal
+- **Inline** endpoints hold the lock for the whole handler execution, and rely on the
+  processor's automatic lock renewal
   (`ConfigureProcessor(o => o.MaxAutoLockRenewalDuration = ...)`, SDK default 5 minutes).
+  Raise that for inline handlers that can run longer.
 
-Keep `BufferingLimits` sized so the backlog clears within the lock duration, or lengthen the
-queue's `LockDuration`.
+Where the lock duration *does* interact with buffering is prefetch: messages fetched ahead by
+`PrefetchCount` age against their locks before Wolverine ever receives them — see the prefetch
+section above.
 
 ## The send side
 

--- a/docs/guide/messaging/transports/sqs/performance.md
+++ b/docs/guide/messaging/transports/sqs/performance.md
@@ -43,20 +43,23 @@ does not leave settled messages to reappear at their visibility timeout.
 ## Visibility timeout: size it against your processing window
 
 Wolverine sets each received message's visibility timeout at receive (default **120 seconds**)
-and does **not** extend it while messages wait in the local worker queue or execute. If
-(queued messages ÷ processing rate) + handler time can exceed the visibility timeout, SQS
-redelivers messages that are still in flight:
+and never calls `ChangeMessageVisibility` to extend it. How much of your processing that
+window has to cover depends on the endpoint mode, because each mode deletes the message from
+SQS at a different point:
 
-- **Durable** endpoints deduplicate redeliveries through the inbox — you pay wasted work, not
-  duplicate side effects.
-- **Buffered** endpoints delete messages from SQS *as soon as they are buffered*, before
-  handling — so instead of duplicates you get at-most-once semantics: an ungraceful crash
-  loses the buffered backlog.
-- **Inline** endpoints delete after successful handling — safest, and the visibility timeout
-  only needs to cover a single handler execution.
-
-Rule of thumb: keep `BufferingLimits.Maximum × average handler time ÷ MaximumParallelMessages`
-comfortably under the visibility timeout, or raise the timeout on the queue.
+- **Durable** endpoints delete the message as soon as it has been written to the durable
+  inbox — *before* the handler runs. The local backlog lives in your database, not under an
+  SQS timer, so the visibility timeout only has to cover the receive-to-insert round trip.
+  If that insert is ever slower than the timeout (an overloaded database), SQS redelivers and
+  the inbox deduplicates the copy — wasted work, not duplicate side effects.
+- **Buffered** endpoints delete messages *as soon as they are buffered*, before handling — so
+  the visibility timeout is moot, and instead of duplicates you get at-most-once semantics: an
+  ungraceful crash loses the buffered backlog.
+- **Inline** endpoints delete only after successful handling, so the visibility timeout must
+  cover a **single handler execution**. A handler that runs longer than the timeout is
+  redelivered *while it is still running*, and the second copy executes too. Raise the
+  timeout on the endpoint (`.VisibilityTimeout(...)`) to comfortably exceed your slowest
+  inline handler.
 
 ## The send side: batch API, one batch in flight
 


### PR DESCRIPTION
## What

Docs-only. Rewrites two sections of the transport performance pages:

- `docs/guide/messaging/transports/sqs/performance.md` — "Visibility timeout: size it against your processing window"
- `docs/guide/messaging/transports/azureservicebus/performance.md` — "Lock duration vs. processing window"

## Why

Both sections framed the broker window (SQS visibility timeout / ASB lock duration) as covering the *local buffered backlog*, with a `BufferingLimits × handler time ÷ MaximumParallelMessages` sizing rule and the claim that Durable endpoints "deduplicate redeliveries through the inbox — wasted work". Re-reading `DurableReceiver` for the GH-3493/3494 re-evaluation showed that isn't where the window sits:

| Mode | Broker delivery settled… | So the window must cover… |
|---|---|---|
| **Durable** | immediately after the inbox `INSERT` succeeds, **before** the handler runs (`DurableReceiver` posts to `_completeBlock` right after `StoreIncomingAsync`, single and `Envelope[]` paths) | receive → insert round trip only; the backlog lives in the database |
| **Buffered** | on receipt | nothing — moot (at-most-once on crash, as before) |
| **Inline** | after successful handling | the whole handler execution |

For Inline the two transports differ, and the old text understated the SQS case: ASB inline rides the processor's `MaxAutoLockRenewalDuration`, but Wolverine has **no `ChangeMessageVisibility` call anywhere**, so an SQS inline handler that outlives `VisibilityTimeout` (120s default) is redelivered *while still running* and the second copy executes too. The SQS section now says that plainly and points at `.VisibilityTimeout(...)`.

The ASB section also now points the real buffering-vs-lock interaction where it lives — prefetched messages aging against their locks — which the page's prefetch section already warns about.

Context and the matching corrections on the issues: [#3493 comment](https://github.com/JasperFx/wolverine/issues/3493#issuecomment-5386510571), [#3494 comment](https://github.com/JasperFx/wolverine/issues/3494#issuecomment-5386510490).

## Test plan

- [x] Docs only; no code touched.
- [x] Both files still render as plain Markdown sections (no new VitePress containers introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
