### PR TITLE
GH-4026: stop the NATS durable redelivery storm (9.5x max durable throughput)

### DIFF
--- a/src/Testing/KafkaPerfRig/WolverineNats.cs
+++ b/src/Testing/KafkaPerfRig/WolverineNats.cs
@@ -21,7 +21,16 @@ public static class WolverineNats
         RigHandlerSettings.SequenceByGame = cfg.Sequencing == "semaphore";
 
         var builder = Host.CreateDefaultBuilder()
-            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .ConfigureLogging(logging =>
+            {
+                logging.SetMinimumLevel(LogLevel.Warning);
+                // RIG_LOG_LISTENER=1: see back-pressure pauses / restarts (logged at Information)
+                if (Environment.GetEnvironmentVariable("RIG_LOG_LISTENER") == "1")
+                {
+                    logging.AddFilter("Wolverine.Transports.ListeningAgent", LogLevel.Information);
+                    logging.AddFilter("Wolverine.Runtime.BackPressureAgent", LogLevel.Information);
+                }
+            })
             .UseWolverine(opts =>
             {
                 opts.Durability.Mode = DurabilityMode.Solo;
@@ -50,6 +59,11 @@ public static class WolverineNats
 
         await host.WaitForShutdownAsync();
 
+        // The max-throughput cells leave millions of unconsumed messages in the per-run stream (the
+        // publisher is ~100x faster than a durable consumer); without this they accumulate across runs
+        // (67M messages / 101 GB after one afternoon) and slow the server down for every later cell.
+        await deleteRunStreamAsync(cfg);
+
         StageRecorder.Dump(cfg.OutDir, "nats-consumer", new
         {
             harness = "wolverine-nats",
@@ -62,6 +76,21 @@ public static class WolverineNats
             maxParallel = cfg.MaxParallel,
             maxReceive = cfg.MaxReceive
         });
+    }
+
+    private static async Task deleteRunStreamAsync(RigConfig cfg)
+    {
+        try
+        {
+            await using var connection = new NATS.Client.Core.NatsConnection(new NATS.Client.Core.NatsOpts { Url = cfg.NatsUrl });
+            var js = new NATS.Client.JetStream.NatsJSContext(connection);
+            await js.DeleteStreamAsync(cfg.NatsStream);
+            Console.WriteLine($"[rig] deleted JetStream stream {cfg.NatsStream}");
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"[rig] could not delete JetStream stream {cfg.NatsStream}: {e.Message}");
+        }
     }
 
     private static void configureListener(NatsListenerConfiguration listener, RigConfig cfg)

--- a/src/Testing/KafkaPerfRig/rig.sh
+++ b/src/Testing/KafkaPerfRig/rig.sh
@@ -37,6 +37,11 @@ if [[ ! -x "$BIN" ]]; then
 fi
 
 echo "[rig.sh] run $RIG_RUN_ID: harness=$HARNESS warmup=${WARMUP}s duration=${DURATION}s"
+
+# Durable cells write tens of thousands of rows into the rig schema per run and nothing consumes the
+# leftovers of an aborted run; after enough runs Wolverine's startup recovery (update ... set owner_id = 0)
+# times out scanning the table and the consumer host fails to start. Start every run from a clean schema.
+docker exec wolverine-postgresql-1 psql -U postgres -c "drop schema if exists ${RIG_PG_SCHEMA:-kafka_rig} cascade" >/dev/null 2>&1 || true
 env | grep '^RIG_' | sort | tee "$RIG_OUT/config.env"
 
 "$BIN" "${HARNESS}-consumer" >"$RIG_OUT/consumer.log" 2>&1 &
@@ -59,9 +64,8 @@ trap - EXIT
 # and letting them accumulate across runs eventually fills the Docker VM disk and takes every
 # container down (learned the hard way on 2026-07-19).
 if [[ "$HARNESS" == nats* ]]; then
