### PR TITLE
GH-3778: make the application-assembly divergence warning mean something

### DIFF
--- a/src/Testing/CoreTests/Configuration/never_an_application_assembly.cs
+++ b/src/Testing/CoreTests/Configuration/never_an_application_assembly.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using JasperFx;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3778. The stack walk that picks an application assembly — and feeds the divergence warning —
+/// knew about System*/Microsoft*/test runners and nothing else, so it happily adopted assemblies that
+/// cannot be an application. Measured on a fully green CoreTests run, 41 of 46 warnings named a
+/// runtime-compiled assembly (Roslyn's random "ofqrxydn.tlz" names, i.e. Wolverine's own generated
+/// code) and 5 named JasperFx. After this predicate: 46 warnings became 1, and that 1 is real.
+/// </summary>
+public class never_an_application_assembly
+{
+    [Fact]
+    public void a_dynamic_assembly_is_never_the_application()
+    {
+        var dynamic = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("some_dynamic_assembly"), AssemblyBuilderAccess.Run);
+
+        WolverineOptions.IsNeverAnApplicationAssembly(dynamic).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void jasperfx_itself_is_never_the_application()
+    {
+        // JasperFx carries no ignore marker of its own -- core Wolverine excludes itself with
+        // [assembly: WolverineIgnore], JasperFx has nothing equivalent -- so it has to be named.
+        WolverineOptions.IsNeverAnApplicationAssembly(typeof(JasperFxOptions).Assembly).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_normal_assembly_on_disk_still_qualifies()
+    {
+        // The guard rail: this must stay narrow, or the walk skips the real application and falls
+        // back to the entry assembly.
+        WolverineOptions.IsNeverAnApplicationAssembly(GetType().Assembly).ShouldBeFalse();
+        WolverineOptions.IsNeverAnApplicationAssembly(typeof(Module1.IModuleService).Assembly).ShouldBeFalse();
+    }
+}

--- a/src/Testing/CoreTests/Configuration/remembered_application_assembly_reuse_warning.cs
+++ b/src/Testing/CoreTests/Configuration/remembered_application_assembly_reuse_warning.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using JasperFx;
+using Module1;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
@@ -39,6 +40,29 @@ public class remembered_application_assembly_reuse_warning
     }
 
     [Fact]
