### PR TITLE
GH-4028: make UseDurableInbox() on a Redis stream a real durable inbox

### DIFF
--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -360,6 +360,24 @@ public class OurRedisJsonMapper<TMessage> : EnvelopeMapper<StreamEntry, List<Nam
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Redis/Wolverine.Redis.Tests/DocumentationSamples.cs#L230-L291' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ourredisjsonmapper' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Durable Inbox <Badge type="tip" text="6.30" />
+
+`UseDurableInbox()` on a Redis stream listener means exactly what it means on every other transport:
+each message is written to your configured message store (`PersistMessagesWithPostgresql()` etc.) **before**
+its stream entry is acknowledged, is handled from there, and scheduled retries are parked in the inbox. A
+process crash mid-handler therefore replays the message from the inbox instead of losing it. Because the
+entry is acknowledged as soon as it is durable, the consumer group's pending list stays short regardless of
+how long handlers take.
+
+::: warning
+Before 6.30 the Redis stream endpoint was marked `IDatabaseBackedEndpoint`, which made a "durable" listener
+skip the inbox write entirely and acknowledge the entry **on receipt** — effectively at-most-once on a crash,
+and scheduled retries went to Redis's own scheduled set rather than the inbox. If you were running
+`UseDurableInbox()` on Redis without a message store, that configuration now requires one, the same as for
+RabbitMQ, Kafka or SQS. If what you actually wanted was Redis-native scheduled retries without a database,
+use the default `BufferedInMemory()` (or `ProcessInline()`) listener: those schedule natively in Redis.
+:::
+
 ## Scheduled Messaging <Badge type="tip" text="5.10" />
 
 The Redis transport supports native Redis message scheduling for delayed or scheduled delivery. There's no configuration

--- a/src/Transports/Redis/Wolverine.Redis.Tests/DatabaseBackedEndpointTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/DatabaseBackedEndpointTests.cs
@@ -5,6 +5,7 @@ using Shouldly;
 using StackExchange.Redis;
 using Wolverine.Configuration;
 using Wolverine.Redis.Internal;
+using Wolverine.Transports;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Util;
@@ -22,7 +23,7 @@ public class DatabaseBackedEndpointTests
     }
 
     [Fact]
-    public async Task redis_endpoint_implements_idatabase_backed_endpoint()
+    public async Task redis_endpoint_is_not_database_backed_and_its_listener_schedules_natively_when_not_durable()
     {
         var streamKey = $"dbe-test-{Guid.NewGuid():N}";
         using var host = await Host.CreateDefaultBuilder()
@@ -38,10 +39,13 @@ public class DatabaseBackedEndpointTests
         var transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
         var endpoint = transport.StreamEndpoint(streamKey);
 
-        // Verify it implements IDatabaseBackedEndpoint
-        endpoint.ShouldBeAssignableTo<IDatabaseBackedEndpoint>();
+        // GH-4028: IDatabaseBackedEndpoint made DurableReceiver skip the inbox INSERT and ACK on receipt,
+        // which is the opposite of what UseDurableInbox() promises. The Redis-native scheduled retry now
+        // lives on the listener, and only for the non-durable modes.
+        endpoint.ShouldNotBeAssignableTo<IDatabaseBackedEndpoint>();
+        typeof(ISupportNativeScheduling).IsAssignableFrom(typeof(RedisStreamListener)).ShouldBeTrue();
 
-        _output.WriteLine("✓ RedisStreamEndpoint implements IDatabaseBackedEndpoint");
+        _output.WriteLine("✓ RedisStreamEndpoint is no longer IDatabaseBackedEndpoint; RedisStreamListener is ISupportNativeScheduling");
     }
 
     [Fact]
@@ -59,7 +63,7 @@ public class DatabaseBackedEndpointTests
 
         var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
         var transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
-        var endpoint = transport.StreamEndpoint(streamKey) as IDatabaseBackedEndpoint;
+        var endpoint = transport.StreamEndpoint(streamKey);
         var database = transport.GetDatabase(database: 0);
         var scheduledKey = transport.StreamEndpoint(streamKey).ScheduledMessagesKey;
 
