### PR TITLE
GH-3712: validate or warn on silently-ignored listener configuration combos

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -64,7 +64,10 @@ Use the `Inline` mode if you care about message ordering or if you do not want g
 without having to use any kind of message persistence.
 
 To improve throughput, you can direct Wolverine to use a number of parallel listeners, but the default is
-just 1 per listening endpoint.
+just 1 per listening endpoint. Note that `ListenerCount()` — and *not* `MaximumParallelMessages()` — is the
+throughput knob for an `Inline` endpoint, because an `Inline` endpoint has no local execution block for
+`MaximumParallelMessages()` to size. See [Which settings apply in which mode](#which-settings-apply-in-which-mode)
+below.
 
 ### Processing Inline While Draining
 
@@ -178,6 +181,61 @@ Or set a global default for all listening endpoints using a policy:
 ```csharp
 opts.Policies.AllListeners(x => x.MaximumParallelMessages = 5);
 ```
+
+## Which settings apply in which mode
+
+Several listener settings only mean something for a mode that has a *local execution block* — the in-memory
+queue that `BufferedInMemory` and `Durable` endpoints put between the transport listener and your handlers.
+An `Inline` endpoint has no such block: it executes each message directly on the transport's listening
+callback. Settings that size or shard that block therefore do nothing on an `Inline` endpoint.
+
+| Setting | `Inline` | `BufferedInMemory` | `Durable` |
+| --- | --- | --- | --- |
+| `MaximumParallelMessages(n)` / `Sequential()` | ignored (warns) | ✔️ | ✔️ |
+| `PartitionProcessingByGroupId(slots)` | **throws at startup** | ✔️ | ✔️ |
+| `BufferedInMemory(limits)` / `UseDurableInbox(limits)` back pressure | ignored (warns) | ✔️ | ✔️ |
+| `ListenerCount(n)` | ✔️ | ✔️ | ✔️ |
+| `ListenWithStrictOrdering()` / `ListenOnlyAtLeader()` | ✔️ (exclusivity only) | ✔️ | ✔️ |
+| `ExclusiveNodeWithParallelism(n)` | ✔️ exclusivity, parallelism ignored (warns) | ✔️ | ✔️ |
+| `CircuitBreaker()` | ✔️ | ✔️ | ✔️ |
+
+As of Wolverine 6.30, these combinations are no longer silently accepted:
+
+* `ProcessInline()` together with `PartitionProcessingByGroupId()` throws an
+  `InvalidListenerConfigurationException` at bootstrap. Partitioned processing is a *guarantee* — messages
+  sharing a group id never run concurrently — and an `Inline` endpoint cannot make it, so failing to start
+  is preferable to quietly not honoring it.
+* `ProcessInline()` together with an explicit parallelism or `BufferingLimits` logs a warning at startup, and
+  Wolverine normalizes `MaxDegreeOfParallelism` to 1.
+
+That normalization also removes an order dependency: `.MaximumParallelMessages(20).ProcessInline()` and
+`.ProcessInline().MaximumParallelMessages(20)` now leave the endpoint in exactly the same state. The
+`wolverine describe` and `wolverine diagnose` listener tables likewise print `n/a (Inline)` for parallelism
+rather than a number the endpoint never reads.
+
+How many messages an `Inline` listener actually handles at once is up to the transport's own listener — for
+example RabbitMQ's `ConsumerDispatchConcurrency` — plus `ListenerCount()`.
+
+::: warning
+This most often bites with a [partitioned messaging topology](/guide/messaging/partitioning) on RabbitMQ,
+because RabbitMQ queues are `Inline` by default. A topology built with `PublishToShardedRabbitQueues()` sets
+the group id slots on its listeners, so unless you also opt those listeners into a mode that can honor them
+Wolverine will now refuse to start:
+
+```csharp
+opts.MessagePartitioning.PublishToShardedRabbitQueues("letters", 4, topology =>
+{
+    topology.MessagesImplementing<ILetterMessage>();
+    topology.MaxDegreeOfParallelism = PartitionSlots.Five;
+
+    // Required -- RabbitMQ queues are Inline by default, and an Inline
+    // listener cannot honor the group id ordering guarantee
+    topology.ConfigureListening(x => x.BufferedInMemory());
+});
+```
+
+Before this check that configuration started cleanly and simply did not partition anything.
+:::
 
 ## Strictly Ordered Listeners <Badge type="tip" text="2.3" />
 

--- a/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
+++ b/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
@@ -1,0 +1,203 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3712. Listener settings that a given EndpointMode simply ignores used to be accepted in silence.
+/// </summary>
+public class listener_configuration_validation
+{
+    private static Endpoint compiledEndpoint(Action<WolverineOptions> configure, string uri = "stub://one")
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(configure).Build();
+
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = options.Transports.AllEndpoints().Single(x => x.Uri == new Uri(uri));
+        endpoint.Compile(runtime);
+
+        return endpoint;
+    }
+
+    [Fact]
+    public void inline_plus_partitioned_processing_is_fatal()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .ProcessInline()
+                .PartitionProcessingByGroupId(PartitionSlots.Five);
+        });
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+        problem.Message.ShouldContain("PartitionProcessingByGroupId()");
+        problem.Message.ShouldContain("stub://one");
+        problem.Message.ShouldContain("BufferedInMemory or Durable");
+    }
+
+    [Fact]
+    public async Task inline_plus_partitioned_processing_stops_the_host_from_starting()
+    {
+        var ex = await Should.ThrowAsync<InvalidListenerConfigurationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+            {
+                opts.ListenForMessagesFrom("stub://partitioned-inline")
+                    .ProcessInline()
+                    .PartitionProcessingByGroupId(PartitionSlots.Nine);
+            }).StartAsync();
+        });
+
+        ex.Message.ShouldContain("stub://partitioned-inline");
+        ex.Message.ShouldContain("PartitionProcessingByGroupId()");
+    }
+
+    [Fact]
+    public void inline_plus_explicit_parallelism_only_warns()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .ProcessInline()
+                .MaximumParallelMessages(20);
+        });
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+        problem.Message.ShouldContain("maximum parallelism of 20");
+        problem.Message.ShouldContain("MaximumParallelMessages()");
+    }
+
+    [Fact]
+    public void inline_plus_exclusive_node_with_parallelism_only_warns()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(_ => { }).Build();
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        // ExclusiveNodeWithParallelism() is only on the concrete ListenerConfiguration
+        var endpoint = new StubEndpoint("exclusive-inline", new StubTransport());
+        var config = new ListenerConfiguration(endpoint);
+        config.ExclusiveNodeWithParallelism(20);
+        config.ProcessInline();
+        ((IDelayedEndpointConfiguration)config).Apply();
+
+        endpoint.Compile(runtime);
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+        problem.Message.ShouldContain("maximum parallelism of 20");
+
+        // The exclusivity half of that method still applies
+        endpoint.ListenerScope.ShouldBe(ListenerScope.Exclusive);
+        endpoint.MaxDegreeOfParallelism.ShouldBe(1);
+    }
+
+    [Fact]
+    public void inline_plus_buffering_limits_only_warns()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .BufferedInMemory(new BufferingLimits(250, 100))
+                .ProcessInline();
+        });
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+        problem.Message.ShouldContain("BufferingLimits");
+    }
+
+    [Fact]
+    public void plain_inline_endpoint_has_no_problems()
+    {
+        var endpoint = compiledEndpoint(opts => { opts.ListenForMessagesFrom("stub://one").ProcessInline(); });
+
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+
+        // ...and the default parallelism is not reported as though it were live
+        endpoint.MaxDegreeOfParallelism.ShouldBe(1);
+        endpoint.DescribeMaxDegreeOfParallelism().ShouldBe("n/a (Inline)");
+    }
+
+    [Fact]
+    public void buffered_plus_partitioned_processing_is_still_valid()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .BufferedInMemory()
+                .MaximumParallelMessages(10)
+                .PartitionProcessingByGroupId(PartitionSlots.Five);
+        });
+
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+        endpoint.MaxDegreeOfParallelism.ShouldBe(10);
+        endpoint.DescribeMaxDegreeOfParallelism().ShouldBe("10");
+    }
+
+    [Fact]
+    public void durable_plus_partitioned_processing_is_still_valid()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .UseDurableInbox(new BufferingLimits(250, 100))
+                .PartitionProcessingByGroupId(PartitionSlots.Three);
+        });
+
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_send_only_endpoint_is_not_validated_as_a_listener()
+    {
+        var endpoint = compiledEndpoint(opts => opts.PublishAllMessages().To("stub://sender"), "stub://sender");
+
+        endpoint.Mode = EndpointMode.Inline;
+        endpoint.MaxDegreeOfParallelism = 20;
+
+        endpoint.IsListener.ShouldBeFalse();
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void process_inline_and_maximum_parallel_messages_converge_regardless_of_call_order(bool inlineFirst)
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            var config = opts.ListenForMessagesFrom("stub://one");
+
+            if (inlineFirst)
+            {
+                config.ProcessInline().MaximumParallelMessages(20);
+            }
+            else
+            {
+                config.MaximumParallelMessages(20).ProcessInline();
+            }
+        });
+
+        endpoint.Mode.ShouldBe(EndpointMode.Inline);
+        endpoint.MaxDegreeOfParallelism.ShouldBe(1);
+        endpoint.DiscardedMaxDegreeOfParallelism.ShouldBe(20);
+
+        // Same two calls, same warning, either way around
+        ListenerConfigurationValidator.Validate(endpoint).Single()
+            .Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+    }
+}

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -179,6 +179,8 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     private IMessageSerializer? _defaultSerializer;
 
     private bool _hasCompiled;