+    public async Task captures_the_assembly_that_called_UseWolverine_not_the_one_that_called_Build()
+    {
+        // GH-3778. IHostBuilder.UseWolverine() defers into a ConfigureServices callback that runs during
+        // Build(), so re-deriving the caller from the stack inside WolverineOptions' constructor learns
+        // who called BUILD, not who registered Wolverine. Any harness whose hosts are built by a shared
+        // helper in another assembly — which is most of them — therefore resolved to that helper, and the
+        // divergence warning it feeds fired on healthy hosts: instrumenting a fully green CIPolecat shard
+        // found RegistrationCallingAssembly resolving to Wolverine.SqlServer on 81 of 82 hosts.
+        var builder = Host.CreateDefaultBuilder().UseWolverine();
+
+        // Registered above, in THIS assembly. Built below, in Module1.
+        using var host = HostBuiltFromAnotherAssembly.Build(builder);
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+
+        options.RegistrationCallingAssembly!.GetName().Name.ShouldBe(ThisTestAssembly.GetName().Name);
+        options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public void warns_when_the_adopted_assembly_diverges_from_where_the_host_registered()
     {
         var options = new WolverineOptions();
@@ -71,6 +95,70 @@ public class remembered_application_assembly_reuse_warning
         options.ReadJasperFxOptions(JasperFxWithApplicationAssembly(registered!));
 
         options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// GH-3778. Routes through the GH-3776 branch — a JasperFx-pinned assembly that is a TEST RUNNER is
+    /// dropped — so ApplicationAssembly is null by the time establishApplicationAssembly(null) runs, and
+    /// the RememberedApplicationAssembly branch is the one that decides. That is the branch that used to
+    /// adopt a process-wide pin in silence.
+    /// </summary>
+    private static JasperFxOptions JasperFxPinnedToTheTestRunner()
+    {
+        return new JasperFxOptions { ApplicationAssembly = typeof(FactAttribute).Assembly };
+    }
+
+    [Fact]
+    public void warns_when_the_remembered_assembly_diverges_from_where_the_host_registered()
+    {
+        var previous = WolverineOptions.RememberedApplicationAssembly;
+
+        try
+        {
+            var options = new WolverineOptions();
+            var registered = options.RegistrationCallingAssembly;
+            registered.ShouldNotBeNull();
+
+            // What a FIRST host registered from another assembly leaves behind for every later host.
+            WolverineOptions.RememberedApplicationAssembly = WolverineAssembly;
+            registered!.GetName().Name.ShouldNotBe(WolverineAssembly.GetName().Name);
+
+            options.ReadJasperFxOptions(JasperFxPinnedToTheTestRunner());
+
+            // The pin is still adopted -- this fix makes it audible, it does not change what wins.
+            options.ApplicationAssembly!.GetName().Name.ShouldBe(WolverineAssembly.GetName().Name);
+
+            options.ApplicationAssemblyReuseWarning.ShouldNotBeNull();
+            options.ApplicationAssemblyReuseWarning.ShouldContain(registered.GetName().Name!);
+            options.ApplicationAssemblyReuseWarning.ShouldContain(WolverineAssembly.GetName().Name!);
+        }
+        finally
+        {
+            // Process-wide static: leaving it set would pin handler discovery for every later test.
+            WolverineOptions.RememberedApplicationAssembly = previous;
+        }
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_remembered_assembly_matches_where_the_host_registered()
+    {
+        var previous = WolverineOptions.RememberedApplicationAssembly;
+
+        try
+        {
+            var options = new WolverineOptions();
+            options.RegistrationCallingAssembly.ShouldNotBeNull();
+
+            WolverineOptions.RememberedApplicationAssembly = options.RegistrationCallingAssembly;
+
+            options.ReadJasperFxOptions(JasperFxPinnedToTheTestRunner());
+
+            options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+        }
+        finally
+        {
+            WolverineOptions.RememberedApplicationAssembly = previous;
+        }
     }
 
     [Fact]

--- a/src/Testing/Module1/HostBuiltFromAnotherAssembly.cs
+++ b/src/Testing/Module1/HostBuiltFromAnotherAssembly.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Module1;
+
+/// <summary>
+/// GH-3778. Stands in for the very common test-harness shape where one assembly registers Wolverine
+/// and a SHARED HELPER IN ANOTHER ASSEMBLY builds the host. IHostBuilder.UseWolverine() defers its
+/// real work into a ConfigureServices callback that runs during Build(), so the caller's frame at
+/// registration time is long gone by then — which is what made RegistrationCallingAssembly resolve
+/// to whoever called Build() rather than to whoever called UseWolverine().
+/// </summary>
+public static class HostBuiltFromAnotherAssembly
+{
+    public static IHost Build(IHostBuilder builder) => builder.Build();
+}

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -57,9 +57,15 @@ public static class HostBuilderExtensions
     /// <returns></returns>
     public static IHostBuilder UseWolverine(this IHostBuilder builder, Action<WolverineOptions>? overrides = null, ExtensionDiscovery discovery = ExtensionDiscovery.Automatic)
     {
+        // GH-3778: captured HERE rather than inside the callback below. ConfigureServices does not run
+        // until Build(), by which point this caller's frame is gone and the constructor's own stack walk
+        // resolves to whoever called Build() instead — a shared host-building helper, in most test
+        // harnesses. This is the last point at which the registering assembly is still on the stack.
+        var registeredFrom = WolverineOptions.CaptureCallingAssemblyForRegistration();
+
         return builder.ConfigureServices(services =>
         {
-            services.AddWolverine(discovery, overrides);
+            services.AddWolverine(discovery, overrides, registeredFrom);
         });
     }
 
@@ -81,7 +87,21 @@ public static class HostBuilderExtensions
     /// <returns></returns>
     public static IServiceCollection AddWolverine(this IServiceCollection services, ExtensionDiscovery discovery, Action<WolverineOptions>? configure = null)
     {
+        return services.AddWolverine(discovery, configure, null);
+    }
+
+    /// <summary>
+    /// GH-3778. <paramref name="registeredFrom"/> carries an assembly captured at an entry point that
+    /// defers its registration, where the constructor's own stack walk would resolve to the wrong
+    /// caller. Null means "the constructor's answer is the best one available", which is the case for
+    /// every entry point that registers immediately.
+    /// </summary>
+    internal static IServiceCollection AddWolverine(this IServiceCollection services, ExtensionDiscovery discovery,
+        Action<WolverineOptions>? configure, Assembly? registeredFrom)
+    {
         var options = new WolverineOptions();
+        options.UseRegistrationCallingAssembly(registeredFrom);
+
         return AddWolverine(services, options, discovery, configure);
     }
 

--- a/src/Wolverine/WolverineOptions.Assemblies.cs
+++ b/src/Wolverine/WolverineOptions.Assemblies.cs
@@ -67,7 +67,7 @@ public sealed partial class WolverineOptions
     // reachable methods, so the practical risk is low even outside the AOT path.
     [UnconditionalSuppressMessage("Trimming", "IL2026",
         Justification = "Best-effort caller-assembly resolution; AOT-clean apps set ApplicationAssembly explicitly. See AOT guide.")]
-    private Assembly? determineCallingAssembly()
+    private static Assembly? determineCallingAssembly()
     {
         var stack = new StackTrace();
         var frames = stack.GetFrames();
@@ -99,7 +99,7 @@ public sealed partial class WolverineOptions
             }
 
             if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft") ||
-                IsTestRunnerAssembly(assemblyName))
+                IsTestRunnerAssembly(assemblyName) || IsNeverAnApplicationAssembly(assembly))
             {
                 continue;
             }
@@ -132,6 +132,41 @@ public sealed partial class WolverineOptions
                || assemblyName.StartsWith("JetBrains.", StringComparison.OrdinalIgnoreCase);
     }
 
