### PR TITLE
GH-4022: reject ProcessInline() on a local queue instead of throwing at the first send

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -207,6 +207,11 @@ As of Wolverine 6.30, these combinations are no longer silently accepted:
   is preferable to quietly not honoring it.
 * `ProcessInline()` together with an explicit parallelism or `BufferingLimits` logs a warning at startup, and
   Wolverine normalizes `MaxDegreeOfParallelism` to 1.
+* `ProcessInline()` on a [local queue](/guide/messaging/transports/local) throws a `NotSupportedException`
+  right where you call it, because a local queue has no transport listener to be inline with — the queue
+  itself *is* the local execution block. A local queue that reaches `Inline` through one of the lazily
+  resolved configuration points (`LocalQueueFor<T>()`, `IConfigureLocalQueue`) throws an
+  `InvalidListenerConfigurationException` at bootstrap instead.
 
 That normalization also removes an order dependency: `.MaximumParallelMessages(20).ProcessInline()` and
 `.ProcessInline().MaximumParallelMessages(20)` now leave the endpoint in exactly the same state. The

--- a/docs/guide/messaging/transports/local.md
+++ b/docs/guide/messaging/transports/local.md
@@ -207,6 +207,19 @@ using var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EnqueueSamples.cs#L25-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_local_queues' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: warning
+A local queue can only be `BufferedInMemory` (the default) or `Durable`. `ProcessInline()` means "execute
+the message on the transport's own listening callback instead of queueing it", and a local queue has no
+transport listener — the queue itself *is* Wolverine's local execution block, so there would be nothing
+left to run the message. As of Wolverine 6.30 `ProcessInline()` throws a `NotSupportedException` right
+where you call it on a local queue, and a local queue that reaches `Inline` some other way (through
+`LocalQueueFor<T>()` or `IConfigureLocalQueue`, whose queues resolve lazily) stops the host from starting
+with an `InvalidListenerConfigurationException`. Earlier versions accepted the configuration and then threw
+a bare, message-less `NotSupportedException` the first time anything sent to the queue.
+
+If what you wanted was one message at a time, use `Sequential()`.
+:::
+
 ## Using IConfigureLocalQueue to Configure Local Queues <Badge type="tip" text="3.7" />
 
 ::: info

--- a/src/Testing/CoreTests/Configuration/configuring_endpoints.cs
+++ b/src/Testing/CoreTests/Configuration/configuring_endpoints.cs
@@ -28,7 +28,9 @@ public class configuring_endpoints : IDisposable
             opts.ListenForMessagesFrom("local://two").MaximumParallelMessages(11);
             opts.ListenForMessagesFrom("local://three").UseDurableInbox();
             opts.ListenForMessagesFrom("local://four").UseDurableInbox().BufferedInMemory();
-            opts.ListenForMessagesFrom("local://five").ProcessInline().TelemetryEnabled(false);
+            // NOTE: no ProcessInline() here. A local queue cannot be Inline -- see
+            // process_inline_is_not_allowed_on_a_local_queue below.
+            opts.ListenForMessagesFrom("local://five").TelemetryEnabled(false);
 
             opts.ListenForMessagesFrom("local://durable1").UseDurableInbox(new BufferingLimits(500, 250));
             opts.ListenForMessagesFrom("local://buffered1").BufferedInMemory(new BufferingLimits(250, 100));
@@ -205,12 +207,15 @@ public class configuring_endpoints : IDisposable
     }
 
     [Fact]
-    public void configure_process_inline()
+    public void process_inline_is_not_allowed_on_a_local_queue()
     {
+        // GH-4022. Used to be accepted here and then throw a bare, message-less NotSupportedException out
+        // of LocalQueue.BuildAgent() the first time anything sent to the queue.
+        var ex = Should.Throw<NotSupportedException>(() =>
+            theOptions.ListenForMessagesFrom("local://five").ProcessInline());
 
-        localQueue("five")
-            .Mode
-            .ShouldBe(EndpointMode.Inline);
+        ex.Message.ShouldContain("ProcessInline");
+        ex.Message.ShouldContain("BufferedInMemory");
     }
 
     [Fact]

--- a/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
+++ b/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
@@ -4,6 +4,7 @@ using Shouldly;
 using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
