### PR TITLE
GH-4000: attach the derived Event Model slice to the gRPC RPC that starts it

### DIFF
--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -339,6 +339,26 @@ What is deliberately *not* visible here: imperative `session.Events.Append(...)`
 invisible at runtime, so only declarative returns are reported; CritterWatch's source generator covers the
 imperative case.
 
+### The slice next to the route
+
+The assembled model is one picture of the whole service. A monitoring console often wants the other view —
+walking the surface area endpoint by endpoint and asking "what does *this* one do?" — so the derived slice is
+also attached to the descriptor of the thing that starts it:
+
+| Descriptor | Slot | What it carries |
+| --- | --- | --- |
+| `MessageHandlerDescriptor` | `EventModel` | the handler chain's slice (GH-3988) |
+| `GrpcRpcDescriptor` | `EventModel` | the slice of the message the RPC forwards to the bus, with the RPC as its trigger (GH-4000) |
+
+Both slots are nullable and additive on the wire, and both are *the same slice* the assembled model carries —
+derived once, by the same code, so the two cannot drift.
+
+Because an RPC's generated wrapper forwards its request to the bus, the slice on a `GrpcRpcDescriptor` is the
+forwarded message's whole slice — handler, aggregates, emitted events, cascaded messages — not merely a note
+that something was published. When nothing in the process handles that message, the slice is trigger-only: there
+is still a boundary worth rendering. And where two RPCs forward the *same* message, each descriptor names its own
+RPC as the trigger, while the assembled model — which folds a message into one slice — can only name the first.
+
 ### Naming the external system on an endpoint
 
 The *edge* of a translation slice is derived — a listener that receives from, or a subscriber that publishes to,

--- a/src/Testing/CoreTests/Acceptance/event_model_per_rpc_4000.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_per_rpc_4000.cs
@@ -1,0 +1,109 @@
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel3988;
+
+// GH-4000: the derived slice attached to the *route*, not only to the assembled model. An RPC forwards
+// its request to the bus, so the slice a GrpcRpcDescriptor carries is the forwarded message's slice with
+// the RPC stamped on as its trigger — the same slice, derived the same way, that
+// ServiceCapabilities.EventModel carries for it.
+public class event_model_per_rpc_4000 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    private static GrpcEndpointDescriptor rpc<TRequest>(string method) => new(
+        "Orders", method, typeof(TRequest), null, typeof(PlaceOrderHandler),
+        GrpcServiceDiscoveryMode.CodeFirst, GrpcRpcStreamKind.Unary);
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "event-model-4000";
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(PlaceOrderHandler));
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private WolverineOptions theOptions => _host.Services.GetRequiredService<WolverineOptions>();
+
+    [Fact]
+    public void an_rpc_forwarding_a_handled_message_carries_that_messages_whole_slice()
+    {
+        var slice = WolverineEventModelSource.ForGrpcEndpoint(rpc<PlaceOrder>("Place"), theOptions);
+
+        slice.Name.ShouldBe(nameof(PlaceOrder));
+        slice.CommandType!.Name.ShouldBe(nameof(PlaceOrder));
+        // the handler roles are the point: an RPC descriptor reader sees what the message does, not
+        // merely that something was forwarded
+        slice.HandlerType!.Name.ShouldBe(nameof(PlaceOrderHandler));
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
+
+        slice.TriggerKind.ShouldBe(TriggerKind.Grpc);
+        slice.TriggerOrigin!.GrpcService.ShouldBe("Orders");
+        slice.TriggerOrigin.GrpcMethod.ShouldBe("Place");
+        slice.TriggerOrigin.Label.ShouldBe("Orders/Place");
+    }
+
+    [Fact]
+    public void an_rpc_whose_message_nothing_here_handles_is_trigger_only()
+    {
+        var slice = WolverineEventModelSource.ForGrpcEndpoint(rpc<CancelOrder>("Cancel"), theOptions);
+
+        slice.Name.ShouldBe(nameof(CancelOrder));
+        slice.CommandType!.Name.ShouldBe(nameof(CancelOrder));
+        slice.HandlerType.ShouldBeNull();
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.TriggerKind.ShouldBe(TriggerKind.Grpc);
+        slice.TriggerLabel.ShouldBe("Orders/Cancel");
+    }
+
+    [Fact]
+    public void without_options_there_is_still_a_trigger_only_slice()
+    {
+        // the export path can describe a host whose handler graph is not available; the RPC still renders
+        var slice = WolverineEventModelSource.ForGrpcEndpoint(rpc<PlaceOrder>("Place"), null);
+
+        slice.Name.ShouldBe(nameof(PlaceOrder));
+        slice.HandlerType.ShouldBeNull();
+        slice.TriggerKind.ShouldBe(TriggerKind.Grpc);
+    }
+
+    [Fact]
+    public void the_per_rpc_slice_is_the_slice_the_assembled_model_carries()
+    {
+        var endpoint = rpc<PlaceOrder>("Place");
+        var perRpc = WolverineEventModelSource.ForGrpcEndpoint(endpoint, theOptions);
+
+        var assembled = WolverineEventModelSource.Describe(theOptions, new StubGrpcManifest(endpoint))
+            .Slices.Single(x => x.Name == nameof(PlaceOrder));
+
+        perRpc.Name.ShouldBe(assembled.Name);
+        perRpc.CommandType!.FullName.ShouldBe(assembled.CommandType!.FullName);
+        perRpc.HandlerType!.FullName.ShouldBe(assembled.HandlerType!.FullName);
+        perRpc.Pattern.ShouldBe(assembled.Pattern);
+        perRpc.TriggerKind.ShouldBe(assembled.TriggerKind);
+        perRpc.TriggerOrigin!.Label.ShouldBe(assembled.TriggerOrigin!.Label);
+        perRpc.EmittedEvents.Select(x => x.FullName).ShouldBe(assembled.EmittedEvents.Select(x => x.FullName));
+        perRpc.PublishedMessages.Select(x => x.FullName).ShouldBe(assembled.PublishedMessages.Select(x => x.FullName));
+        perRpc.AggregateTypes.Select(x => x.FullName).ShouldBe(assembled.AggregateTypes.Select(x => x.FullName));
+        perRpc.ReadModelTypes.Select(x => x.FullName).ShouldBe(assembled.ReadModelTypes.Select(x => x.FullName));
+    }
+
+    private sealed class StubGrpcManifest(params GrpcEndpointDescriptor[] endpoints) : IGrpcEndpointManifest
+    {
+        public IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; } = endpoints;
+    }
+}

