### PR TITLE
GH-4033: skip the test matrix for markdown-only changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,25 @@ name: tests
 on:
   push:
     branches: [ main ]
+    # A markdown-only change cannot alter a single test outcome, and this matrix costs ~211 runner-minutes
+    # per run (35 jobs). Those minutes are the binding constraint on this repo's CI, not wall clock: a merge
+    # wave on 2026-08-23 put 26 runs in the queue with 0 in progress for ~2.5 hours, which left three merges
+    # to main unverifiable for the duration. Skipping docs is the cheapest minute back. See #4033.
+    #
+    # SAFE ONLY WHILE THESE CHECKS ARE NOT REQUIRED. A required status check that never reports because its
+    # workflow was path-filtered leaves a PR permanently unmergeable -- the classic version of this mistake.
+    # Confirmed at the time of writing: `main` has no branch protection, and the only ruleset ("Copilot")
+    # carries deletion / non_fast_forward / copilot_code_review and no required_status_checks. If required
+    # checks are ever added for these jobs, this filter has to go, or gain a companion job that reports
+    # success on the skipped path.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Toward #4033. A markdown-only change cannot alter a test outcome, and this matrix costs **~211 runner-minutes per run** across 35 jobs.

The concrete motivation is one day old: #4034 was a two-line docs edit, and merging it queued a full `tests.yml` run on `main` for nothing — on a day when the queue had already hit **26 runs with 0 in progress for ~2.5 hours**, leaving three merges to `main` unverifiable while it drained.

## What changed

`paths-ignore` for `docs/**` and `**/*.md`, on **both** `push` and `pull_request`:

- the `pull_request` half saves the run per docs PR;
- the `push` half saves the run on `main` after it merges — which is where #4034's waste actually landed.

`fsharp.yml` already uses a `pull_request` `paths` filter, so path filtering is not a new idea in this repo.

## Two things checked rather than assumed

**1. These checks are not required.** This is the failure mode that makes path filters notorious: a required status check whose workflow is path-filtered never reports, and the PR becomes permanently unmergeable. Verified before writing the filter — `main` has no branch protection (`/branches/main/protection` → 404 *Branch not protected*), and the sole ruleset, "Copilot", carries `deletion` / `non_fast_forward` / `copilot_code_review` and **no** `required_status_checks`. A comment on the filter records this, so the constraint is visible to whoever adds required checks later rather than being rediscovered by a stuck PR.

**2. Nothing in the build or tests reads a `.md` file.** The only markdown reachable from a csproj is a bare `<None Include="Runtime\Metrics\METRICS.md" />` — IDE visibility, not packed, not copied to output. The other `.md` mentions in csproj files are comment text.

## Docs PRs still report checks

`dotnet.yml`, `command-line.yml` and `http.yml` carry no path filters, so a docs-only PR still runs `build`, `test`, `command-line` and `describe-handlers-smoke`. It reports a healthy set of checks rather than an empty one — worth stating, because "PR with zero checks" is the other way this kind of change goes wrong.

## The flakiness roll-up is unaffected

It tolerates a gap by design: `flakiness-report.sh` walks back through **up to six** completed `main` runs looking for a baseline, precisely so a run that published nothing doesn't cost the diff. A skipped docs run just isn't a candidate.

## Verification, and its limit

The YAML parses and the workflow is structurally intact — both triggers carry the filter, `workflow_dispatch` survives, 34 matrix targets, `timeout-minutes: 20`, both jobs present.

Being straight about what that does *not* prove: I can't demonstrate the skip from inside this PR, because this PR changes `.github/workflows/tests.yml`, which is not an ignored path — so the full matrix runs here, which is itself the useful half of the check (the filter does not over-match). **The skip is proven by the next markdown-only PR after this merges**, and #3521's remaining docs work is a natural candidate.

## Possible follow-up

`docs.yml` is `workflow_dispatch`-only, so a docs PR gets no vitepress build check at all today — a broken snippet reference or malformed markdown isn't caught until someone publishes. Out of scope here, but worth its own issue if it matters.
