### PR TITLE
GH-3855: restart a wedged service container once, and record it

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Bobcat.Supervisor;
@@ -137,7 +138,8 @@ partial class Build
     }
 
     /// <summary>
-    /// Polls until a service reports itself ready, and <b>throws</b> when the budget runs out.
+    /// Polls until a service reports itself ready. When the budget runs out it restarts the container
+    /// and probes once more; a service that fails to serve twice <b>throws</b> and kills the job.
     ///
     /// <para>Every gate in this file used to log a warning and carry on. That is how
     /// <c>CIAzureServiceBus</c> spent 22 of its 25-retry budget on four consecutive <i>green</i> main
@@ -149,13 +151,73 @@ partial class Build
     ///
     /// <para>A container that never starts should fail its job in seconds with a message naming the
     /// service, not hand the whole suite to a broker that cannot serve it.</para>
+    ///
+    /// <para>GH-3855 added the restart. The cost is the worst case: a service that is genuinely dead
+    /// now burns twice its budget plus a restart before the job dies, so a budget here is a number
+    /// that gets doubled. That is deliberate — these gates are fatal on purpose, there are many of
+    /// them across the matrix, and an occurrence that costs a rerun and teaches nothing is the more
+    /// expensive of the two.</para>
     /// </summary>
+    /// <param name="composeService">
+    /// The docker compose service name (e.g. <c>sqlserver</c>), which is what the evidence dump and
+    /// the restart address. Deliberately separate from the display name: "SQL Server" is what a
+    /// reader of the log wants and <c>sqlserver</c> is what compose answers to.
+    /// </param>
     /// <param name="probe">
     /// Returns null when the service is ready, or a short reason why it is not. Exceptions are
     /// treated as "not ready" and their message becomes the reason, so the final error carries the
     /// last real failure rather than a generic timeout.
     /// </param>
-    void awaitService(string name, TimeSpan budget, Func<string> probe)
+    void awaitService(string name, string composeService, TimeSpan budget, Func<string> probe)
+    {
+        var first = pollForReadiness(name, budget, probe);
+        if (first.Ready) return;
+
+        // GH-3855. A gate that expires is not necessarily a gate whose budget was too small. Measured
+        // across seven consecutive passing CIPersistence runs, SQL Server was ready on attempt 4, in
+        // 28-35s, every time -- 4x headroom against this same 2 minute budget. The run that failed
+        // burned all 61 attempts and never came up, which is a different failure, not a slower one:
+        // its container took the full 10s SIGTERM grace period to die at teardown, so it was alive
+        // and wedged rather than dead. Widening the budget fixes nothing there; restarting it might.
+        //
+        // The evidence dump comes FIRST, before the restart destroys the container's own account of
+        // why it never initialized. That account was missing entirely from the run that prompted
+        // this, which is why all that could be established was circumstantial.
+        captureServiceEvidence(name, composeService, "before restart");
+        restartService(name, composeService);
+
+        var second = pollForReadiness(name, budget, probe);
+        if (!second.Ready)
+        {
+            // Twice is a real signal rather than a wedge, so this is the throw the job dies on --
+            // now with two attempts' worth of evidence attached to it.
+            captureServiceEvidence(name, composeService, "after restart");
+
+            throw new InvalidOperationException(
+                $"{name} was not ready after {budget.TotalSeconds:n0}s ({first.Attempts} attempts), " +
+                $"was restarted, and was still not ready after a further {budget.TotalSeconds:n0}s " +
+                $"({second.Attempts} attempts). " +
+                $"Last attempt before the restart: {first.LastReason} " +
+                $"Last attempt after it: {second.LastReason}");
+        }
+
+        // Recorded, never reported as clean -- the same rule RetryFailuresInFreshProcess already
+        // states. A silent restart would convert a degrading runner or a bad image push into
+        // invisible latency, so this lands in the retry ledger where the roll-up diffs it against
+        // the previous main run and a trend becomes visible.
+        Log.Warning(
+            "{Service} was not ready after {Budget}s ({Attempts} attempts), but came up after a restart. " +
+            "This is recorded in the retry ledger, NOT treated as a clean start",
+            name, budget.TotalSeconds, first.Attempts);
+
+        recordServiceRestart(name, composeService, first.Attempts, first.LastReason, second.Attempts);
+    }
+
+    /// <summary>
+    /// One pass of the polling loop: returns rather than throws, so <see cref="awaitService"/> owns
+    /// what an expired budget means.
+    /// </summary>
+    static ReadinessResult pollForReadiness(string name, TimeSpan budget, Func<string> probe)
     {
         var deadline = DateTime.UtcNow.Add(budget);
         var lastReason = "no attempt completed";
@@ -171,7 +233,7 @@ partial class Build
                 if (reason is null)
                 {
                     Log.Information("{Service} is up and ready (attempt {Attempts})", name, attempts);
-                    return;
+                    return new ReadinessResult(true, attempts, null);
                 }
 
                 lastReason = reason;
@@ -181,14 +243,98 @@ partial class Build
                 lastReason = e.Message;
             }
 
