### PR TITLE
GH-3708 (step 1): add EndpointMode.NativeAck as a default-closed, opt-in mode

### DIFF
--- a/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
+++ b/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Transports.Local;
+using Wolverine.Transports.Stub;
+using Wolverine.Transports.Tcp;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-3708. EndpointMode.NativeAck is opt-in per transport. These tests exist because the obvious way to add a
+/// fourth mode -- routing it through supportsMode() -- is default-open, and several overrides would have accepted
+/// it silently on transports whose settlement model cannot express out-of-order completion.
+/// </summary>
+public class native_ack_mode_gate
+{
+    /// <summary>An endpoint type that has opted in, standing in for RabbitMQ until it does.</summary>
+    private class NativeAckCapableEndpoint : StubEndpoint
+    {
+        public NativeAckCapableEndpoint(string queueName, StubTransport transport) : base(queueName, transport)
+        {
+        }
+
+        protected override bool supportsNativeAck => true;
+    }
+
+    [Fact]
+    public void no_endpoint_type_accepts_native_ack_by_default()
+    {
+        var endpoint = new StubEndpoint("one", new StubTransport());
+
+        endpoint.SupportsMode(EndpointMode.NativeAck).ShouldBeFalse();
+
+        var ex = Should.Throw<InvalidOperationException>(() => endpoint.Mode = EndpointMode.NativeAck);
+        ex.Message.ShouldContain("does not support EndpointMode.NativeAck");
+        ex.Message.ShouldContain("supportsNativeAck");
+
+        endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+    }
+
+    [Fact]
+    public void an_endpoint_that_opts_in_accepts_native_ack()
+    {
+        var endpoint = new NativeAckCapableEndpoint("two", new StubTransport());
+
+        endpoint.SupportsMode(EndpointMode.NativeAck).ShouldBeTrue();
+
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+    }
+
+    /// <summary>
+    /// The whole reason NativeAck is gated on its own predicate. Both of these overrides are written as negations,
+    /// so a fourth enum member routed through supportsMode() would have satisfied them.
+    /// </summary>
+    [Fact]
+    public void a_supportsMode_override_written_as_a_negation_does_not_leak_native_ack()
+    {
+        // TcpEndpoint.supportsMode is "mode != EndpointMode.Inline"
+        var tcp = new TcpEndpoint("localhost", 5099);
+
+        tcp.SupportsMode(EndpointMode.Durable).ShouldBeTrue();
+        tcp.SupportsMode(EndpointMode.NativeAck).ShouldBeFalse();
+
+        Should.Throw<InvalidOperationException>(() => tcp.Mode = EndpointMode.NativeAck);
+    }
+
+    [Fact]
+    public void a_local_queue_never_accepts_native_ack()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.ListenForMessagesFrom("local://nativeack");
+        }).Build();
+
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        var queue = options.Transports.AllEndpoints().OfType<LocalQueue>().First();
+
+        queue.SupportsMode(EndpointMode.NativeAck).ShouldBeFalse();
+        Should.Throw<InvalidOperationException>(() => queue.Mode = EndpointMode.NativeAck);
+    }
+
+    [Fact]
+    public void native_ack_does_not_enforce_back_pressure()
+    {
+        var endpoint = new NativeAckCapableEndpoint("three", new StubTransport());
+
+        endpoint.ShouldEnforceBackPressure().ShouldBeTrue();
+
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        // Broker prefetch is what bounds a native-ack endpoint, so no BackPressureAgent -- same as Inline
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void native_ack_still_reports_its_parallelism_in_diagnostics()
+    {
+        var endpoint = new NativeAckCapableEndpoint("four", new StubTransport());
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.MaxDegreeOfParallelism = 12;
+
+        // Unlike Inline, this mode DOES read MaxDegreeOfParallelism -- it sizes the execution block. GH-3712.
+        endpoint.ModeIgnoresParallelism.ShouldBeFalse();
+        endpoint.DescribeMaxDegreeOfParallelism().ShouldBe("12");
+    }
+
+    [Fact]
+    public void a_global_partitioned_topology_rejects_native_ack()
+    {
+        var topology = new GlobalPartitionedMessageTopology(new WolverineOptions());
+
+        var ex = Should.Throw<ArgumentOutOfRangeException>(() => topology.Mode(EndpointMode.NativeAck));
+        ex.Message.ShouldContain("companion local queue");
+    }
+
+    [Fact]
+    public void the_listener_config_validator_leaves_native_ack_alone()
+    {
+        var endpoint = new NativeAckCapableEndpoint("five", new StubTransport())
+        {
+            IsListener = true,
+            GroupShardingSlotNumber = PartitionSlots.Five
+        };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.MaxDegreeOfParallelism = 10;
+
+        // Partitioned processing plus real parallelism is the POINT of this mode, so the GH-3712 checks -- which
+        // reject exactly that combination on an Inline endpoint -- must not fire here.
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -92,6 +92,17 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
                 case EndpointMode.BufferedInMemory:
                 case EndpointMode.Durable:
                     return (ushort)(MaxDegreeOfParallelism * 2);
+
+                case EndpointMode.NativeAck:
+                    // GH-3708. Prefetch IS the back pressure for this mode -- nothing is acked until the handler
+                    // succeeds, so the unacked window is what bounds the in-memory execution block. It has to cover
+                    // every lane that can be busy at once, which is the partition slot count when the endpoint is
+                    // group-partitioned and MaxDegreeOfParallelism otherwise, doubled so a lane is never starved
+                    // waiting on the next delivery.
+                    var lanes = GroupShardingSlotNumber.HasValue
+                        ? Math.Max((int)GroupShardingSlotNumber.Value, MaxDegreeOfParallelism)
+                        : MaxDegreeOfParallelism;
+                    return (ushort)(lanes * 2);
             }
 
             return 100;

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -71,7 +71,19 @@ public enum EndpointMode
     ///     Incoming messages are processed inline with the external message listening. Outgoing messages are delivered inline
     ///     with the triggering operation
     /// </summary>
-    Inline
+    Inline,
+
+    /// <summary>
+    ///     Incoming messages flow through an in-memory (optionally group-partitioned) execution block while the broker
+    ///     delivery is held unacknowledged, and are settled natively -- acked on handler success, nacked or dead-lettered
+    ///     on terminal failure -- from the completion continuation. Buffered's throughput and partitioning with Inline's
+    ///     no-loss guarantee, and no database involvement. See GH-3708.
+    ///     <para>
+    ///     Opt-in per transport: a transport must override <c>supportsNativeAck</c> to accept this mode, because most
+    ///     settlement models cannot express out-of-order completion.
+    ///     </para>
+    /// </summary>
+    NativeAck
 }
 
 public enum EndpointRole
