### PR TITLE
GH-3711: batch the durable inbox's mark-as-handled UPDATE (O1b)

### DIFF
--- a/docs/guide/durability/index.md
+++ b/docs/guide/durability/index.md
@@ -223,6 +223,29 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L82-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_durable_inbox' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Batched Inbox Writes <Badge type="tip" text="6.30" />
+
+The durable inbox costs two database writes per message: the `INSERT` when the message arrives, and
+the `UPDATE` that marks it handled when the handler finishes. Neither is issued one message at a time
+under load. Wolverine coalesces both into short micro-batches:
+
+- **Arrival**: transports that receive in batches (SQS, Azure Service Bus, Pub/Sub) hand the whole
+  batch to the inbox in one round trip, and the one-at-a-time push transports (RabbitMQ, Kafka)
+  accumulate deliveries for up to 5ms — or `MaximumMessagesToReceive` (default 100), whichever comes
+  first — before one batched insert.
+- **Completion**: successful handler completions accumulate for up to 5ms — or
+  `DurabilitySettings.MarkAsHandledBatchSize` (default 100) of them, whichever comes first — and
+  are marked handled with one batched `UPDATE`. A batch that fails for any reason falls back to
+  marking each message individually, with retries, so nothing is lost — only the round trip is
+  shared. A completion is never held longer than the window, and a message already marked handled
+  inside a transactional middleware's own transaction is skipped.
+
+The result is that under load the inbox cost is paid per batch rather than per message on both the
+way in and the way out. `MaximumMessagesToReceive(1)` on a RabbitMQ or Kafka endpoint gives strict
+one-at-a-time persistence on arrival; `opts.Durability.MarkAsHandledBatchSize = 1` does the same for
+completion. The 6.x line only: none of this batching exists on 5.x, so a user reporting durable-inbox
+overhead on 5.x may simply need to upgrade.
+
 ### Who Recovers the Inbox <Badge type="tip" text="6.22" />
 
 An incoming envelope in durable storage is either owned by a specific node (its `owner_id` is that node's

--- a/docs/guide/durability/index.md
+++ b/docs/guide/durability/index.md
@@ -233,12 +233,15 @@ under load. Wolverine coalesces both into short micro-batches:
   batch to the inbox in one round trip, and the one-at-a-time push transports (RabbitMQ, Kafka)
   accumulate deliveries for up to 5ms — or `MaximumMessagesToReceive` (default 100), whichever comes
   first — before one batched insert.
-- **Completion**: successful handler completions accumulate for up to 5ms — or
-  `DurabilitySettings.MarkAsHandledBatchSize` (default 100) of them, whichever comes first — and
-  are marked handled with one batched `UPDATE`. A batch that fails for any reason falls back to
-  marking each message individually, with retries, so nothing is lost — only the round trip is
-  shared. A completion is never held longer than the window, and a message already marked handled
-  inside a transactional middleware's own transaction is skipped.
+- **Completion**: concurrent handler completions share one batched mark-as-handled `UPDATE` (up to
+  `DurabilitySettings.MarkAsHandledBatchSize` of them, default 100). One flush is in flight at a
+  time and everything that completes while it runs joins the next one, so batches form from
+  concurrency alone: a lone completion is flushed immediately, nothing waits on a timer, and every
+  completion still waits for its own `UPDATE` to land before the message counts as handled — a
+  tracked session finishing still means the inbox row is `Handled`. A batch that fails for any
+  reason falls back to marking each message individually, with retries, so nothing is lost — only
+  the round trip is shared. A message already marked handled inside a transactional middleware's own
+  transaction is skipped.
 
 The result is that under load the inbox cost is paid per batch rather than per message on both the
 way in and the way out. `MaximumMessagesToReceive(1)` on a RabbitMQ or Kafka endpoint gives strict

--- a/docs/guide/messaging/transports/rabbitmq/performance.md
+++ b/docs/guide/messaging/transports/rabbitmq/performance.md
@@ -66,9 +66,11 @@ was measured at roughly **10% slower** and rejected (GH-3492).
   inbox insert (up to `MaximumMessagesToReceive`, default 100), so under load the write cost is
   paid per batch rather than per message — measured locally this took a 2,000 msg/s stream from
   unbounded backlog to sub-millisecond delivery p50, and nearly tripled the maximum sustained
-  durable rate (GH-3492). Set `MaximumMessagesToReceive(1)` for strict message-at-a-time
-  persistence. Database write latency still bounds the ceiling; scale with `ListenerCount` and
-  keep the inbox database close.
+  durable rate (GH-3492). Completions are coalesced the same way on the way out — one batched
+  mark-as-handled `UPDATE` per window instead of one per message (GH-3711; opt out with
+  `opts.Durability.MarkAsHandledBatchSize = 1`). Set `MaximumMessagesToReceive(1)` for strict
+  message-at-a-time persistence on arrival. Database write latency still bounds the ceiling;
+  scale with `ListenerCount` and keep the inbox database close.
 
 ## Prefetch
 

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/batched_mark_as_handled_3711.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/batched_mark_as_handled_3711.cs
@@ -1,0 +1,196 @@
+using JasperFx.Core;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3711 (O1b). DurableReceiver used to issue one MarkIncomingEnvelopeAsHandledAsync(Envelope) per
+/// completion; now completions are coalesced behind a short max-age window into the IReadOnlyList
+/// overload, the way the inbox INSERT already is.
+/// </summary>
+public class batched_mark_as_handled_3711 : IAsyncDisposable
+{
+    private readonly IListener theListener = Substitute.For<IListener>();
+    private readonly IHandlerPipeline thePipeline = Substitute.For<IHandlerPipeline>();
+    private readonly MockWolverineRuntime theRuntime = new();
+    private DurableReceiver? theReceiver;
+
+    private DurableReceiver buildReceiver(int batchSize = 100)
+    {
+        theRuntime.DurabilitySettings.MarkAsHandledBatchSize = batchSize;
+        var endpoint = new StubEndpoint("one", new StubTransport());
+        theReceiver = new DurableReceiver(endpoint, theRuntime, thePipeline);
+        return theReceiver;
+    }
+
+    private static Envelope envelope()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+        return envelope;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (theReceiver != null)
+        {
+            await theReceiver.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task completions_inside_the_window_are_marked_handled_as_one_batch()
+    {
+        var receiver = buildReceiver();
+        var envelopes = Enumerable.Range(0, 5).Select(_ => envelope()).ToArray();
+
+        foreach (var e in envelopes)
+        {
+            await receiver.CompleteAsync(e);
+        }
+
+        await receiver.DrainAsync();
+
+        // One round trip, not five
+        await theRuntime.Storage.Inbox.Received(1)
+            .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list =>
+                list.Count == 5 && envelopes.All(list.Contains)));
+        await theRuntime.Storage.Inbox.DidNotReceive().MarkIncomingEnvelopeAsHandledAsync(Arg.Any<Envelope>());
+    }
+
+    [Fact]
+    public async Task a_lone_completion_is_flushed_by_the_window_not_held_for_a_full_batch()
+    {
+        var receiver = buildReceiver();
+        var lone = envelope();
+
+        await receiver.CompleteAsync(lone);
+
+        // No drain, no other completions: the max-age timer has to ship it on its own. A batch of one
+        // takes the per-envelope path.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (theRuntime.Storage.Inbox.ReceivedCalls().Any(c => c.GetMethodInfo().Name == nameof(IMessageInbox.MarkIncomingEnvelopeAsHandledAsync)))
+            {
+                break;
+            }
+
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+
+        await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(lone);
+    }
+
+    [Fact]
+    public async Task a_full_batch_flushes_on_size_before_the_window()
+    {
+        var receiver = buildReceiver(batchSize: 3);
+        var envelopes = Enumerable.Range(0, 6).Select(_ => envelope()).ToArray();
+
+        foreach (var e in envelopes)
+        {
+            await receiver.CompleteAsync(e);
+        }
+
+        await receiver.DrainAsync();
+
+        await theRuntime.Storage.Inbox.Received(2)
+            .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list => list.Count == 3));
+    }
+
+    [Fact]
+    public async Task envelopes_already_marked_handled_by_transactional_middleware_are_skipped()
+    {
+        var receiver = buildReceiver();
+        var fresh = envelope();
+        var alreadyHandled = envelope();
+        alreadyHandled.Status = EnvelopeStatus.Handled;
+        var alsoFresh = envelope();
+
+        await receiver.CompleteAsync(fresh);
+        await receiver.CompleteAsync(alreadyHandled);
+        await receiver.CompleteAsync(alsoFresh);
+
+        await receiver.DrainAsync();
+
+        await theRuntime.Storage.Inbox.Received(1)
+            .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list =>
+                list.Count == 2 && list.Contains(fresh) && list.Contains(alsoFresh) && !list.Contains(alreadyHandled)));
+    }
+
+    [Fact]
+    public async Task a_failed_batch_falls_back_to_marking_one_at_a_time()
+    {
+        var receiver = buildReceiver();
+        var envelopes = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+
+        theRuntime.Storage.Inbox.MarkIncomingEnvelopeAsHandledAsync(Arg.Any<IReadOnlyList<Envelope>>())
+            .Throws(new InvalidOperationException("the batch UPDATE blew up"));
+
+        foreach (var e in envelopes)
+        {
+            await receiver.CompleteAsync(e);
+        }
+
+        await receiver.DrainAsync();
+
+        // Nothing is lost: every envelope is retried individually through the per-envelope block
+        foreach (var e in envelopes)
+        {
+            await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(e);
+        }
+    }
+
+    [Fact]
+    public async Task a_batch_size_of_one_opts_out_of_batching()
+    {
+        var receiver = buildReceiver(batchSize: 1);
+        var envelopes = Enumerable.Range(0, 3).Select(_ => envelope()).ToArray();
+
+        foreach (var e in envelopes)
+        {
+            await receiver.CompleteAsync(e);
+        }
+
+        await receiver.DrainAsync();
+
+        // The escape hatch: one UPDATE per completion, as before
+        foreach (var e in envelopes)
+        {
+            await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(e);
+        }
+
+        await theRuntime.Storage.Inbox.DidNotReceive().MarkIncomingEnvelopeAsHandledAsync(Arg.Any<IReadOnlyList<Envelope>>());
+    }
+
+    [Fact]
+    public async Task batch_message_children_are_marked_handled_together()
+    {
+        var receiver = buildReceiver();
+        var children = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+        var batch = new Envelope(new object[] { "a", "b", "c", "d" }, children);
+
+        await receiver.CompleteAsync(batch);
+        await receiver.DrainAsync();
+
+        await theRuntime.Storage.Inbox.Received(1)
+            .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list =>
+                list.Count == 4 && children.All(list.Contains)));
+    }
+
+    [Fact]
+    public void the_window_matches_the_insert_side()
+    {
+        DurableReceiver.MarkAsHandledBatchWindow.ShouldBe(5.Milliseconds());
+    }
+}

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/batched_mark_as_handled_3711.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/batched_mark_as_handled_3711.cs
@@ -1,4 +1,3 @@
-using JasperFx.Core;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Shouldly;
@@ -14,8 +13,8 @@ namespace CoreTests.Runtime.WorkerQueues;
 
 /// <summary>
 /// GH-3711 (O1b). DurableReceiver used to issue one MarkIncomingEnvelopeAsHandledAsync(Envelope) per