--- a/src/Wolverine.Grpc.Tests/grpc_event_model_slice_4000.cs
+++ b/src/Wolverine.Grpc.Tests/grpc_event_model_slice_4000.cs
@@ -1,0 +1,147 @@
+using GreeterCodeFirstGrpc.Messages;
+using GreeterProtoFirstGrpc.Messages;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
+using Xunit;
+using ProtoGreeterHandler = GreeterProtoFirstGrpc.Server.GreeterHandler;
+
+namespace Wolverine.Grpc.Tests;
+
+// GH-4000: the Event Model slice reaches CritterWatch *next to the RPC that starts it*, not only through
+// the assembled ServiceCapabilities.EventModel. Because the generated wrapper forwards the request to the
+// bus, the slice on a GrpcRpcDescriptor is the forwarded message's whole slice — handler, aggregates,
+// events, cascaded messages — with the RPC stamped on as the trigger.
+[Collection(GrpcSerialTestsCollection.Name)]
+public class grpc_event_model_slice_4000 : IClassFixture<GrpcCapabilitiesFixture>
+{
+    private readonly GrpcCapabilitiesFixture _fixture;
+
+    public grpc_event_model_slice_4000(GrpcCapabilitiesFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private GrpcRpcDescriptor source(GrpcServiceDiscoveryMode mode, string method)
+        => _fixture.SourceEndpoints.Single(e => e.Mode == mode && e.MethodName == method);
+
+    [Fact]
+    public void every_rpc_carries_a_slice_triggered_by_itself()
+    {
+        _fixture.SourceEndpoints.ShouldNotBeEmpty();
+
+        foreach (var endpoint in _fixture.SourceEndpoints)
+        {
+            var slice = endpoint.EventModel.ShouldNotBeNull();
+
+            slice.TriggerKind.ShouldBe(TriggerKind.Grpc);
+            slice.TriggerOrigin.ShouldNotBeNull();
+            slice.TriggerOrigin.GrpcService.ShouldBe(endpoint.ServiceName);
+            slice.TriggerOrigin.GrpcMethod.ShouldBe(endpoint.MethodName);
+            slice.CommandType!.FullName.ShouldBe(endpoint.RequestType!.FullName);
+        }
+    }
+
+    [Fact]
+    public void the_capabilities_snapshot_carries_the_slice_on_every_rpc()
+    {
+        // the payload a monitoring console actually reads
+        _fixture.Capabilities.GrpcEndpoints.ShouldNotBeEmpty();
+        _fixture.Capabilities.GrpcEndpoints.ShouldAllBe(e =>
+            e.EventModel != null && e.EventModel.TriggerKind == TriggerKind.Grpc);
+
+        var sayHello = _fixture.Capabilities.GrpcEndpoints
+            .Single(e => e.ServiceName == "Greeter" && e.MethodName == "SayHello");
+        sayHello.EventModel!.HandlerType!.FullName.ShouldBe(typeof(ProtoGreeterHandler).FullName);
+    }
+
+    [Fact]
+    public void the_proto_first_unary_slice_carries_the_forwarded_messages_handler_roles()
+    {
+        var slice = source(GrpcServiceDiscoveryMode.ProtoFirst, "SayHello").EventModel.ShouldNotBeNull();
+
+        slice.Name.ShouldBe(nameof(HelloRequest));
+        slice.CommandType!.FullName.ShouldBe(typeof(HelloRequest).FullName);
+        slice.HandlerType!.FullName.ShouldBe(typeof(ProtoGreeterHandler).FullName);
+        slice.TriggerOrigin!.Label.ShouldBe("Greeter/SayHello");
+    }
+
+    // This host discovers the code-first *contract* assembly but not its handlers, which is exactly the
+    // case an RPC forwarding a message nothing in the process handles has to cover: there is still a
+    // boundary to render, so the slice is trigger-only rather than absent.
+    [Fact]
+    public void an_rpc_whose_message_nothing_here_handles_is_trigger_only()
+    {
+        var slice = source(GrpcServiceDiscoveryMode.CodeFirst, "Greet").EventModel.ShouldNotBeNull();
+
+        slice.Name.ShouldBe(nameof(GreetRequest));
+        slice.CommandType!.FullName.ShouldBe(typeof(GreetRequest).FullName);
+        slice.HandlerType.ShouldBeNull();
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.TriggerOrigin!.Label.ShouldBe("GreeterCodeFirstService/Greet");
+    }
+
+    // The acceptance criterion of GH-4000: the slice on the route and the slice in the assembled model are
+    // the same slice, because they are derived once by the same code.
+    [Fact]
+    public void each_rpc_slice_is_the_slice_the_assembled_model_carries_for_it()
+    {
+        var model = _fixture.Capabilities.EventModel.ShouldNotBeNull();
+
+        foreach (var endpoint in _fixture.SourceEndpoints)
+        {
+            var perRpc = endpoint.EventModel.ShouldNotBeNull();
+            var assembled = model.Slices
+                .FirstOrDefault(x => x.CommandType?.FullName == endpoint.RequestType!.FullName);
+
+            if (assembled is null)
+            {
+                // The assembled model merges slices by NAME, so two unrelated messages whose simple names
+                // collide -- the proto-first and code-first StreamGreetingsRequest here -- fold into one
+                // slice and the loser has no slice of its own left to compare against. Nothing folds per
+                // route, which is one more reason the route-attached copy is worth carrying.
+                model.Slices.ShouldContain(x => x.Name == endpoint.RequestType!.Name);
+                continue;
+            }
+
+            assembled.Name.ShouldBe(perRpc.Name);
+            assembled.HandlerType?.FullName.ShouldBe(perRpc.HandlerType?.FullName);
+            assembled.Pattern.ShouldBe(perRpc.Pattern);
+            assembled.TriggerKind.ShouldBe(perRpc.TriggerKind);
+            assembled.EmittedEvents.Select(x => x.FullName)
+                .ShouldBe(perRpc.EmittedEvents.Select(x => x.FullName));
+            assembled.PublishedMessages.Select(x => x.FullName)
+                .ShouldBe(perRpc.PublishedMessages.Select(x => x.FullName));
+            assembled.AggregateTypes.Select(x => x.FullName)
+                .ShouldBe(perRpc.AggregateTypes.Select(x => x.FullName));
+            assembled.ReadModelTypes.Select(x => x.FullName)
+                .ShouldBe(perRpc.ReadModelTypes.Select(x => x.FullName));
+        }
+    }
+
+    // ...with one honest exception, and it is the reason attaching the slice per route is worth doing.
+    // The model folds every source's view of a message into ONE slice, so when several RPCs forward the
+    // same message it can only name one of them as the trigger — here SayHello and the client-streaming
+    // CollectGreetings both forward HelloRequest, and the model keeps whichever it stamped first. The
+    // copy hanging off a route names *that* route, so an operator reading the RPC sees its own trigger.
+    [Fact]
+    public void a_message_forwarded_by_more_than_one_rpc_keeps_its_own_trigger_per_route()
+    {
+        var forwardingHello = _fixture.SourceEndpoints
+            .Where(x => x.RequestType!.FullName == typeof(HelloRequest).FullName)
+            .ToArray();
+
+        forwardingHello.Length.ShouldBeGreaterThan(1);
+        forwardingHello.Select(x => x.EventModel!.TriggerOrigin!.Label)
+            .ShouldBe(forwardingHello.Select(x => $"{x.ServiceName}/{x.MethodName}"));
+
+        var assembled = _fixture.Capabilities.EventModel!.Slices
+            .First(x => x.CommandType?.FullName == typeof(HelloRequest).FullName);
+
+        // the model's single trigger is one of them — the first in service::method order
+        assembled.TriggerOrigin!.Label
+            .ShouldBe(forwardingHello.Select(x => $"{x.ServiceName}/{x.MethodName}")
+                .OrderBy(x => x, StringComparer.Ordinal).First());
+    }
+}

--- a/src/Wolverine.Grpc/GrpcEndpointDescriptorSource.cs
+++ b/src/Wolverine.Grpc/GrpcEndpointDescriptorSource.cs
@@ -1,6 +1,7 @@
 using JasperFx.Descriptors;
 using Wolverine.Configuration;
 using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
 
 namespace Wolverine.Grpc;
 
@@ -14,12 +15,14 @@ namespace Wolverine.Grpc;
 internal sealed class GrpcEndpointDescriptorSource : IGrpcEndpointDescriptorSource
 {
     private readonly IGrpcEndpointManifest _manifest;
+    private readonly WolverineOptions? _options;
     private readonly object _lock = new();
     private volatile IReadOnlyList<GrpcRpcDescriptor>? _endpoints;
 
-    public GrpcEndpointDescriptorSource(IGrpcEndpointManifest manifest)
+    public GrpcEndpointDescriptorSource(IGrpcEndpointManifest manifest, WolverineOptions? options = null)
     {
         _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+        _options = options;
     }
 
     public IReadOnlyList<GrpcRpcDescriptor> Endpoints
@@ -33,12 +36,12 @@ internal sealed class GrpcEndpointDescriptorSource : IGrpcEndpointDescriptorSour
 
             lock (_lock)
             {
-                return _endpoints ??= _manifest.Endpoints.Select(toDescriptor).ToArray();
+                return _endpoints ??= _manifest.Endpoints.Select(entry => toDescriptor(entry, _options)).ToArray();
             }
         }
     }
 