@@ -370,6 +382,20 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
         get => _mode;
         set
         {
+            // GH-3708. NativeAck is gated on its OWN predicate rather than through supportsMode(), deliberately.
+            // supportsMode() is default-open -- the base returns true, and several overrides are written as
+            // negations (TcpEndpoint's "mode != Inline", SignalRTransport's "mode != Durable") or as a blanket
+            // true (HttpEndpoint) -- so routing this member through it would have every un-audited transport
+            // silently accept a mode whose settlement model it cannot express. A separate default-false predicate
+            // cannot be leaked by an existing override, so only a transport that opts in explicitly accepts it.
+            if (value == EndpointMode.NativeAck && !supportsNativeAck)
+            {
+                throw new InvalidOperationException(
+                    $"Endpoint of type {GetType().Name} does not support EndpointMode.{nameof(EndpointMode.NativeAck)}. " +
+                    "Native ack processing requires a transport that settles each delivery individually and can settle " +
+                    "deliveries out of order; the transport opts in by overriding supportsNativeAck.");
+            }
+
             if (!supportsMode(value))
             {
                 throw new InvalidOperationException(
@@ -676,11 +702,20 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     }
 
     /// <summary>
+    /// GH-3708. Does this endpoint's transport accept <see cref="EndpointMode.NativeAck"/>? Default is <c>false</c> for
+    /// every endpoint type -- unlike <see cref="supportsMode"/>, which is default-open. A transport may only answer true
+    /// if it settles each delivery individually AND tolerates settling them out of order, because the partitioned
+    /// execution block completes messages in handler-completion order rather than delivery order. Kafka, for instance,
+    /// cannot: a cumulative offset commit has no way to express a gap.
+    /// </summary>
+    protected virtual bool supportsNativeAck => false;
+
+    /// <summary>
     /// Check if this endpoint supports the specified mode
     /// </summary>
     public bool SupportsMode(EndpointMode mode)
     {
-        return supportsMode(mode);
+        return mode == EndpointMode.NativeAck ? supportsNativeAck : supportsMode(mode);
     }
 
     // Is this endpoint part of a sharded messaging topology?
@@ -780,7 +815,9 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
 
     public virtual bool ShouldEnforceBackPressure()
     {
-        return Mode != EndpointMode.Inline;
+        // GH-3708: a NativeAck endpoint is bounded by the broker's prefetch window -- it never acks on receipt, so
+        // the broker stops delivering -- which makes an in-process BackPressureAgent redundant, same as Inline.
+        return Mode is not (EndpointMode.Inline or EndpointMode.NativeAck);
     }
 
     /// <summary>

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -465,9 +465,20 @@ public class EndpointCollection : IEndpointCollection
                 return new InlineSendingAgent(_runtime.LoggerFactory.CreateLogger<InlineSendingAgent>(), sender,
                     endpoint, _runtime.MessageTrackingFor(endpoint),
                     _runtime.DurabilitySettings, _runtime, sendingPolicies);
+
+            case EndpointMode.NativeAck:
+                // GH-3708. Mode is a single property governing BOTH directions, so an endpoint that listens with
+                // native acks and is also used for replies or sending arrives here. NativeAck describes how incoming
+                // deliveries are settled and says nothing about sending; on the outgoing side it means exactly what
+                // BufferedInMemory means -- no outbox. Without this arm such an endpoint hit the throw below, which
+                // carried no message at all.
+                return new BufferedSendingAgent(_runtime.LoggerFactory.CreateLogger<BufferedSendingAgent>(),
+                    _runtime.MessageTrackingFor(endpoint), sender, _runtime.DurabilitySettings,
+                    endpoint, _runtime, sendingPolicies);
         }
 
-        throw new InvalidOperationException();
+        throw new InvalidOperationException(
+            $"Unknown {nameof(EndpointMode)} '{endpoint.Mode}' for the sending endpoint at {endpoint.Uri}");
     }
 
     private SendingFailurePolicies? resolveSendingFailurePolicies(Endpoint endpoint)