-/// completion; now completions are coalesced behind a short max-age window into the IReadOnlyList
-/// overload, the way the inbox INSERT already is.
+/// completion; concurrent completions now share one IReadOnlyList flush -- while CompleteAsync still
+/// does not return until the envelope's UPDATE has landed.
 /// </summary>
 public class batched_mark_as_handled_3711 : IAsyncDisposable
 {
@@ -39,6 +38,36 @@ public class batched_mark_as_handled_3711 : IAsyncDisposable
         return envelope;
     }
 
+    /// <summary>
+    /// Hold the FIRST inbox call open so every completion posted meanwhile piles up behind it, then
+    /// release it. That is the only way to make "batches form from concurrency" deterministic.
+    /// </summary>
+    private (TaskCompletionSource gate, TaskCompletionSource firstCallStarted) gateTheFirstInboxCall()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = true;
+
+        theRuntime.Storage.Inbox.MarkIncomingEnvelopeAsHandledAsync(Arg.Any<Envelope>())
+            .Returns(_ => hold());
+        theRuntime.Storage.Inbox.MarkIncomingEnvelopeAsHandledAsync(Arg.Any<IReadOnlyList<Envelope>>())
+            .Returns(_ => hold());
+
+        Task hold()
+        {
+            if (first)
+            {
+                first = false;
+                started.TrySetResult();
+                return gate.Task;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        return (gate, started);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (theReceiver != null)
@@ -48,61 +77,75 @@ public class batched_mark_as_handled_3711 : IAsyncDisposable
     }
 
     [Fact]
-    public async Task completions_inside_the_window_are_marked_handled_as_one_batch()
+    public async Task completions_that_arrive_during_a_flush_share_the_next_flush()
     {
         var receiver = buildReceiver();
-        var envelopes = Enumerable.Range(0, 5).Select(_ => envelope()).ToArray();
+        var (gate, firstCallStarted) = gateTheFirstInboxCall();
 
-        foreach (var e in envelopes)
-        {
-            await receiver.CompleteAsync(e);
-        }
+        var first = envelope();
+        var firstCompletion = receiver.CompleteAsync(first).AsTask();
+        await firstCallStarted.Task;
 
-        await receiver.DrainAsync();
+        // These arrive while the first UPDATE is "in flight"
+        var others = Enumerable.Range(0, 5).Select(_ => envelope()).ToArray();
+        var otherCompletions = others.Select(e => receiver.CompleteAsync(e).AsTask()).ToArray();
 
-        // One round trip, not five
+        // Nothing has been released yet -- none of them is "handled"
+        firstCompletion.IsCompleted.ShouldBeFalse();
+        otherCompletions.Any(x => x.IsCompleted).ShouldBeFalse();
+
+        gate.SetResult();
+        await Task.WhenAll(otherCompletions.Append(firstCompletion)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // The lone first completion took the per-envelope path; the five that piled up went as ONE batch
+        await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(first);
         await theRuntime.Storage.Inbox.Received(1)
             .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list =>
-                list.Count == 5 && envelopes.All(list.Contains)));
-        await theRuntime.Storage.Inbox.DidNotReceive().MarkIncomingEnvelopeAsHandledAsync(Arg.Any<Envelope>());
+                list.Count == 5 && others.All(list.Contains)));
     }
 
     [Fact]