@@ -123,7 +127,7 @@ public class DatabaseBackedEndpointTests
 
         var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
         var transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
-        var endpoint = transport.StreamEndpoint(streamKey) as IDatabaseBackedEndpoint;
+        var endpoint = transport.StreamEndpoint(streamKey);
         var database = transport.GetDatabase(database: 0);
         var scheduledKey = transport.StreamEndpoint(streamKey).ScheduledMessagesKey;
 
@@ -183,7 +187,7 @@ public class DatabaseBackedEndpointTests
 
         var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
         var transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
-        var endpoint = transport.StreamEndpoint(streamKey) as IDatabaseBackedEndpoint;
+        var endpoint = transport.StreamEndpoint(streamKey);
         var database = transport.GetDatabase(database: 0);
         var scheduledKey = transport.StreamEndpoint(streamKey).ScheduledMessagesKey;
 

--- a/src/Transports/Redis/Wolverine.Redis.Tests/EndToEndRetryTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/EndToEndRetryTests.cs
@@ -40,8 +40,11 @@ public class EndToEndRetryTests(ITestOutputHelper output): IAsyncLifetime
                 // Configure routing to our test stream (without SendInline to ensure durable processing)
                 opts.PublishMessage<E2EFailingCommand>().ToRedisStream(_streamKey);
 
+                // GH-4028: the Redis-native scheduled retry (the sorted set this test inspects) is the
+                // non-durable path now. A Durable Redis listener uses the real inbox, including for its
+                // scheduled retries -- see durable_inbox_is_real_4028.
                 opts.ListenToRedisStream(_streamKey, "e2e-retry-group")
-                    .UseDurableInbox() // Use Durable endpoint (for Redis streams BufferedInMemory is default)
+                    .BufferedInMemory()
                     .StartFromBeginning();
 
                 // Configure a retry policy
@@ -73,8 +76,8 @@ public class EndToEndRetryTests(ITestOutputHelper output): IAsyncLifetime
     [Fact]
     public async Task message_with_retry_policy_saves_to_redis_and_retries()
     {
-        _endpoint.Mode.ShouldBe(EndpointMode.Durable, "Endpoint should be in Durable mode for retries to work");
-        _endpoint.ShouldBeAssignableTo<IDatabaseBackedEndpoint>("Endpoint should implement IDatabaseBackedEndpoint");
+        _endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        _endpoint.ShouldNotBeAssignableTo<IDatabaseBackedEndpoint>("GH-4028: that marker skipped the inbox and ACKed on receipt");
 
         _tracker.FailCount = 1; // Fail once, then succeed
 

--- a/src/Transports/Redis/Wolverine.Redis.Tests/NativeSchedulingRetryTests.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/NativeSchedulingRetryTests.cs
@@ -24,17 +24,18 @@ public class NativeSchedulingRetryTests
     }
 
     [Fact]
-    public void redis_endpoint_implements_idatabase_backed_endpoint()
+    public void redis_endpoint_is_not_database_backed_and_the_listener_owns_native_scheduling()
     {
-        // Verify that RedisStreamEndpoint implements IDatabaseBackedEndpoint interface
-        var endpointType = typeof(RedisStreamEndpoint);
-        var interfaceType = typeof(IDatabaseBackedEndpoint);
-        
-        interfaceType.IsAssignableFrom(endpointType).ShouldBeTrue(
-            "RedisStreamEndpoint should implement IDatabaseBackedEndpoint");
-        
-        _output.WriteLine("✓ RedisStreamEndpoint implements IDatabaseBackedEndpoint interface");
-        _output.WriteLine("  This enables DurableReceiver to call ScheduleRetryAsync() for native retry scheduling");
+        // GH-4028: IDatabaseBackedEndpoint on the endpoint made DurableReceiver skip the inbox INSERT and
+        // complete the delivery on receipt -- "UseDurableInbox()" on a Redis stream never wrote the inbox
+        // and XACKed before the handler ran. The native scheduled retry is now a listener concern, and a
+        // Durable listener routes scheduled retries through the inbox like every other transport.
+        typeof(IDatabaseBackedEndpoint).IsAssignableFrom(typeof(RedisStreamEndpoint)).ShouldBeFalse(
+            "RedisStreamEndpoint must not be IDatabaseBackedEndpoint -- that marker skips the inbox");
+        typeof(ISupportNativeScheduling).IsAssignableFrom(typeof(RedisStreamListener)).ShouldBeTrue(
+            "RedisStreamListener owns Redis-native scheduled retries for the non-durable modes");
+
+        _output.WriteLine("✓ RedisStreamEndpoint is not IDatabaseBackedEndpoint; RedisStreamListener is ISupportNativeScheduling");
     }
 
     [Fact]