+    // GH-3778: assemblies that cannot be the application, whatever the stack says.
+    //
+    // This is where the divergence warning's noise actually came from, and it is not what the issue
+    // guessed. Instrumenting a fully green CoreTests run, 41 of 46 warnings named an assembly like
+    // "ofqrxydn.tlz" -- Roslyn's Path.GetRandomFileName() default, i.e. Wolverine's OWN generated code
+    // assembly, whose name is different on every run. Another 5 named "JasperFx". Not one named an
+    // extension. The walk knew about System*/Microsoft*/test runners and nothing else, so the first
+    // frame outside Wolverine was frequently code Wolverine had generated moments earlier.
+    //
+    // This matters beyond the warning: the same walk picks the application assembly for handler
+    // discovery in the else-branch of establishApplicationAssembly. Adopting a generated assembly
+    // there means scanning an assembly with no handlers in it -- the same silent-discovery-failure
+    // shape as GH-3776, which took a day to find the last time.
+    [UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "The empty-Location case IS the intent here. In a single-file app every assembly reports an empty location, so this predicate skips them all and determineCallingAssembly falls through to its Assembly.GetEntryAssembly() fallback — which in a single-file app is the application assembly. Correct answer either way.")]
+    internal static bool IsNeverAnApplicationAssembly(Assembly assembly)
+    {
+        // Reflection.Emit output. Never on disk, never the application.
+        if (assembly.IsDynamic) return true;
+
+        // Runtime-compiled and loaded from a byte array (JasperFx.RuntimeCompiler), which is what the
+        // random 8.3-style names above are.
+        //
+        // Single-file publish also reports an empty Location for every assembly, so there the walk
+        // skips everything and lands on the Assembly.GetEntryAssembly() fallback below -- which in a
+        // single-file app IS the application assembly. Right answer, different route.
+        if (assembly.Location.IsEmpty()) return true;
+
+        // The framework underneath Wolverine. Core Wolverine already excludes itself by carrying
+        // [assembly: WolverineIgnore]; JasperFx carries no such marker, so it is named here.
+        var name = assembly.GetName().Name;
+        return name is not null &&
+               (name == "JasperFx" || name.StartsWith("JasperFx.", StringComparison.OrdinalIgnoreCase));
+    }
+
     private void establishApplicationAssembly(string? assemblyName)
     {
         if (assemblyName.IsNotEmpty())
@@ -140,7 +175,13 @@ public sealed partial class WolverineOptions
         }
         else if (RememberedApplicationAssembly != null)
         {
+            // GH-3778: this branch adopts an assembly pinned by whichever host started FIRST in the
+            // process — the precise situation the divergence warning exists for — and used to do it
+            // in silence. Only the jasperfx.ApplicationAssembly path in ReadJasperFxOptions checked,
+            // so the warning could not fire on the path most likely to need it. JasperFxOptions
+            // already calls its equivalent from the same branch; this closes the gap.
             ApplicationAssembly = RememberedApplicationAssembly;
+            CheckForDivergentApplicationAssembly(RememberedApplicationAssembly);
         }
         else
         {
@@ -166,6 +207,33 @@ public sealed partial class WolverineOptions
     internal void CaptureRegistrationCallingAssembly()
     {
         RegistrationCallingAssembly = determineCallingAssembly();
+    }
+
+    /// <summary>
+    /// GH-3778. Resolves the calling assembly from an entry point, BEFORE any WolverineOptions
+    /// exists.
+    ///
+    /// <para>IHostBuilder.UseWolverine() defers its real work into a ConfigureServices callback that
+    /// does not run until Build(). By then the registering caller's frame is gone, so deriving it
+    /// inside the constructor learns who called <b>Build</b>, not who called <b>UseWolverine</b> —
+    /// and in a harness whose hosts are built by a shared helper in another assembly, which is most
+    /// of them, those are different assemblies. Capturing at the entry point is the only place the
+    /// answer is still on the stack.</para>
+    /// </summary>
+    internal static Assembly? CaptureCallingAssemblyForRegistration() => determineCallingAssembly();
+
+    /// <summary>
+    /// Applies an assembly captured at the entry point by
+    /// <see cref="CaptureCallingAssemblyForRegistration"/>. A null is ignored rather than overwriting
+    /// a value the constructor resolved: an entry point that could not identify its caller has
+    /// nothing better to offer than what the constructor already found.
+    /// </summary>
+    internal void UseRegistrationCallingAssembly(Assembly? assembly)
+    {
+        if (assembly != null)
+        {
+            RegistrationCallingAssembly = assembly;
+        }
     }
 
     // GH-3521: record a warning (buffered until a logger exists at runtime startup) when the application


### PR DESCRIPTION
Closes #3778.

The GH-3521 warning exists so that a silent first-host-wins application-assembly pin leaves a breadcrumb instead of a `No routes can be determined` mystery. It did neither: one path could never warn, and the other warned almost always — so neither its presence nor its absence carried information. On #3776 that cost real time; "zero occurrences of the warning in the failing logs" was recorded as grounds for ruling out an application-assembly problem, and that was precisely the bug.

## Three defects, not the two on the issue

**1. The `RememberedApplicationAssembly` branch could not warn.** `establishApplicationAssembly` adopted a process-wide pin — exactly the situation the warning exists for — and never called `CheckForDivergentApplicationAssembly`. Only the `jasperfx.ApplicationAssembly` path did. `JasperFxOptions` already calls its equivalent from the same branch, so this was an omission rather than a deliberate difference.

**2. `RegistrationCallingAssembly` did not mean what its name says.** `IHostBuilder.UseWolverine()` defers into a `ConfigureServices` callback that does not run until `Build()`. By then the registering caller's frame is gone, so deriving it inside the constructor learns **who called `Build()`**, not who called `UseWolverine()`. In any harness whose hosts are built by a shared helper in another assembly — most of them — those are different assemblies. It is now captured at the entry point, the last place the answer is still on the stack.

This one already had a witness in the codebase. From `is_single_node_listener.cs`:

> Deliberately built inside each test rather than from `IAsyncLifetime.InitializeAsync`: a Wolverine host created from xUnit's async-lifetime path resolves its calling assembly to "testhost", which pins the process-wide `RememberedApplicationAssembly` and trips `remembered_application_assembly_reuse_warning`.

Someone had already restructured a test to work around this defect.

**3. The stack walk adopted assemblies that cannot be an application.** This is where the noise actually came from, and it is **not** what the issue guessed. Instrumenting a fully green `CoreTests` run:

| "registered from" | count |
|---|--:|
| `ofqrxydn.tlz`, `0p1gznkf.fva`, … (runtime-compiled) | **41** |
| `JasperFx` | 5 |
| a real application assembly | 1 |

Those random 8.3-style names are Roslyn's `Path.GetRandomFileName()` default — they are **Wolverine's own generated code assemblies**. Not one warning named an extension. The walk knew about `System*`/`Microsoft*`/test runners and nothing else, so the first frame outside Wolverine was frequently code Wolverine had generated moments earlier.

This reaches past the warning: the same walk picks the application assembly for handler discovery in the else-branch of `establishApplicationAssembly`. Adopting a generated assembly there means scanning an assembly with no handlers in it — the same silent-discovery-failure shape as GH-3776.

It also explains why this was so hard to reason about: the offending assembly name is **different on every run**, so the warning count moved between runs on its own.

## Measured result

Full `CoreTests` suite, 2495 tests, warnings emitted on a green run:

| | warnings |
|---|--:|
| before | **44** |
| after | **1** |

The remaining 1 is a true positive — a host that really did inherit `Module1`'s pin. The suite is green either way; this is about whether the diagnostic can be reasoned from.

## Verification

Both behavioural fixes were driven from a red baseline, not asserted after the fact:

- **Defect 2** — a new test registers Wolverine in `CoreTests` and builds the host from a helper in `Module1`. Without the fix it resolves `Module1`; the assertion failure names it outright. Added `Module1/HostBuiltFromAnotherAssembly.cs` for that shape.
- **Defect 1** — with the added `CheckForDivergentApplicationAssembly` call commented out, the new Remembered-branch test fails with a null warning; restored, it passes.
- **Defect 3** — unit tests over the new `IsNeverAnApplicationAssembly` predicate cover a real `AssemblyBuilder` dynamic assembly, `JasperFx`, and the guard rail that a normal on-disk assembly still qualifies (the predicate must stay narrow, or the walk skips the real application).
- Full `wolverine.slnx` built at `-c Release -f net9.0`, 0 errors.

One note for review: the runtime-compiled case is detected via an empty `Assembly.Location`, which trips `IL3000` because single-file publish reports empty for everything. That is suppressed with justification — in a single-file app the predicate skips them all and the walk falls through to its `Assembly.GetEntryAssembly()` fallback, which in a single-file app *is* the application assembly. Right answer, different route.

Related: #3521, #3576, #3776, JasperFx/jasperfx#600, JasperFx/jasperfx#601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