-    private static GrpcRpcDescriptor toDescriptor(GrpcEndpointDescriptor entry)
+    private static GrpcRpcDescriptor toDescriptor(GrpcEndpointDescriptor entry, WolverineOptions? options)
     {
         var descriptor = new GrpcRpcDescriptor
         {
@@ -53,6 +56,18 @@ internal sealed class GrpcEndpointDescriptorSource : IGrpcEndpointDescriptorSour
         };
 
         descriptor.AddTag("grpc");
+
+        // GH-4000: the Event Modeling slice this RPC starts, attached to the RPC itself rather than left
+        // to be found in the assembled model. Diagnostic: an endpoint whose roles cannot be read simply
+        // has no slice, the rest of the descriptor is unaffected.
+        try
+        {
+            descriptor.EventModel = WolverineEventModelSource.ForGrpcEndpoint(entry, options);
+        }
+        catch (Exception)
+        {
+            descriptor.EventModel = null;
+        }
 
         return descriptor;
     }

--- a/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
+++ b/src/Wolverine.Grpc/WolverineGrpcExtensions.cs
@@ -80,8 +80,11 @@ public static class WolverineGrpcExtensions
 
         // GH-3267: surface the manifest along the ServiceCapabilities descriptor path (ServiceCapabilities.GrpcEndpoints)
         // so a monitoring console can discover the gRPC services this app exposes, parallel to AspNet/HTTP endpoints.
