### PR TITLE
GH-4018: turn off AutoCompleteMessages on the inline Azure Service Bus processor

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/listening.md
+++ b/docs/guide/messaging/transports/azureservicebus/listening.md
@@ -95,9 +95,9 @@ await host.StartAsync();
 
 ::: warning
 Wolverine's inline listener acknowledges, defers, and dead letters messages against the message lock, so it
-requires the peek-lock receive model. The `ReceiveMode` you set in `ConfigureProcessor()` is therefore
-ignored and always re-asserted to `ServiceBusReceiveMode.PeekLock`. All other `ServiceBusProcessorOptions`
-properties are honored. Session-based listeners (`RequireSessions()`) do not use a `ServiceBusProcessor` and
+requires the peek-lock receive model and settles every message itself. The `ReceiveMode` and
+`AutoCompleteMessages` you set in `ConfigureProcessor()` are therefore ignored and always re-asserted to
+`ServiceBusReceiveMode.PeekLock` and `false`. All other `ServiceBusProcessorOptions` properties are honored. Session-based listeners (`RequireSessions()`) do not use a `ServiceBusProcessor` and
 are not affected by this option.
 :::
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_processor_options.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_processor_options.cs
@@ -72,6 +72,31 @@ public class configuring_processor_options
     }
 
     [Fact]
+    public void build_processor_options_turns_off_auto_complete_by_default()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+
+        // GH-4018: the SDK default is true, which lets the processor complete a message that
+        // Wolverine failed to settle on the first attempt -- a dead letter whose first try threw
+        // is then completed behind the retry's back and is neither dead lettered nor redelivered.
+        AzureServiceBusTransport.BuildProcessorOptions(queue).AutoCompleteMessages.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void build_processor_options_reasserts_auto_complete_off_over_user_configuration()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["incoming"];
+        queue.ConfigureProcessor = o => o.AutoCompleteMessages = true;
+
+        var options = AzureServiceBusTransport.BuildProcessorOptions(queue);
+
+        // Same contract as the session processor path and as ReceiveMode: Wolverine owns settlement
+        options.AutoCompleteMessages.ShouldBeFalse();
+    }
+
+    [Fact]
     public void build_processor_options_is_valid_when_no_action_is_configured()
     {
         var transport = new AzureServiceBusTransport();
@@ -81,5 +106,6 @@ public class configuring_processor_options
 
         options.ShouldNotBeNull();
         options.ReceiveMode.ShouldBe(ServiceBusReceiveMode.PeekLock);
+        options.AutoCompleteMessages.ShouldBeFalse();
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusQueueListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusQueueListenerConfiguration.cs
@@ -70,8 +70,8 @@ public class
     ///     listener when running in the inline (<c>ProcessInline()</c>) mode. This is the way to raise
     ///     <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration" /> for inline handlers that
     ///     run longer than the Azure SDK's default of five minutes. Wolverine reserves control of the
-    ///     properties it depends on for message acknowledgement (currently <c>ReceiveMode</c>), which are
-    ///     re-asserted after this action runs.
+    ///     properties it depends on for message acknowledgement (<c>ReceiveMode</c> and
+    ///     <c>AutoCompleteMessages</c>), which are re-asserted after this action runs.
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusSubscriptionListenerConfiguration.cs
@@ -69,8 +69,8 @@ public class AzureServiceBusSubscriptionListenerConfiguration : InteroperableLis
     ///     subscription listener when running in the inline (<c>ProcessInline()</c>) mode. This is the way
     ///     to raise <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration" /> for inline handlers
     ///     that run longer than the Azure SDK's default of five minutes. Wolverine reserves control of the
-    ///     properties it depends on for message acknowledgement (currently <c>ReceiveMode</c>), which are
-    ///     re-asserted after this action runs.
+    ///     properties it depends on for message acknowledgement (<c>ReceiveMode</c> and
+    ///     <c>AutoCompleteMessages</c>), which are re-asserted after this action runs.
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
@@ -204,6 +204,15 @@ public partial class AzureServiceBusTransport
         // defer, and dead letter messages, so this cannot be honored from user configuration.
         options.ReceiveMode = ServiceBusReceiveMode.PeekLock;
 
+        // GH-4018: Wolverine settles every inline delivery itself through the ProcessMessageEventArgs
+        // (complete / defer / dead letter, each behind a RetryBlock). The SDK default of true let the
+        // processor ALSO complete any message it had not seen settled successfully when the callback
+        // returned -- and a settle attempt that threw does not count. So a dead-letter whose first
+        // attempt failed transiently was completed by the processor on the way out, and the queued
+        // retry then hit an invalid lock: the message was neither dead lettered nor redelivered.
+        // The session-processor path already forces this off; the two must agree.
+        options.AutoCompleteMessages = false;
+
         return options;
     }
 


### PR DESCRIPTION
Closes #4018. Split out of #3494 (§0 flagged it; #3674 surfaced `MaxConcurrentCalls` but left this alone).

## What

`AzureServiceBusTransport.BuildProcessorOptions` now sets `AutoCompleteMessages = false` after `ConfigureProcessor` runs, in the same reserved-by-Wolverine block that already re-asserts `ReceiveMode = PeekLock`. That matches `BuildSessionProcessorOptions`, which has forced it off since #3533.

## Why

The inline listener settles every delivery itself — complete / defer / dead-letter through the `ProcessMessageEventArgs`, each behind a `RetryBlock`. With the SDK default of `true`, the processor *also* completed any message it had not seen settled successfully when `processMessageAsync` returned — and a settle attempt that threw does not count as settled.

Concrete failure: handler throws → error policy says dead-letter → first `DeadLetterAsync` throws (transient) → `RetryBlock` queues a background retry → callback returns normally → **SDK auto-completes the message** → the retry fails with an invalid lock. Net: not in the DLQ, not redelivered. Gone.

It also blocked GH-4012's "give up settling and leave the delivery for broker redelivery" outcome on inline ASB, since the SDK would complete it on the way out.

## Changes

- `AzureServiceBusTransport.Listening.cs` — the one-line option plus the why.
- `configuring_processor_options.cs` — `build_processor_options_turns_off_auto_complete_by_default`, `build_processor_options_reasserts_auto_complete_off_over_user_configuration`, and the no-action test now also asserts it.
- XML docs on `ConfigureProcessor` (queue + subscription) and `docs/.../azureservicebus/listening.md` now name both reserved properties (`ReceiveMode`, `AutoCompleteMessages`) instead of "currently `ReceiveMode`".

## Test evidence

Against the docker emulator, serial, one process:

| Class | Result |
|---|---|
| `configuring_processor_options` (unit) | 7/7 |
| `InlineSendingAndReceivingCompliance` (requeue, both DLQ paths, schedule retry, too-busy, request/reply…) | ✅ |
| `end_to_end`, `dead_letter_queue_recovery`, `connection_state_3237`, `using_native_scheduling` | ✅ |
| **Total** | **47 passed / 0 failed**, 3m52s |

The inline compliance suite is the behavioral gate here: every inline settle path (complete, defer/requeue, dead-letter, scheduled retry) runs with auto-complete off, so if any of them had been quietly relying on the SDK to finish the job, it would show up as a stuck or duplicated message. I did not add a fault-injected "first dead-letter attempt fails" test — there is no seam to make `DeadLetterAsync` throw on demand without restructuring the listener, and that felt out of proportion for a one-line option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