+using Wolverine.Transports.Local;
 using Wolverine.Transports.Stub;
 using Xunit;
 
@@ -173,6 +174,74 @@ public class listener_configuration_validation
         ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
     }
 
+    // GH-4022. A local queue can only be BufferedInMemory or Durable -- it has no transport
+    // listener for Inline to execute a message on.
+    [Fact]
+    public void process_inline_on_a_local_queue_throws_eagerly()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(_ => { }).Build();
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+
+        // Used to be accepted here, then throw a bare, message-less NotSupportedException out of
+        // LocalQueue.BuildAgent() the first time anything sent to the queue.
+        var ex = Should.Throw<NotSupportedException>(() => options.LocalQueue("inline-local").ProcessInline());
+
+        ex.Message.ShouldContain("ProcessInline");
+        ex.Message.ShouldContain("BufferedInMemory");
+        ex.Message.ShouldContain("UseDurableInbox");
+    }
+
+    [Fact]
+    public void a_local_queue_in_inline_mode_is_fatal()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(_ => { }).Build();
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        // Assigning the mode directly gets around the eager guard on ProcessInline()
+        var queue = options.Transports.GetOrCreate<LocalTransport>().QueueFor("inline-local");
+        queue.Mode = EndpointMode.Inline;
+        queue.Compile(runtime);
+
+        var problem = ListenerConfigurationValidator.Validate(queue).Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+        problem.Message.ShouldContain("ProcessInline()");
+        problem.Message.ShouldContain("local://inline-local");
+    }
+
+    [Fact]
+    public async Task a_lazily_configured_inline_local_queue_stops_the_host_from_starting()
+    {
+        // LocalQueueFor<T>() resolves its queue lazily, so ProcessInline()'s eager guard never sees a
+        // LocalQueue and the bootstrap validation is the only thing standing between this configuration
+        // and a message-less NotSupportedException at the first send.
+        var ex = await Should.ThrowAsync<InvalidListenerConfigurationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+            {
+                opts.LocalQueueFor<InlineLocalQueueMessage>().ProcessInline();
+            }).StartAsync();
+        });
+
+        ex.Message.ShouldContain("ProcessInline()");
+        ex.Message.ShouldContain("local queue");
+    }
+
+    [Fact]
+    public void a_normal_local_queue_has_no_problems()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(_ => { }).Build();
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var queue = options.Transports.GetOrCreate<LocalTransport>().QueueFor("buffered-local");
+        queue.Compile(runtime);
+
+        queue.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        ListenerConfigurationValidator.Validate(queue).ShouldBeEmpty();
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -201,3 +270,5 @@ public class listener_configuration_validation
             .Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
     }
 }
+
+public record InlineLocalQueueMessage(string Name);

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -403,9 +403,16 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
     /// Sequential(), and PartitionProcessingByGroupId() inapplicable -- Wolverine normalizes
     /// MaxDegreeOfParallelism to 1 at bootstrap for an Inline endpoint and rejects partitioned
     /// processing outright. See GH-3712.