+    private int _maxDegreeOfParallelism = Math.Max(Environment.ProcessorCount, 5);
+    private BufferingLimits _bufferingLimits = new(1000, 500);
 
     private EndpointMode _mode = EndpointMode.BufferedInMemory;
     private string? _name;
@@ -208,12 +210,58 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     /// Controls the maximum number of messages that could be processed at one time.
     /// Default is the greater of Environment.ProcessorCount or 5. Setting this to 1 makes this listening endpoint
     /// be ordered in its processing.
+    ///
+    /// Only applies to <see cref="EndpointMode.BufferedInMemory"/> and <see cref="EndpointMode.Durable"/>
+    /// endpoints, because it governs the size of Wolverine's local execution block -- and an
+    /// <see cref="EndpointMode.Inline"/> endpoint has no execution block at all. An Inline endpoint's
+    /// concurrency is whatever the transport listener itself does; this value is normalized to 1 at
+    /// <see cref="Compile"/> time for an Inline endpoint. See GH-3712.
     /// </summary>
-    public int MaxDegreeOfParallelism { get; set; } = Math.Max(Environment.ProcessorCount, 5);
-    
+    public int MaxDegreeOfParallelism
+    {
+        get => _maxDegreeOfParallelism;
+        set
+        {
+            _maxDegreeOfParallelism = value;
+
+            // GH-3712. Distinguishes "the user asked for parallelism" from "nobody ever touched this",
+            // so the Inline coherence check can warn about the former without nagging about the default.
+            MaxDegreeOfParallelismIsExplicit = true;
+        }
+    }
+
+    /// <summary>
+    /// GH-3712. Has anything actually assigned <see cref="MaxDegreeOfParallelism"/>, as opposed to
+    /// leaving the Environment.ProcessorCount-derived default in place?
+    /// </summary>
+    internal bool MaxDegreeOfParallelismIsExplicit { get; private set; }
+
+    /// <summary>
+    /// GH-3712. The explicitly configured <see cref="MaxDegreeOfParallelism"/> that <see cref="Compile"/>
+    /// discarded because this endpoint's mode ignores it. Null when nothing was discarded.
+    /// </summary>
+    internal int? DiscardedMaxDegreeOfParallelism { get; private set; }
+
+    /// <summary>
+    /// GH-3712. Does this endpoint's mode ignore <see cref="MaxDegreeOfParallelism"/> outright? Used by the
+    /// diagnostics output so an ignored setting is never displayed as though it were live.
+    /// </summary>
+    internal bool ModeIgnoresParallelism => Mode == EndpointMode.Inline;
+
+    /// <summary>
+    /// GH-3712. Render <see cref="MaxDegreeOfParallelism"/> for diagnostics, saying "n/a" rather than
+    /// printing a dead number for a mode that never reads it.
+    /// </summary>
+    internal string DescribeMaxDegreeOfParallelism()
+    {
+        return ModeIgnoresParallelism ? $"n/a ({Mode})" : MaxDegreeOfParallelism.ToString();
+    }
+
     /// <summary>
     /// If specified, directs this endpoint to use by GroupId sharding in processing.
