### PR TITLE
Bump RabbitMQ.Client 7.1.2 -> 7.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,17 @@
 
 ### Dependencies
 
+- **RabbitMQ.Client 7.1.2 → 7.2.2.** Nine months of client fixes, several of them in exactly the
+  connection- and channel-churn area Wolverine's listeners live in: races in `AsyncManualResetEvent`,
+  a `SemaphoreFullException`, a connection leak in `AutorecoveringConnection`, publisher confirms being
+  handled after dispose, `TryComplete` during channel shutdown, heartbeat callbacks no longer crashing
+  the process on an exception, and recovery retried when a topology operation times out.
+
+  This deliberately does **not** fix [#3950](https://github.com/JasperFx/wolverine/issues/3950).
+  `SessionManager.Lookup` still reads its session map with an indexer, and is byte-identical in v7.1.2,
+  v7.2.2, and the client's `main` — so one rejected delivery tag on a busy channel can still escalate
+  into a library-initiated close of the whole connection. That fix has to happen upstream.
+
 - **Weasel 9.26.0.** Two defects that Wolverine's new fail-fast migrations (below) turned from a logged
   line into a failed startup: `Table.FetchExisting` filtered the PostgreSQL catalog with
   `NOT nspname LIKE 'pg%'`, which hid every index in a *user* schema whose name began with "pg", so those

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,7 +100,7 @@
     <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.52" />
     <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-    <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.2" />
     <PackageVersion Include="RavenDB.Client" Version="7.0.2" />
     <PackageVersion Include="RavenDB.DependencyInjection" Version="5.0.1" />
     <PackageVersion Include="RavenDB.TestDriver" Version="7.0.2" />


### PR DESCRIPTION
One-line pin change plus a CHANGELOG entry. We were on **7.1.2 (March 2025)**; **7.2.2** shipped August 2026, so this closes a nine-month gap.

## Why

Several 7.2.x fixes land in exactly the connection- and channel-churn area Wolverine's listeners live in:

- **7.2.0** — races in `AsyncManualResetEvent`, a `SemaphoreFullException`, a connection leak in `AutorecoveringConnection` during creation, publisher confirms handled after dispose, connection/channel cancellation tokens properly floating into handlers
- **7.2.1** — `TryComplete` instead of `Complete` during channel shutdown, heartbeat read/write callbacks no longer crashing the process on an exception, unconditional semaphore release in `BasicPublishAsync`
- **7.2.2** — recovery retried when a topology operation times out

Target frameworks and transitive dependencies are **identical** between 7.1.2 and 7.2.2 (`net8.0` + `netstandard2.0`; `System.IO.Pipelines` 8.0.0, `System.Threading.RateLimiting` 8.0.0), so this is a pin change and nothing else — no API surface to absorb.

## This is explicitly NOT a fix for #3950

Worth stating plainly so nobody closes that issue off the back of this PR.

`SessionManager.Lookup` still reads its session map with an indexer, and is **byte-identical in v7.1.2, v7.2.2, and the client's `main`**:

```csharp
public ISession Lookup(int number)
{
    lock (_sessionMap)
    {
        /*
         * Note: rabbitmq/rabbitmq-server#13337
         * When investigating the above issue, a couple KeyNotFoundExceptions
         * were thrown here during test shutdown. No reliable reproducer.
         */
        return _sessionMap[number];
    }
}
```

Verified by diffing the upstream source across all three refs, not by reading changelogs. One rejected delivery tag on a busy channel can still escalate into a library-initiated close of the whole connection. That fix belongs upstream, and a report with a reproducer is drafted separately.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, zero new warnings (re-run after rebasing onto current `main`)
- Full `Wolverine.RabbitMQ.Tests` against docker-compose Rabbit (broker 4.2.5): **506 passed / 0 failed**, confirmed via TRX (`total 506, passed 506, failed 0, error 0, timeout 0, aborted 0`)

**One caveat, stated rather than buried.** An earlier local run of the same suite on 7.2.2 reported `505 passed / 1 failed`. I cannot name the test: that run's output was piped through `tail`, which kept the summary and discarded the failure detail, and the clean re-run cannot recover what failed. It did not reproduce across a second full run, and this suite has known cross-class order dependence (see #3726), so a flake is the likely explanation — but that is inference, not diagnosis. CI running the full matrix here is the real check, which is part of why this is a PR rather than a direct push.