@@ -49,7 +50,7 @@ public class NativeSchedulingRetryTests
             "DurableReceiver should implement ISupportNativeScheduling");
         
         _output.WriteLine("✓ DurableReceiver implements ISupportNativeScheduling");
-        _output.WriteLine("  Combined with IDatabaseBackedEndpoint, this enables native retry scheduling");
+        _output.WriteLine("  A Durable Redis listener routes scheduled retries through this, i.e. the inbox");
     }
 
     [Fact]
@@ -65,11 +66,11 @@ public class NativeSchedulingRetryTests
 
         var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
         var transport = runtime.Options.Transports.GetOrCreate<RedisTransport>();
-        var endpoint = transport.StreamEndpoint(streamKey) as IDatabaseBackedEndpoint;
+        var endpoint = transport.StreamEndpoint(streamKey);
         var database = transport.GetDatabase(database: 0);
-        var scheduledKey = transport.StreamEndpoint(streamKey).ScheduledMessagesKey;
+        var scheduledKey = endpoint.ScheduledMessagesKey;
 
-        endpoint.ShouldNotBeNull("Endpoint should implement IDatabaseBackedEndpoint");
+        endpoint.ShouldNotBeNull();
 
         // Clear the scheduled set
         await database.KeyDeleteAsync(scheduledKey);

--- a/src/Transports/Redis/Wolverine.Redis.Tests/Samples/RedisTransportWithScheduling.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/Samples/RedisTransportWithScheduling.cs
@@ -30,11 +30,11 @@ internal static class RedisTransportWithSchedulingSample
                 .SendInline();
 
             opts.ListenToRedisStream("wolverine-messages", "default")
-                .EnableNativeDeadLetterQueue() // Enable DLQ for failed messages
-                .UseDurableInbox(); // Use durable inbox so retry messages are persisted
+                .EnableNativeDeadLetterQueue(); // Enable DLQ for failed messages
 