+    ///
+    /// Not valid on a local queue, which has no transport listener to be inline with -- that combination
+    /// throws here rather than at the first send. See GH-4022.
     /// </summary>
     public TSelf ProcessInline()
     {
+        if (_endpoint is LocalQueue)
+            throw new NotSupportedException(
+                $"Wolverine cannot use the {nameof(ProcessInline)} option for local queues. Inline means \"execute the message on the transport's own listening callback instead of queueing it\", and a local queue has no transport listener -- the queue itself *is* Wolverine's local execution block, so there would be nothing left to run the message. Use {nameof(BufferedInMemory)}() (the default) or {nameof(UseDurableInbox)}() instead, plus {nameof(Sequential)}() if what you wanted was one message at a time.");
+
         // GH-3712. The MaxDegreeOfParallelism = 1 clamp deliberately does NOT happen here. Clamping
         // eagerly made the endpoint's final state depend on whether ProcessInline() was called before
         // or after MaximumParallelMessages(); Endpoint.Compile() now normalizes it for every Inline

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -65,6 +65,25 @@ internal static class ListenerConfigurationValidator
 
         var name = describe(endpoint);
 
+        if (endpoint is LocalQueue)
+        {
+            // GH-4022. ListenerConfiguration.ProcessInline() refuses this eagerly, but only when it was handed the
+            // queue itself. LocalQueueFor<T>()/IConfigureLocalQueue resolve their queue lazily through
+            // LocalTransport.ConfigureQueueFor(), so the eager guard cannot see a LocalQueue there and the
+            // mode is not settled until Compile(). Catch that path here instead of at LocalQueue.BuildAgent(),
+            // which does not run until something first sends to the queue.
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Fatal,
+                $"Invalid listener configuration for {name}: ProcessInline() was configured on a local queue. Inline means " +
+                "\"execute the message on the transport's own listening callback instead of queueing it\", and a local queue has no " +
+                "transport listener -- the queue itself is Wolverine's local execution block, so there would be nothing left to run " +
+                "the message. Use BufferedInMemory() (the default for a local queue) or UseDurableInbox(), plus Sequential() if what " +
+                "you wanted was one message at a time.");
+
+            // Everything below is about settings an Inline endpoint merely ignores. This queue is not
+            // going to start at all, so there is no point piling warnings on top of the reason why.
+            yield break;
+        }
+
         if (endpoint.GroupShardingSlotNumber.HasValue)
         {
             yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Fatal,

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -578,6 +578,15 @@ public partial class WolverineRuntime
             }
         }
 
+        // GH-3712. Say out loud when a listening endpoint's mode ignores the settings it was given --
+        // most importantly Inline together with PartitionProcessingByGroupId(), which silently dropped
+        // the group id ordering guarantee. Runs even when the external transports are stubbed, so a
+        // test host surfaces the same misconfiguration a deployed one would.
+        //
+        // Deliberately ahead of the sending agents below: an Inline local queue cannot build one at all,
+        // and LocalQueue.BuildAgent()'s throw is a much worse error message than the validator's. See GH-4022.
+        validateListenerConfiguration();
+
         foreach (var transport in Options.Transports)
         {
             // A transport that failed to initialize under ContinueOnFailures has no usable endpoints
@@ -595,12 +604,6 @@ public partial class WolverineRuntime
                 _endpoints.StoreSendingAgent(agent);
             }
         }
-
-        // GH-3712. Say out loud when a listening endpoint's mode ignores the settings it was given --
-        // most importantly Inline together with PartitionProcessingByGroupId(), which silently dropped
-        // the group id ordering guarantee. Runs even when the external transports are stubbed, so a
-        // test host surfaces the same misconfiguration a deployed one would.
-        validateListenerConfiguration();
 
         if (!Options.ExternalTransportsAreStubbed)
         {

--- a/src/Wolverine/Transports/Local/LocalQueue.cs
+++ b/src/Wolverine/Transports/Local/LocalQueue.cs
@@ -40,12 +40,14 @@ public class LocalQueue : Endpoint
 
     public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException(
+            $"{this} does not have a transport listener. A local queue is fed by in-process sends rather than by an external broker, so its ISendingAgent is both ends of it. See BuildAgent().");
     }
 
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException(
+            $"{this} does not have a transport sender. A local queue's ISendingAgent enqueues directly into its own execution block. See BuildAgent().");
     }
 
     protected internal override ISendingAgent StartSending(IWolverineRuntime runtime, Uri? replyUri)
@@ -67,8 +69,14 @@ public class LocalQueue : Endpoint
 
             EndpointMode.Durable => new DurableLocalQueue(this, (WolverineRuntime)runtime),
 
-            EndpointMode.Inline => throw new NotSupportedException(),
-            _ => throw new InvalidOperationException()
+            // GH-4022. Normally unreachable: ListenerConfiguration.ProcessInline() refuses a local queue eagerly, and
+            // ListenerConfigurationValidator catches the lazily-configured queues at bootstrap. Kept as a
+            // real message rather than a bare throw because this is the last line of defense for anything
+            // that assigns Endpoint.Mode directly.
+            EndpointMode.Inline => throw new NotSupportedException(
+                $"{this} cannot run in {nameof(EndpointMode)}.{nameof(EndpointMode.Inline)}. Inline means \"execute the message on the transport's own listening callback instead of queueing it\", and a local queue has no transport listener -- the queue itself is Wolverine's local execution block. Use {nameof(EndpointMode.BufferedInMemory)} or {nameof(EndpointMode.Durable)}."),
+
+            _ => throw new InvalidOperationException($"Unknown {nameof(EndpointMode)} value '{Mode}' on {this}")
         };
     }
 