+        // GH-4000: WolverineOptions comes along so each descriptor can carry the Event Model slice of the
+        // message its RPC forwards to the bus, not just the RPC's own shape.
         services.AddSingleton<IGrpcEndpointDescriptorSource>(sp =>
-            new GrpcEndpointDescriptorSource(sp.GetRequiredService<IGrpcEndpointManifest>()));
+            new GrpcEndpointDescriptorSource(sp.GetRequiredService<IGrpcEndpointManifest>(),
+                sp.GetService<WolverineOptions>()));
 
         services.AddSingleton<WolverineGrpcExceptionInterceptor>();
         services.AddSingleton<WolverineGrpcServicePropagationInterceptor>();

--- a/src/Wolverine/Configuration/Capabilities/GrpcRpcDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/GrpcRpcDescriptor.cs
@@ -1,4 +1,5 @@
 using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
 
 namespace Wolverine.Configuration.Capabilities;
 
@@ -47,4 +48,18 @@ public class GrpcRpcDescriptor : OptionsDescription
     /// <summary>The forwarding origin — the discovered service identity (proto-first stub or code-first contract
     /// interface) whose generated wrapper performs the bus dispatch.</summary>
     public TypeDescriptor? Origin { get; set; }
+
+    /// <summary>
+    /// The Event Modeling slice this RPC starts (GH-4000): the RPC itself as the trigger, and — because the
+    /// generated wrapper forwards the request to the bus — the forwarded message's slice around it, with the
+    /// handler, the aggregate(s) it decides against and the events it emits. A trigger-only slice when nothing
+    /// in this process handles the forwarded message. Null only when the roles could not be read.
+    /// </summary>
+    /// <remarks>
+    /// The sibling of <see cref="MessageHandlerDescriptor.EventModel"/>, and the same slice the assembled
+    /// <see cref="ServiceCapabilities.EventModel"/> carries for this RPC — derived once, by
+    /// <c>WolverineEventModelSource.ForGrpcEndpoint</c>, so the two cannot disagree. Additive and nullable on
+    /// the wire: a payload written before the slot existed reads back as the descriptor it always was.
+    /// </remarks>
+    public EventModelSliceDescriptor? EventModel { get; set; }
 }

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -57,16 +57,8 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         var stickyEndpoints = new Dictionary<string, HashSet<Uri>>(StringComparer.Ordinal);
         var knownTypes = new Dictionary<string, Type>(StringComparer.Ordinal);
 
