### PR TITLE
GH-4026: batched inbox arrival for durable Kafka topic groups, NATS JetStream and Pulsar listeners

### DIFF
--- a/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
+++ b/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
@@ -15,6 +15,7 @@
         <ProjectReference Include="..\..\Transports\Kafka\Wolverine.Kafka\Wolverine.Kafka.csproj" />
         <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
         <ProjectReference Include="..\..\Transports\NATS\Wolverine.Nats\Wolverine.Nats.csproj" />
+        <ProjectReference Include="..\..\Transports\Pulsar\Wolverine.Pulsar\Wolverine.Pulsar.csproj" />
         <ProjectReference Include="..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
         <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>

--- a/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
+++ b/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Transports\Kafka\Wolverine.Kafka\Wolverine.Kafka.csproj" />
         <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
+        <ProjectReference Include="..\..\Transports\NATS\Wolverine.Nats\Wolverine.Nats.csproj" />
         <ProjectReference Include="..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
         <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>

--- a/src/Testing/KafkaPerfRig/Program.cs
+++ b/src/Testing/KafkaPerfRig/Program.cs
@@ -67,9 +67,17 @@ switch (role)
         await NativeRabbitTwin.RunPublisherAsync(cfg);
         break;
 
+    case "nats-consumer":
+        await WolverineNats.RunConsumerAsync(cfg);
+        break;
+
+    case "nats-publisher":
+        await WolverineNats.RunPublisherAsync(cfg);
+        break;
+
     default:
         Console.WriteLine(
-            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit>-<consumer|publisher>");
+            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit|nats>-<consumer|publisher>");
         Console.WriteLine("Configuration via RIG_* environment variables; see RigConfig.cs and rig.sh.");
         return 1;
 }

--- a/src/Testing/KafkaPerfRig/Program.cs
+++ b/src/Testing/KafkaPerfRig/Program.cs
@@ -75,9 +75,17 @@ switch (role)
         await WolverineNats.RunPublisherAsync(cfg);
         break;
 
+    case "pulsar-consumer":
+        await WolverinePulsar.RunConsumerAsync(cfg);
+        break;
+
+    case "pulsar-publisher":
+        await WolverinePulsar.RunPublisherAsync(cfg);
+        break;
+
     default:
         Console.WriteLine(
-            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit|nats>-<consumer|publisher>");
+            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit|nats|pulsar>-<consumer|publisher>");
         Console.WriteLine("Configuration via RIG_* environment variables; see RigConfig.cs and rig.sh.");
         return 1;
 }

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -78,6 +78,14 @@ public class RigConfig
     public string NatsSmallSubject => $"{NatsSubjectPrefix}.small";
     public string NatsLargeSubject => $"{NatsSubjectPrefix}.large";
 
+    // GH-4026: concurrent publish loops in max-throughput mode (rate < 0). 1 = the original single loop.
+    public int Publishers { get; } = envInt("RIG_PUBLISHERS", 1);
+
+    // --- Pulsar (GH-4026) ---
+    public string PulsarUrl { get; } = env("RIG_PULSAR_URL", "pulsar://localhost:6650");
+    public string PulsarSmallTopic => $"persistent://public/default/rig-small-{RunId}";
+    public string PulsarLargeTopic => $"persistent://public/default/rig-large-{RunId}";
+
     private static string env(string key, string fallback)
     {
         return Environment.GetEnvironmentVariable(key) is { Length: > 0 } value ? value : fallback;

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -69,6 +69,15 @@ public class RigConfig
     // native Rabbit twin prefetch; match Wolverine's listener PreFetchCount default of 100
     public ushort RabbitPrefetch { get; } = (ushort)envInt("RIG_RABBIT_PREFETCH", 100);
 
+    // --- NATS JetStream (GH-4026) ---
+    public string NatsUrl { get; } = env("RIG_NATS_URL", "nats://localhost:4222");
+    // Stream names are uppercase identifiers; subjects are dotted. Both suffixed with the run id so every
+    // run starts on a fresh stream + consumers.
+    public string NatsStream => $"RIG_{RunId.ToUpperInvariant().Replace('-', '_')}";
+    public string NatsSubjectPrefix => $"rig.{RunId}";
+    public string NatsSmallSubject => $"{NatsSubjectPrefix}.small";
+    public string NatsLargeSubject => $"{NatsSubjectPrefix}.large";
+
     private static string env(string key, string fallback)
     {
         return Environment.GetEnvironmentVariable(key) is { Length: > 0 } value ? value : fallback;

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -52,6 +52,15 @@ public class RigConfig
     // GH-3492 RO6: per-endpoint consumer dispatch concurrency. 0 leaves the transport-wide default.
     public int DispatchConcurrency { get; } = envInt("RIG_DISPATCH_CONCURRENCY", 0);
 
+    // GH-4026: listen to both Kafka topics through ONE KafkaTopicGroup consumer (ListenToKafkaTopics)
+    // instead of one KafkaListener per topic.
+    public bool KafkaTopicGroup { get; } = envInt("RIG_KAFKA_TOPIC_GROUP", 0) == 1;
+
+    // GH-4026: MaximumMessagesToReceive for durable Kafka listeners; 0 leaves the default (100).
+    // 1 is the pre-GH-4026 topic-group behavior (one record per inbox insert), so a cell pair of
+    // RIG_MAX_RECEIVE=1 vs default measures the drain inside one build.
+    public int MaxReceive { get; } = envInt("RIG_MAX_RECEIVE", 0);
+
     // --- RabbitMQ (GH-3492) ---
     public string RabbitUri { get; } = env("RIG_RABBIT_URI", "amqp://guest:guest@localhost:5672");
     public string SmallQueue => $"rig-small-{RunId}";

--- a/src/Testing/KafkaPerfRig/WolverineConsumer.cs
+++ b/src/Testing/KafkaPerfRig/WolverineConsumer.cs
@@ -34,8 +34,15 @@ public static class WolverineConsumer
                     opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
                 }
 
-                configureListener(opts.ListenToKafkaTopic(cfg.SmallTopic), cfg);
-                configureListener(opts.ListenToKafkaTopic(cfg.LargeTopic), cfg);
+                if (cfg.KafkaTopicGroup)
+                {
+                    configureTopicGroup(opts.ListenToKafkaTopics(cfg.SmallTopic, cfg.LargeTopic), cfg);
+                }
+                else
+                {
+                    configureListener(opts.ListenToKafkaTopic(cfg.SmallTopic), cfg);
+                    configureListener(opts.ListenToKafkaTopic(cfg.LargeTopic), cfg);
+                }
             });
 
         using var host = builder.Build();
@@ -80,6 +87,41 @@ public static class WolverineConsumer
         if (cfg.MaxParallel > 0)
         {
             listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        if (cfg.MaxReceive > 0)
+        {
+            listener.MaximumMessagesToReceive(cfg.MaxReceive);
+        }
+    }
+
+    // GH-4026: no StampingKafkaMapper here (the topic-group configuration has no UseInterop), so the
+    // rig's t2 stage falls back to handler entry; throughput and handler/total stages are unaffected.
+    private static void configureTopicGroup(KafkaTopicGroupListenerConfiguration listener, RigConfig cfg)
+    {
+        listener.Specification(spec => spec.NumPartitions = (short)cfg.Partitions);
+
+        switch (cfg.ConsumerMode)
+        {
+            case "durable":
+                listener.UseDurableInbox();
+                break;
+            case "inline":
+                listener.ProcessInline();
+                break;
+            default:
+                listener.BufferedInMemory();
+                break;
+        }
+
+        if (cfg.MaxParallel > 0)
+        {
+            listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        if (cfg.MaxReceive > 0)
+        {
+            listener.MaximumMessagesToReceive(cfg.MaxReceive);
         }
     }
 }

