### PR TITLE
GH-4019: opt-in visibility heartbeat for inline Amazon SQS listeners

### DIFF
--- a/docs/guide/messaging/transports/sqs/performance.md
+++ b/docs/guide/messaging/transports/sqs/performance.md
@@ -43,9 +43,10 @@ does not leave settled messages to reappear at their visibility timeout.
 ## Visibility timeout: size it against your processing window
 
 Wolverine sets each received message's visibility timeout at receive (default **120 seconds**)
-and never calls `ChangeMessageVisibility` to extend it. How much of your processing that
-window has to cover depends on the endpoint mode, because each mode deletes the message from
-SQS at a different point:
+and, unless you opt into the inline heartbeat described below, never calls
+`ChangeMessageVisibility` to extend it. How much of your processing that window has to cover
+depends on the endpoint mode, because each mode deletes the message from SQS at a different
+point:
 
 - **Durable** endpoints delete the message as soon as it has been written to the durable
   inbox — *before* the handler runs. The local backlog lives in your database, not under an
@@ -56,10 +57,35 @@ SQS at a different point:
   the visibility timeout is moot, and instead of duplicates you get at-most-once semantics: an
   ungraceful crash loses the buffered backlog.
 - **Inline** endpoints delete only after successful handling, so the visibility timeout must