-    /// Only impacts Buffered or Durable endpoints though.
+    /// Only impacts Buffered or Durable endpoints though -- an Inline endpoint has no execution block
+    /// to shard, so Wolverine rejects that combination at bootstrap rather than silently dropping the
+    /// grouping semantics. See GH-3712.
     /// </summary>
     public PartitionSlots? GroupShardingSlotNumber { get; set; }
 
@@ -262,10 +310,27 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     public EndpointRole Role { get; internal set; }
 
     /// <summary>
-    ///     Local message buffering limits and restart thresholds for back pressure mechanics
+    ///     Local message buffering limits and restart thresholds for back pressure mechanics.
+    ///     Inert on an <see cref="EndpointMode.Inline"/> endpoint, which never builds a
+    ///     <c>BackPressureAgent</c> -- see <see cref="ShouldEnforceBackPressure"/> and GH-3712.
     /// </summary>
     [ChildDescription]
-    public BufferingLimits BufferingLimits { get; set; } = new(1000, 500);
+    public BufferingLimits BufferingLimits
+    {
+        get => _bufferingLimits;
+        set
+        {
+            _bufferingLimits = value;
+
+            // GH-3712, same rationale as MaxDegreeOfParallelismIsExplicit
+            BufferingLimitsAreExplicit = true;
+        }
+    }
+
+    /// <summary>
+    /// GH-3712. Has anything actually assigned <see cref="BufferingLimits"/>?
+    /// </summary>
+    internal bool BufferingLimitsAreExplicit { get; private set; }
 
     /// <summary>
     ///     If present, adds a circuit breaker to the active listening agent