-        void describe(HandlerChain chain)
+        foreach (var chain in DescribedChains(options))
         {
-            if (chain.MessageType.IsSystemMessageType()) return;
-
-            // sticky handlers live on per-endpoint sub-chains, so walk those whether or not the
-            // parent chain has a default handler of its own
-            foreach (var sticky in chain.ByEndpoint) describe(sticky);
-
-            if (chain.Handlers.Count == 0) return;
-
             var slice = EventModelRoles.ForHandlerChain(chain);
             slices.Add(slice);
 
@@ -95,15 +87,36 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
             }
         }
 
-        foreach (var chain in options.HandlerGraph.Chains.OrderBy(x => x.MessageType.FullName, StringComparer.Ordinal))
-        {
-            describe(chain);
-        }
-
         var model = new EventModelDescriptor(options.ServiceName, slices) { Aggregates = aggregates };
         model = ApplyGrpcTriggers(model, grpc);
         model = ApplyExternalSystems(model, options, stickyEndpoints, knownTypes, includeInbound: true);
         return FinishModel(model);
+    }
+
+    /// <summary>
+    ///     Every handler chain that gets a slice, in the order the model lists them: sticky per-endpoint
+    ///     sub-chains ahead of the parent chain they hang off, whole graph ordered by message type. Shared
+    ///     with <see cref="ForGrpcEndpoint" /> so a slice attached to one route is the same slice, chosen the
+    ///     same way, as the one the assembled model carries.
+    /// </summary>
+    internal static IEnumerable<HandlerChain> DescribedChains(WolverineOptions options)
+        => options.HandlerGraph.Chains
+            .OrderBy(x => x.MessageType.FullName, StringComparer.Ordinal)
+            .SelectMany(describedChains);
+
+    private static IEnumerable<HandlerChain> describedChains(HandlerChain chain)
+    {
+        if (chain.MessageType.IsSystemMessageType()) yield break;
+
+        // sticky handlers live on per-endpoint sub-chains, so walk those whether or not the
+        // parent chain has a default handler of its own
+        foreach (var sticky in chain.ByEndpoint)
+        foreach (var described in describedChains(sticky))
+        {
+            yield return described;
+        }
+
+        if (chain.Handlers.Count > 0) yield return chain;
     }
 
     /// <summary>