-    public async Task a_lone_completion_is_flushed_by_the_window_not_held_for_a_full_batch()
+    public async Task complete_async_does_not_return_until_the_update_has_landed()
+    {
+        var receiver = buildReceiver();
+        var (gate, firstCallStarted) = gateTheFirstInboxCall();
+
+        var completion = receiver.CompleteAsync(envelope()).AsTask();
+        await firstCallStarted.Task;
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+        completion.IsCompleted.ShouldBeFalse("CompleteAsync returned before the inbox UPDATE finished");
+
+        gate.SetResult();
+        await completion.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_lone_completion_is_flushed_immediately_on_the_per_envelope_path()
     {
         var receiver = buildReceiver();
         var lone = envelope();
 
         await receiver.CompleteAsync(lone);
 
-        // No drain, no other completions: the max-age timer has to ship it on its own. A batch of one
-        // takes the per-envelope path.
-        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            if (theRuntime.Storage.Inbox.ReceivedCalls().Any(c => c.GetMethodInfo().Name == nameof(IMessageInbox.MarkIncomingEnvelopeAsHandledAsync)))
-            {
-                break;
-            }
-
-            await Task.Delay(10, TestContext.Current.CancellationToken);
-        }
-
         await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(lone);
+        await theRuntime.Storage.Inbox.DidNotReceive().MarkIncomingEnvelopeAsHandledAsync(Arg.Any<IReadOnlyList<Envelope>>());
     }
 
     [Fact]
-    public async Task a_full_batch_flushes_on_size_before_the_window()
+    public async Task a_pile_up_larger_than_the_batch_size_is_flushed_in_chunks()
     {
         var receiver = buildReceiver(batchSize: 3);
-        var envelopes = Enumerable.Range(0, 6).Select(_ => envelope()).ToArray();
+        var (gate, firstCallStarted) = gateTheFirstInboxCall();
 
-        foreach (var e in envelopes)
-        {
-            await receiver.CompleteAsync(e);
-        }
+        var first = receiver.CompleteAsync(envelope()).AsTask();
+        await firstCallStarted.Task;
 
-        await receiver.DrainAsync();
+        var others = Enumerable.Range(0, 6).Select(_ => envelope()).ToArray();
+        var completions = others.Select(e => receiver.CompleteAsync(e).AsTask()).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(completions.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await theRuntime.Storage.Inbox.Received(2)
             .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list => list.Count == 3));
@@ -112,60 +155,57 @@ public class batched_mark_as_handled_3711 : IAsyncDisposable
     public async Task envelopes_already_marked_handled_by_transactional_middleware_are_skipped()
     {
         var receiver = buildReceiver();
-        var fresh = envelope();
         var alreadyHandled = envelope();
         alreadyHandled.Status = EnvelopeStatus.Handled;
-        var alsoFresh = envelope();
 
-        await receiver.CompleteAsync(fresh);
         await receiver.CompleteAsync(alreadyHandled);
-        await receiver.CompleteAsync(alsoFresh);
 
-        await receiver.DrainAsync();
-
-        await theRuntime.Storage.Inbox.Received(1)
-            .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list =>
-                list.Count == 2 && list.Contains(fresh) && list.Contains(alsoFresh) && !list.Contains(alreadyHandled)));
+        await theRuntime.Storage.Inbox.DidNotReceive().MarkIncomingEnvelopeAsHandledAsync(alreadyHandled);
+        await theRuntime.Storage.Inbox.DidNotReceive().MarkIncomingEnvelopeAsHandledAsync(Arg.Any<IReadOnlyList<Envelope>>());
     }
 
     [Fact]