-  cover a **single handler execution**. A handler that runs longer than the timeout is
-  redelivered *while it is still running*, and the second copy executes too. Raise the
-  timeout on the endpoint (`.VisibilityTimeout(...)`) to comfortably exceed your slowest
-  inline handler.
+  cover the **whole received batch**, not just one handler: an inline listener works through
+  the up-to-10 messages of a receive one at a time, so the last message of the batch has been
+  aging against the timeout through every handler before it. Past the timeout SQS redelivers
+  the message *while it is still being handled* (or still waiting its turn), the second copy
+  executes too, and the first copy's eventual delete carries a stale receipt handle that SQS
+  accepts without deleting anything. Either raise the timeout on the endpoint
+  (`.VisibilityTimeout(...)`) to comfortably exceed `MaxNumberOfMessages × your slowest
+  handler`, or turn on the heartbeat:
+
+<!-- snippet: sample_sqs_extend_visibility_while_handling -->
+<a id='snippet-sample_sqs_extend_visibility_while_handling'></a>
+```cs
+opts.ListenToSqsQueue("slow-work", q => q.VisibilityTimeout = 60)
+    .ProcessInline()
+    // GH-4019: keep the messages of each received batch invisible while their
+    // handlers run, extending by the visibility timeout every half timeout
+    .ExtendVisibilityWhileHandling();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqs_extend_visibility_while_handling' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`ExtendVisibilityWhileHandling()` (inline endpoints only — Durable and Buffered have already
+deleted the message by the time a handler runs) issues a `ChangeMessageVisibilityBatch` for
+every message of the batch that is still in flight at each half-timeout tick, so a batch that
+finishes inside half the timeout costs no extra API calls at all. Each message is kept
+invisible for at most 12 hours from its receipt (the SQS limit; lower it with the optional
+`maximum` argument), after which Wolverine stops extending and logs a warning. It is opt-in in
+6.x because it adds billable API calls under sustained slow handling and changes when a
+crashed node's in-flight messages reappear.
 
 ## The send side: batch API, one batch in flight
 

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_visibility_heartbeat_4019.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/sqs_visibility_heartbeat_4019.cs
@@ -1,0 +1,241 @@
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+/// <summary>
+/// GH-4019. The scheduling half of the inline visibility heartbeat, with the SQS call stubbed out.
+/// The LocalStack half lives in inline_visibility_heartbeat_4019.
+/// </summary>
+public class sqs_visibility_heartbeat_4019 : IAsyncDisposable
+{
+    private readonly List<Message[]> _extensions = new();
+    private readonly List<Message> _reject = new();
+    private readonly Uri _uri = new("sqs://heartbeat");
+    private SqsVisibilityHeartbeat? _heartbeat;
+
+    private SqsVisibilityHeartbeat start(TimeSpan? visibility = null, TimeSpan? maximum = null, TimeSpan? interval = null)
+    {
+        _heartbeat = new SqsVisibilityHeartbeat(
+            visibility ?? 10.Seconds(),
+            maximum ?? 12.Hours(),
+            (messages, _) =>
+            {
+                lock (_extensions)
+                {
+                    _extensions.Add(messages);
+                }
+
+                IReadOnlyList<Message> rejected = messages.Where(m => _reject.Contains(m)).ToList();
+                return Task.FromResult(rejected);
+            },
+            _uri, NullLogger.Instance, CancellationToken.None, interval ?? 50.Milliseconds());
+
+        return _heartbeat;
+    }
+
+    private static Message message(string handle)
+    {
+        return new Message { MessageId = handle, ReceiptHandle = handle };
+    }
+
+    private int extensionCount()
+    {
+        lock (_extensions)
+        {
+            return _extensions.Count;
+        }
+    }
+
+    private Message[] lastExtension()
+    {
+        lock (_extensions)
+        {
+            return _extensions.Last();
+        }
+    }
+
+    private static async Task waitUntil(Func<bool> condition, TimeSpan? timeout = null)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout ?? 5.Seconds());
+        while (!condition())
+        {
+            if (DateTimeOffset.UtcNow > deadline)
+            {
+                throw new TimeoutException("Condition not met in time");
+            }
+
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_heartbeat != null)
+        {
+            await _heartbeat.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void default_interval_is_half_the_visibility_timeout()
+    {
+        var heartbeat = new SqsVisibilityHeartbeat(120.Seconds(), 12.Hours(),
+            (_, _) => Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()), _uri,
+            NullLogger.Instance, CancellationToken.None);
+
+        heartbeat.Interval.ShouldBe(60.Seconds());
+        _heartbeat = heartbeat;
+    }
+
+    [Fact]
+    public void default_interval_never_drops_under_one_second()
+    {
+        var heartbeat = new SqsVisibilityHeartbeat(1.Seconds(), 12.Hours(),
+            (_, _) => Task.FromResult<IReadOnlyList<Message>>(Array.Empty<Message>()), _uri,
+            NullLogger.Instance, CancellationToken.None);
+
+        heartbeat.Interval.ShouldBe(1.Seconds());
+        _heartbeat = heartbeat;
+    }
+
+    [Fact]
+    public async Task nothing_is_extended_when_nothing_is_in_flight()
+    {
+        start();
+
+        await Task.Delay(300, TestContext.Current.CancellationToken);
+
+        extensionCount().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task tracked_messages_are_extended_on_every_tick_until_settled()
+    {
+        var heartbeat = start();
+        var one = message("one");
+        var two = message("two");
+
+        heartbeat.Track([one, two]);
+        heartbeat.InFlightCount.ShouldBe(2);
+
+        await waitUntil(() => extensionCount() >= 2);
+        lastExtension().Select(x => x.ReceiptHandle).OrderBy(x => x).ShouldBe(["one", "two"]);
+
+        heartbeat.Settled(one);
+        heartbeat.InFlightCount.ShouldBe(1);
+
+        // Give the loop a couple of ticks to see the change, then every extension is "two" only
+        await Task.Delay(150, TestContext.Current.CancellationToken);
+        var before = extensionCount();
+        await waitUntil(() => extensionCount() > before);
+        lastExtension().Select(x => x.ReceiptHandle).ShouldBe(["two"]);
+    }
+
+    [Fact]
+    public async Task untrack_stops_every_extension()
+    {
+        var heartbeat = start();
+        var messages = new[] { message("a"), message("b"), message("c") };
+
+        heartbeat.Track(messages);
+        await waitUntil(() => extensionCount() >= 1);
+
+        heartbeat.Untrack(messages);
+        heartbeat.InFlightCount.ShouldBe(0);
+
+        // Let any in-progress tick finish, then nothing else lands
+        await Task.Delay(150, TestContext.Current.CancellationToken);
+        var count = extensionCount();
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+        extensionCount().ShouldBe(count);
+    }
+
+    [Fact]
+    public async Task a_message_sqs_refuses_to_extend_is_dropped()
+    {
+        var heartbeat = start();
+        var good = message("good");
+        var stale = message("stale");
+        _reject.Add(stale);
+
+        heartbeat.Track([good, stale]);
+
+        await waitUntil(() => heartbeat.InFlightCount == 1);
+
+        // Only the live one is still being kept alive
+        await Task.Delay(150, TestContext.Current.CancellationToken);
+        var before = extensionCount();
+        await waitUntil(() => extensionCount() > before);
+        lastExtension().Select(x => x.ReceiptHandle).ShouldBe(["good"]);
+    }
+
+    [Fact]
+    public async Task a_message_is_not_extended_past_the_maximum()
+    {
+        // Visibility 200ms, maximum 500ms: the first tick or two extend it, then an extension would carry
+        // it past the maximum and it is dropped instead
+        var heartbeat = start(visibility: 200.Milliseconds(), maximum: 500.Milliseconds(), interval: 50.Milliseconds());
+        var message = sqs_visibility_heartbeat_4019.message("long-runner");
+
+        heartbeat.Track([message]);
+
+        await waitUntil(() => extensionCount() >= 1);
+        await waitUntil(() => heartbeat.InFlightCount == 0, 3.Seconds());
+
+        // And it stays dropped
+        var count = extensionCount();
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+        extensionCount().ShouldBe(count);
+    }
+
+    [Fact]
+    public async Task tick_is_a_no_op_when_the_extension_throws_and_the_loop_keeps_going()
+    {
+        var calls = 0;
+        var heartbeat = new SqsVisibilityHeartbeat(10.Seconds(), 12.Hours(), (_, _) =>
+        {
+            Interlocked.Increment(ref calls);
+            throw new InvalidOperationException("SQS is having a moment");
+        }, _uri, NullLogger.Instance, CancellationToken.None, 50.Milliseconds());
+        _heartbeat = heartbeat;
+
+        heartbeat.Track([message("x")]);
+
+        await waitUntil(() => Volatile.Read(ref calls) >= 3);
+        heartbeat.InFlightCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void maximum_visibility_extension_is_bounded_by_the_sqs_limit()
+    {
+        var queue = new AmazonSqsTransport().Queues["inline"];
+
+        queue.MaximumVisibilityExtension = 1.Hours();
+        queue.MaximumVisibilityExtension.ShouldBe(1.Hours());
+
+        Should.Throw<ArgumentOutOfRangeException>(() => queue.MaximumVisibilityExtension = 13.Hours());
+        Should.Throw<ArgumentOutOfRangeException>(() => queue.MaximumVisibilityExtension = TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void extend_visibility_while_handling_is_off_by_default_and_configurable()
+    {
+        var transport = new AmazonSqsTransport();
+        var queue = transport.Queues["inline"];
+        queue.ExtendVisibilityWhileHandling.ShouldBeFalse();
+        queue.MaximumVisibilityExtension.ShouldBe(AmazonSqsQueue.MaximumSqsVisibilityExtension);
+
+        var configuration = new AmazonSqsListenerConfiguration(queue);
+        configuration.ProcessInline().ExtendVisibilityWhileHandling(2.Hours());
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        queue.Mode.ShouldBe(EndpointMode.Inline);
+        queue.ExtendVisibilityWhileHandling.ShouldBeTrue();
+        queue.MaximumVisibilityExtension.ShouldBe(2.Hours());
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs
@@ -217,6 +217,23 @@ public class Bootstrapping
         #endregion
     }
 
+    private async Task extending_visibility_while_handling()
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransport().AutoProvision();
+
+                #region sample_sqs_extend_visibility_while_handling
+                opts.ListenToSqsQueue("slow-work", q => q.VisibilityTimeout = 60)
+                    .ProcessInline()
+                    // GH-4019: keep the messages of each received batch invisible while their
+                    // handlers run, extending by the visibility timeout every half timeout
+                    .ExtendVisibilityWhileHandling();
+                #endregion
+            }).StartAsync();
+    }
+
     private async Task publishing()
     {
         #region sample_subscriber_rules_for_sqs

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/inline_visibility_heartbeat_4019.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/inline_visibility_heartbeat_4019.cs
@@ -1,0 +1,141 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+/// <summary>
+/// GH-4019, against LocalStack. An inline handler that outlives the queue's visibility timeout. With
+/// the heartbeat the message executes once; without it SQS redelivers mid-execution and a second
+/// listener runs it again. The second test pins today's behavior on purpose, so the feature cannot
+/// silently stop doing anything without a test going red.
+/// </summary>
+public class inline_visibility_heartbeat_4019
+{
+    // Short enough to keep the tests quick, long enough that LocalStack's second-granularity
+    // visibility clock is not the thing being measured
+    private const int VisibilityTimeoutSeconds = 2;
+    private static readonly TimeSpan ObservationWindow = 14.Seconds();
+
+    private static async Task<IHost> startHost(string queueName, bool extendVisibility)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally().AutoProvision();
+
+                var listener = opts.ListenToSqsQueue(queueName, q =>
+                    {
+                        q.VisibilityTimeout = VisibilityTimeoutSeconds;
+                        q.WaitTimeSeconds = 1;
+                    })
+                    .ProcessInline()
+                    // The second listener is what picks up a redelivered copy while the first is still
+                    // running the handler
+                    .ListenerCount(2);
+
+                if (extendVisibility)
+                {
+                    listener.ExtendVisibilityWhileHandling();
+                }
+
+                opts.PublishAllMessages().ToSqsQueue(queueName).SendInline();
+            }).StartAsync();
+    }
+
+    private static async Task<int> executionsAfterObservationWindow(IHost host, Guid id)
+    {
+        await host.MessageBus().SendAsync(new SlowSqsMessage(id));
+        await Task.Delay(ObservationWindow, TestContext.Current.CancellationToken);
+        return SlowSqsMessageTracker.ExecutionsOf(id);
+    }
+
+    [Fact]
+    public async Task with_the_heartbeat_a_handler_longer_than_the_visibility_timeout_executes_once()
+    {
+        var queueName = "heartbeat-on-" + Guid.NewGuid().ToString("N")[..8];
+        using var host = await startHost(queueName, extendVisibility: true);
+        try
+        {
+            var id = Guid.NewGuid();
+            var executions = await executionsAfterObservationWindow(host, id);
+
+            executions.ShouldBe(1);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task without_the_heartbeat_the_message_is_redelivered_and_executed_again_mid_handler()
+    {
+        var queueName = "heartbeat-off-" + Guid.NewGuid().ToString("N")[..8];
+        using var host = await startHost(queueName, extendVisibility: false);
+        try
+        {
+            var id = Guid.NewGuid();
+            var executions = await executionsAfterObservationWindow(host, id);
+
+            // This is the defect. The first execution is still running at the 2 second mark when SQS
+            // makes the message visible again, and the other listener starts it over.
+            executions.ShouldBeGreaterThanOrEqualTo(2);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public void the_heartbeat_is_only_built_for_inline_endpoints()
+    {
+        var transport = new AmazonSqsTransport();
+
+        var buffered = transport.Queues["buffered"];
+        buffered.ExtendVisibilityWhileHandling = true;
+        buffered.Mode.ShouldNotBe(EndpointMode.Inline);
+
+        var inline = transport.Queues["inline"];
+        inline.ExtendVisibilityWhileHandling = true;
+        inline.Mode = EndpointMode.Inline;
+
+        SqsListener.ShouldExtendVisibility(buffered).ShouldBeFalse();
+        SqsListener.ShouldExtendVisibility(inline).ShouldBeTrue();
+
+        inline.ExtendVisibilityWhileHandling = false;
+        SqsListener.ShouldExtendVisibility(inline).ShouldBeFalse();
+    }
+}
+
+public record SlowSqsMessage(Guid Id);
+
+public static class SlowSqsMessageTracker
+{
+    private static readonly ConcurrentDictionary<Guid, int> Executions = new();
+
+    public static void Record(Guid id)
+    {
+        Executions.AddOrUpdate(id, 1, (_, count) => count + 1);
+    }
+
+    public static int ExecutionsOf(Guid id)
+    {
+        return Executions.GetValueOrDefault(id);
+    }
+}
+
+public static class SlowSqsMessageHandler
+{
+    public static async Task Handle(SlowSqsMessage message)
+    {
+        // Counted at the start, so a second delivery that begins while the first is still running
+        // shows up inside the observation window
+        SlowSqsMessageTracker.Record(message.Id);
+        await Task.Delay(6.Seconds());
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/AmazonSqsListenerConfiguration.cs
@@ -102,6 +102,35 @@ public class AmazonSqsListenerConfiguration : ListenerConfiguration<AmazonSqsLis
     }
 
     /// <summary>
+    ///     For an inline (<c>ProcessInline()</c>) listener: keep the messages of each received batch
+    ///     invisible to other consumers by extending their visibility timeout while they wait for, and
+    ///     run through, their handlers. Without this, Wolverine sets the visibility timeout once on
+    ///     receive, and an inline listener handles a batch one message at a time -- so a batch whose
+    ///     handlers collectively take longer than the timeout has its later messages redelivered and
+    ///     executed a second time while the first execution is still running. Extension calls are only
+    ///     made when a batch is still in flight at half the visibility timeout, so fast handlers pay
+    ///     nothing. Has no effect on Buffered or Durable listeners, which delete the message before the
+    ///     handler runs. See GH-4019.
+    /// </summary>
+    /// <param name="maximum">
+    ///     Longest any single message is kept invisible from its receipt before Wolverine stops
+    ///     extending it. Defaults to, and cannot exceed, the SQS limit of 12 hours
+    /// </param>
+    public AmazonSqsListenerConfiguration ExtendVisibilityWhileHandling(TimeSpan? maximum = null)
+    {
+        add(e =>
+        {
+            e.ExtendVisibilityWhileHandling = true;
+            if (maximum.HasValue)
+            {
+                e.MaximumVisibilityExtension = maximum.Value;
+            }
+        });
+
+        return this;
+    }
+
+    /// <summary>
     ///     Split a message whose body would exceed SQS's hard 256KB limit into several SQS messages, and
     ///     reassemble it on the receiving side. A listener reassembles fragments whether or not this is
     ///     set -- the framing is self-describing -- so this only really matters on the sending side and

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -202,6 +202,46 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     public TimeSpan DeleteMessageBatchTimeout { get; set; } = TimeSpan.FromMilliseconds(50);
 
     /// <summary>
+    ///     Hard Amazon SQS limit on how long a single received message can be kept invisible, measured
+    ///     from its receipt, across any number of <c>ChangeMessageVisibility</c> calls.
+    /// </summary>
+    public static readonly TimeSpan MaximumSqsVisibilityExtension = TimeSpan.FromHours(12);
+
+    /// <summary>
+    ///     GH-4019. For an <c>Inline</c> listener only: keep the messages of a received batch invisible
+    ///     by extending their visibility timeout (<c>ChangeMessageVisibilityBatch</c>, every half
+    ///     <see cref="VisibilityTimeout" />) until each is settled. Wolverine otherwise sets the
+    ///     visibility once on receive and an inline listener handles the batch one message at a time,
+    ///     so a batch whose handlers collectively outlive the timeout has its later messages redelivered
+    ///     -- and executed again -- while they are still being handled. Costs nothing for a batch that
+    ///     finishes inside half the timeout. Ignored for Buffered and Durable endpoints, which delete the
+    ///     message before the handler runs. Default false.
+    /// </summary>
+    public bool ExtendVisibilityWhileHandling { get; set; }
+
+    private TimeSpan _maximumVisibilityExtension = MaximumSqsVisibilityExtension;
+
+    /// <summary>
+    ///     The longest a single message is kept invisible from its receipt by
+    ///     <see cref="ExtendVisibilityWhileHandling" /> before Wolverine stops extending it and lets SQS
+    ///     redeliver. Bounded above by the SQS limit of 12 hours. Default 12 hours.
+    /// </summary>
+    public TimeSpan MaximumVisibilityExtension
+    {
+        get => _maximumVisibilityExtension;
+        set
+        {
+            if (value <= TimeSpan.Zero || value > MaximumSqsVisibilityExtension)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaximumVisibilityExtension),
+                    $"Must be greater than zero and no more than {MaximumSqsVisibilityExtension}");
+            }
+
+            _maximumVisibilityExtension = value;
+        }
+    }
+
+    /// <summary>
     ///     Additional configuration for how an SQS queue should be created
     /// </summary>
     [ChildDescription]
@@ -706,6 +746,10 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         sibling.MessageAttributeNames = MessageAttributeNames;
         sibling.FragmentOversizedMessages = FragmentOversizedMessages;
         sibling.FragmentReassemblyTimeout = FragmentReassemblyTimeout;
+        sibling.DeleteMessageBatchSize = DeleteMessageBatchSize;
+        sibling.DeleteMessageBatchTimeout = DeleteMessageBatchTimeout;
+        sibling.ExtendVisibilityWhileHandling = ExtendVisibilityWhileHandling;
+        sibling.MaximumVisibilityExtension = MaximumVisibilityExtension;
 
         // Share the interop mapper strategy so tenant traffic serializes identically to the shared account.
         sibling.Mapper = Mapper;

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -2,6 +2,7 @@ using Amazon.SQS.Model;
 using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 
@@ -33,6 +34,11 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     // framing is unambiguous, so a listener reads it whether or not this same endpoint would send
     // that way, and an asymmetrically configured pair still works.
     private readonly SqsFragmentReassembler _reassembler;
+
+    // GH-4019: inline listeners only. Keeps a received batch invisible while its handlers run, because
+    // the inline receiver works through the batch one message at a time and the visibility timeout
+    // was only ever set once, on the receive. Null unless the endpoint opts in.
+    private readonly SqsVisibilityHeartbeat? _heartbeat;
 
     public SqsListener(IWolverineRuntime runtime, AmazonSqsQueue queue, AmazonSqsTransport transport,
         IReceiver receiver)
@@ -92,6 +98,12 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
             _deleteBlock = new Block<Message[]>((batch, _) => deleteBatchAsync(batch));
             _deleteBatching = new BatchingChannel<Message>(_queue.DeleteMessageBatchTimeout, _deleteBlock,
                 _queue.DeleteMessageBatchSize);
+        }
+
+        if (ShouldExtendVisibility(_queue))
+        {
+            _heartbeat = new SqsVisibilityHeartbeat(TimeSpan.FromSeconds(_queue.VisibilityTimeout),
+                _queue.MaximumVisibilityExtension, extendVisibilityAsync, _queue.Uri, logger, runtime.Cancellation);
         }
 
         // GH-3236: the receive loop is now a shared BackgroundReceiveLoop — it owns the task, the
@@ -183,10 +195,81 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         // ReSharper disable once CoVariantArrayConversion
         if (envelopes.Any())
         {
-            await _receiver.ReceivedAsync(this, envelopes.ToArray());
+            if (_heartbeat == null)
+            {
+                await _receiver.ReceivedAsync(this, envelopes.ToArray());
+            }
+            else
+            {
+                // Only the messages that became envelopes. Fragments still waiting on their siblings in
+                // the reassembler are meant to reappear at the visibility timeout if the set never completes.
+                var inFlight = envelopes.OfType<AmazonSqsEnvelope>().SelectMany(x => x.SqsMessages).ToArray();
+                _heartbeat.Track(inFlight);
+                try
+                {
+                    await _receiver.ReceivedAsync(this, envelopes.ToArray());
+                }
+                finally
+                {
+                    // The inline receiver has run every handler by now. Anything still unsettled is in
+                    // a requeue or dead-letter retry block that deletes it; stop holding it invisible.
+                    _heartbeat.Untrack(inFlight);
+                }
+            }
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// GH-4019: the heartbeat only makes sense for an inline listener. Durable deletes the message right
+    /// after the inbox insert and Buffered deletes on receipt, so neither holds a message under the
+    /// visibility timeout while a handler runs.
+    /// </summary>
+    internal static bool ShouldExtendVisibility(AmazonSqsQueue queue)
+    {
+        return queue.ExtendVisibilityWhileHandling && queue.Mode == EndpointMode.Inline;
+    }
+
+    /// <summary>
+    /// GH-4019: re-arm the visibility timeout on these in-flight messages. Returns the ones SQS would
+    /// not extend -- a stale receipt handle means the message was already deleted or redelivered, and
+    /// there is nothing left to keep alive.
+    /// </summary>
+    private async Task<IReadOnlyList<Message>> extendVisibilityAsync(Message[] messages, CancellationToken token)
+    {
+        var dropped = new List<Message>();
+
+        foreach (var chunk in messages.Chunk(AmazonSqsQueue.MaximumDeleteBatchSize))
+        {
+            var entries = new List<ChangeMessageVisibilityBatchRequestEntry>(chunk.Length);
+            for (var i = 0; i < chunk.Length; i++)
+            {
+                entries.Add(new ChangeMessageVisibilityBatchRequestEntry(i.ToString(), chunk[i].ReceiptHandle)
+                {
+                    VisibilityTimeout = _queue.VisibilityTimeout
+                });
+            }
+
+            var response = await _transport.Client!.ChangeMessageVisibilityBatchAsync(_queue.QueueUrl, entries, token);
+            if (response.Failed == null || response.Failed.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var entry in response.Failed)
+            {
+                if (int.TryParse(entry.Id, out var index) && index >= 0 && index < chunk.Length)
+                {
+                    _logger.LogDebug(
+                        "SQS would not extend the visibility of message {MessageId} at {Uri}: {Code} - {Message}. No longer keeping it invisible",
+                        chunk[index].MessageId, _queue.Uri, entry.Code, entry.Message);
+                    dropped.Add(chunk[index]);
+                }
+            }
+        }
+
+        return dropped;
     }
 
     public ReceiveLoopStatus ReceiveLoopStatus => _loop.ReceiveLoopStatus;
@@ -216,6 +299,11 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     public async ValueTask DisposeAsync()
     {
         await _loop.DisposeAsync();
+        if (_heartbeat != null)
+        {
+            await _heartbeat.DisposeAsync();
+        }
+
         await flushPendingDeletesAsync();
         _requeueBlock.Dispose();
         _deadLetterBlock?.Dispose();
@@ -336,6 +424,8 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
 
     public Task CompleteAsync(Message sqsMessage)
     {
+        _heartbeat?.Settled(sqsMessage);
+
         if (_deleteBatching == null)
         {
             return _transport.Client!.DeleteMessageAsync(_queue.QueueUrl, sqsMessage.ReceiptHandle);

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsVisibilityHeartbeat.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsVisibilityHeartbeat.cs
@@ -1,0 +1,199 @@
+using System.Collections.Concurrent;
+using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.AmazonSqs.Internal;
+
+/// <summary>
+///     GH-4019. Keeps the SQS messages an <em>inline</em> listener is still working on invisible by
+///     periodically extending their visibility timeout until they are settled. Wolverine sets the
+///     visibility timeout once, on the receive, and an inline listener processes a received batch one
+///     message at a time -- so the tenth message of a receive has been aging against that timeout
+///     through nine handler executions before its own starts. Past the timeout SQS redelivers the
+///     message while the handler is still running, the second copy executes too, and the first
+///     copy's eventual delete carries a stale receipt handle that SQS accepts without deleting anything.
+/// </summary>
+/// <remarks>
+///     Only meaningful for <see cref="Wolverine.Configuration.EndpointMode.Inline" />. Durable endpoints
+///     delete the message right after the inbox insert and buffered endpoints delete on receipt, so
+///     neither holds a message under the visibility timeout while a handler runs. The SQS call itself
+///     is injected so the scheduling can be tested without a broker; the tick is a maximum age, not a
+///     debounce, and nothing is sent on a tick when nothing is in flight -- a listener whose batches
+///     finish inside half the visibility timeout never issues an extension at all.
+/// </remarks>
+internal class SqsVisibilityHeartbeat : IAsyncDisposable
+{
+    /// <summary>
+    ///     Extend the visibility of these messages. Returns the messages that should no longer be
+    ///     tracked, e.g. because SQS rejected their receipt handle (already deleted or redelivered).
+    /// </summary>
+    public delegate Task<IReadOnlyList<Message>> ExtendVisibility(Message[] messages, CancellationToken token);
+
+    private readonly ConcurrentDictionary<string, Tracked> _inFlight = new();
+    private readonly ExtendVisibility _extend;
+    private readonly TimeSpan _interval;
+    private readonly TimeSpan _extension;
+    private readonly TimeSpan _maximum;
+    private readonly ILogger _logger;
+    private readonly Uri _uri;
+    private readonly CancellationTokenSource _cancellation;
+    private readonly Task _loop;
+
+    /// <param name="visibilityTimeout">The queue's visibility timeout; each extension re-arms the message for this long</param>
+    /// <param name="maximum">Longest a single message is kept invisible from its receipt. SQS caps this at 12 hours</param>
+    /// <param name="extend">The SQS call</param>
+    /// <param name="uri">Endpoint Uri, for logging</param>
+    /// <param name="logger"></param>
+    /// <param name="cancellation">Runtime shutdown</param>
+    /// <param name="interval">Tick interval. Defaults to half the visibility timeout, never under one second</param>
+    public SqsVisibilityHeartbeat(TimeSpan visibilityTimeout, TimeSpan maximum, ExtendVisibility extend, Uri uri,
+        ILogger logger, CancellationToken cancellation, TimeSpan? interval = null)
+    {
+        _extension = visibilityTimeout;
+        _maximum = maximum;
+        _extend = extend;
+        _uri = uri;
+        _logger = logger;
+
+        var half = TimeSpan.FromTicks(visibilityTimeout.Ticks / 2);
+        _interval = interval ?? (half < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : half);
+
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        _loop = Task.Run(runAsync);
+    }
+
+    public TimeSpan Interval => _interval;
+
+    /// <summary>
+    ///     Number of messages currently being kept alive
+    /// </summary>
+    public int InFlightCount => _inFlight.Count;
+
+    /// <summary>
+    ///     Start keeping these received messages invisible until each is settled or untracked
+    /// </summary>
+    public void Track(IEnumerable<Message> messages)
+    {
+        var now = DateTimeOffset.UtcNow;
+        foreach (var message in messages)
+        {
+            if (message.ReceiptHandle == null) continue;
+            _inFlight.TryAdd(message.ReceiptHandle, new Tracked(message, now));
+        }
+    }
+
+    /// <summary>
+    ///     This message has been settled (deleted, or handed to a requeue/dead-letter path that
+    ///     deletes it); stop extending it.
+    /// </summary>
+    public void Settled(Message message)
+    {
+        if (message.ReceiptHandle != null)
+        {
+            _inFlight.TryRemove(message.ReceiptHandle, out _);
+        }
+    }
+
+    /// <summary>
+    ///     Stop tracking every one of these messages, settled or not. Called when a received batch has
+    ///     been fully processed -- anything still unsettled is in a retry block that will delete it.
+    /// </summary>
+    public void Untrack(IEnumerable<Message> messages)
+    {
+        foreach (var message in messages)
+        {
+            Settled(message);
+        }
+    }
+
+    private async Task runAsync()
+    {
+        var token = _cancellation.Token;
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_interval, token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (_inFlight.IsEmpty) continue;
+
+            try
+            {
+                await TickAsync(token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                // Next tick tries again; an extension that never lands only means the message
+                // reappears at its visibility timeout, which is exactly today's behavior.
+                _logger.LogWarning(e, "Error extending the visibility of in-flight SQS messages at {Uri}", _uri);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     One pass: extend everything in flight that is still inside the maximum, drop what is not.
+    ///     Exposed for tests.
+    /// </summary>
+    internal async Task TickAsync(CancellationToken token)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var due = new List<Message>();
+
+        foreach (var pair in _inFlight)
+        {
+            var tracked = pair.Value;
+
+            // Every extension pushes the message's invisibility out by the full visibility timeout,
+            // so stop before an extension would carry it past the maximum
+            if (now - tracked.ReceivedAt + _extension > _maximum)
+            {
+                if (_inFlight.TryRemove(pair.Key, out _))
+                {
+                    _logger.LogWarning(
+                        "Message {MessageId} at {Uri} has been in flight for {Elapsed} and will not be kept invisible past the maximum of {Maximum}; SQS may redeliver it while it is still being handled",
+                        tracked.Message.MessageId, _uri, now - tracked.ReceivedAt, _maximum);
+                }
+
+                continue;
+            }
+
+            due.Add(tracked.Message);
+        }
+
+        if (due.Count == 0) return;
+
+        var dropped = await _extend(due.ToArray(), token);
+        foreach (var message in dropped)
+        {
+            Settled(message);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellation.CancelAsync();
+        try
+        {
+            // The loop exits on the next tick at the latest; bound the wait so disposal of a
+            // listener can never hang on it
+            await _loop.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Cancelled or timed out -- either way the loop is done with as far as we care
+        }
+
+        _cancellation.Dispose();
+    }
+
+    private sealed record Tracked(Message Message, DateTimeOffset ReceivedAt);
+}


### PR DESCRIPTION
Closes #4019. Split out of #3493 (the narrowed SO5); the docs side of that narrowing landed in #4015.

## The defect

Wolverine sets `VisibilityTimeout` once on the `ReceiveMessage` request (default 120 s) and had zero `ChangeMessageVisibility` call sites. That is fine for Durable (deletes right after the inbox insert) and Buffered (deletes on receipt), but an **inline** listener deletes only after the handler — and `InlineReceiver.ReceivedAsync(Envelope[])` works through the batch **sequentially**, so the 10th message of a receive has been aging against the timeout through nine handler executions before its own starts. Past the timeout:

1. SQS makes the message visible again; another listener (or node) receives it with a new receipt handle and starts a second execution while the first is still running.
2. The first execution finishes and deletes with the **original** receipt handle — which SQS accepts as a success without deleting anything (per the `DeleteMessage` docs). The batched delete from #3673 reports the same.

Reproduced on LocalStack: a 6 s inline handler on a 2 s visibility timeout with `ListenerCount(2)` executes **≥ 2** times. That reproduction is kept as a test.

## The fix

`ExtendVisibilityWhileHandling(TimeSpan? maximum = null)` on `AmazonSqsListenerConfiguration` (+ `AmazonSqsQueue.ExtendVisibilityWhileHandling` / `MaximumVisibilityExtension`). Opt-in.

- New `SqsVisibilityHeartbeat` (`Internal/`): tracks the SQS messages of the received batch, ticks every `VisibilityTimeout / 2` (never under 1 s), and calls an injected extend function for everything still unsettled → `SqsListener.extendVisibilityAsync` issues `ChangeMessageVisibilityBatch` in chunks of 10, re-arming each message for `VisibilityTimeout`. **A batch that finishes inside half the timeout never issues a call** — the heartbeat only costs anything when you were about to lose.
- `SqsListener.CompleteAsync(Message)` — the single funnel every delete, requeue and dead-letter path goes through — marks the message settled; the batch is untracked when `ReceivedAsync` returns (anything still unsettled is in a retry block that deletes it).
- Entries SQS refuses (stale handle = already deleted/redelivered) are dropped; an extend call that throws is logged and retried next tick; a message is never kept invisible past `MaximumVisibilityExtension` (default **and** ceiling: the SQS limit of 12 h), after which it is dropped with a warning.
- Gated to `EndpointMode.Inline` (`SqsListener.ShouldExtendVisibility`): setting it on a Buffered/Durable endpoint is a no-op, since those have already deleted the message by the time a handler runs.
- Disposal is bounded (5 s) so a dead heartbeat loop can't hang listener teardown.

Fragments waiting in the reassembler are deliberately **not** tracked — an incomplete set is supposed to reappear at the visibility timeout.

### Why opt-in (for now)
It adds billable API calls under sustained slow handling and changes when a crashed node's in-flight messages reappear (up to 12 h instead of the timeout). Given the zero-cost-when-fast property it is a reasonable default-on candidate for the next major; flagging rather than deciding that here.

### Drive-by
`AmazonSqsQueue.BuildTenantSibling` was not copying `DeleteMessageBatchSize` / `DeleteMessageBatchTimeout` from #3673; it now copies those plus the two new options.

## Tests

| | Result |
|---|---|
| `Internal/sqs_visibility_heartbeat_4019` — scheduling with the SQS call stubbed: interval rules, nothing sent when idle, extend-until-settled, untrack, refused-entry drop, maximum cap, exception keeps the loop alive, option guard rails | 10/10 |
| `inline_visibility_heartbeat_4019` (LocalStack) — 6 s handler / 2 s visibility / 2 listeners: **with** heartbeat executes once; **without** executes ≥ 2 (pins the defect); inline-only gate | 3/3 |
| `InlineSendingAndReceivingCompliance`, `BufferedSendingAndReceivingCompliance`, `AmazonSqsPerTenantConnectionTests`, `AmazonSqsPerTenantConfigurationTests`, `send_and_receive_oversized_messages_3926`, `sqs_batch_chunking_3493` | 67/67 |

Docs: new paragraph + `sample_sqs_extend_visibility_while_handling` snippet in `docs/guide/messaging/transports/sqs/performance.md` (the section #4015 rewrote), and the inline bullet now states the batch-wide exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