### PR DESCRIPTION
Closes #4022.

A local queue configured with `ProcessInline()` was accepted in silence and then threw a bare, message-less `NotSupportedException` out of `LocalQueue.BuildAgent()` — in practice at the first send to that queue, with nothing in the message pointing back at the configuration line that caused it.

`Inline` means "execute the message on the transport's own listening callback instead of queueing it", and a local queue has no transport listener — `BuildListenerAsync()` throws by design, and the queue itself *is* Wolverine's local execution block, so there would be nothing left to run the message. The combination has no valid interpretation, so it is now refused at the earliest point that can see it.

This is the local-queue instance of the problem #4017 (GH-3712) fixed for external listeners, which deliberately left this case alone to keep its scope tight. It builds directly on that PR's `ListenerConfigurationValidator`.

## What changed

* **`ListenerConfiguration.ProcessInline()` throws eagerly** when `_endpoint is LocalQueue`, with a message naming the alternatives. This matches how `ExclusiveNodeWithParallelism()` and `ListenWithStrictOrdering()` already guard the same way, and it puts the throw on the user's own configuration line.
* **`ListenerConfigurationValidator` reports `LocalQueue` + `Inline` as `Fatal`**, so the host refuses to start. `validateListenerConfiguration()` moves ahead of the `AutoStartSendingAgent()`/`StartSending()` loop in `startMessagingTransportsAsync()` — an Inline local queue cannot build a sending agent at all, so without the move `BuildAgent()` threw first and the validator never got a word in.
* **`LocalQueue`'s three `NotSupportedException`s say what they mean** (`BuildAgent`, `BuildListenerAsync`, `CreateSender`), as the last line of defense for anything assigning `Endpoint.Mode` directly.

## The two checks are not redundant

Worth stating explicitly, because the natural review reaction is that one of them can be deleted:

The eager guard **cannot** cover `LocalQueueFor<T>()` or `IConfigureLocalQueue`. Both resolve their queue lazily through `LocalTransport.ConfigureQueueFor()`, which builds a `LocalQueueConfiguration(Func<LocalQueue>)` — `_endpoint` is null at call time, so there is no `LocalQueue` for the guard to see. Those paths reach the validator and nothing else.

Conversely the validator alone would give a worse error for the common direct case, where the eager throw lands on the offending configuration line instead of at bootstrap.

## Does the new bootstrap throw break existing apps?

The two ways a global policy could force `Inline` onto a local queue were both checked, and neither reaches one:

* **`opts.Policies.AllListeners(x => x.ProcessInline())`** — `IPolicies.AllListeners` (`WolverineOptions.Policies.cs:118`) early-returns for `e is LocalQueue` before it ever constructs the `ListenerConfiguration`, so a global inline policy never touches a local queue through either check.
* **`DurabilityMode.Serverless`** — `ServerlessEndpointsMustBeInlinePolicy` does force `Mode = Inline` on every endpoint, but Serverless calls `Options.Transports.RemoveLocal()` first, so there are no local queues left for it to hit.

The only configurations this newly rejects are the ones that were already broken, just later and less legibly.

## Test fallout

`CoreTests.Configuration.configuring_endpoints` configured exactly this shape on `local://five`, and only passed because that fixture calls `.Build()` and never `StartAsync()`. `local://five` drops the `ProcessInline()`, and the old `configure_process_inline` assertion becomes `process_inline_is_not_allowed_on_a_local_queue`.

Four tests added to `listener_configuration_validation.cs`: the eager throw, the validator's fatal verdict, the lazily-configured queue stopping the host from starting (which is what caught the ordering problem above), and a normal local queue still validating clean.

## Verification

* `dotnet build wolverine.slnx -c Release -f net9.0` — succeeded, 0 warnings, 0 errors
* Full CoreTests (`dotnet run -f net9.0`) — **2507 total, 0 failed, 2 skipped**, 2m44s

Both run against the current `origin/main` (`7de86288a`), so they include #4014 and #4016 as well as #4017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