-    public async Task a_failed_batch_falls_back_to_marking_one_at_a_time()
+    public async Task a_failed_batch_falls_back_to_marking_one_at_a_time_and_still_releases_the_completions()
     {
         var receiver = buildReceiver();
-        var envelopes = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+        var (gate, firstCallStarted) = gateTheFirstInboxCall();
 
         theRuntime.Storage.Inbox.MarkIncomingEnvelopeAsHandledAsync(Arg.Any<IReadOnlyList<Envelope>>())
             .Throws(new InvalidOperationException("the batch UPDATE blew up"));
 
-        foreach (var e in envelopes)
-        {
-            await receiver.CompleteAsync(e);
-        }
+        var first = receiver.CompleteAsync(envelope()).AsTask();
+        await firstCallStarted.Task;
 
-        await receiver.DrainAsync();
+        var others = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+        var completions = others.Select(e => receiver.CompleteAsync(e).AsTask()).ToArray();
 
-        // Nothing is lost: every envelope is retried individually through the per-envelope block
-        foreach (var e in envelopes)
+        gate.SetResult();
+        await Task.WhenAll(completions.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Nothing is lost: every envelope of the failed batch went through the per-envelope path
+        foreach (var e in others)
         {
             await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(e);
         }
     }
 
     [Fact]
-    public async Task a_batch_size_of_one_opts_out_of_batching()
+    public async Task a_batch_size_of_one_opts_out_of_coalescing()
     {
         var receiver = buildReceiver(batchSize: 1);
-        var envelopes = Enumerable.Range(0, 3).Select(_ => envelope()).ToArray();
+        var (gate, firstCallStarted) = gateTheFirstInboxCall();
 
-        foreach (var e in envelopes)
-        {
-            await receiver.CompleteAsync(e);
-        }
+        var first = receiver.CompleteAsync(envelope()).AsTask();
+        await firstCallStarted.Task;
 
-        await receiver.DrainAsync();
+        var others = Enumerable.Range(0, 3).Select(_ => envelope()).ToArray();
+        var completions = others.Select(e => receiver.CompleteAsync(e).AsTask()).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(completions.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // The escape hatch: one UPDATE per completion, as before
-        foreach (var e in envelopes)
+        foreach (var e in others)
         {
             await theRuntime.Storage.Inbox.Received(1).MarkIncomingEnvelopeAsHandledAsync(e);
         }
@@ -174,23 +214,30 @@ public class batched_mark_as_handled_3711 : IAsyncDisposable
     }
 
     [Fact]
-    public async Task batch_message_children_are_marked_handled_together()
+    public async Task batch_message_children_are_marked_handled_as_one_flush()
     {
         var receiver = buildReceiver();
         var children = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
         var batch = new Envelope(new object[] { "a", "b", "c", "d" }, children);
 
+        // No gate needed: CompleteAsync posts every child before awaiting any, so the first child starts
+        // the flush loop and the other three are waiting for it by the time it looks again
         await receiver.CompleteAsync(batch);
-        await receiver.DrainAsync();
 
-        await theRuntime.Storage.Inbox.Received(1)
-            .MarkIncomingEnvelopeAsHandledAsync(Arg.Is<IReadOnlyList<Envelope>>(list =>
-                list.Count == 4 && children.All(list.Contains)));
-    }
+        var calls = theRuntime.Storage.Inbox.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IMessageInbox.MarkIncomingEnvelopeAsHandledAsync))
+            .ToList();
 
-    [Fact]
-    public void the_window_matches_the_insert_side()
-    {
-        DurableReceiver.MarkAsHandledBatchWindow.ShouldBe(5.Milliseconds());
+        // Every child was marked exactly once, across at most two calls (the first child alone, then the rest)
+        var marked = calls.SelectMany(c => c.GetArguments()[0] switch
+        {
+            Envelope e => [e],
+            IReadOnlyList<Envelope> list => list,
+            _ => Array.Empty<Envelope>()
+        }).ToList();
+
+        marked.Count.ShouldBe(4);
+        children.All(marked.Contains).ShouldBeTrue();
+        calls.Count.ShouldBeLessThanOrEqualTo(2);
     }
 }

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -132,6 +132,17 @@ public class DurabilitySettings : IDescribeMyself
     public int MaximumAckAttempts { get; set; } = 3;
 
     /// <summary>
+    /// GH-3711. How many successful handler completions a durable endpoint coalesces into one
+    /// batched mark-as-handled <c>UPDATE</c> against the inbox. Completions accumulate for at most
+    /// <see cref="Wolverine.Runtime.WorkerQueues.DurableReceiver.MarkAsHandledBatchWindow" /> (5ms)
+    /// or until this many are pending, whichever comes first, and are then marked handled in a single
+    /// round trip -- the completion-side twin of the batched inbox insert. A batch that fails falls
+    /// back to marking each envelope individually with retries. Set to 1 to mark every completion in
+    /// its own round trip as before. Default 100.
+    /// </summary>
+    public int MarkAsHandledBatchSize { get; set; } = 100;
+
+    /// <summary>
     /// If non-null, this directs Wolverine to "push" any message in the durable outbox that is older
     /// than the configured time even if the message is marked as owned by an active node
     /// </summary>

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -132,13 +132,13 @@ public class DurabilitySettings : IDescribeMyself
     public int MaximumAckAttempts { get; set; } = 3;
 
     /// <summary>
-    /// GH-3711. How many successful handler completions a durable endpoint coalesces into one
-    /// batched mark-as-handled <c>UPDATE</c> against the inbox. Completions accumulate for at most
-    /// <see cref="Wolverine.Runtime.WorkerQueues.DurableReceiver.MarkAsHandledBatchWindow" /> (5ms)
-    /// or until this many are pending, whichever comes first, and are then marked handled in a single
-    /// round trip -- the completion-side twin of the batched inbox insert. A batch that fails falls
-    /// back to marking each envelope individually with retries. Set to 1 to mark every completion in
-    /// its own round trip as before. Default 100.
+    /// GH-3711. The most successful handler completions a durable endpoint coalesces into one batched
+    /// mark-as-handled <c>UPDATE</c> against the inbox. One flush is in flight at a time and every
+    /// completion that arrives while it runs joins the next flush, so batches form from concurrency
+    /// alone -- a lone completion is still flushed immediately, and every completion still waits for
+    /// its own UPDATE to land before the message counts as handled. A batch that fails falls back to
+    /// marking each envelope individually with retries. Set to 1 to mark every completion in its own
+    /// round trip as before. Default 100.
     /// </summary>
     public int MarkAsHandledBatchSize { get; set; } = 100;
 

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -26,6 +26,14 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     // ReSharper disable once InconsistentNaming
     protected readonly ILogger _logger;
     private readonly RetryBlock<Envelope> _markAsHandled;