--- a/src/Testing/KafkaPerfRig/WolverineNats.cs
+++ b/src/Testing/KafkaPerfRig/WolverineNats.cs
@@ -1,0 +1,132 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine;
+using Wolverine.Nats;
+using Wolverine.Nats.Configuration;
+using Wolverine.Postgresql;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// NATS JetStream twins of WolverineRabbit for GH-4026, sharing the corpus, rate loops, stage clock,
+/// and recorder. No stamping mapper, so the t2 stage falls back to handler entry; throughput and the
+/// handler/total stages are unaffected.
+/// </summary>
+public static class WolverineNats
+{
+    public static async Task RunConsumerAsync(RigConfig cfg)
+    {
+        RigHandlerSettings.HandlerMs = cfg.HandlerMs;
+        RigHandlerSettings.SequenceByGame = cfg.Sequencing == "semaphore";
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+                opts.Discovery.IncludeType<RigHandlers>();
+
+                opts.UseNats(cfg.NatsUrl)
+                    .AutoProvision()
+                    .UseJetStream(_ => { })
+                    .DefineWorkQueueStream(cfg.NatsStream, _ => { }, $"{cfg.NatsSubjectPrefix}.*");
+
+                if (cfg.ConsumerMode == "durable")
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                }
+
+                configureListener(opts.ListenToNatsSubject(cfg.NatsSmallSubject)
+                    .UseJetStream(cfg.NatsStream, $"rig-small-{cfg.RunId}"), cfg);
+                configureListener(opts.ListenToNatsSubject(cfg.NatsLargeSubject)
+                    .UseJetStream(cfg.NatsStream, $"rig-large-{cfg.RunId}"), cfg);
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine nats consumer up: {cfg.Describe()}");
+
+        await host.WaitForShutdownAsync();
+
+        StageRecorder.Dump(cfg.OutDir, "nats-consumer", new
+        {
+            harness = "wolverine-nats",
+            mode = cfg.ConsumerMode,
+            send = cfg.SendMode,
+            batchSize = cfg.BatchSize,
+            batchTimeoutMs = cfg.BatchTimeoutMs,
+            sequencing = cfg.Sequencing,
+            handlerMs = cfg.HandlerMs,
+            maxParallel = cfg.MaxParallel,
+            maxReceive = cfg.MaxReceive
+        });
+    }
+
+    private static void configureListener(NatsListenerConfiguration listener, RigConfig cfg)
+    {
+        switch (cfg.ConsumerMode)
+        {
+            case "durable":
+                listener.UseDurableInbox();
+                break;
+            case "inline":
+                listener.ProcessInline();
+                break;
+            default:
+                listener.BufferedInMemory();
+                break;
+        }
+
+        if (cfg.MaxParallel > 0)
+        {
+            listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        if (cfg.MaxReceive > 0)
+        {
+            listener.MaximumMessagesToReceive(cfg.MaxReceive);
+        }
+    }
+
+    public static async Task RunPublisherAsync(RigConfig cfg)
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+
+                opts.UseNats(cfg.NatsUrl)
+                    .AutoProvision()
+                    .UseJetStream(_ => { })
+                    .DefineWorkQueueStream(cfg.NatsStream, _ => { }, $"{cfg.NatsSubjectPrefix}.*");
+
+                // Inline sends so every publish is a real JetStream publish; the receive side is what
+                // these cells measure
+                opts.PublishMessage<SmallEvent>().ToNatsSubject(cfg.NatsSmallSubject).SendInline();
+                opts.PublishMessage<LargeEvent>().ToNatsSubject(cfg.NatsLargeSubject).SendInline();
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine nats publisher up: {cfg.Describe()}");
+
+        var bus = host.MessageBus();
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new SmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small },
+                new DeliveryOptions { GroupId = gameId }).AsTask(),
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new LargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large },
+                new DeliveryOptions { GroupId = gameId }).AsTask());
+
+        Console.WriteLine($"[rig] nats publisher done: {counters.small} small, {counters.large} large. Draining...");
+
+        await Task.Delay(3000);
+        await host.StopAsync();
+    }
+}

--- a/src/Testing/KafkaPerfRig/WolverinePublisher.cs
+++ b/src/Testing/KafkaPerfRig/WolverinePublisher.cs
@@ -85,30 +85,42 @@ public static class PublishLoops
             }
 
             // rate < 0 = max-throughput mode: publish as fast as the publisher can sustain.