@@ -250,44 +263,75 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         var slices = model.Slices.ToList();
         foreach (var endpoint in grpc.Endpoints.OrderBy(x => x.ServiceName + "::" + x.MethodName, StringComparer.Ordinal))
         {
-            var origin = new PublisherOrigin
-            {
-                GrpcService = endpoint.ServiceName,
-                GrpcMethod = endpoint.MethodName,
-                Label = $"{endpoint.ServiceName}/{endpoint.MethodName}"
-            };
+            var origin = GrpcOriginFor(endpoint);
 
             var index = slices.FindIndex(x => x.CommandType?.FullName == endpoint.RequestType.FullName);
             if (index >= 0)
             {
-                var existing = slices[index];
-                slices[index] = existing with
-                {
-                    TriggerKind = TriggerKind.Grpc,
-                    TriggerOrigin = existing.TriggerOrigin ?? origin
-                };
+                slices[index] = withGrpcTrigger(slices[index], origin);
             }
             else
             {
-                slices.Add(new EventModelSliceDescriptor(
-                    endpoint.RequestType.Name,
-                    origin.Label,
-                    null,
-                    JasperFx.Descriptors.TypeDescriptor.For(endpoint.RequestType),
-                    null,
-                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
-                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
-                    Array.Empty<JasperFx.Descriptors.TypeDescriptor>())
-                {
-                    Pattern = SlicePattern.Command,
-                    TriggerKind = TriggerKind.Grpc,
-                    TriggerOrigin = origin
-                });
+                slices.Add(grpcTriggerOnlySlice(endpoint, origin));
             }
         }
 
         return model with { Slices = slices };
     }
+
+    /// <summary>
+    ///     GH-4000: the Event Model slice for one gRPC RPC, so the descriptor for that RPC can carry the
+    ///     slice next to the method rather than leaving a consumer to find it in the assembled model. The
+    ///     RPC forwards its request to the bus, so the slice is the <em>forwarded message's</em> slice with
+    ///     the RPC stamped on as its trigger — or, when nothing in this process handles that message, the
+    ///     trigger-only slice the assembled model would carry for it.
+    /// </summary>
+    /// <param name="endpoint">The discovered RPC.</param>
+    /// <param name="options">The Wolverine options, so the forwarded message's handler chain can be found. Null yields the trigger-only slice.</param>
+    public static EventModelSliceDescriptor ForGrpcEndpoint(GrpcEndpointDescriptor endpoint, WolverineOptions? options)
+    {
+        var origin = GrpcOriginFor(endpoint);
+
+        // the same chain, chosen the same way, that Describe() would have turned into the slice
+        // ApplyGrpcTriggers then stamps: first match in model order wins
+        var chain = options is null
+            ? null
+            : DescribedChains(options).FirstOrDefault(x => x.MessageType.FullName == endpoint.RequestType.FullName);
+
+        return chain is null
+            ? grpcTriggerOnlySlice(endpoint, origin)
+            : withGrpcTrigger(EventModelRoles.ForHandlerChain(chain), origin);
+    }
+
+    internal static PublisherOrigin GrpcOriginFor(GrpcEndpointDescriptor endpoint) => new()
+    {
+        GrpcService = endpoint.ServiceName,
+        GrpcMethod = endpoint.MethodName,
+        Label = $"{endpoint.ServiceName}/{endpoint.MethodName}"
+    };
+
+    private static EventModelSliceDescriptor withGrpcTrigger(EventModelSliceDescriptor slice, PublisherOrigin origin)
+        => slice with
+        {
+            TriggerKind = TriggerKind.Grpc,
+            TriggerOrigin = slice.TriggerOrigin ?? origin
+        };
+
+    private static EventModelSliceDescriptor grpcTriggerOnlySlice(GrpcEndpointDescriptor endpoint, PublisherOrigin origin)
+        => new(
+            endpoint.RequestType.Name,
+            origin.Label,
+            null,
+            JasperFx.Descriptors.TypeDescriptor.For(endpoint.RequestType),
+            null,
+            Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+            Array.Empty<JasperFx.Descriptors.TypeDescriptor>(),
+            Array.Empty<JasperFx.Descriptors.TypeDescriptor>())
+        {
+            Pattern = SlicePattern.Command,
+            TriggerKind = TriggerKind.Grpc,
+            TriggerOrigin = origin
+        };
 
     /// <summary>
     ///     Model-wide derivations that need every slice at once: a slice whose command is an event some