@@ -556,7 +621,30 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
             }
         }
 
+        normalizeForMode();
+
         _hasCompiled = true;
+    }
+
+    /// <summary>
+    /// GH-3712. Converge the endpoint on one state per mode regardless of the order the fluent calls were
+    /// made in. <c>ProcessInline()</c> used to clamp MaxDegreeOfParallelism eagerly, which meant
+    /// <c>.MaximumParallelMessages(20).ProcessInline()</c> and <c>.ProcessInline().MaximumParallelMessages(20)</c>
+    /// ended with different endpoint state for the same two calls. Doing it here -- after endpoint policies and
+    /// all delayed configuration have run -- makes the final mode, not the call sequence, decide.
+    /// </summary>
+    private void normalizeForMode()
+    {
+        if (Mode != EndpointMode.Inline) return;
+
+        if (MaxDegreeOfParallelismIsExplicit && _maxDegreeOfParallelism > 1)
+        {
+            DiscardedMaxDegreeOfParallelism = _maxDegreeOfParallelism;
+        }
+
+        // Assign the backing field directly so the "was explicitly set" flag still reflects
+        // the *user's* intent rather than this normalization.
+        _maxDegreeOfParallelism = 1;
     }
 
     private IWireTap? ResolveWireTap(IWolverineRuntime runtime)

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -103,7 +103,11 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
     /// specified number of slots. Use this to group messages to prevent concurrent
     /// processing of messages with the same GroupId while allowing parallel work across
     /// GroupIds. The number of "slots" reflects the maximum number of parallel messages
-    /// that can be handled concurrently
+    /// that can be handled concurrently.
+    ///
+    /// Requires a BufferedInMemory or Durable endpoint. Combining this with ProcessInline()
+    /// throws at bootstrap, because an Inline endpoint has no local execution block to shard
+    /// and the group id guarantee would silently not exist. See GH-3712.
     /// </summary>
     /// <param name="numberOfSlots"></param>
     /// <returns></returns>
@@ -236,6 +240,10 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
     /// Configure this listener to run exclusively on a single node in the cluster,
     /// but allow parallel message processing within that node. This is useful for
     /// scenarios where you need single-node consistency but want to maintain throughput.
+    ///
+    /// The parallelism half of this has no effect on an Inline endpoint, which has no local
+    /// execution block to size -- Wolverine normalizes MaxDegreeOfParallelism to 1 and logs a
+    /// warning in that case. The exclusive-node half still applies. See GH-3712.
     /// </summary>
     /// <param name="maxParallelism">Maximum number of messages to process in parallel on the exclusive node. Default is 10.</param>
     /// <param name="endpointName">Optional endpoint name for identification</param>
@@ -328,6 +336,12 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         return this.As<TSelf>();
     }
 
