### PR TITLE
GH-3521: name the application-assembly static in the docs

### DIFF
--- a/docs/guide/handlers/discovery.md
+++ b/docs/guide/handlers/discovery.md
@@ -58,7 +58,8 @@ to bootstrap your application in integration tests to avoid any problems around 
 :::
 
 ::: warning The application assembly is pinned process-wide (test harnesses)
-The resolved application assembly is cached in a **process-wide static** the first time any host in the process
+The resolved application assembly is cached in a **process-wide static** — `WolverineOptions.RememberedApplicationAssembly`,
+mirrored one level down by `JasperFxOptions.RememberedApplicationAssembly` — the first time any host in the process
 falls through to the automatic call-stack determination. In a normal application that runs a single host this is
 harmless. But in a **test process that stands up multiple Wolverine hosts** (xUnit/vstest), whichever test class
 runs *first* pins the scanned assembly for every later host that doesn't set one explicitly — so if an earlier host
@@ -69,9 +70,13 @@ The symptom is quiet and downstream — `No routes can be determined for Envelop
 null scatter/gather results — and it is **order-dependent**: the suite passes in isolation, fails in a full run, and
 can flip between builds as recompilation reshuffles test order.
 
-Wolverine now logs a **warning at startup** when a host adopts an application assembly that differs from where it was
+Wolverine logs a **warning at startup** when a host adopts an application assembly that differs from where it was
 actually registered, naming both assemblies. If you see that warning (or the routing symptom above), set the
 application assembly explicitly on the affected host, or add the missing assembly to discovery — see just below.
+
+This warning only became dependable with GH-3778. Before that fix it could not fire on the
+`RememberedApplicationAssembly` path at all — the very case described here — and elsewhere it frequently named the
+wrong "registered from" assembly, so on older releases neither its presence nor its absence proves much.
 :::
 
 In testing scenarios, if you're bootstrapping the application independently somehow of the application's "official" configuration, you may have to help


### PR DESCRIPTION
Toward #3521's ask 2 — but much smaller than that ask implied, because **most of it was already done.**

## Correcting my own earlier comment

I said on #3521 that ask 2 was "NOT done", citing `grep -rln RememberedApplicationAssembly docs/` returning nothing. That was a false negative: the docs describe the behaviour thoroughly, they just never name the identifier. Both blocks were added by #3530, the original warning PR:

- `docs/guide/handlers/discovery.md` — a warning block under **Assembly Discovery** covering the process-wide cache, the multi-host test-process case, the order-dependence, the quiet downstream symptom, and both remedies.
- `docs/guide/testing.md` — a warning block in the introduction pointing at it.

That is essentially what ask 2 asked for, in both of the places it asked for. I was wrong to call it missing.

## What was actually missing

**The identifier.** `RememberedApplicationAssembly` appears **zero** times in the docs. Anyone who meets it in IntelliSense, a stack trace, or a code review and searches the documentation finds nothing — which is the specific failure mode "document the static" is meant to prevent. This names it, and its `JasperFxOptions` twin.

## And a claim the block was making that was not true

The block said:

> Wolverine **now** logs a warning at startup when a host adopts an application assembly that differs from where it was actually registered

That was not true for the scenario the block itself describes. Until GH-3778 (#4024, merged), `establishApplicationAssembly` adopted `RememberedApplicationAssembly` **without ever calling the divergence check** — so the process-wide pin, the entire subject of that warning block, was the one path that could not produce a warning. And where the check did run it named the wrong "registered from" assembly on 44 of 45 firings in a green suite.

So a reader on an older release who followed this advice would have concluded from silence that they did not have the problem. The added paragraph says plainly that the signal is only dependable from GH-3778 onward.

Docs only — no code change.