+
+    // GH-3711 (O1b): mark-as-handled was the last per-message durable write. The inbox INSERT has
+    // been micro-batched since GH-3492, but every completion still issued its own UPDATE through
+    // _markAsHandled -- the IReadOnlyList overload on IMessageInbox was unreachable from here. Now
+    // completions accumulate behind a short max-age window and flush as one round trip. Null when
+    // DurabilitySettings.MarkAsHandledBatchSize is 1, the escape hatch back to one UPDATE per message.
+    private readonly BatchingChannel<Envelope>? _markAsHandledBatching;
+    private readonly Block<Envelope[]>? _markAsHandledBatchBlock;
     private readonly RetryBlock<Envelope> _moveToErrors;
     private readonly IBlock<Envelope> _receiver;
     private readonly RetryBlock<Envelope> _receivingOne;
@@ -195,6 +203,13 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             }, _logger,
             _settings.Cancellation);
 
+        if (_settings.MarkAsHandledBatchSize > 1)
+        {
+            _markAsHandledBatchBlock = new Block<Envelope[]>((batch, _) => markBatchAsHandledAsync(batch));
+            _markAsHandledBatching = new BatchingChannel<Envelope>(MarkAsHandledBatchWindow, _markAsHandledBatchBlock,
+                _settings.MarkAsHandledBatchSize);
+        }
+
         _incrementAttempts = new RetryBlock<Envelope>((e, _) => _inbox.IncrementIncomingEnvelopeAttemptsAsync(e),
             _logger, _settings.Cancellation);
 
@@ -270,6 +285,17 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         _incrementAttempts.Dispose();
         _scheduleExecution.Dispose();
+
+        if (_markAsHandledBatching != null)
+        {
+            await _markAsHandledBatching.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_markAsHandledBatchBlock != null)
+        {
+            await _markAsHandledBatchBlock.DisposeAsync().ConfigureAwait(false);
+        }
+
         _markAsHandled.Dispose();
         _moveToErrors.Dispose();
         _receivingOne.Dispose();