+    /// <summary>
+    /// The maximum number of messages this endpoint will execute in parallel through Wolverine's
+    /// local execution block. Only applies to BufferedInMemory and Durable endpoints; an Inline
+    /// endpoint's concurrency belongs to the transport listener instead, and Wolverine logs a warning
+    /// if this is combined with ProcessInline(). See GH-3712.
+    /// </summary>
     public TSelf MaximumParallelMessages(int maximumParallelHandlers)
     {
         add(e =>
@@ -350,6 +364,10 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         return BufferedInMemory();
     }
 
+    /// <summary>
+    /// Force this endpoint to execute one message at a time through Wolverine's local execution block.
+    /// Only applies to BufferedInMemory and Durable endpoints -- see MaximumParallelMessages() and GH-3712.
+    /// </summary>
     public TSelf Sequential()
     {
         add(e =>
@@ -379,13 +397,20 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         return this.As<TSelf>();
     }
 
+    /// <summary>
+    /// Process incoming messages inline with the transport's own listening callback, with no local
+    /// execution block and no inbox in between. Note that this makes MaximumParallelMessages(),
+    /// Sequential(), and PartitionProcessingByGroupId() inapplicable -- Wolverine normalizes
+    /// MaxDegreeOfParallelism to 1 at bootstrap for an Inline endpoint and rejects partitioned
+    /// processing outright. See GH-3712.
+    /// </summary>
     public TSelf ProcessInline()
     {
-        add(e =>
-        {
-            e.Mode = EndpointMode.Inline;
-            e.MaxDegreeOfParallelism = 1;
-        });
+        // GH-3712. The MaxDegreeOfParallelism = 1 clamp deliberately does NOT happen here. Clamping
+        // eagerly made the endpoint's final state depend on whether ProcessInline() was called before
+        // or after MaximumParallelMessages(); Endpoint.Compile() now normalizes it for every Inline
+        // endpoint once all of the configuration has been applied.
+        add(e => e.Mode = EndpointMode.Inline);
         return this.As<TSelf>();
     }
 

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Transports.Local;
+
+namespace Wolverine.Configuration;
+
+internal enum ListenerConfigurationSeverity
+{
+    /// <summary>
+    /// The setting is inert, but the endpoint still does something reasonable. Log and carry on.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// The setting asked for a processing guarantee the endpoint's mode cannot deliver. Refuse to start.
+    /// </summary>
+    Fatal
+}
+
+internal record ListenerConfigurationProblem(
+    Endpoint Endpoint,
+    ListenerConfigurationSeverity Severity,
+    string Message);
+
+/// <summary>
+/// GH-3712. Several listener configuration combinations used to be accepted in silence and then do
+/// nothing at runtime -- most damagingly <c>ProcessInline()</c> together with
+/// <c>PartitionProcessingByGroupId()</c>, which reads as "messages sharing a group id never run
+/// concurrently" and delivered no such thing. Everything Wolverine's Inline listening path ignores is
+/// enumerated here so a misconfiguration is either refused at bootstrap or said out loud in the log.
+/// </summary>
+internal static class ListenerConfigurationValidator
+{
+    /// <summary>
+    /// Validate every listening endpoint, logging the warnings and throwing on the first fatal problem.
+    /// Expects the endpoints to have already been compiled, so that endpoint policies and delayed
+    /// configuration have had their say about the final mode.
+    /// </summary>
+    internal static void AssertValid(IEnumerable<Endpoint> endpoints, ILogger? logger)
+    {
+        var problems = endpoints.SelectMany(Validate).ToArray();
+
+        foreach (var problem in problems.Where(x => x.Severity == ListenerConfigurationSeverity.Warning))
+        {
+            logger?.LogWarning(problem.Message);
+        }
+
+        var fatal = problems.FirstOrDefault(x => x.Severity == ListenerConfigurationSeverity.Fatal);
+        if (fatal != null)
+        {
+            throw new InvalidListenerConfigurationException(fatal.Message);
+        }
+    }
+
+    internal static IEnumerable<ListenerConfigurationProblem> Validate(Endpoint endpoint)
+    {
+        if (!endpoint.IsListener && endpoint is not LocalQueue)
+        {
+            yield break;
+        }
+
+        if (endpoint.Mode != EndpointMode.Inline)
+        {
+            yield break;
+        }
+
+        var name = describe(endpoint);
+
+        if (endpoint.GroupShardingSlotNumber.HasValue)
+        {
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Fatal,
+                $"Invalid listener configuration for {name}: PartitionProcessingByGroupId() was configured on an Inline endpoint. " +
+                "Partitioned processing is implemented by Wolverine's local execution block, and an Inline endpoint executes each message " +
+                "directly on the transport's listening callback without one -- so the group id ordering guarantee would silently not exist. " +
+                "Either remove ProcessInline() (partitioned processing requires BufferedInMemory or Durable), or remove " +
+                "PartitionProcessingByGroupId() from this endpoint.");
+        }
+
+        if (endpoint.DiscardedMaxDegreeOfParallelism is { } discarded)
+        {
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Warning,
+                $"Ignored listener configuration for {name}: a maximum parallelism of {discarded} was configured on an Inline endpoint, " +
+                "and Wolverine has reset it to 1. MaximumParallelMessages(), Sequential(), ExclusiveNodeWithParallelism() and " +
+                "ExclusiveNodeWithSessionOrdering() all size Wolverine's local execution block, which an Inline endpoint does not have. " +
+                "How many messages an Inline listener handles at once is decided by the transport's own listener (for example RabbitMQ's " +
+                "ConsumerDispatchConcurrency). Use BufferedInMemory() or UseDurableInbox() if you want Wolverine to govern the parallelism.");
+        }
+
+        if (endpoint.BufferingLimitsAreExplicit)
+        {
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Warning,
+                $"Ignored listener configuration for {name}: BufferingLimits were configured on an Inline endpoint. Back pressure is applied " +
+                "by counting messages queued in Wolverine's local execution block, so an Inline endpoint never starts a BackPressureAgent " +
+                "and these limits do nothing. Use BufferedInMemory(limits) or UseDurableInbox(limits) if you want back pressure.");
+        }
+    }
+
+    private static string describe(Endpoint endpoint)
+    {
+        return endpoint.EndpointName == endpoint.Uri.ToString()
+            ? $"endpoint '{endpoint.Uri}'"
+            : $"endpoint '{endpoint.EndpointName}' ({endpoint.Uri})";
+    }
+}
+
+/// <summary>
+/// GH-3712. Thrown at bootstrap when a listening endpoint's configuration asks for a processing
+/// guarantee that its <see cref="EndpointMode"/> cannot deliver.
+/// </summary>
+public class InvalidListenerConfigurationException : Exception
+{
+    public InvalidListenerConfigurationException(string message) : base(message)
+    {
+    }
+}