-            // schedule retry delays
-            // if durable, these will be scheduled natively in Redis
+            // schedule retry delays. On a Buffered (the default) or Inline Redis listener these are
+            // parked natively in Redis, in the stream's scheduled sorted set; a Durable listener
+            // schedules them through its message store's inbox like every other transport
             opts.OnException<Exception>()
                 .ScheduleRetry(
                     TimeSpan.FromSeconds(10),

--- a/src/Transports/Redis/Wolverine.Redis.Tests/durable_inbox_is_real_4028.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/durable_inbox_is_real_4028.cs
@@ -1,0 +1,184 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using StackExchange.Redis;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+/// <summary>
+/// GH-4028. <c>UseDurableInbox()</c> on a Redis stream used to mean "skip the inbox and XACK on receipt"
+/// because <see cref="RedisStreamEndpoint"/> was <c>IDatabaseBackedEndpoint</c>. These pin the real
+/// durable-inbox contract: the message is written to the inbox before the stream entry is acknowledged,
+/// the row is <c>Incoming</c> while the handler runs, and a scheduled retry is parked in the inbox rather
+/// than in the Redis scheduled sorted set.
+/// </summary>
+[Collection("durable_inbox_is_real_4028")]
+public class durable_inbox_is_real_4028 : IAsyncLifetime
+{
+    private string _streamKey = null!;
+    private IHost _host = null!;
+    private IMessageStore _store = null!;
+    private RedisStreamEndpoint _endpoint = null!;
+    private IDatabase _database = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _streamKey = $"durable-real-{Guid.NewGuid():N}";
+        BlockingRedisHandler.Reset();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.ScheduledJobFirstExecution = 100.Milliseconds();
+                opts.Durability.ScheduledJobPollingTime = 200.Milliseconds();
+
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "redis_durable_4028");
+
+                opts.PublishMessage<BlockingRedisMessage>().ToRedisStream(_streamKey).SendInline();
+                opts.PublishMessage<RetryOnceRedisMessage>().ToRedisStream(_streamKey).SendInline();
+
+                opts.ListenToRedisStream(_streamKey, "durable-real-group")
+                    .UseDurableInbox()
+                    .StartFromBeginning();
+
+                opts.Policies.OnException<InvalidOperationException>().ScheduleRetry(1.Seconds());
+
+                opts.Discovery.IncludeType(typeof(BlockingRedisHandler));
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        _store = _host.Services.GetRequiredService<IMessageStore>();
+        await _store.Admin.ClearAllAsync();
+
+        var transport = _host.Services.GetRequiredService<IWolverineRuntime>().Options.Transports.GetOrCreate<RedisTransport>();
+        _endpoint = transport.StreamEndpoint(_streamKey);
+        _database = transport.GetDatabase(database: _endpoint.DatabaseId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        BlockingRedisHandler.Release();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static async Task waitUntil(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (!await condition())
+        {
+            if (DateTimeOffset.UtcNow > deadline)
+            {
+                throw new TimeoutException("Condition was not met in time");
+            }
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public void the_endpoint_is_not_database_backed_and_durable_mode_is_really_durable()
+    {
+        _endpoint.ShouldNotBeAssignableTo<IDatabaseBackedEndpoint>();
+        _endpoint.Mode.ShouldBe(EndpointMode.Durable);
+    }
+
+    [Fact]
+    public async Task a_message_is_in_the_inbox_and_acked_on_the_stream_before_its_handler_finishes()
+    {
+        var id = Guid.NewGuid();
+        await _host.MessageBus().PublishAsync(new BlockingRedisMessage(id));
+
+        // The handler is parked; the message must already be durable
+        await waitUntil(() => Task.FromResult(BlockingRedisHandler.Started.Task.IsCompleted), 30.Seconds());
+
+        var counts = await _store.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(1, "the envelope must be in the inbox as Incoming while the handler runs");
+
+        // ...and because it is durable, the stream entry was acknowledged right after the insert, so
+        // nothing is left pending on the consumer group
+        var pending = await _database.StreamPendingAsync(_streamKey, _endpoint.ConsumerGroup!);
+        pending.PendingMessageCount.ShouldBe(0);
+
+        BlockingRedisHandler.Release();
+
+        await waitUntil(async () => (await _store.Admin.FetchCountsAsync()).Incoming == 0, 30.Seconds());
+        BlockingRedisHandler.Executions(id).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_scheduled_retry_is_parked_in_the_inbox_not_in_the_redis_scheduled_set()
+    {
+        var id = Guid.NewGuid();
+        await _host.MessageBus().PublishAsync(new RetryOnceRedisMessage(id));
+
+        // First attempt fails and schedules a retry 1s out: the inbox holds it as Scheduled
+        await waitUntil(async () => (await _store.Admin.FetchCountsAsync()).Scheduled >= 1, 30.Seconds());
+
+        // The Redis-native scheduled sorted set is the NON-durable mechanism and must be untouched here
+        (await _database.SortedSetLengthAsync(_endpoint.ScheduledMessagesKey)).ShouldBe(0);
+
+        // ...and the retry still happens, from the inbox
+        await waitUntil(() => Task.FromResult(BlockingRedisHandler.Executions(id) >= 2), 30.Seconds());
+        await waitUntil(async () => (await _store.Admin.FetchCountsAsync()).Scheduled == 0, 30.Seconds());
+    }
+}
+
+public record BlockingRedisMessage(Guid Id);
+
+public record RetryOnceRedisMessage(Guid Id);
+
+public static class BlockingRedisHandler
+{
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, int> _executions = new();
+    private static TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static TaskCompletionSource Started { get; private set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static int Executions(Guid id)
+    {
+        return _executions.GetValueOrDefault(id);
+    }
+
+    public static void Reset()
+    {
+        _executions.Clear();
+        _gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Release()
+    {
+        _gate.TrySetResult();
+    }
+
+    public static async Task Handle(BlockingRedisMessage message)
+    {
+        _executions.AddOrUpdate(message.Id, 1, (_, n) => n + 1);
+        Started.TrySetResult();
+        await _gate.Task;
+    }
+
+    public static void Handle(RetryOnceRedisMessage message)
+    {
+        var attempt = _executions.AddOrUpdate(message.Id, 1, (_, n) => n + 1);
+        if (attempt == 1)
+        {
+            throw new InvalidOperationException("first attempt fails on purpose");
+        }
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis.Tests/rate_limiting_end_to_end.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/rate_limiting_end_to_end.cs
@@ -35,8 +35,10 @@ public class rate_limiting_end_to_end(ITestOutputHelper output) : IAsyncLifetime
 
                 opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
                 opts.PublishAllMessages().ToRedisStream(streamKey);
+                // GH-4028: Redis-native scheduling (which this test is about) is the Buffered/Inline path
+                // now; a Durable listener schedules through the inbox and needs a message store.
                 opts.ListenToRedisStream(streamKey, groupName)
-                    .UseDurableInbox()
+                    .BufferedInMemory()
                     .StartFromBeginning();
 
                 opts.RateLimitEndpoint(endpointUri, _limit);

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
@@ -11,7 +11,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.Redis.Internal;
 
-public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeMapper>, IBrokerEndpoint, IBrokerQueue, IDatabaseBackedEndpoint
+public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeMapper>, IBrokerEndpoint, IBrokerQueue
 {
     private readonly RedisTransport _transport;
 
@@ -402,7 +402,20 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
         }
     }
 
-    // IDatabaseBackedEndpoint implementation
+    /// <summary>
+    ///     Park a message in this stream's scheduled sorted set until <see cref="Envelope.ScheduledTime" />,
+    ///     when the listener's polling loop moves it back onto the stream. This is the Redis-native
+    ///     scheduled retry that Buffered and Inline listeners use through
+    ///     <see cref="Wolverine.Transports.ISupportNativeScheduling" /> on <see cref="RedisStreamListener" />.
+    /// </summary>
+    /// <remarks>
+    ///     GH-4028. This endpoint used to implement <c>IDatabaseBackedEndpoint</c> so that DurableReceiver
+    ///     would route scheduled retries here. That marker also told DurableReceiver to skip the inbox INSERT
+    ///     and complete the delivery on receipt -- so "UseDurableInbox()" on a Redis stream ACKed every
+    ///     message before its handler ran and never wrote the inbox at all. A Durable Redis listener now
+    ///     goes through the real inbox like every other transport, including for scheduled retries;
+    ///     Redis-native scheduling is for the non-durable modes.
+    /// </remarks>
     public async Task ScheduleRetryAsync(Envelope envelope, CancellationToken cancellation)
     {
         try

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -10,7 +10,8 @@ using Wolverine.Transports;
 
 namespace Wolverine.Redis.Internal;
 
-public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportConnectionState, IReportReceiveLoopHealth
+public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportConnectionState, IReportReceiveLoopHealth,
+    ISupportNativeScheduling
 {
     private readonly RedisTransport _transport;
     private readonly RedisStreamEndpoint _endpoint;
@@ -241,6 +242,25 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
         {
             _logger.LogWarning(ex, "Error ACKing Redis stream message for envelope {EnvelopeId}", envelope.Id);
         }
+    }
+
+    /// <summary>
+    ///     GH-4028. Redis-native scheduled retries for the non-durable modes: the message is parked in the
+    ///     stream's scheduled sorted set and the polling loop puts it back on the stream when it is due. A
+    ///     Durable listener deliberately reports <c>false</c> here so the scheduled retry goes through the
+    ///     inbox like every other durable transport -- a listener-level reschedule bypasses the inbox
+    ///     entirely, and re-adding the same envelope id to the stream would collide with the inbox row on
+    ///     redelivery and be discarded as a duplicate.
+    /// </summary>
+    public bool NativeSchedulingEnabled => _endpoint.Mode != EndpointMode.Durable;
+
+    public async Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time)
+    {
+        envelope.ScheduledTime = time;
+
+        // Park the copy first, then settle the original: a crash in between costs a duplicate, not a loss
+        await _endpoint.ScheduleRetryAsync(envelope, _cancellation.Token);
+        await CompleteAsync(envelope);
     }
 
     public async ValueTask DeferAsync(Envelope envelope)


### PR DESCRIPTION
Closes #4028 (option B). Found while auditing arrival-side batching for #4026.

## The defect

`RedisStreamEndpoint` implemented `IDatabaseBackedEndpoint` to get Redis-native scheduled retries out of `DurableReceiver`. That marker does two things in `DurableReceiver`, and Redis only wanted one:

1. routes scheduled retries to `endpoint.ScheduleRetryAsync` (intended);
2. sets `ShouldPersistBeforeProcessing = false` and **completes the delivery on receipt** — which for Redis is `XACK` before the handler runs, with **no inbox write at all**.

So `ListenToRedisStream(...).UseDurableInbox()` was at-most-once on a crash — the exact semantics the mode name says it avoids — and the Redis test suite ran "durable" listeners with **no message store configured**, which only worked because of this. With a real store configured, every completion also issued a mark-as-handled `UPDATE` against a row that never existed.

## The fix

- **`RedisStreamEndpoint` is no longer `IDatabaseBackedEndpoint`.** A Durable Redis listener now behaves like every other durable transport: `INSERT` into the inbox **before** the stream entry is acknowledged, handled from the inbox, scheduled retries parked in the inbox. It requires a configured message store, as everywhere else.
- **Redis-native scheduled retries are kept for the non-durable modes** via `RedisStreamListener : ISupportNativeScheduling` (`NativeSchedulingEnabled => Mode != Durable`): park the copy in the stream's scheduled sorted set, then ACK the original (that order so a crash in between costs a duplicate, not a loss). This is strictly better than before for **Buffered** (was in-memory scheduling, lost on crash) and **Inline** (was the inbox, which needed a store). `RedisStreamEndpoint.ScheduleRetryAsync` stays as the method behind it, with docs explaining why.
- A Durable listener deliberately reports `NativeSchedulingEnabled == false`: `MessageContext.ReScheduleAsync` prefers a listener-level rescheduler and **never completes the envelope** in that path, so re-adding the same envelope id to the stream would leave the inbox row orphaned and the redelivered copy would be discarded as a duplicate. The inbox is the only correct place for a durable scheduled retry.

## Tests

| | Result |
|---|---|
| **new `durable_inbox_is_real_4028`** (Redis + Postgres inbox): (a) with the handler parked, the inbox shows the row `Incoming` **and** the consumer group's pending list is already empty — durable, then acked; (b) a `ScheduleRetry` lands in the inbox as `Scheduled`, the Redis scheduled sorted set stays empty, and the retry still runs; (c) the endpoint is not `IDatabaseBackedEndpoint` | 3/3 |
| `EndToEndRetryTests`, `rate_limiting_end_to_end` — both assert the Redis-native scheduled set, i.e. the non-durable path, and both used `UseDurableInbox()` with no store; switched to `BufferedInMemory()` (the code path they were really testing) | ✅ |
| `DatabaseBackedEndpointTests`, `NativeSchedulingRetryTests` — now assert the endpoint is **not** database-backed and the listener owns native scheduling; the `ScheduleRetryAsync` sorted-set tests are unchanged | ✅ |
| **full `Wolverine.Redis.Tests`** | **147 / 147** |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

## Docs / behaviour change

New "Durable Inbox" section in `docs/guide/messaging/transports/redis.md` with a warning box describing the pre-6.30 behaviour and the migration: if you were running `UseDurableInbox()` on Redis without a store you now need one; if you actually wanted Redis-native scheduled retries without a database, the default `BufferedInMemory()` (or `ProcessInline()`) listener is that. The scheduling sample no longer pairs `UseDurableInbox()` with "scheduled natively in Redis".

This is a behaviour change for anyone on Redis "durable" today — but the behaviour they had was not durable, so I'd argue it's a bug fix with a loud note rather than a major-version item. Flagging it explicitly so you can disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