-            if (DateTime.UtcNow >= deadline) break;
+            if (DateTime.UtcNow >= deadline) return new ReadinessResult(false, attempts, lastReason);
 
             Thread.Sleep(2000);
         }
+    }
 
-        throw new InvalidOperationException(
-            $"{name} was not ready after {budget.TotalSeconds:n0}s ({attempts} attempts). " +
-            $"Last attempt: {lastReason}");
+    record ReadinessResult(bool Ready, int Attempts, string LastReason);
+
+    /// <summary>
+    /// Dumps what the container itself has to say about why it never came up: <c>compose ps</c> for
+    /// its state, its own logs, and the host's free memory.
+    ///
+    /// <para>None of this existed on the failure path before GH-3855, so a wedged container took its
+    /// explanation with it -- memory pressure, a bad layer and a genuine startup fault all look
+    /// identical from outside. Best effort throughout: reporting on the failure must never replace
+    /// the failure, or the job dies with a worse message than the one it already had.</para>
+    /// </summary>
+    void captureServiceEvidence(string name, string composeService, string moment)
+    {
+        var grouped = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
+        if (grouped) Console.WriteLine($"::group::{name} readiness evidence ({moment})");
+
+        try
+        {
+            runDiagnostic(composeTool(), $"compose ps {composeService}");
+            runDiagnostic(composeTool(), $"compose logs --tail=200 {composeService}");
+
+            // Linux-only, and the runner is the only place this matters -- a developer machine has
+            // no OOM killer story worth telling here.
+            if (File.Exists("/usr/bin/free")) runDiagnostic("free", "-m");
+        }
+        finally
+        {
+            if (grouped) Console.WriteLine("::endgroup::");
+        }
+    }
+
+    /// <summary>
+    /// Restarts a single compose service. Failure here is deliberately not fatal: the throw that
+    /// matters is the second readiness failure, and it carries a far better message than "docker
+    /// compose restart exited 1" would.
+    /// </summary>
+    void restartService(string name, string composeService)
+    {
+        Log.Warning("Restarting the {Service} container ({ComposeService}) and probing once more", name, composeService);
+        runDiagnostic(composeTool(), $"compose restart {composeService}");
+    }
+
+    /// <summary>
+    /// Runs a diagnostic command, logging whatever it produced. Never throws -- see
+    /// <see cref="captureServiceEvidence"/>.
+    /// </summary>
+    static void runDiagnostic(string tool, string arguments)
+    {
+        try
+        {
+            var process = ProcessTasks
+                .StartProcess(tool, arguments, logOutput: false, logInvocation: false)
+                .AssertWaitForExit();
+
+            var output = string.Join(Environment.NewLine, process.Output.Select(x => x.Text));
+
+            Log.Information("$ {Tool} {Arguments} (exit {ExitCode}){NewLine}{Output}",
+                tool, arguments, process.ExitCode, Environment.NewLine, output);
+        }
+        catch (Exception e)
+        {
+            Log.Warning("Could not run `{Tool} {Arguments}`: {Message}", tool, arguments, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// docker, or podman where that is what is installed. Same resolution <see cref="ComposeUp"/>
+    /// uses, so the evidence and restart paths cannot end up talking to a different daemon than the
+    /// one that started the container.
+    /// </summary>
+    static string composeTool()
+    {
+        bool isAvailable(string toolName)
+        {
+            try
+            {
+                ToolPathResolver.GetPathExecutable(toolName);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        return new List<string> { "docker", "podman" }.FirstOrDefault(isAvailable) ?? "docker";
     }
 
     /// <summary>
@@ -209,7 +355,7 @@ partial class Build
         // checking that something is listening — the distinction the ASB gate was built on.
         using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
 
-        awaitService("GCP Pub/Sub emulator", TimeSpan.FromSeconds(60), () =>
+        awaitService("GCP Pub/Sub emulator", "gcp-pubsub", TimeSpan.FromSeconds(60), () =>
         {
             var response = http.GetAsync("http://localhost:8085/").GetAwaiter().GetResult();
 
@@ -235,7 +381,7 @@ partial class Build
     {
         using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
 
-        awaitService("Pulsar", TimeSpan.FromMinutes(3), () =>
+        awaitService("Pulsar", "pulsar", TimeSpan.FromMinutes(3), () =>
         {
             // /admin/v2/brokers/health is the broker's own readiness answer, not merely "something
             // is listening on 8080" — it stays unavailable while the standalone cluster boots.
@@ -281,7 +427,7 @@ partial class Build
             .SetErrorHandler((_, _) => { })
             .Build();
 
-        awaitService("Kafka", TimeSpan.FromSeconds(60), () =>
+        awaitService("Kafka", "kafka", TimeSpan.FromSeconds(60), () =>
         {
             // Throws until the broker will actually serve; awaitService turns that into the reason.
             var metadata = admin.GetMetadata(TimeSpan.FromSeconds(5));
@@ -298,7 +444,7 @@ partial class Build
         // was never true: each failed attempt could burn the connection's own 5s timeout before the
         // 2s sleep, so 30 attempts was anywhere from 60s to 210s depending on how the failure came
         // back. A deadline says what it means.
-        awaitService("SQL Server", TimeSpan.FromMinutes(2), () =>
+        awaitService("SQL Server", "sqlserver", TimeSpan.FromMinutes(2), () =>
         {
             using var conn = new Microsoft.Data.SqlClient.SqlConnection(
                 "Server=localhost,1434;User Id=sa;Password=P@55w0rd;Timeout=5;Encrypt=False");
@@ -312,7 +458,7 @@ partial class Build
 
     void WaitForMySqlToBeReady()
     {
-        awaitService("MySQL", TimeSpan.FromMinutes(2), () =>
+        awaitService("MySQL", "mysql", TimeSpan.FromMinutes(2), () =>
         {
             using var conn = new MySqlConnector.MySqlConnection(
                 "Server=localhost;Port=3306;Database=wolverine;User=root;Password=P@55w0rd;");
@@ -330,7 +476,7 @@ partial class Build
         // budget. Connecting as the application user against FREEPDB1 (rather than pinging the
         // listener) is deliberate: the listener answers well before the pluggable database will
         // accept an application login.
-        awaitService("Oracle", TimeSpan.FromMinutes(3), () =>
+        awaitService("Oracle", "oracle", TimeSpan.FromMinutes(3), () =>
         {
             using var conn = new Oracle.ManagedDataAccess.Client.OracleConnection(
                 "User Id=wolverine;Password=wolverine;Data Source=localhost:1521/FREEPDB1");
@@ -346,7 +492,7 @@ partial class Build
     {
         using var httpClient = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
 
-        awaitService("LocalStack", TimeSpan.FromMinutes(2), () =>
+        awaitService("LocalStack", "localstack", TimeSpan.FromMinutes(2), () =>
         {
             var response = httpClient.GetAsync("http://localhost:4566/_localstack/health")
                 .GetAwaiter().GetResult();
@@ -387,7 +533,7 @@ partial class Build
         // and carry on, so an emulator that never came up at all still fed the entire suite into a
         // broker that could not serve it — and the resulting failures read as flaky tests rather than
         // as infrastructure that never started.
-        awaitService("Azure Service Bus emulator", TimeSpan.FromMinutes(3), () =>
+        awaitService("Azure Service Bus emulator", "asb-emulator", TimeSpan.FromMinutes(3), () =>
         {
             using (var tcpClient = new System.Net.Sockets.TcpClient())
             {

--- a/build/RetryLedger.cs
+++ b/build/RetryLedger.cs
@@ -78,6 +78,91 @@ partial class Build
     }
 
     /// <summary>
+    /// GH-3855. Records that a readiness gate had to restart a container before the service came up.
+    ///
+    /// <para>Kept in the ledger rather than only in the job log, because the whole point of the
+    /// restart is that it makes the job PASS. A silent recovery turns a degrading runner or a bad
+    /// image push into invisible latency, and the ledger is the one surface here that diffs a run
+    /// against the previous main run — which is what makes "this started happening" visible at all.
+    /// The same rule the fresh-process retry already states: a pass on a retry is reported as flaky,
+    /// never as clean.</para>
+    ///
+    /// <para>Written as its own entry with zero tests rather than folded into a project's row: this
+    /// happened <i>above</i> the test runner, before a single test existed to attribute it to, and
+    /// inflating CleanPasses/Tests to carry it would corrupt the columns that do mean tests.</para>
+    /// </summary>
+    void recordServiceRestart(string service, string composeService, int attemptsBefore, string lastReason,
+        int attemptsAfter)
+    {
+        var entry = new LedgerEntry
+        {
+            Job = ledgerJobName,
+            // Not a project. Named for what it is so a reader of the raw ledger is not left looking
+            // for a test project by this name -- and kept to characters that are safe in a file
+            // name, because these two fields compose one. "n/a" for the framework was the first
+            // version of this and its slash sent the write into a directory that does not exist.
+            Project = $"readiness-gate-{composeService}",
+            Framework = "gate",
+            ServiceRestarts =
+            [
+                new ServiceRestart
+                {
+                    Service = service,
+                    ComposeService = composeService,
+                    AttemptsBeforeRestart = attemptsBefore,
+                    AttemptsAfterRestart = attemptsAfter,
+                    Reason = condense(lastReason)
+                }
+            ]
+        };
+
+        writeLedgerFile(entry);
+        appendRestartToStepSummary(entry.ServiceRestarts[0]);
+        annotateRestart(entry.Job, entry.ServiceRestarts[0]);
+    }
+
+    static void appendRestartToStepSummary(ServiceRestart restart)
+    {
+        var summaryFile = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+        if (string.IsNullOrEmpty(summaryFile)) return;
+
+        try
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine();
+            builder.AppendLine(
+                $"> **Restarted `{restart.ComposeService}`** — {restart.Service} was not ready after " +
+                $"{restart.AttemptsBeforeRestart} attempts, came up {restart.AttemptsAfterRestart} " +
+                $"attempt(s) after a restart. This job is NOT a clean start.");
+
+            if (restart.Reason is not null)
+            {
+                builder.AppendLine("> ");
+                builder.AppendLine($"> Last failure before the restart: `{restart.Reason}`");
+            }
+
+            builder.AppendLine();
+
+            File.AppendAllText(summaryFile, builder.ToString());
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Could not append the {Service} restart to $GITHUB_STEP_SUMMARY", restart.Service);
+        }
+    }
+
+    static void annotateRestart(string job, ServiceRestart restart)
+    {
+        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != "true") return;
+
+        Console.WriteLine(
+            $"::warning title={job}: restarted {restart.ComposeService}::" +
+            $"{restart.Service} was not ready after {restart.AttemptsBeforeRestart} attempts and was " +
+            $"restarted; it came up {restart.AttemptsAfterRestart} attempt(s) later. " +
+            $"Last failure before the restart: {restart.Reason ?? "none recorded"}");
+    }
+
+    /// <summary>
     /// Why a retried test failed the first time.
     ///
     /// <para>The ledger named the flaky test but threw away the reason, and Bobcat's own log keeps
@@ -165,6 +250,24 @@ partial class Build
         return flattened.Length <= limit ? flattened : flattened[..limit] + "…";
     }
 
+    /// <summary>
+    /// Strips anything that cannot appear in a file name. The ledger's name is composed from values
+    /// that are chosen elsewhere, and a stray path separator in one of them does not fail loudly —
+    /// <see cref="writeLedgerFile"/> catches, warns and carries on by design, so the ledger simply
+    /// goes missing and the roll-up reports the job as unmeasured. Cheaper to make that unreachable.
+    /// </summary>
+    static string fileNameSafe(string name)
+    {
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(invalid, '-');
+        }
+
+        // Not invalid, but a file name with spaces in it is a nuisance in every shell that later
+        // touches the artifact.
+        return name.Replace(' ', '-');
+    }
+
     static void writeLedgerFile(LedgerEntry entry)
     {
         try
@@ -173,7 +276,7 @@ partial class Build
 
             // One file per project+framework: a target can run several projects, and a project can
             // run under several TFMs, so neither alone is a unique key.
-            var fileName = $"{entry.Job}.{entry.Project}.{entry.Framework}.json";
+            var fileName = fileNameSafe($"{entry.Job}.{entry.Project}.{entry.Framework}.json");
             var path = LedgerDirectory / fileName;
 
             File.WriteAllText(path, JsonSerializer.Serialize(entry, LedgerJson));
@@ -306,6 +409,32 @@ partial class Build
         /// working against ledgers written by older runs.
         /// </summary>
         public FlakyFailure[] FlakyFailures { get; init; } = [];
+
+        /// <summary>
+        /// Containers a readiness gate had to restart before the service came up. Additive and
+        /// defaulted for the same reason as <see cref="FlakyFailures"/>: the roll-up's baseline is
+        /// downloaded from an EARLIER run's artifact, so the jq that reads this must survive a
+        /// ledger written before the field existed. See GH-3855.
+        /// </summary>
+        public ServiceRestart[] ServiceRestarts { get; init; } = [];
+    }
+
+    /// <summary>
+    /// One container a readiness gate restarted. See <see cref="recordServiceRestart"/>.
+    /// </summary>
+    class ServiceRestart
+    {
+        /// <summary>Display name of the service, e.g. "SQL Server".</summary>
+        public string Service { get; init; }
+
+        /// <summary>Its docker compose service name, e.g. "sqlserver".</summary>
+        public string ComposeService { get; init; }
+
+        public int AttemptsBeforeRestart { get; init; }
+        public int AttemptsAfterRestart { get; init; }
+
+        /// <summary>The gate's last failure reason before the restart, flattened to one line.</summary>
+        public string Reason { get; init; }
     }
 
     /// <summary>

--- a/build/build.cs
+++ b/build/build.cs
@@ -463,7 +463,7 @@ partial class Build : NukeBuild
     /// </summary>
     private void WaitForDatabaseToBeReady()
     {
-        awaitService("PostgreSQL", TimeSpan.FromMinutes(2), () =>
+        awaitService("PostgreSQL", "postgresql", TimeSpan.FromMinutes(2), () =>
         {
             using var conn = new Npgsql.NpgsqlConnection(PostgresConnectionString + ";Pooling=false");
             conn.Open();

--- a/build/flakiness-report.sh
+++ b/build/flakiness-report.sh
@@ -63,11 +63,15 @@ jq '[group_by(.Job)[] | {
       failed:        (map(.Failed)           | add),
       indeterminate: (map(.Indeterminate)    | add),
       flakyTests:    (map(.FlakyTests[])     | unique),
-      flakyFailures: (map(.FlakyFailures // [] | .[]) | unique)
+      flakyFailures: (map(.FlakyFailures // [] | .[]) | unique),
+      serviceRestarts: (map(.ServiceRestarts // [] | .[]))
     }] | sort_by(-.retries, .job)' \
   "${output_dir}/entries.json" > "${output_dir}/aggregate.json"
 
 total_retries=$(jq '[.[] | .retries] | add // 0' "${output_dir}/aggregate.json")
+# GH-3855. A readiness gate that restarted a wedged container and then succeeded makes the job PASS,
+# so without this the recovery is invisible and a degrading runner reads as clean.
+total_restarts=$(jq '[.[] | (.serviceRestarts // []) | length] | add // 0' "${output_dir}/aggregate.json")
 total_tests=$(jq '[.[] | .tests] | add // 0' "${output_dir}/aggregate.json")
 reporting_jobs=$(jq 'length' "${output_dir}/aggregate.json")
 
@@ -100,8 +104,12 @@ else
 fi
 
 baseline_retries=""
+baseline_restarts=""
 if [ -n "${baseline_file}" ]; then
   baseline_retries=$(jq '[.[] | .retries] | add // 0' "${baseline_file}")
+  # `// []` is load-bearing: the baseline comes from an EARLIER run's artifact, which may predate
+  # the field entirely. Without it one older baseline nulls the whole roll-up.
+  baseline_restarts=$(jq '[.[] | (.serviceRestarts // []) | length] | add // 0' "${baseline_file}")
 fi
 
 # ── Jobs that reported nothing ──────────────────────────────────────────────
@@ -176,6 +184,20 @@ delta_for() {
     echo
   fi
 
+  if [ "${total_restarts}" != "0" ]; then
+    echo "> **Containers restarted by a readiness gate: ${total_restarts}** (baseline: ${baseline_restarts:-—})"
+    echo ">"
+    echo "> A service did not come up within its budget, was restarted, and came up on the second"
+    echo "> try. The job passed, so nothing else here would say so. Treat it as recovered, not clean."
+    echo ">"
+    jq -r '.[] | . as $j | (.serviceRestarts // [])[]
+           | "> - **\($j.job)** restarted `\(.ComposeService)` — \(.Service) not ready after "
+             + "\(.AttemptsBeforeRestart) attempts, up \(.AttemptsAfterRestart) attempt(s) after the "
+             + "restart\(if .Reason then ". Last failure: `\(.Reason)`" else "" end)"' \
+      "${output_dir}/aggregate.json"
+    echo
+  fi
+
   if [ "${total_retries}" = "0" ] && [ "$(jq '[.[] | select(.failed > 0 or .indeterminate > 0)] | length' "${output_dir}/aggregate.json")" = "0" ]; then
     echo "No job spent a retry."
   else
@@ -218,6 +240,6 @@ delta_for() {
 } >> "${summary}"
 
 # Also on stdout, so the roll-up is greppable from `gh run view --log` the way the per-job lines are.
-echo "=== flakiness roll-up: ${total_retries} retries, baseline ${baseline_retries:-none} (run ${baseline_run:-none}) ==="
+echo "=== flakiness roll-up: ${total_retries} retries, ${total_restarts} container restarts, baseline ${baseline_retries:-none} (run ${baseline_run:-none}) ==="
 
 exit 0


### PR DESCRIPTION
Closes #3855.

A readiness gate that expires kills its job with no retry and no evidence. `CIPersistence` died that way on [run 31032276642](https://github.com/JasperFx/wolverine/actions/runs/31032276642/job/92395651173): SQL Server never came up in 120s while `CISqlServer` passed on the same commit from the same digest-pinned image, and a rerun was clean.

**The budget was not the problem.** Across seven consecutive passing `CIPersistence` runs SQL Server is ready on **attempt 4, in 28–35s** — 4× headroom against the same 2-minute budget. The failing run burned all 61 attempts, and its container took the full 10s SIGTERM grace period to die at teardown, so it was **alive and wedged**, not dead. Widening the budget fixes nothing.

## What changed

**1. `awaitService` restarts once before giving up.** Bobcat's supervisor cannot reach this failure — `RetryFailuresInFreshProcess` lives in `RunTestProject`, and the gate fails a layer above it, before a single test exists to attribute the failure to. So the gate now dumps evidence, runs `compose restart` on that one service, and probes once more. Failing twice is a real signal and still throws, now naming both attempts.

**2. The failure path captures evidence.** There was no `compose ps`, no `compose logs`, no `free -m`, so the container's own account of why it never initialized was gone by the time anyone looked — the `Kernel OOM report` step is gated on `matrix.memory_telemetry`, which only the three Marten shards set. The dump runs **before** the restart, so the restart cannot destroy what explains it.

**3. A recovered gate is recorded, never reported as clean** — the rule `RetryFailuresInFreshProcess` already states. It lands in the retry ledger as its own zero-test entry, and the roll-up gains a restart section with the same baseline diff that retries get:

```
> **Containers restarted by a readiness gate: 1** (baseline: 0)
>
> A service did not come up within its budget, was restarted, and came up on the second
> try. The job passed, so nothing else here would say so. Treat it as recovered, not clean.
>
> - **CIPersistence** restarted `sqlserver` — SQL Server not ready after 61 attempts, up 4
>   attempt(s) after the restart. Last failure: `...pre-login handshake...`
```

Without that section a successful restart makes the job pass and **nothing anywhere says so**, which is how a degrading runner or a bad image push becomes invisible latency.

The restart is its own ledger entry rather than a column on a project's row because it happened *above* the test runner — inflating `Tests`/`CleanPasses` to carry it would corrupt the columns that do mean tests.

## Cost, stated plainly

A service that is genuinely dead now burns **twice its budget** plus a restart before the job dies. That is deliberate: these gates are fatal on purpose, there are many of them across the matrix, and an occurrence that costs a rerun and teaches nothing is the more expensive of the two.

## Verification

Exercised end to end against a real stopped container (`redis-server`, in an isolated compose project, via a scratch Nuke target since removed):

- **Recovery path** — gate expires after 6 attempts → `::group::Redis readiness evidence (before restart)` with `compose ps` and `compose logs` → `compose restart` → up on attempt 1 → `WRN ... NOT treated as a clean start` → `::warning title=CIScratch: restarted redis-server` → ledger JSON written with the `ServiceRestarts` entry.
- **Twice-failed path** — throws `Redis was not ready after 10s (6 attempts), was restarted, and was still not ready after a further 10s (6 attempts). Last attempt before the restart: ... Last attempt after it: ...`, with a second evidence group.
- **Roll-up** — rendered the restart section from that real ledger on a run with **zero** retries, which is exactly the case that used to read as clean.
- **Backward compatibility** — ran the roll-up against a baseline written *before* the `ServiceRestarts` field existed, confirming the `// []` guard holds. That guard is the script's own stated rule; without it one older baseline nulls the whole report.

One defect was found and fixed during that verification: the first version set `Framework = "n/a"`, whose slash sent the ledger write into a non-existent directory — and `writeLedgerFile` catches and warns by design, so it failed *silently*. The name is now composed through a `fileNameSafe` helper so a stray separator cannot quietly cost a ledger again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