--- a/src/Wolverine/Diagnostics/WolverineDiagnosticsCommand.cs
+++ b/src/Wolverine/Diagnostics/WolverineDiagnosticsCommand.cs
@@ -637,7 +637,7 @@ public class WolverineDiagnosticsCommand : JasperFxAsyncCommand<WolverineDiagnos
                     ep.Uri.ToString().EscapeMarkup(),
                     ep.EndpointName.EscapeMarkup(),
                     ep.Mode.ToString(),
-                    ep.MaxDegreeOfParallelism.ToString());
+                    ep.DescribeMaxDegreeOfParallelism());
             }
 
             AnsiConsole.Write(listenerTable);

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -596,6 +596,12 @@ public partial class WolverineRuntime
             }
         }
 
+        // GH-3712. Say out loud when a listening endpoint's mode ignores the settings it was given --
+        // most importantly Inline together with PartitionProcessingByGroupId(), which silently dropped
+        // the group id ordering guarantee. Runs even when the external transports are stubbed, so a
+        // test host surfaces the same misconfiguration a deployed one would.
+        validateListenerConfiguration();
+
         if (!Options.ExternalTransportsAreStubbed)
         {
             await Endpoints.StartListenersAsync();
@@ -604,6 +610,26 @@ public partial class WolverineRuntime
         {
             Logger.LogInformation("All external endpoint listeners are disabled because of configuration");
         }
+    }
+
+    /// <summary>
+    /// GH-3712. Compile every listening endpoint and check its settings against its mode. Compilation has to
+    /// happen first, because endpoint policies and delayed configuration are what settle the final mode --
+    /// and it is idempotent, so the later StartListenerAsync() call is unaffected.
+    /// </summary>
+    private void validateListenerConfiguration()
+    {
+        var listeners = Options.Transports
+            .SelectMany(x => x.Endpoints())
+            .Where(x => x.IsListener || x is LocalQueue)
+            .ToArray();
+
+        foreach (var endpoint in listeners)
+        {
+            endpoint.Compile(this);
+        }
+
+        ListenerConfigurationValidator.AssertValid(listeners, Logger);
     }
 
     /// <summary>

--- a/src/Wolverine/WolverineSystemPart.cs
+++ b/src/Wolverine/WolverineSystemPart.cs
@@ -171,7 +171,7 @@ internal class WolverineSystemPart : SystemPartBase
                 listener.Uri.ToString(),
                 listener.EndpointName,
                 listener.Mode.ToString(),