--- a/src/Wolverine/Configuration/IEndpointPolicy.cs
+++ b/src/Wolverine/Configuration/IEndpointPolicy.cs
@@ -13,6 +13,10 @@ internal class ServerlessEndpointsMustBeInlinePolicy : IEndpointPolicy
     {
         try
         {
+            // GH-3708: this silently downgrades a NativeAck endpoint to Inline, which drops its partitioning and
+            // parallelism. Correct for Serverless -- there is no long-running process to hold an execution block --
+            // but it should say so out loud once a transport can actually opt into NativeAck. Tracked with the
+            // fluent API work rather than here, because nothing can reach this state yet.
             endpoint.Mode = EndpointMode.Inline;
         }
         catch (Exception e)

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedMessageTopology.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedMessageTopology.cs
@@ -37,6 +37,18 @@ public class GlobalPartitionedMessageTopology
     /// </exception>
     public GlobalPartitionedMessageTopology Mode(EndpointMode mode)
     {
+        if (mode == EndpointMode.NativeAck)
+        {
+            // GH-3708. A global partitioned topology bridges its external listener into a companion LOCAL queue
+            // (GlobalPartitionedReceiverBridge), and a local queue has no broker delivery to settle -- so the
+            // native ack would have nothing to ack against. Endpoint-level PartitionProcessingByGroupId() on a
+            // NativeAck listener is the supported shape for partitioned native-ack processing.
+            throw new ArgumentOutOfRangeException(nameof(mode),
+                $"{nameof(EndpointMode)}.{nameof(EndpointMode.NativeAck)} is not supported for global partitioned topologies. "
+                + "Partitioned slots bridge into a companion local queue, which has no broker delivery to settle natively. "
+                + "Use PartitionProcessingByGroupId() directly on the native-ack listener instead.");
+        }
+
         if (mode == EndpointMode.Inline)
         {
             throw new ArgumentOutOfRangeException(nameof(mode),

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -591,8 +591,16 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             case EndpointMode.BufferedInMemory:
                 return new BufferedReceiver(Endpoint, _runtime, _pipeline);
 
+            case EndpointMode.NativeAck:
+                // GH-3708. The enum member and its transport opt-in gate landed ahead of the receiver so that the
+                // mode is never briefly default-open. Unreachable today: no transport overrides supportsNativeAck,
+                // so Endpoint.Mode cannot be set to this value. NativeAckReceiver replaces this arm.
+                throw new NotSupportedException(
+                    $"EndpointMode.NativeAck is not implemented yet for {Endpoint.Uri}. See https://github.com/JasperFx/wolverine/issues/3708");
+
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(Endpoint.Mode), Endpoint.Mode,
+                    $"Unknown {nameof(EndpointMode)} for the listening endpoint at {Endpoint.Uri}");
         }
     }
 }