-  # JetStream streams are work queues here; deleting the per-run stream drops its consumers and messages
-  STREAM="RIG_$(echo "$RIG_RUN_ID" | tr '[:lower:]-' '[:upper:]_')"
-  docker exec wolverine-nats-1 nats stream rm -f "$STREAM" >/dev/null 2>&1 || true
+  # The nats consumer deletes its own per-run stream on shutdown (the nats image has no CLI)
+  :
 elif [[ "$HARNESS" == pulsar* ]]; then
   curl -s -X DELETE "http://localhost:8080/admin/v2/persistent/public/default/rig-small-${RIG_RUN_ID}?force=true" >/dev/null 2>&1 || true
   curl -s -X DELETE "http://localhost:8080/admin/v2/persistent/public/default/rig-large-${RIG_RUN_ID}?force=true" >/dev/null 2>&1 || true

--- a/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
@@ -20,6 +20,12 @@ internal class JetStreamSubscriber : INatsSubscriber
     private INatsJSConsumer? _consumer;
     private Task? _consumerTask;
 
+    // GH-4026: the ONLY thing that ends an active ConsumeAsync enumeration is cancelling its token --
+    // INatsJSConsumer is a metadata handle, and "disposing" it does not stop the pull. This is the
+    // subscriber's own stop signal so disposal can end consumption while the listener's token (which
+    // gates the ack RetryBlock) stays live long enough to settle everything already persisted.
+    private CancellationTokenSource? _consumeCancellation;
+
     // GH-4026: Durable endpoints coalesce consumed messages for up to 5ms (or MaximumMessagesToReceive)
     // and hand the inbox one Envelope[] per window, the way the RabbitMQ and Kafka listeners do. Null
     // for Buffered/Inline, or when MaximumMessagesToReceive is 1.
@@ -155,11 +161,27 @@ internal class JetStreamSubscriber : INatsSubscriber
                 _endpoint.MaximumMessagesToReceive);
         }
 