-            // The consumer-side sustained receive rate is the measurement.
+            // The consumer-side sustained receive rate is the measurement. GH-4026: RIG_PUBLISHERS
+            // runs that many concurrent loops, for transports whose single awaited publish is slow
+            // enough (Pulsar: ~2ms per produce) that one loop can't saturate the consumer.
             if (rate < 0)
             {
-                var sent = 0;
-                while (!cancellation.IsCancellationRequested)
+                var publishers = Math.Max(1, cfg.Publishers);
+                var counts = new int[publishers];
+
+                async Task loopOneAsync(int index)
                 {
-                    var gameId = games[sent % games.Length];
-                    try
+                    var sent = 0;
+                    while (!cancellation.IsCancellationRequested)
                     {
-                        await publish(gameId, sent, Stopwatch.GetTimestamp(), inWarmup());
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        break;
+                        var seq = sent * publishers + index;
+                        var gameId = games[seq % games.Length];
+                        try
+                        {
+                            await publish(gameId, seq, Stopwatch.GetTimestamp(), inWarmup());
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+
+                        sent++;
+                        if (index == 0 && sent % 50_000 == 0)
+                        {
+                            Console.WriteLine($"[rig] published {sent * publishers} (approx, across {publishers} loops)");
+                        }
                     }
 
-                    sent++;
-                    if (sent % 50_000 == 0)
-                    {
-                        Console.WriteLine($"[rig] published {sent}");
-                    }
+                    counts[index] = sent;
                 }
 
-                return sent;
+                await Task.WhenAll(Enumerable.Range(0, publishers).Select(loopOneAsync));
+                return counts.Sum();
             }
 
             var count = 0;

--- a/src/Testing/KafkaPerfRig/WolverinePulsar.cs
+++ b/src/Testing/KafkaPerfRig/WolverinePulsar.cs
@@ -1,0 +1,123 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Pulsar;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// Pulsar twins of WolverineRabbit for GH-4026, sharing the corpus, rate loops, stage clock, and
+/// recorder. No stamping mapper, so the t2 stage falls back to handler entry; throughput and the
+/// handler/total stages are unaffected.
+/// </summary>
+public static class WolverinePulsar
+{
+    public static async Task RunConsumerAsync(RigConfig cfg)
+    {
+        RigHandlerSettings.HandlerMs = cfg.HandlerMs;
+        RigHandlerSettings.SequenceByGame = cfg.Sequencing == "semaphore";
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+                opts.Discovery.IncludeType<RigHandlers>();
+
+                opts.UsePulsar(b => b.ServiceUrl(new Uri(cfg.PulsarUrl)));
+
+                if (cfg.ConsumerMode == "durable")
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                }
+
+                configureListener(opts.ListenToPulsarTopic(cfg.PulsarSmallTopic), cfg);
+                configureListener(opts.ListenToPulsarTopic(cfg.PulsarLargeTopic), cfg);
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine pulsar consumer up: {cfg.Describe()}");
+
+        await host.WaitForShutdownAsync();
+
+        StageRecorder.Dump(cfg.OutDir, "pulsar-consumer", new
+        {
+            harness = "wolverine-pulsar",
+            mode = cfg.ConsumerMode,
+            send = cfg.SendMode,
+            batchSize = cfg.BatchSize,
+            batchTimeoutMs = cfg.BatchTimeoutMs,
+            sequencing = cfg.Sequencing,
+            handlerMs = cfg.HandlerMs,
+            maxParallel = cfg.MaxParallel,
+            maxReceive = cfg.MaxReceive
+        });
+    }
+
+    private static void configureListener(PulsarListenerConfiguration listener, RigConfig cfg)
+    {
+        switch (cfg.ConsumerMode)
+        {
+            case "durable":
+                listener.UseDurableInbox();
+                break;
+            case "inline":
+                listener.ProcessInline();
+                break;
+            default:
+                listener.BufferedInMemory();
+                break;
+        }
+
+        if (cfg.MaxParallel > 0)
+        {
+            listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        if (cfg.MaxReceive > 0)
+        {
+            listener.MaximumMessagesToReceive(cfg.MaxReceive);
+        }
+    }
+
+    public static async Task RunPublisherAsync(RigConfig cfg)
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+
+                opts.UsePulsar(b => b.ServiceUrl(new Uri(cfg.PulsarUrl)));
+
+                // Inline sends so every publish is a real Pulsar produce; the receive side is what these
+                // cells measure
+                opts.PublishMessage<SmallEvent>().ToPulsarTopic(cfg.PulsarSmallTopic).SendInline();
+                opts.PublishMessage<LargeEvent>().ToPulsarTopic(cfg.PulsarLargeTopic).SendInline();
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine pulsar publisher up: {cfg.Describe()}");
+
+        var bus = host.MessageBus();
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new SmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small },
+                new DeliveryOptions { GroupId = gameId }).AsTask(),
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new LargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large },
+                new DeliveryOptions { GroupId = gameId }).AsTask());
+
+        Console.WriteLine($"[rig] pulsar publisher done: {counters.small} small, {counters.large} large. Draining...");
+
+        await Task.Delay(3000);
+        await host.StopAsync();
+    }
+}