--- a/src/Wolverine/Transports/Local/LocalQueue.cs
+++ b/src/Wolverine/Transports/Local/LocalQueue.cs
@@ -73,6 +73,11 @@ public class LocalQueue : Endpoint
             // ListenerConfigurationValidator catches the lazily-configured queues at bootstrap. Kept as a
             // real message rather than a bare throw because this is the last line of defense for anything
             // that assigns Endpoint.Mode directly.
+            EndpointMode.NativeAck => throw new NotSupportedException(
+                $"{this} cannot run in {nameof(EndpointMode)}.{nameof(EndpointMode.NativeAck)}. Native acks settle a "
+                + "delivery back to a message broker, and a local queue has no broker to settle against. Use "
+                + $"{nameof(EndpointMode.BufferedInMemory)} or {nameof(EndpointMode.Durable)}. See GH-3708."),
+
             EndpointMode.Inline => throw new NotSupportedException(
                 $"{this} cannot run in {nameof(EndpointMode)}.{nameof(EndpointMode.Inline)}. Inline means \"execute the message on the transport's own listening callback instead of queueing it\", and a local queue has no transport listener -- the queue itself is Wolverine's local execution block. Use {nameof(EndpointMode.BufferedInMemory)} or {nameof(EndpointMode.Durable)}."),
 


### PR DESCRIPTION
First step of the build order in https://github.com/JasperFx/wolverine/issues/3708#issuecomment-5387782934. Plumbing only.

**No behavior changes.** `EndpointMode.NativeAck` now exists, but no transport opts in, so `Endpoint.Mode` cannot be set to it and nothing reaches the new code paths. The point of landing this separately is that the member is never briefly default-open, and that the switch sweep is reviewable on its own rather than buried in the receiver PR.

## The gate, and why it isn't `supportsMode`

`NativeAck` is gated on its own predicate:

```csharp
protected virtual bool supportsNativeAck => false;
```

consulted by the `Mode` setter *independently* of `supportsMode()`. That is deliberate. `supportsMode()` is default-open, and it is not only the base that returns `true`:

| Site | Current | Would a 4th member pass? |
| --- | --- | --- |
| `Endpoint.supportsMode` (base) | `=> true` | yes — ASB, SQS, SNS, Pub/Sub, Kafka, MQTT, Redis, Pulsar, Stub, LocalQueue |
| `TcpEndpoint.cs:36` | `mode != EndpointMode.Inline` | **yes** |
| `SignalRTransport.cs:182` | `mode != EndpointMode.Durable` | **yes** |
| `HttpEndpoint.cs:86` | `=> true` | **yes** |
| RDBMS queues, `NatsEndpoint` (`_ => false`), `GrpcEndpoint`, control endpoints | positive lists | no ✔ |

Routing the member through `supportsMode()` would therefore have had a dozen transports silently accept a mode whose settlement model they cannot express — and would have required auditing every one of them. A default-false predicate cannot be leaked by an override that predates it. A transport opts in when it is ready; RabbitMQ does so in a later step.

## Switch sweep

C# does not require exhaustive `switch` *statements*, so none of these would have produced a compile error. Each was found by grep, not by the compiler.

- **`EndpointCollection.buildSendingAgent:448`** — gets a `NativeAck` arm. `Mode` is a single property governing both directions, so an endpoint that listens with native acks and is also used for replies landed on this method's fallthrough: `throw new InvalidOperationException()` with **no message at all**. It now maps to `BufferedSendingAgent` (the mode describes incoming settlement and says nothing about sending; "no outbox" is exactly Buffered), and the fallthrough now names the mode and the endpoint.
- **`LocalQueue.BuildAgent`** — rejects it with a real message rather than the bare fallthrough. This is the same treatment GH-4022 / #4027 just gave `Inline`; without it, a new enum member re-creates precisely that bug.
- **`GlobalPartitionedMessageTopology.Mode()`** — rejects it. Partitioned slots bridge into a companion *local* queue via `GlobalPartitionedReceiverBridge`, and a local queue has no broker delivery to settle. `PartitionProcessingByGroupId()` directly on a native-ack listener is the supported shape.
- **`Endpoint.ShouldEnforceBackPressure()`** — false for this mode. Nothing is acked until the handler succeeds, so the broker's prefetch window *is* the back pressure and an in-process `BackPressureAgent` is redundant, same as `Inline`.
- **`ListeningAgent.buildReceiverAsync`** — explicit arm throwing a `NotSupportedException` that names the issue, replacing what would otherwise be a bare `ArgumentOutOfRangeException`. Unreachable today; `NativeAckReceiver` replaces it in step 3.
- **`RabbitMqQueue.PreFetchCount`** — sizes the unacked window to cover every lane that can be busy at once (partition slots when group-partitioned, else `MaxDegreeOfParallelism`), doubled so a lane never starves waiting on the next delivery.
- **`ServerlessEndpointsMustBeInlinePolicy`** — comment only. Coercing to `Inline` is correct for Serverless (no long-running process to hold an execution block), but it silently drops partitioning; that deserves to be said out loud once a transport can actually opt in, which is why it is noted rather than half-implemented here.

`Endpoint.ModeIgnoresParallelism` needed no change — `NativeAck` *does* read `MaxDegreeOfParallelism`, so GH-3712's diagnostics remain correct as written. There is a test pinning that.

## Tests

`src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs` — 8 tests: default-closed for every endpoint type; an opted-in endpoint accepts it; **`TcpEndpoint` specifically does not leak it** through its negation-shaped override; local queues never accept it; back pressure off; parallelism still reported in diagnostics; global partitioned topologies reject it; and the GH-3712 listener validator leaves `NativeAck` alone, since partitioning plus real parallelism is the entire point of the mode.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors
- CoreTests — 2529 total, 0 failed, 2 skipped

## Not in this PR

`NativeAckReceiver` (step 3), #4011's `EnqueueDirectlyAsync` branch (step 4), the RabbitMQ opt-in (step 5), and `ProcessInParallelWithNativeAcks()` plus the GH-3712 doc/validator-message debt (step 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)