-                listener.MaxDegreeOfParallelism.ToString(),
+                listener.DescribeMaxDegreeOfParallelism(),
                 listener.SerializerDescription(_runtime.Options)
             );
         }


### PR DESCRIPTION
Closes #3712.

## The problem

Listener settings that a given `EndpointMode` simply does not read were accepted in silence. The worst of them reads as a *guarantee*:

```csharp
opts.ListenToRabbitQueue("orders")
    .ProcessInline()
    .PartitionProcessingByGroupId(PartitionSlots.Five);   // did nothing at all
```

`GroupShardingSlotNumber` is only read by `BufferedReceiver` and `DurableReceiver`; `InlineReceiver` ignores it. So that configuration started cleanly, logged nothing, and gave the user no group-id ordering whatsoever.

`ProcessInline()` also carried an order-dependent clamp: `.MaximumParallelMessages(20).ProcessInline()` ended at `MaxDegreeOfParallelism == 1`, while `.ProcessInline().MaximumParallelMessages(20)` ended at `20` — a value nothing reads, but which the `wolverine describe` listener table displayed as if it were live.

## What changed

**A bootstrap validation pass** (`ListenerConfigurationValidator`, called from `startMessagingTransportsAsync` before listeners start). It compiles every listening endpoint first — endpoint policies and delayed configuration are what settle the final mode — then checks settings against that mode:

| Combination | Result |
| --- | --- |
| `Inline` + `PartitionProcessingByGroupId()` | **throws** `InvalidListenerConfigurationException` |
| `Inline` + explicit parallelism (`MaximumParallelMessages`, `Sequential`, `ExclusiveNodeWithParallelism`, …) | warning, value normalized to 1 |
| `Inline` + customized `BufferingLimits` | warning (an Inline endpoint never starts a `BackPressureAgent`) |

Partitioning throws rather than warns because it is the only one of the three that is a *guarantee* — silently not honoring it surfaces as intermittent concurrency collisions under load, not as an obvious failure. The other two are inert but harmless, so existing apps carrying a stale value keep starting.

**The order dependence is gone.** `ProcessInline()` no longer clamps eagerly; `Endpoint.Compile()` normalizes `MaxDegreeOfParallelism` to 1 for every Inline endpoint once all configuration has been applied. Both call orders now leave identical endpoint state, and `Endpoint.DiscardedMaxDegreeOfParallelism` records what the user actually asked for so the warning can name it.

**Diagnostics stop printing dead numbers.** `wolverine describe` and `wolverine diagnose` render `n/a (Inline)` for parallelism instead of a value the endpoint never reads.

**Docs.** `docs/guide/messaging/listeners.md` gains a "which settings apply in which mode" matrix, plus xml-doc fixes on `ExclusiveNodeWithParallelism`, `MaximumParallelMessages`, `Sequential`, `PartitionProcessingByGroupId`, and `ProcessInline`.

## ⚠️ Note for RabbitMQ users of partitioned topologies

RabbitMQ queues default to `Inline`, and `PublishToShardedRabbitQueues()` sets the group-id slots on its listeners. A topology that does **not** also call `ConfigureListening(x => x.BufferedInMemory())` (or `UseDurableInbox()`) will now fail to start instead of starting cleanly and not partitioning anything. Every sample and test in this repo already does; the docs now say so explicitly. Silently upgrading those listeners to `Buffered` was considered and rejected — it would trade one silent surprise for a worse one, since Buffered changes the delivery guarantee.

## Tests

`src/Testing/CoreTests/Configuration/listener_configuration_validation.cs` — 11 tests covering each combination's severity and message, both `ProcessInline()`/`MaximumParallelMessages()` call orders converging, the `n/a` rendering, a real host refusing to start, and the false-positive guards (Buffered/Durable + partitioning still valid; a send-only endpoint is not validated as a listener).

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings
- CoreTests: 2498 total, 0 failed
- PolicyTests, MessageRoutingTests, BackPressureTests: green

## Follow-up spotted, not fixed here

A local queue set to `Inline` is accepted at configuration time and then throws a bare, message-less `NotSupportedException` from `LocalQueue.BuildAgent` the first time anything sends to it (`src/Wolverine/Transports/Local/LocalQueue.cs:70`). Same family of problem, but outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)