--- a/src/Testing/KafkaPerfRig/cells-nats.sh
+++ b/src/Testing/KafkaPerfRig/cells-nats.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# GH-4026 NATS JetStream cells — same shape as cells-rabbit.sh, nats harness.
+# Requires: docker compose up -d nats postgresql
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WARMUP="${CELL_WARMUP:-20}"
+DURATION="${CELL_DURATION:-120}"
+
+run_cell() {
+  local name="$1" harness="$2"
+  shift 2
+  if [[ "${SELECTED:-0}" == "1" ]] && ! printf '%s\n' "${CELLS[@]}" | grep -qx "$name"; then
+    return 0
+  fi
+  echo ""
+  echo "=================== CELL: $name ==================="
+  RIG_WARMUP_S="$WARMUP" RIG_DURATION_S="$DURATION" ./rig.sh "$harness" "$name" "$@" || echo "[cells] $name FAILED"
+}
+
+if [[ $# -gt 0 ]]; then
+  SELECTED=1
+  CELLS=("$@")
+else
+  SELECTED=0
+  CELLS=()
+fi
+
+# --- max-throughput cells (uncapped publisher, no handler work) ---
+
+NMAX="RIG_SMALL_RATE=-1 RIG_LARGE_RATE=0 RIG_HANDLER_MS=0 RIG_SEQ=none RIG_SEND_MODE=inline RIG_WARMUP_S=15 RIG_DURATION_S=45"
+
+run_cell n-max-buffered    nats $NMAX RIG_MODE=buffered
+# GH-4026: -1 pins MaximumMessagesToReceive=1, which is exactly the pre-GH-4026 JetStream durable path
+# (one message per inbox insert); n-max-durable is the 5ms / MaximumMessagesToReceive window.
+run_cell n-max-durable-1   nats $NMAX RIG_MODE=durable RIG_MAX_RECEIVE=1
+run_cell n-max-durable     nats $NMAX RIG_MODE=durable

--- a/src/Testing/KafkaPerfRig/cells-pulsar.sh
+++ b/src/Testing/KafkaPerfRig/cells-pulsar.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# GH-4026 Pulsar cells — same shape as cells-rabbit.sh, pulsar harness.
+# Requires: docker compose up -d pulsar postgresql
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WARMUP="${CELL_WARMUP:-20}"
+DURATION="${CELL_DURATION:-120}"
+
+run_cell() {
+  local name="$1" harness="$2"
+  shift 2
+  if [[ "${SELECTED:-0}" == "1" ]] && ! printf '%s\n' "${CELLS[@]}" | grep -qx "$name"; then
+    return 0
+  fi
+  echo ""
+  echo "=================== CELL: $name ==================="
+  RIG_WARMUP_S="$WARMUP" RIG_DURATION_S="$DURATION" ./rig.sh "$harness" "$name" "$@" || echo "[cells] $name FAILED"
+}
+
+if [[ $# -gt 0 ]]; then
+  SELECTED=1
+  CELLS=("$@")
+else
+  SELECTED=0
+  CELLS=()
+fi
+
+# --- max-throughput cells (uncapped publisher, no handler work) ---
+
+# RIG_PUBLISHERS=32: one awaited DotPulsar produce is ~2ms, so a single loop tops out around 450/s and
+# publisher-bounds every cell (measured 2026-08-23: buffered, durable-1 and durable all ~450/s with
+# published == consumed). 32 concurrent loops push the publisher well past the consumer.
+PMAX="RIG_SMALL_RATE=-1 RIG_LARGE_RATE=0 RIG_HANDLER_MS=0 RIG_SEQ=none RIG_SEND_MODE=inline RIG_PUBLISHERS=32 RIG_WARMUP_S=15 RIG_DURATION_S=45"
+
+run_cell p-max-buffered    pulsar $PMAX RIG_MODE=buffered
+# GH-4026: -1 pins MaximumMessagesToReceive=1, which is exactly the pre-GH-4026 Pulsar durable path
+# (one message per inbox insert); p-max-durable is the 5ms / MaximumMessagesToReceive window.
+run_cell p-max-durable-1   pulsar $PMAX RIG_MODE=durable RIG_MAX_RECEIVE=1
+run_cell p-max-durable     pulsar $PMAX RIG_MODE=durable

--- a/src/Testing/KafkaPerfRig/cells.sh
+++ b/src/Testing/KafkaPerfRig/cells.sh
@@ -73,6 +73,11 @@ run_cell max-buffered       wolverine $MAX
 run_cell max-native         native    $MAX
 run_cell max-durable        wolverine $MAX RIG_MODE=durable
 
+# GH-4026: one KafkaTopicGroup consumer over both topics. -group-1 pins MaximumMessagesToReceive=1,
+# which is exactly the pre-GH-4026 topic-group path (one record per inbox insert); -group is the drain.
+run_cell max-durable-group-1 wolverine $MAX RIG_MODE=durable RIG_KAFKA_TOPIC_GROUP=1 RIG_MAX_RECEIVE=1
+run_cell max-durable-group   wolverine $MAX RIG_MODE=durable RIG_KAFKA_TOPIC_GROUP=1
+
 echo ""
 echo "[cells] sweep complete. Summaries:"
 for f in rig-results/*/*-summary.json; do

--- a/src/Testing/KafkaPerfRig/rig.sh
+++ b/src/Testing/KafkaPerfRig/rig.sh
@@ -58,7 +58,11 @@ trap - EXIT
 # Best-effort per-run broker cleanup: max-throughput cells write millions of messages per run,
 # and letting them accumulate across runs eventually fills the Docker VM disk and takes every
 # container down (learned the hard way on 2026-07-19).
-if [[ "$HARNESS" == *rabbit* ]]; then
+if [[ "$HARNESS" == nats* ]]; then
+  # JetStream streams are work queues here; deleting the per-run stream drops its consumers and messages
+  STREAM="RIG_$(echo "$RIG_RUN_ID" | tr '[:lower:]-' '[:upper:]_')"
+  docker exec wolverine-nats-1 nats stream rm -f "$STREAM" >/dev/null 2>&1 || true
+elif [[ "$HARNESS" == *rabbit* ]]; then
   docker exec wolverine-rabbitmq-1 rabbitmqctl delete_queue "rig-small-${RIG_RUN_ID}" >/dev/null 2>&1 || true
   docker exec wolverine-rabbitmq-1 rabbitmqctl delete_queue "rig-large-${RIG_RUN_ID}" >/dev/null 2>&1 || true
 else

--- a/src/Testing/KafkaPerfRig/rig.sh
+++ b/src/Testing/KafkaPerfRig/rig.sh
@@ -62,6 +62,9 @@ if [[ "$HARNESS" == nats* ]]; then
   # JetStream streams are work queues here; deleting the per-run stream drops its consumers and messages
   STREAM="RIG_$(echo "$RIG_RUN_ID" | tr '[:lower:]-' '[:upper:]_')"
   docker exec wolverine-nats-1 nats stream rm -f "$STREAM" >/dev/null 2>&1 || true
+elif [[ "$HARNESS" == pulsar* ]]; then
+  curl -s -X DELETE "http://localhost:8080/admin/v2/persistent/public/default/rig-small-${RIG_RUN_ID}?force=true" >/dev/null 2>&1 || true
+  curl -s -X DELETE "http://localhost:8080/admin/v2/persistent/public/default/rig-large-${RIG_RUN_ID}?force=true" >/dev/null 2>&1 || true
 elif [[ "$HARNESS" == *rabbit* ]]; then
   docker exec wolverine-rabbitmq-1 rabbitmqctl delete_queue "rig-small-${RIG_RUN_ID}" >/dev/null 2>&1 || true
   docker exec wolverine-rabbitmq-1 rabbitmqctl delete_queue "rig-large-${RIG_RUN_ID}" >/dev/null 2>&1 || true

--- a/src/Transports/Kafka/Wolverine.Kafka.Tests/durable_topic_group_batching_4026.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka.Tests/durable_topic_group_batching_4026.cs
@@ -1,0 +1,143 @@
+using System.Collections.Concurrent;
+using Confluent.Kafka;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Kafka.Tests;
+
+/// <summary>
+/// GH-4026. A Durable KafkaTopicGroup (ListenToKafkaTopics) now drains up to MaximumMessagesToReceive
+/// already-fetched records into one batched inbox insert, like the single-topic KafkaListener has since
+/// GH-3490. End to end over real Kafka + a real Postgres inbox: a burst across both topics is handled
+/// exactly once per message and leaves nothing stranded as Incoming.
+/// </summary>
+public class durable_topic_group_batching_4026 : IAsyncLifetime
+{
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
+    private string _alpha = null!;
+    private string _beta = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        TopicGroupBurstHandler.Reset();
+
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        _alpha = $"group-batch-alpha-{suffix}";
+        _beta = $"group-batch-beta-{suffix}";
+
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString)
+                    .AutoProvision()
+                    .ConfigureConsumers(c =>
+                    {
+                        c.AutoOffsetReset = AutoOffsetReset.Earliest;
+                        c.GroupId = $"group-batch-{suffix}";
+                    });
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "kafka_group_batch");
+
+                opts.ListenToKafkaTopics(_alpha, _beta)
+                    .UseDurableInbox()
+                    // Small enough that a 60 message burst has to span several drains
+                    .MaximumMessagesToReceive(10);
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseKafka(KafkaContainerFixture.ConnectionString).AutoProvision();
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.PublishMessage<GroupBurstAlpha>().ToKafkaTopic(_alpha).SendInline();
+                opts.PublishMessage<GroupBurstBeta>().ToKafkaTopic(_beta).SendInline();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _sender.StopAsync();
+        _sender.Dispose();
+        await _receiver.StopAsync();
+        _receiver.Dispose();
+    }
+
+    [Fact]
+    public async Task a_burst_across_both_topics_is_handled_once_each_and_leaves_nothing_incoming()
+    {
+        var bus = _sender.MessageBus();
+        var ids = new List<Guid>();
+
+        for (var i = 0; i < 30; i++)
+        {
+            var a = Guid.NewGuid();
+            var b = Guid.NewGuid();
+            ids.Add(a);
+            ids.Add(b);
+            await bus.PublishAsync(new GroupBurstAlpha(a));
+            await bus.PublishAsync(new GroupBurstBeta(b));
+        }
+
+        var deadline = DateTimeOffset.UtcNow.Add(60.Seconds());
+        while (TopicGroupBurstHandler.Count < ids.Count && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        TopicGroupBurstHandler.Count.ShouldBe(ids.Count);
+        foreach (var id in ids)
+        {
+            TopicGroupBurstHandler.Executions(id).ShouldBe(1);
+        }
+
+        // Every record went through the inbox and out again
+        var store = _receiver.Services.GetRequiredService<IMessageStore>();
+        var counts = await store.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(0);
+    }
+}
+
+public record GroupBurstAlpha(Guid Id);
+
+public record GroupBurstBeta(Guid Id);
+
+public static class TopicGroupBurstHandler
+{
+    private static readonly ConcurrentDictionary<Guid, int> _executions = new();
+
+    public static int Count => _executions.Count;
+
+    public static int Executions(Guid id)
+    {
+        return _executions.GetValueOrDefault(id);
+    }
+
+    public static void Reset()
+    {
+        _executions.Clear();
+    }
+
+    public static void Handle(GroupBurstAlpha message)
+    {
+        _executions.AddOrUpdate(message.Id, 1, (_, n) => n + 1);
+    }
+
+    public static void Handle(GroupBurstBeta message)
+    {
+        _executions.AddOrUpdate(message.Id, 1, (_, n) => n + 1);
+    }
+}

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaTopicGroupListener.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 using Wolverine.Util;
@@ -73,28 +74,18 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
 
         try
         {
-            var message = result.Message;
-
-            // Seed the offset watermark in consume (in-order) order so out-of-order handler completion can never
-            // commit past this still-in-flight offset (GH-3161).
-            _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
-
-            var envelope = _endpoint.EnvelopeMapper!.CreateEnvelope(result.Topic, message);
-            envelope.TopicName = result.Topic;
-            envelope.Offset = result.Offset.Value;
-            envelope.PartitionId = result.Partition.Value;
-
-            if (_endpoint.GroupByMessageKey)
+            // GH-4026: the same durable micro-batching KafkaListener has had since GH-3490. A durable topic
+            // group used to hand the inbox one envelope per record -- one INSERT round trip each -- while
+            // the single-topic listener drained up to MaximumMessagesToReceive already-fetched records into
+            // one batched insert. Topic groups have no retry tiers, so the only gate is the mode.
+            if (_endpoint.Mode == EndpointMode.Durable && _endpoint.MaximumMessagesToReceive > 1)
             {
-                // GH-3140: shard by-key processing on the Kafka message key.
-                envelope.GroupId = message.Key;
+                await consumeManyAsync(result);
             }
-            else if (_endpoint.StampConsumerGroupIdOnEnvelope)
+            else
             {
-                envelope.GroupId = Config.GroupId;
+                await consumeSingleAsync(result);
             }
-
-            await _receiver.ReceivedAsync(this, envelope);
         }
         catch (OperationCanceledException)
         {
@@ -109,6 +100,89 @@ public class KafkaTopicGroupListener : IListener, IDisposable, ISupportDeadLette
         }
 
         return true;
+    }
+
+    private async Task consumeSingleAsync(ConsumeResult<string, byte[]> result)
+    {
+        // Seed the offset watermark in consume (in-order) order so out-of-order handler completion can never
+        // commit past this still-in-flight offset (GH-3161).
+        _committer.Track(result.Topic, result.Partition.Value, result.Offset.Value);
+
+        var envelope = buildEnvelope(result);
+        await _receiver.ReceivedAsync(this, envelope);
+    }
+
+    private async Task consumeManyAsync(ConsumeResult<string, byte[]> first)
+    {
+        var envelopes = new List<Envelope>(Math.Min(_endpoint.MaximumMessagesToReceive, 32));
+        var current = first;
+
+        while (true)
+        {
+            // Track in consume order BEFORE dispatch so the watermark can never commit past an
+            // in-flight record (GH-3161), poison pills included.
+            _committer.Track(current.Topic, current.Partition.Value, current.Offset.Value);
+
+            try
+            {
+                envelopes.Add(buildEnvelope(current));
+            }
+            catch (Exception e)
+            {
+                // Poison pill mid-batch: advance past its offset, keep the rest of the batch.
+                _committer.Complete(current.Topic, current.Partition.Value, current.Offset.Value);
+                _logger.LogError(e, "Error trying to map Kafka message to a Wolverine envelope");
+            }
+
+            if (envelopes.Count >= _endpoint.MaximumMessagesToReceive)
+            {
+                break;
+            }
+
+            // Zero-timeout poll: only drains records librdkafka already holds locally — never
+            // waits on the broker, so a quiet topic still processes each record immediately.
+            var next = _consumer.Consume(TimeSpan.Zero);
+            if (next == null)
+            {
+                break;
+            }
+
+            current = next;
+        }
+
+        switch (envelopes.Count)
+        {
+            case 0:
+                return;
+            case 1:
+                await _receiver.ReceivedAsync(this, envelopes[0]);
+                return;
+            default:
+                await _receiver.ReceivedAsync(this, envelopes.ToArray());
+                return;
+        }
+    }
+
+    private Envelope buildEnvelope(ConsumeResult<string, byte[]> result)
+    {
+        var message = result.Message;
+
+        var envelope = _endpoint.EnvelopeMapper!.CreateEnvelope(result.Topic, message);
+        envelope.TopicName = result.Topic;
+        envelope.Offset = result.Offset.Value;
+        envelope.PartitionId = result.Partition.Value;
+
+        if (_endpoint.GroupByMessageKey)
+        {
+            // GH-3140: shard by-key processing on the Kafka message key.
+            envelope.GroupId = message.Key;
+        }
+        else if (_endpoint.StampConsumerGroupIdOnEnvelope)
+        {
+            envelope.GroupId = Config.GroupId;
+        }
+
+        return envelope;
     }
 
     public ConsumerConfig Config { get; }

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroupListenerConfiguration.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopicGroupListenerConfiguration.cs
@@ -40,6 +40,23 @@ public class KafkaTopicGroupListenerConfiguration : ListenerConfiguration<KafkaT
     }
 
     /// <summary>
+    /// For a Durable topic group: the most already-fetched records the consume loop drains in one
+    /// pass so the inbox persists them with one batched insert instead of one insert per record --
+    /// the same knob as the single-topic listener's. 1 reverts to strict record-at-a-time
+    /// consumption. Ignored for Buffered/Inline endpoints. Default 100. See GH-4026.
+    /// </summary>
+    public KafkaTopicGroupListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        if (maximum < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Must be at least 1");
+        }
+
+        add(group => group.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
     /// Enable native dead letter queue support for this listener group.
     /// </summary>
     /// <returns></returns>

--- a/src/Transports/NATS/Wolverine.Nats.Tests/durable_jetstream_batching_4026.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/durable_jetstream_batching_4026.cs
@@ -1,0 +1,134 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Nats.Tests;
+
+/// <summary>
+/// GH-4026. A Durable JetStream listener now coalesces consumed messages for up to 5ms (or
+/// MaximumMessagesToReceive) into one batched inbox insert, like the RabbitMQ and Kafka listeners.
+/// End to end over a real NATS server + a real Postgres inbox: a burst is handled exactly once per
+/// message and leaves nothing stranded as Incoming.
+/// </summary>
+[Collection("NATS Integration")]
+public class durable_jetstream_batching_4026 : IAsyncLifetime
+{
+    private readonly NatsContainerFixture _fixture;
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
+
+    public durable_jetstream_batching_4026(NatsContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        JetStreamBurstHandler.Reset();
+
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var streamName = $"BATCH_{suffix}";
+        var subject = $"batch.{suffix}.work";
+
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.UseNats(_fixture.ConnectionString)
+                    .AutoProvision()
+                    .UseJetStream(_ => { })
+                    .DefineWorkQueueStream(streamName, _ => { }, $"batch.{suffix}.*");
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "nats_batch_4026");
+
+                opts.ListenToNatsSubject(subject)
+                    .UseJetStream(streamName, $"batch-consumer-{suffix}")
+                    .UseDurableInbox()
+                    // Small enough that a 60 message burst has to span several windows
+                    .MaximumMessagesToReceive(10);
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseNats(_fixture.ConnectionString).AutoProvision().UseJetStream(_ => { });
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.PublishMessage<JetStreamBurst>().ToNatsSubject(subject).SendInline();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _sender.StopAsync();
+        _sender.Dispose();
+        await _receiver.StopAsync();
+        _receiver.Dispose();
+    }
+
+    [Fact]
+    public async Task a_burst_is_handled_once_each_and_leaves_nothing_incoming()
+    {
+        var bus = _sender.MessageBus();
+        var ids = new List<Guid>();
+
+        for (var i = 0; i < 60; i++)
+        {
+            var id = Guid.NewGuid();
+            ids.Add(id);
+            await bus.PublishAsync(new JetStreamBurst(id));
+        }
+
+        var deadline = DateTimeOffset.UtcNow.Add(60.Seconds());
+        while (JetStreamBurstHandler.Count < ids.Count && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        JetStreamBurstHandler.Count.ShouldBe(ids.Count);
+        foreach (var id in ids)
+        {
+            JetStreamBurstHandler.Executions(id).ShouldBe(1);
+        }
+
+        // Every message went through the inbox and out again
+        var store = _receiver.Services.GetRequiredService<IMessageStore>();
+        var counts = await store.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(0);
+    }
+}
+
+public record JetStreamBurst(Guid Id);
+
+public static class JetStreamBurstHandler
+{
+    private static readonly ConcurrentDictionary<Guid, int> _executions = new();
+
+    public static int Count => _executions.Count;
+
+    public static int Executions(Guid id)
+    {
+        return _executions.GetValueOrDefault(id);
+    }
+
+    public static void Reset()
+    {
+        _executions.Clear();
+    }
+
+    public static void Handle(JetStreamBurst message)
+    {
+        _executions.AddOrUpdate(message.Id, 1, (_, n) => n + 1);
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/Configuration/NatsListenerConfiguration.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Configuration/NatsListenerConfiguration.cs
@@ -11,6 +11,23 @@ public class NatsListenerConfiguration
         : base(endpoint) { }
 
     /// <summary>
+    /// For a Durable JetStream listener: the most consumed messages the subscriber coalesces (for at
+    /// most 5ms) into one batched inbox insert instead of one insert per message -- the same knob the
+    /// RabbitMQ and Kafka listeners have. 1 reverts to strict message-at-a-time persistence. Ignored
+    /// for Buffered/Inline endpoints and for core NATS. Default 100. See GH-4026.
+    /// </summary>
+    public NatsListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        if (maximum < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Must be at least 1");
+        }
+
+        add(e => e.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
     /// Use JetStream for durable messaging
     /// </summary>
     public NatsListenerConfiguration UseJetStream(

--- a/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
@@ -1,8 +1,10 @@
+using JasperFx.Blocks;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
 using NATS.Client.JetStream.Models;
 using NATS.Net;
+using Wolverine.Configuration;
 using Wolverine.Transports;
 
 namespace Wolverine.Nats.Internal;
@@ -17,6 +19,12 @@ internal class JetStreamSubscriber : INatsSubscriber
     private readonly INatsJSContext _jetStreamContext;
     private INatsJSConsumer? _consumer;
     private Task? _consumerTask;
+
+    // GH-4026: Durable endpoints coalesce consumed messages for up to 5ms (or MaximumMessagesToReceive)
+    // and hand the inbox one Envelope[] per window, the way the RabbitMQ and Kafka listeners do. Null
+    // for Buffered/Inline, or when MaximumMessagesToReceive is 1.
+    private BatchingChannel<Envelope>? _batching;
+    private Block<Envelope[]>? _batchFlush;
 
     public JetStreamSubscriber(
         NatsEndpoint endpoint,
@@ -140,6 +148,13 @@ internal class JetStreamSubscriber : INatsSubscriber
             );
         }
 
+        if (_endpoint.Mode == EndpointMode.Durable && _endpoint.MaximumMessagesToReceive > 1)
+        {
+            _batchFlush = new Block<Envelope[]>((batch, _) => deliverBatchAsync(batch, listener, receiver));
+            _batching = new BatchingChannel<Envelope>(TimeSpan.FromMilliseconds(5), _batchFlush,
+                _endpoint.MaximumMessagesToReceive);
+        }
+
         _consumerTask = Task.Run(
             async () =>
             {
@@ -176,7 +191,14 @@ internal class JetStreamSubscriber : INatsSubscriber
                         var envelope = new NatsEnvelope(null, msg);
                         _mapper.MapIncomingToEnvelope(envelope, msg);
 
-                        await receiver.ReceivedAsync(listener, envelope);
+                        if (_batching != null)
+                        {
+                            await _batching.PostAsync(envelope);
+                        }
+                        else
+                        {
+                            await receiver.ReceivedAsync(listener, envelope);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -190,6 +212,39 @@ internal class JetStreamSubscriber : INatsSubscriber
             },
             cancellation
         );
+    }
+
+    /// <summary>
+    ///     GH-4026: one coalesced window of messages to the receiver. A failure NAKs every message in the
+    ///     batch so JetStream redelivers them, exactly as the single-message path would for one.
+    /// </summary>
+    private async Task deliverBatchAsync(Envelope[] batch, IListener listener, IReceiver receiver)
+    {
+        try
+        {
+            await receiver.ReceivedAsync(listener, batch);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Failure receiving a batch of {Count} JetStream messages from subject {Subject}, NAKing them for redelivery",
+                batch.Length, _endpoint.Subject);
+
+            foreach (var envelope in batch.OfType<NatsEnvelope>())
+            {
+                try
+                {
+                    if (envelope.JetStreamMsg != null)
+                    {
+                        await envelope.JetStreamMsg.NakAsync();
+                    }
+                }
+                catch (Exception nakException)
+                {
+                    _logger.LogError(nakException, "Failure NAKing JetStream message for envelope {EnvelopeId}", envelope.Id);
+                }
+            }
+        }
     }
 
     public Task RepublishAsync(NatsEnvelope envelope, CancellationToken cancellation)
@@ -226,6 +281,23 @@ internal class JetStreamSubscriber : INatsSubscriber
             catch (OperationCanceledException)
             {
                 // Expected during shutdown
+            }
+        }
+
+        // GH-4026: whatever the consume loop posted but the 5ms window has not flushed yet still has to
+        // reach the inbox (or be NAKed) before this subscriber goes away, or it sits un-ACKed until
+        // AckWait and is redelivered. Bounded so a wedged receiver can never hang disposal.
+        if (_batching != null)
+        {
+            try
+            {
+                _batching.TriggerBatch();
+                _batching.Complete();
+                await _batching.WaitForCompletionAsync().WaitAsync(TimeSpan.FromSeconds(30));
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error flushing the pending JetStream receive batch for subject {Subject}", _endpoint.Subject);
             }
         }
     }

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
@@ -81,6 +81,15 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
     public string? StreamName { get; set; }
     public string? ConsumerName { get; set; }
     public bool UseJetStream { get; set; }
+
+    /// <summary>
+    ///     GH-4026. For a Durable JetStream listener: the most consumed messages the subscriber coalesces
+    ///     (for at most 5ms) into one batched inbox insert, instead of one insert round trip per message --
+    ///     the same micro-batching the RabbitMQ and Kafka listeners have. 1 reverts to strict
+    ///     message-at-a-time persistence. Ignored for Buffered/Inline endpoints and for core NATS.
+    ///     Default 100.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 100;
     public bool DeadLetterQueueEnabled { get; set; } = true;
     public string? DeadLetterSubject { get; set; }
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/durable_batching_4026.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/durable_batching_4026.cs
@@ -1,0 +1,121 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// GH-4026. A Durable Pulsar listener now coalesces consumed messages for up to 5ms (or
+/// MaximumMessagesToReceive) into one batched inbox insert, like the RabbitMQ, Kafka and NATS
+/// listeners. End to end over a real Pulsar + a real Postgres inbox: a burst is handled exactly once
+/// per message and leaves nothing stranded as Incoming.
+/// </summary>
+[Collection("acceptance")]
+public class durable_batching_4026 : IAsyncLifetime
+{
+    private IHost _receiver = null!;
+    private IHost _sender = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        PulsarBurstHandler.Reset();
+
+        var topicPath = $"persistent://public/default/durable-batch-{Guid.NewGuid():N}";
+
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "pulsar_batch_4026");
+
+                opts.ListenToPulsarTopic(topicPath)
+                    .UseDurableInbox()
+                    // Small enough that a 60 message burst has to span several windows
+                    .MaximumMessagesToReceive(10);
+
+                opts.Discovery.IncludeAssembly(GetType().Assembly);
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+                opts.Policies.DisableConventionalLocalRouting();
+
+                opts.PublishMessage<PulsarBurst>().ToPulsarTopic(topicPath).SendInline();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _sender.StopAsync();
+        _sender.Dispose();
+        await _receiver.StopAsync();
+        _receiver.Dispose();
+    }
+
+    [Fact]
+    public async Task a_burst_is_handled_once_each_and_leaves_nothing_incoming()
+    {
+        var bus = _sender.MessageBus();
+        var ids = new List<Guid>();
+
+        for (var i = 0; i < 60; i++)
+        {
+            var id = Guid.NewGuid();
+            ids.Add(id);
+            await bus.PublishAsync(new PulsarBurst(id));
+        }
+
+        var deadline = DateTimeOffset.UtcNow.Add(60.Seconds());
+        while (PulsarBurstHandler.Count < ids.Count && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        PulsarBurstHandler.Count.ShouldBe(ids.Count);
+        foreach (var id in ids)
+        {
+            PulsarBurstHandler.Executions(id).ShouldBe(1);
+        }
+
+        // Every message went through the inbox and out again
+        var store = _receiver.Services.GetRequiredService<IMessageStore>();
+        var counts = await store.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(0);
+    }
+}
+
+public record PulsarBurst(Guid Id);
+
+public static class PulsarBurstHandler
+{
+    private static readonly ConcurrentDictionary<Guid, int> _executions = new();
+
+    public static int Count => _executions.Count;
+
+    public static int Executions(Guid id)
+    {
+        return _executions.GetValueOrDefault(id);
+    }
+
+    public static void Reset()
+    {
+        _executions.Clear();
+    }
+
+    public static void Handle(PulsarBurst message)
+    {
+        _executions.AddOrUpdate(message.Id, 1, (_, n) => n + 1);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -93,6 +93,15 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     public bool UseNativeRedelivery { get; internal set; }
 
     /// <summary>
+    ///     GH-4026. For a Durable listener: the most consumed messages the listener coalesces (for at most
+    ///     5ms) into one batched inbox insert, instead of one insert round trip per message -- the same
+    ///     micro-batching the RabbitMQ, Kafka and NATS listeners have. 1 reverts to strict
+    ///     message-at-a-time persistence. Ignored for Buffered/Inline endpoints and for the retry-letter
+    ///     consumer. Default 100.
+    /// </summary>
+    public int MaximumMessagesToReceive { get; set; } = 100;
+
+    /// <summary>
     ///     How this listener acknowledges completed messages: individually (default), cumulatively, or
     ///     batched. See <see cref="PulsarAckStrategy"/>.
     /// </summary>

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 using DotPulsar;
 using DotPulsar.Abstractions;
 using DotPulsar.Extensions;
+using JasperFx.Blocks;
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 
@@ -22,6 +25,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     private readonly Task? _receivingRetryLoop;
     private readonly PulsarEndpoint _endpoint;
     private readonly PulsarAckHandler _ackHandler;
+
+    // GH-4026: a Durable endpoint coalesces consumed messages for up to 5ms (or MaximumMessagesToReceive)
+    // and hands the inbox one Envelope[] per window, the way the RabbitMQ, Kafka and NATS listeners do.
+    // Null for Buffered/Inline, or when MaximumMessagesToReceive is 1. The retry-letter consumer stays
+    // one at a time.
+    private readonly BatchingChannel<Envelope>? _batching;
+    private readonly Block<Envelope[]>? _batchFlush;
+    private readonly ILogger? _logger;
     private readonly Schemas.IPulsarMessageCodec? _codec;
     private IProducer<ReadOnlySequence<byte>>? _retryLetterQueueProducer;
     private IProducer<ReadOnlySequence<byte>>? _dlqProducer;
@@ -114,6 +125,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
 
         trySetupNativeResiliency(endpoint, transport);
 
+        if (endpoint.Mode == EndpointMode.Durable && endpoint.MaximumMessagesToReceive > 1)
+        {
+            _logger = runtime.LoggerFactory.CreateLogger<PulsarListener>();
+            _batchFlush = new Block<Envelope[]>((batch, _) => deliverBatchAsync(batch));
+            _batching = new BatchingChannel<Envelope>(TimeSpan.FromMilliseconds(5), _batchFlush,
+                endpoint.MaximumMessagesToReceive);
+        }
+
         _receivingLoop = Task.Run(async () =>
         {
             await foreach (var message in _consumer.Messages(combined.Token))
@@ -136,7 +155,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
                     envelope.Message = _codec.Decode(message.Data);
                 }
 
-                await receiver.ReceivedAsync(this, envelope);
+                if (_batching != null)
+                {
+                    await _batching.PostAsync(envelope);
+                }
+                else
+                {
+                    await receiver.ReceivedAsync(this, envelope);
+                }
             }
         }, combined.Token);
 
@@ -218,6 +244,37 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             endpoint.EffectiveDeadLetterTopic?.TopicName ?? $"{endpoint.TopicName}-DLQ");
     }
 
+    /// <summary>
+    ///     GH-4026: one coalesced window of messages to the receiver. A failure defers every message in
+    ///     the batch -- native redelivery or ack-and-requeue, whichever this endpoint is configured for --
+    ///     exactly as the single-message path would for one.
+    /// </summary>
+    private async Task deliverBatchAsync(Envelope[] batch)
+    {
+        try
+        {
+            await _receiver.ReceivedAsync(this, batch);
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e,
+                "Failure receiving a batch of {Count} Pulsar messages at {Address}, deferring them for redelivery",
+                batch.Length, Address);
+
+            foreach (var envelope in batch)
+            {
+                try
+                {
+                    await DeferAsync(envelope);
+                }
+                catch (Exception deferException)
+                {
+                    _logger?.LogError(deferException, "Failure deferring Pulsar message for envelope {EnvelopeId}", envelope.Id);
+                }
+            }
+        }
+    }
+
     public ValueTask CompleteAsync(Envelope envelope)
     {
         if (envelope is PulsarEnvelope e)
@@ -270,6 +327,23 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     {
         await _localCancellation.CancelAsync();
         _localCancellation.Dispose();
+
+        // GH-4026: whatever the receive loop posted but the 5ms window has not flushed yet still has to
+        // reach the inbox (or be deferred) before the consumer is torn down. Bounded so a wedged receiver
+        // can never hang disposal.
+        if (_batching != null)
+        {
+            try
+            {
+                _batching.TriggerBatch();
+                _batching.Complete();
+                await _batching.WaitForCompletionAsync().WaitAsync(TimeSpan.FromSeconds(30));
+            }
+            catch (Exception e)
+            {
+                _logger?.LogDebug(e, "Error flushing the pending Pulsar receive batch at {Address}", Address);
+            }
+        }
 
         // Flush any pending batched acks before the consumer is torn down.
         await _ackHandler.DisposeAsync();

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -258,6 +258,23 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     }
 
     /// <summary>
+    /// For a Durable listener: the most consumed messages the listener coalesces (for at most 5ms)
+    /// into one batched inbox insert instead of one insert per message -- the same knob the RabbitMQ,
+    /// Kafka and NATS listeners have. 1 reverts to strict message-at-a-time persistence. Ignored for
+    /// Buffered/Inline endpoints and for the retry-letter consumer. Default 100. See GH-4026.
+    /// </summary>
+    public PulsarListenerConfiguration MaximumMessagesToReceive(int maximum)
+    {
+        if (maximum < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Must be at least 1");
+        }
+
+        add(e => e.MaximumMessagesToReceive = maximum);
+        return this;
+    }
+
+    /// <summary>
     /// Provide a subscription name to Pulsar for this topic
     /// </summary>
     /// <param name="subscriptionName"></param>


### PR DESCRIPTION
Closes #4026. (Branch name says "redis" because that's where the audit started; the Redis row turned out to be moot and became its own correctness issue, #4028: the endpoint is `IDatabaseBackedEndpoint`, so it never inserts into the inbox and ACKs on receipt.)

Three transports, same pattern each: a **Durable** listener that used to hand `DurableReceiver` one envelope per consumed record — one inbox `INSERT` round trip each — now batches into the `Envelope[]` overload the way RabbitMQ and the single-topic Kafka listener have since GH-3490/3492. Every change is measured on the in-repo rig, same box, three interleaved runs per side, with the "before" side pinned **inside the same build** via `MaximumMessagesToReceive=1` (exactly the pre-change code path).

| Transport | Before (one record per insert), msg/s | After, msg/s | Δ |
|---|---|---|---|
| **Kafka topic group** (`ListenToKafkaTopics`) | 1,319.3 / 1,543.9 / 1,308.3 — mean 1,390 | **6,174.5 / 6,018.9 / 5,013.0 — mean 5,736** | **+313 %** |
| **NATS JetStream** | 536.5 / 564.4 / 522.5 — mean 541 | **802.8 / 655.5 / 737.7 — mean 732** | **+35 %** |
| **Pulsar** | 787.8 / 785.2 / 713.6 — mean 762 | **4,279.8 / 3,978.9 / 4,258.7 — mean 4,172** | **+447 %** |

All `max-durable` shape: uncapped publisher, 0 ms handler, Durable/PostgreSQL, 15 s warmup / 45 s measured. No overlap between the before/after distributions in any row. The publisher was verified not to be the cap in each (Kafka and NATS published millions; Pulsar needed `RIG_PUBLISHERS=32` — see below).

## 1. Kafka topic group

`KafkaTopicGroupListener` never got the `KafkaListener` drain. It does now: gate `Mode == Durable && MaximumMessagesToReceive > 1` (topic groups have no retry tiers), zero-timeout `Consume(TimeSpan.Zero)` that only takes what librdkafka already holds (never waits on the broker), offsets tracked in consume order *before* dispatch (GH-3161), poison pills advanced mid-batch. `KafkaTopicGroupListenerConfiguration.MaximumMessagesToReceive(int)` added.

## 2. NATS JetStream

`JetStreamSubscriber` consumed one message at a time and awaited the inbox insert for each. A Durable endpoint now coalesces behind a `BatchingChannel` (5 ms max age, up to the new `NatsEndpoint.MaximumMessagesToReceive`, default 100; `NatsListenerConfiguration.MaximumMessagesToReceive(int)`). A failed batch NAKs every message; disposal flushes the pending window (bounded). Buffered/Inline and core NATS untouched.

**Lead, not in this PR:** `n-max-buffered` is **62,377 msg/s** on the same box, so NATS durable is ~1 % of buffered. The arithmetic is unambiguous — "-1" ≈ 1.85 ms/msg (INSERT RTT + one awaited ack), window ≈ 1.37 ms/msg — so **~1.3 ms of awaited `AckAsync` per message**, issued one at a time in `DurableReceiver`'s post-insert loop, is the remaining ceiling. Durable acks in *receive* order, so a cumulative `AckAll` once per batch would be safe there (Inline acks in completion order — must be gated). Recorded on #4026 for its own issue.

## 3. Pulsar

Same `BatchingChannel` pattern in `PulsarListener`'s main consumer loop (`PulsarEndpoint.MaximumMessagesToReceive`, `PulsarListenerConfiguration.MaximumMessagesToReceive(int)`). A failed batch **defers** every message — native redelivery or ack-and-requeue, whichever the endpoint is configured for — exactly as the single path would; disposal flushes the window before the ack handler/consumer are torn down. The retry-letter consumer stays one-at-a-time.

Measurement note worth keeping: the first Pulsar cells came back ~450/s in **every** mode including buffered, with published == consumed — one awaited DotPulsar produce is ~2 ms, so a single publish loop bounded everything. `RIG_PUBLISHERS=32` (concurrent max-throughput loops, new rig knob) lifts buffered to 15,657/s and the numbers above are from that configuration.

## Rig additions
`RIG_KAFKA_TOPIC_GROUP=1`, `RIG_MAX_RECEIVE=n`, `RIG_PUBLISHERS=n`; Kafka cells `max-durable-group-1` / `max-durable-group`; NATS harness (`WolverineNats`, `cells-nats.sh`, `RIG_NATS_URL`) and Pulsar harness (`WolverinePulsar`, `cells-pulsar.sh`, `RIG_PULSAR_URL`), each with `*-max-buffered` / `*-max-durable-1` / `*-max-durable`.

## Tests

| | Result |
|---|---|
| new `durable_topic_group_batching_4026` (Kafka + Postgres inbox, 60-message burst across two topics, `MaximumMessagesToReceive(10)`: once each, `Incoming` 0) + `multi_topic_listening`, `duplicate_message_handling_with_postgres_inbox`, `externally_owned_topics_are_skipped`, `Bug_2537`, `kafka_by_key_concurrency` | 14/14 |
| new `durable_jetstream_batching_4026` (NATS + Postgres inbox, same shape) + `JetStreamNatsTransportComplianceTests` | 23/23 |
| new `durable_batching_4026` (Pulsar + Postgres inbox, same shape) + `PulsarTransportComplianceTests` | 19 passed / 4 pre-existing skips / 0 failed |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

No changes to ack/commit semantics on any transport.

## MQTT / MQTT5 — declined
The last row on #4026. `MqttListener` acknowledges per message through `MqttApplicationMessageReceivedEventArgs.AcknowledgeAsync`, MQTT is essentially never run with a database inbox, and there is no natural batch to exploit. Not worth a knob, a window, a harness and a measured cell; closing the row with this note — reopen if a user actually shows up with a durable MQTT throughput problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