@@ -304,12 +330,88 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             foreach (var child in envelope.Batch)
             {
                 child.InBatch = false;
-                await _markAsHandled.PostAsync(child).ConfigureAwait(false);
+                await markAsHandledAsync(child).ConfigureAwait(false);
             }
         }
         else
         {
-            await _markAsHandled.PostAsync(envelope).ConfigureAwait(false);
+            await markAsHandledAsync(envelope).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     GH-3711: the maximum age of a pending mark-as-handled batch. Same window the insert side
+    ///     uses (WorkerQueueMessageConsumer / KafkaListener), so a completion never waits longer than
+    ///     this for its UPDATE to be issued.
+    /// </summary>
+    public static readonly TimeSpan MarkAsHandledBatchWindow = TimeSpan.FromMilliseconds(5);
+
+    private ValueTask markAsHandledAsync(Envelope envelope)
+    {
+        if (_markAsHandledBatching != null)
+        {
+            return _markAsHandledBatching.PostAsync(envelope);
+        }
+
+        return new ValueTask(_markAsHandled.PostAsync(envelope));
+    }
+
+    /// <summary>
+    ///     GH-3711: flush one accumulated batch of completions as a single round trip. A batch that
+    ///     fails falls back to the per-envelope retry block, which is the path a batched INSERT already
+    ///     takes on failure -- nothing is ever dropped on the floor, it is just retried one at a time.
+    /// </summary>
+    private async Task markBatchAsHandledAsync(Envelope[] batch)
+    {
+        // Same optimization as the per-envelope block: transactional middleware may already have
+        // marked the envelope handled inside the handler's own transaction
+        var pending = batch.Where(x => x.Status != EnvelopeStatus.Handled).ToList();
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        if (pending.Count == 1)
+        {
+            await _markAsHandled.PostAsync(pending[0]).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            await _inbox.MarkIncomingEnvelopeAsHandledAsync(pending).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e,
+                "Failed to mark a batch of {Count} envelopes as handled at {Uri}; falling back to marking them one at a time",
+                pending.Count, Uri);
+
+            foreach (var envelope in pending)
+            {
+                await _markAsHandled.PostAsync(envelope).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     GH-3711: push every pending completion at the inbox before the per-envelope block drains.
+    ///     Terminal -- the receiver is thrown away after a drain.
+    /// </summary>
+    private async Task flushMarkAsHandledBatchAsync()
+    {
+        if (_markAsHandledBatching == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _markAsHandledBatching.WaitForCompletionAsync().WaitAsync(_settings.DrainTimeout).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error flushing pending mark-as-handled batches at {Uri}", Uri);
         }
     }
 
@@ -450,6 +552,7 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         await _incrementAttempts.DrainAsync().ConfigureAwait(false);
         await _scheduleExecution.DrainAsync().ConfigureAwait(false);
+        await flushMarkAsHandledBatchAsync().ConfigureAwait(false);
         await _markAsHandled.DrainAsync().ConfigureAwait(false);
         await _moveToErrors.DrainAsync().ConfigureAwait(false);
         await _receivingOne.DrainAsync().ConfigureAwait(false);
@@ -464,6 +567,10 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     {
         // Might need to drain the block
         _receiver.Complete();
+
+        // GH-3711: ship whatever completions are still sitting in the batch window. The flush is
+        // async downstream; this just makes sure nothing waits on a timer that may never fire again.
+        _markAsHandledBatching?.TriggerBatch();
 
         _completeBlock.Dispose();
         _deferBlock.Dispose();

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -30,10 +30,10 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     // GH-3711 (O1b): mark-as-handled was the last per-message durable write. The inbox INSERT has
     // been micro-batched since GH-3492, but every completion still issued its own UPDATE through
     // _markAsHandled -- the IReadOnlyList overload on IMessageInbox was unreachable from here. Now
-    // completions accumulate behind a short max-age window and flush as one round trip. Null when
-    // DurabilitySettings.MarkAsHandledBatchSize is 1, the escape hatch back to one UPDATE per message.
-    private readonly BatchingChannel<Envelope>? _markAsHandledBatching;
-    private readonly Block<Envelope[]>? _markAsHandledBatchBlock;
+    // concurrent completions share one flush (see InboxCompletionCoalescer for why the caller still
+    // awaits it). Null when DurabilitySettings.MarkAsHandledBatchSize is 1, the escape hatch back to
+    // one UPDATE per message.
+    private readonly InboxCompletionCoalescer? _completionCoalescer;
     private readonly RetryBlock<Envelope> _moveToErrors;
     private readonly IBlock<Envelope> _receiver;
     private readonly RetryBlock<Envelope> _receivingOne;
@@ -205,9 +205,10 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         if (_settings.MarkAsHandledBatchSize > 1)
         {
-            _markAsHandledBatchBlock = new Block<Envelope[]>((batch, _) => markBatchAsHandledAsync(batch));
-            _markAsHandledBatching = new BatchingChannel<Envelope>(MarkAsHandledBatchWindow, _markAsHandledBatchBlock,
-                _settings.MarkAsHandledBatchSize);
+            _completionCoalescer = new InboxCompletionCoalescer(
+                envelopes => _inbox.MarkIncomingEnvelopeAsHandledAsync(envelopes),
+                envelope => _markAsHandled.PostAsync(envelope),
+                _settings.MarkAsHandledBatchSize, Uri, _logger);
         }
 
         _incrementAttempts = new RetryBlock<Envelope>((e, _) => _inbox.IncrementIncomingEnvelopeAttemptsAsync(e),
@@ -285,17 +286,6 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         _incrementAttempts.Dispose();
         _scheduleExecution.Dispose();
-
-        if (_markAsHandledBatching != null)
-        {
-            await _markAsHandledBatching.DisposeAsync().ConfigureAwait(false);
-        }
-
-        if (_markAsHandledBatchBlock != null)
-        {
-            await _markAsHandledBatchBlock.DisposeAsync().ConfigureAwait(false);
-        }
-
         _markAsHandled.Dispose();
         _moveToErrors.Dispose();
         _receivingOne.Dispose();
@@ -327,11 +317,15 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
                 runtime.BatchingPendingCounts.SettleBatch(envelope);
             }
 
+            // GH-3711: post every child before awaiting any, so the coalescer can take them as one flush
+            var completions = new List<Task>(envelope.Batch.Length);
             foreach (var child in envelope.Batch)
             {
                 child.InBatch = false;
-                await markAsHandledAsync(child).ConfigureAwait(false);
+                completions.Add(markAsHandledAsync(child).AsTask());
             }
+
+            await Task.WhenAll(completions).ConfigureAwait(false);
         }
         else
         {
@@ -339,79 +333,42 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         }
     }
 
-    /// <summary>
-    ///     GH-3711: the maximum age of a pending mark-as-handled batch. Same window the insert side
-    ///     uses (WorkerQueueMessageConsumer / KafkaListener), so a completion never waits longer than
-    ///     this for its UPDATE to be issued.
-    /// </summary>
-    public static readonly TimeSpan MarkAsHandledBatchWindow = TimeSpan.FromMilliseconds(5);
-
-    private ValueTask markAsHandledAsync(Envelope envelope)
-    {
-        if (_markAsHandledBatching != null)
-        {
-            return _markAsHandledBatching.PostAsync(envelope);
-        }
-
-        return new ValueTask(_markAsHandled.PostAsync(envelope));
-    }
-
-    /// <summary>
-    ///     GH-3711: flush one accumulated batch of completions as a single round trip. A batch that
-    ///     fails falls back to the per-envelope retry block, which is the path a batched INSERT already
-    ///     takes on failure -- nothing is ever dropped on the floor, it is just retried one at a time.
-    /// </summary>
-    private async Task markBatchAsHandledAsync(Envelope[] batch)
+    private async ValueTask markAsHandledAsync(Envelope envelope)
     {
         // Same optimization as the per-envelope block: transactional middleware may already have
         // marked the envelope handled inside the handler's own transaction
-        var pending = batch.Where(x => x.Status != EnvelopeStatus.Handled).ToList();
-        if (pending.Count == 0)
+        if (envelope.Status == EnvelopeStatus.Handled)
         {
             return;
         }
 
-        if (pending.Count == 1)
+        if (_completionCoalescer != null)
         {
-            await _markAsHandled.PostAsync(pending[0]).ConfigureAwait(false);
+            await _completionCoalescer.MarkAsHandledAsync(envelope).ConfigureAwait(false);
             return;
         }
 
-        try
-        {
-            await _inbox.MarkIncomingEnvelopeAsHandledAsync(pending).ConfigureAwait(false);
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(e,
-                "Failed to mark a batch of {Count} envelopes as handled at {Uri}; falling back to marking them one at a time",
-                pending.Count, Uri);
-
-            foreach (var envelope in pending)
-            {
-                await _markAsHandled.PostAsync(envelope).ConfigureAwait(false);
-            }
-        }
+        await _markAsHandled.PostAsync(envelope).ConfigureAwait(false);
     }
 
     /// <summary>
-    ///     GH-3711: push every pending completion at the inbox before the per-envelope block drains.
-    ///     Terminal -- the receiver is thrown away after a drain.
+    ///     GH-3711: let any flush in flight finish before the per-envelope block drains, so the
+    ///     fallback path still has somewhere to go.
     /// </summary>
     private async Task flushMarkAsHandledBatchAsync()
     {
-        if (_markAsHandledBatching == null)
+        if (_completionCoalescer == null)
         {
             return;
         }
 
         try
         {
-            await _markAsHandledBatching.WaitForCompletionAsync().WaitAsync(_settings.DrainTimeout).ConfigureAwait(false);
+            await _completionCoalescer.DrainAsync().WaitAsync(_settings.DrainTimeout).ConfigureAwait(false);
         }
         catch (Exception e)
         {
-            _logger.LogDebug(e, "Error flushing pending mark-as-handled batches at {Uri}", Uri);
+            _logger.LogDebug(e, "Error waiting for pending mark-as-handled batches at {Uri}", Uri);
         }
     }
 
@@ -567,10 +524,6 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     {
         // Might need to drain the block
         _receiver.Complete();
-
-        // GH-3711: ship whatever completions are still sitting in the batch window. The flush is
-        // async downstream; this just makes sure nothing waits on a timer that may never fire again.
-        _markAsHandledBatching?.TriggerBatch();
 
         _completeBlock.Dispose();
         _deferBlock.Dispose();

--- a/src/Wolverine/Runtime/WorkerQueues/InboxCompletionCoalescer.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InboxCompletionCoalescer.cs
@@ -1,0 +1,173 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+///     GH-3711 (O1b). Coalesces concurrent durable-inbox completions into one batched mark-as-handled
+///     round trip while preserving the contract that <c>CompleteAsync</c> does not return until the
+///     envelope really is <c>Handled</c> in the database. One flush is in flight at a time; every
+///     completion that arrives while it runs is taken by the next flush as a single batch. There is no
+///     timer: a lone completion is flushed immediately, so trickle traffic pays exactly what it paid
+///     before (one round trip), and batches form from concurrency alone under load.
+/// </summary>
+/// <remarks>
+///     Why not fire-and-forget behind a max-age window like the insert side: the pipeline records
+///     <c>MessageSucceeded</c> for tracked sessions only after <c>CompleteAsync</c> returns, and a great
+///     many tests -- Wolverine's and its users' -- assert inbox state the moment a tracked session
+///     finishes. Decoupling the UPDATE from the completion broke that ordering (CI on the first cut
+///     of #4025). Awaiting the shared flush keeps the ordering and still amortizes the round trip.
+/// </remarks>
+internal class InboxCompletionCoalescer
+{
+    private readonly Func<IReadOnlyList<Envelope>, Task> _markBatch;
+    private readonly Func<Envelope, Task> _markOne;
+    private readonly int _maximumBatchSize;
+    private readonly ILogger _logger;
+    private readonly Uri _uri;
+    private readonly object _lock = new();
+    private readonly List<Pending> _pending = new();
+    private bool _flushing;
+    private Task? _flushLoop;
+
+    /// <param name="markBatch">The batched inbox call. May throw; a failure falls back to <paramref name="markOne" /> per envelope</param>
+    /// <param name="markOne">The per-envelope, retried path. Expected never to throw (a RetryBlock swallows and retries)</param>
+    /// <param name="maximumBatchSize">Most envelopes in one flush</param>
+    /// <param name="uri">Endpoint, for logging</param>
+    /// <param name="logger"></param>
+    public InboxCompletionCoalescer(Func<IReadOnlyList<Envelope>, Task> markBatch, Func<Envelope, Task> markOne,
+        int maximumBatchSize, Uri uri, ILogger logger)
+    {
+        _markBatch = markBatch;
+        _markOne = markOne;
+        _maximumBatchSize = Math.Max(1, maximumBatchSize);
+        _uri = uri;
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Number of completions waiting for the next flush. Exposed for tests.
+    /// </summary>
+    public int PendingCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _pending.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Mark this envelope handled. The returned task completes only after the database has been told,
+    ///     whether by the shared batch or by the per-envelope fallback.
+    /// </summary>
+    public Task MarkAsHandledAsync(Envelope envelope)
+    {
+        var pending = new Pending(envelope, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+
+        var startLoop = false;
+        lock (_lock)
+        {
+            _pending.Add(pending);
+            if (!_flushing)
+            {
+                _flushing = true;
+                startLoop = true;
+            }
+        }
+
+        if (startLoop)
+        {
+            // Off the caller's thread: under sustained load the loop keeps finding work, and the worker
+            // that happened to arrive first must not be conscripted into flushing everyone else's
+            // completions forever.
+            var loop = Task.Run(flushLoopAsync);
+            lock (_lock)
+            {
+                _flushLoop = loop;
+            }
+        }
+
+        return pending.Completion.Task;
+    }
+
+    /// <summary>
+    ///     Wait for any flush in flight (and whatever it sweeps up) to finish. Bounded by the caller.
+    /// </summary>
+    public Task DrainAsync()
+    {
+        Task? loop;
+        lock (_lock)
+        {
+            loop = _flushLoop;
+        }
+
+        return loop ?? Task.CompletedTask;
+    }
+
+    private async Task flushLoopAsync()
+    {
+        while (true)
+        {
+            Pending[] batch;
+            lock (_lock)
+            {
+                if (_pending.Count == 0)
+                {
+                    _flushing = false;
+                    _flushLoop = null;
+                    return;
+                }
+
+                var take = Math.Min(_maximumBatchSize, _pending.Count);
+                batch = _pending.GetRange(0, take).ToArray();
+                _pending.RemoveRange(0, take);
+            }
+
+            await flushAsync(batch).ConfigureAwait(false);
+        }
+    }
+
+    private async Task flushAsync(Pending[] batch)
+    {
+        try
+        {
+            if (batch.Length == 1)
+            {
+                await _markOne(batch[0].Envelope).ConfigureAwait(false);
+            }
+            else
+            {
+                await _markBatch(batch.Select(x => x.Envelope).ToList()).ConfigureAwait(false);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e,
+                "Failed to mark a batch of {Count} envelopes as handled at {Uri}; falling back to marking them one at a time",
+                batch.Length, _uri);
+
+            foreach (var pending in batch)
+            {
+                try
+                {
+                    await _markOne(pending.Envelope).ConfigureAwait(false);
+                }
+                catch (Exception inner)
+                {
+                    // The per-envelope path is a RetryBlock that is expected to swallow and retry;
+                    // if it does throw, the completion still has to be released
+                    _logger.LogError(inner, "Failed to mark envelope {EnvelopeId} as handled at {Uri}", pending.Envelope.Id, _uri);
+                }
+            }
+        }
+
+        foreach (var pending in batch)
+        {
+            pending.Completion.TrySetResult();
+        }
+    }
+
+    private sealed record Pending(Envelope Envelope, TaskCompletionSource Completion);
+}


### PR DESCRIPTION
Part of #3711 (step 2 — "the other per-message durable write"). The step-1 audit is posted on the issue; the arrival-side leftovers are split to #4026, so this closes #3711 when it merges.

Closes #3711

## What was happening

The inbox `INSERT` has been micro-batched since GH-3492, but every successful completion still issued its own `MarkIncomingEnvelopeAsHandledAsync(Envelope)` `UPDATE` through `DurableReceiver._markAsHandled`. The `IReadOnlyList` overload on `IMessageInbox` was **unreachable from the receiver**: the only branch that used it wanted an envelope with `Batch != null`, but `CompleteAsync` posts the *children* of a batch-handler message one at a time and nothing ever posts the parent. So every durable endpoint on every transport paid one round trip per message on the way out, regardless of how its arrival was batched.

## What changes

New `InboxCompletionCoalescer` (internal): **one flush in flight at a time; every completion that arrives while it runs joins the next flush as one `MarkIncomingEnvelopeAsHandledAsync(IReadOnlyList<Envelope>)` call; and every caller awaits its own flush.**

- **No timer.** A lone completion is flushed immediately on the existing per-envelope `RetryBlock` path, so trickle traffic pays exactly what it paid before. Batches form from concurrency alone.
- **`CompleteAsync` still does not return until the `UPDATE` has landed.** This matters: `MessageSucceededContinuation` awaits `CompleteAsync` and only then records `MessageSucceeded` for tracked sessions, so "tracked session finished ⇒ inbox row is `Handled`" has always been the contract — for Wolverine's own tests (~25 files assert inbox counts/status right after `TrackActivity`) and for users' tests. The first cut of this PR used a fire-and-forget `BatchingChannel` and CI caught exactly that: `PolecatTests…Bug_discard_after_failed_outbox_commit` failed 3/3 with `Incoming` 1 instead of 0. The coalescer keeps the ordering and, measured, keeps the whole win.
- A batch that fails falls back to the per-envelope retried path **and still releases every completion** — nothing dropped, only the round trip was shared.
- Batch-handler children are posted before any is awaited, so they share one flush.
- An envelope already marked handled by transactional middleware is skipped, as before.
- `DrainAsync` waits for any in-flight flush (bounded by `DrainTimeout`) before the per-envelope block drains.
- `DurabilitySettings.MarkAsHandledBatchSize` (default 100; **1 = escape hatch** back to one `UPDATE` per completion). Gating on `MaximumMessagesToReceive` like the insert side isn't possible — that property lives on each transport's endpoint type with different defaults, not on core `Endpoint`.
- Store-side nothing changes: `DelegatingMessageInbox` already groups the list by ancillary store, `MultiTenantedMessageStore` by tenant; RDBMS emits the N `UPDATE`s in one command/round trip; Raven patches by id set; Cosmos/Oracle loop inside the call.

Docs: new "Batched Inbox Writes" subsection in `docs/guide/durability/index.md`, and the RabbitMQ performance page's Durable bullet now mentions the completion side and the opt-out.

## Measured (per #3711's "no merge without numbers")

In-repo rig `src/Testing/KafkaPerfRig`, RabbitMQ + PostgreSQL, same box, baseline worktree detached at `origin/main` @ e235a1bef, cells back to back. **`r-max-durable`** — uncapped publisher, 0 ms handler, Durable/PG, 15 s warmup / 45 s measured, three runs each:

| Build | Runs (msg/s) | Mean | vs main |
|---|---|---|---|
| `origin/main` | 3,366.6 / 3,413.4 / 2,987.8 | 3,256 | — |
| first cut (fire-and-forget window) — *not shipped* | 3,451.4 / 3,871.0 / 3,645.7 | 3,656 | +12 % |
| **this PR (awaiting coalescer)** | **3,795.0 / 3,614.6 / 3,678.7** | **3,696** | **+13.5 %** |

The PR's minimum (3,614) is above the baseline's maximum (3,413) — no overlap. Smaller than the insert-side +186 % from GH-3492, as expected: the broker ack is still per message and arrival is already coalesced; this removes the last per-message DB round trip.

**`r-thru-durable`** (2,000/s offered, 5 ms handler, one run each, first-cut build): both hold 2,000/s; total p50 13.59 → 13.60 ms. Not re-run on the final build — the coalescer's lone-completion path is the pre-existing one, so trickle latency is unchanged by construction.

## Tests

| | Result |
|---|---|
| `CoreTests/Runtime/WorkerQueues/batched_mark_as_handled_3711` — completions during a flush share the next flush; **`CompleteAsync` does not return before the UPDATE**; lone completion flushed immediately on the per-envelope path; pile-up larger than the batch size flushed in chunks; transactional-middleware skip; **failed batch → per-envelope fallback, completions still released**; `MarkAsHandledBatchSize = 1` opt-out; batch-message children in one flush | 8/8 |
| The CI-failing `PolecatTests.Bugs.Bug_discard_after_failed_outbox_commit` + `MartenTests` inbox-state classes (`Bug_discard_after_failed_outbox_commit`, `end_to_end_with_persistence`, `idempotency_check_in_marten_envelope_transaction`, `batch_processing`, `Bug_2576…`) | 9/9 |
| Full `CoreTests` (net9.0) | 2,498 passed / 0 failed / 2 skipped |
| `PersistenceTests` `durability_with_local`, `application_of_transaction_middleware`, `persistence_provider_precedence_permutations` | 12/12 |
| `Wolverine.RabbitMQ.Tests` `durable_compliance` + `drain_wait_for_prefetch_repeated_stop` | 23/23 |
| `PostgresqlTests` local transport compliance, table-partitioning compliance, message store tests, partitioned inbox recovery | 121/121 |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean (first cut; re-running on the final commit) |

No changes to ack semantics (per the issue's acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