### PR DESCRIPTION
Part one of #4000. The gRPC half ships here; the HTTP half is blocked on JasperFx/jasperfx#694 (see below).

### What

`GrpcRpcDescriptor.EventModel` — the sibling of `MessageHandlerDescriptor.EventModel`, nullable and additive on the wire. A consumer walking the gRPC surface method by method now sees the slice next to the RPC instead of having to find it in the assembled `ServiceCapabilities.EventModel` and join back by request type.

Because an RPC's generated wrapper forwards its request to the bus, the slice is the **forwarded message's whole slice** — handler, aggregates it decides against, emitted events, cascaded messages — with the RPC stamped on as its trigger, not merely a note that something was published. An RPC whose message nothing in the process handles gets the trigger-only slice; there is still a boundary worth rendering.

### Derived once

`ApplyGrpcTriggers` (the model path) and the new `WolverineEventModelSource.ForGrpcEndpoint` (the per-route path) now share the origin, the stamping, and the trigger-only construction, and both pick the handler chain out of one `DescribedChains` enumeration — the ordering `Describe()` itself walks: sticky per-endpoint sub-chains ahead of the parent chain, whole graph by message type. Two independent ways of choosing "the chain for this message" would have drifted the first time a sticky handler appeared.

### One honest difference

The assembled model folds a message into a single slice, so when **several RPCs forward the same message** it can name only one of them as the trigger — `SayHello` and the client-streaming `CollectGreetings` both forward `HelloRequest` in the test host, and the model keeps whichever it stamped first. Per route there is no fold: each descriptor names its own RPC. That is an argument for the slot rather than against it, and the tests assert it explicitly.

The same fold is why an RPC whose request type's *simple name* collides with another's (proto-first vs code-first `StreamGreetingsRequest`) has no slice of its own left in the model to compare against. Pre-existing merge-by-name behaviour; called out in the test rather than worked around.

### Tests

- `src/Testing/CoreTests/Acceptance/event_model_per_rpc_4000.cs` — the handled / unhandled / no-options paths, and the per-RPC slice matching the assembled model role for role.
- `src/Wolverine.Grpc.Tests/grpc_event_model_slice_4000.cs` — end-to-end on a real host through `ServiceCapabilities.ReadFrom`: every RPC carries a slice triggered by itself, proto-first `SayHello` carries its handler's roles, code-first `Greet` (contract discovered, handler not) is trigger-only, and the multi-RPC trigger case above.

Green locally: CoreTests 2511, Wolverine.Grpc.Tests 306, MartenTests + Wolverine.Http.Tests event-model suites. Full `wolverine.slnx` builds clean on `-f net9.0` (Release).

### The HTTP half

`HttpChainDescriptor` lives in the **JasperFx** assembly while `EventModelSliceDescriptor` lived in **JasperFx.Events**, which references JasperFx — so the slot could not be declared at all. JasperFx/jasperfx#694 moves the Event Modeling *wire descriptors* down into JasperFx (namespace unchanged, type-forwarded) and adds `HttpChainDescriptor.EventModel`. Wolverine populates it from the already-existing `HttpEventModelSource.ForChain(chain)` in `HttpGraphUsageSource` once that ships in a release; #4000 stays open on that item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3