+        _consumeCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        var consumeToken = _consumeCancellation.Token;
+
         _consumerTask = Task.Run(
             async () =>
             {
+                // GH-4026 follow-up: for a Durable endpoint, bound the client-side pull batch to
+                // MaximumMessagesToReceive instead of NATS.Net's default of 1,000. Every pre-fetched
+                // message counts against the consumer's MaxAckPending (server default 1,000) until it is
+                // acked -- so when a back-pressure pause disposed this consumer, up to 1,000
+                // buffered-but-unacked messages sat against that cap until AckWait expired, the restarted
+                // listener was starved of deliveries the whole time, and then all of them came back as
+                // duplicate inbox inserts. Measured on the rig as a durable listener freezing for 30s at
+                // a time and ~4,000 duplicate inserts per minute. Buffered/Inline keep the client default:
+                // they ack on receipt, so their in-flight window stays small without help.
+                var consumeOpts = _endpoint.Mode == EndpointMode.Durable
+                    ? new NatsJSConsumeOpts { MaxMsgs = Math.Max(1, _endpoint.MaximumMessagesToReceive) }
+                    : null;
+
                 await foreach (
-                    var msg in _consumer!.ConsumeAsync<byte[]>(cancellationToken: cancellation)
+                    var msg in _consumer!.ConsumeAsync<byte[]>(opts: consumeOpts, cancellationToken: consumeToken)
                 )
                 {
                     try
@@ -256,7 +278,22 @@ internal class JetStreamSubscriber : INatsSubscriber
 
     public async ValueTask DisposeAsync()
     {
-        // Dispose consumer first - this will cause ConsumeAsync to complete
+        // GH-4026: cancelling the consume token is what actually ends the ConsumeAsync enumeration.
+        // Disposing the consumer handle alone does not -- with the listener re-ordered to dispose the
+        // subscriber before cancelling its own token, relying on the handle left the loop running
+        // forever (observed as a "stopped" rig listener happily consuming another 7 million messages).
+        if (_consumeCancellation != null)
+        {
+            try
+            {
+                await _consumeCancellation.CancelAsync();
+            }
+            catch (ObjectDisposedException)
+            {
+                // already torn down
+            }
+        }
+
         if (_consumer is IAsyncDisposable disposableConsumer)
         {
             try
@@ -275,12 +312,18 @@ internal class JetStreamSubscriber : INatsSubscriber
             try
             {
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                await _consumerTask;
+                // Bounded: the loop can be parked in a back-pressured PostAsync toward a receiver
+                // that is being torn down; disposal must never hang on it
+                await _consumerTask.WaitAsync(TimeSpan.FromSeconds(30));
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
             }
             catch (OperationCanceledException)
             {
                 // Expected during shutdown
+            }
+            catch (TimeoutException)
+            {
+                _logger.LogWarning("Timed out waiting for the JetStream consume loop for {Subject} to stop during disposal", _endpoint.Subject);
             }
         }
 

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsListener.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsListener.cs
@@ -162,8 +162,15 @@ public class NatsListener : IListener, ISupportDeadLetterQueue, IReportConnectio
 
     public async ValueTask StopAsync()
     {
-        await _cancellation.CancelAsync();
+        // Stop new deliveries FIRST -- disposing the subscriber ends the consume loop and flushes the
+        // durable batching window into the inbox -- while this listener's cancellation token is still
+        // live, so the acks for everything just persisted still go out. Cancelling first made the
+        // _complete RetryBlock silently drop every ack issued during the drain, and each dropped ack
+        // became a JetStream redelivery (and a duplicate inbox insert) AckWait later, counting against
+        // the consumer's MaxAckPending the whole time -- a back-pressure pause starved the restarted
+        // listener of deliveries for the full AckWait. See GH-4026.
         await _subscriber.DisposeAsync();
+        await _cancellation.CancelAsync();
     }
 
     public void Dispose()
@@ -176,8 +183,9 @@ public class NatsListener : IListener, ISupportDeadLetterQueue, IReportConnectio
     {
         if (!_cancellation.IsCancellationRequested)
         {
-            await _cancellation.CancelAsync();
+            // Same ordering as StopAsync: no new deliveries, drain, then cancel
             await _subscriber.DisposeAsync();
+            await _cancellation.CancelAsync();
         }
 
         _complete.Dispose();

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -703,17 +703,24 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             }
         }
 
+        // Settle the broker delivery BEFORE enqueueing for execution. The envelope is durable the moment
+        // the inbox write committed (or, for a database-backed endpoint, already was), and the worker
+        // queue is bounded: when it is full EnqueueAsync blocks, and acking after it meant a persisted
+        // message sat un-acked behind the queue. On a back-pressure stop every one of those was then
+        // redelivered by the broker -- for JetStream only after AckWait, and counted against
+        // MaxAckPending the whole time, so the restarted consumer was starved for 30s and then hit
+        // ~1,000 duplicate inserts in a row. See GH-4026.
+        if (envelope.Listener != null)
+        {
+            await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+        }
+
         if (envelope.Status == EnvelopeStatus.Incoming)
         {
             await EnqueueAsync(envelope).ConfigureAwait(false);
         }
 
         _logger.IncomingReceived(envelope, Uri);
-
-        if (envelope.Listener != null)
-        {
-            await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
-        }
     }
 
     private async Task handleDuplicateIncomingEnvelope(Envelope envelope, DuplicateIncomingEnvelopeException e)
@@ -938,10 +945,18 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
 
         if (batchSucceeded)
         {
+            // Settle the whole batch with the broker first, then enqueue -- see receiveOneAsync for why.
+            // Acking per envelope AFTER EnqueueAsync meant that once the bounded worker queue filled, the
+            // rest of an already-persisted batch sat un-acked, and a back-pressure stop turned all of it
+            // into redeliveries and duplicate inserts.
+            foreach (var message in envelopes)
+            {
+                await _completeBlock.PostAsync(message).ConfigureAwait(false);
+            }
+
             foreach (var message in envelopes)
             {
                 await EnqueueAsync(message).ConfigureAwait(false);
-                await _completeBlock.PostAsync(message).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Follow-up to #4029's NATS lead. The lead as written ("~1.3 ms of awaited ack per message; try `AckAll`") was **wrong** — NATS.Net 2.8 publishes acks fire-and-forget, and per-ack cost was never the ceiling. Instrumenting a run at 1 Hz against the JetStream consumer stats and correlating with the listener log showed what actually happens, repeatedly, on every back-pressure pause:

```
delivered frozen for 30s ┐         ack_pending pinned at 1,000 (= MaxAckPending)
                         ├─ AckWait expires → rd=793 redelivery burst → ~1,000 duplicate inserts
restarted listener idle ─┘
```

## Three defects

1. **Stop dropped the drain's acks.** `NatsListener.StopAsync` cancelled the listener's token *before* draining, and `RetryBlock` silently no-ops on a cancelled token — every ack issued while the stop flushed the durable receive window was discarded. Each one became a redelivery `AckWait` (30 s) later.
2. **1,000-message orphan window.** The client pre-fetches up to 1,000 messages (`ConsumeAsync` `MaxMsgs` default), all counting against the consumer's `MaxAckPending` (server default 1,000) until acked. After a stop, the orphans pinned that cap: the **restarted** listener received *nothing* for the full `AckWait`, then ate ~1,000 duplicate inserts in a burst — and a single duplicate fails the whole batched `INSERT` down to the one-at-a-time redrive.
3. **Persisted-but-unacked tail.** `DurableReceiver` acked each envelope only *after* `EnqueueAsync` onto the bounded (10,000) worker block. Once the queue filled, the tail of an already-persisted batch sat un-acked behind it. A persisted message needs nothing else to be safe — settle first, then enqueue. (Generic: applies to every durable transport.)

## The fixes

- `NatsListener.StopAsync`: dispose the subscriber first (ends deliveries, flushes the durable window into the inbox) **while the token is live so the acks go out**; cancel last. The subscriber gains its own consume-loop `CancellationTokenSource`, because cancelling the token is the *only* thing that ends an active `ConsumeAsync` — `INatsJSConsumer` is a metadata handle, and relying on "disposing" it left a stopped listener happily consuming another 7 million messages during one experiment. The consume-task wait at disposal is bounded (30 s) so teardown can never hang.
- `JetStreamSubscriber`: a **Durable** endpoint bounds the pull batch to `MaximumMessagesToReceive` (default 100), shrinking the maximum orphan window 10×. Buffered/Inline keep the client default (they ack on receipt; bounding them costs top-end throughput for nothing — measured 62 k → 30 k when bounded, unchanged at 64 k without).
- `DurableReceiver` (single + batch paths): settle the broker delivery **before** enqueueing for execution, with the reasoning in comments.

## Measured

Rig `n-max-durable` (NATS + PostgreSQL, uncapped inline publisher, 0 ms handler, 15 s warmup / 45 s measured), **both sides against a freshly dropped rig schema**:

| Build | Runs (msg/s) | Duplicates / run | Stop-starve cycles |
|---|---|---|---|
| `main` (post-#4029) | 521.2 / 429.1 — mean 475 | ~3,800 | 3 |
| **this PR** | **4,531.3 / 3,189.8 / 5,880.7 — mean 4,534** | **0** | pauses still occur (14–20) and are now harmless |

**+9.5× mean, no overlap.** `n-max-buffered` unchanged (64,184/s). This also retroactively explains the modest +35 % NATS number in #4029: the batching win there was real but capped by the storm; with the storm gone the durable inbox batching finally shows Kafka/Pulsar-class gains.

### Rig housekeeping that made the numbers honest
- The per-run JetStream stream is now deleted on consumer shutdown — **67 M leftover messages / 101 GB** had accumulated in the broker container across the day's cells and were degrading every later run.
- `rig.sh` drops the rig's Postgres schema per run — **6 M leftover inbox rows** made Wolverine's startup recovery (`update … set owner_id = 0`) time out before the consumer host even started.

## Tests

| | Result |
|---|---|
| full `Wolverine.Nats.Tests` (incl. `durable_jetstream_batching_4026`, JetStream compliance) | **153/153** |
| full `CoreTests` — includes the GH-3711 mark-as-handled and GH-4012 ack-budget suites over the reordered settle path | **2,523 / 0** |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

No ack-semantics changes: acks are still explicit and per message; only *when* they are issued (immediately after persistence) and how teardown treats the ones in flight changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
