### PR TITLE
GH-3708: EndpointMode.NativeAck — partitioned, parallel processing with native broker acks

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -93,6 +93,60 @@ With this flag enabled:
 
 This is useful when deferring partially-processed batches could lead to latency outliers.
 
+## Native Ack Endpoints <Badge type="tip" text="6.30" />
+
+`NativeAck` fills the cell the other three modes leave empty: **Buffered's throughput and partitioning with
+Inline's no-loss guarantee, and no database involvement.**
+
+| | Broker ack timing | Loss window | Parallelism | Group partitioning | DB cost |
+| --- | --- | --- | --- | --- | --- |
+| `Inline` | after handler success | none | `ListenerCount` only | none | none |
+| `NativeAck` | after handler success | none | `MaximumParallelMessages` | ✔️ | none |
+| `BufferedInMemory` | at receipt, **before** the handler | crash loses buffered messages | `MaximumParallelMessages` | ✔️ | none |
+| `Durable` | after the inbox insert | none | `MaximumParallelMessages` | ✔️ | inbox insert + mark-handled |
+
+```csharp
+opts.ListenToRabbitQueue("webhooks")
+    .ProcessInParallelWithNativeAcks()
+    .PartitionProcessingByGroupId(PartitionSlots.Five)
+    .MaximumParallelMessages(10);
+```
+
+The delivery is held unacknowledged while the message flows through an in-memory, optionally
+group-partitioned execution block, and is settled natively from the completion continuation — acked on
+handler success, nacked or dead-lettered on terminal failure. Nothing is written to a database.
+
+::: warning The guarantee, stated exactly
+**Protection against intra-group concurrency is the hard guarantee. Strict sequential processing in original
+delivery order is not.**
+
+The sequential lane per group slot structurally guarantees that no two messages sharing a group id execute
+concurrently on the owning node. Original-order processing is *not* guaranteed under failure, requeue, or
+broker redelivery — a failed or redelivered message re-enters its lane later, never concurrently. That is the
+honest contract for native-ack retry semantics on every broker. If you need strict order under failure, use
+the durable inbox.
+:::
+
+Three consequences follow from never acking at receipt, and all three are the point rather than side effects:
+
+* **Back pressure is the broker's prefetch window**, not `BufferingLimits`. The broker stops delivering once
+  its unacked ceiling is reached, so no `BackPressureAgent` is created. On RabbitMQ the prefetch default
+  covers every lane that can be busy at once — the partition slot count when group-partitioned, otherwise
+  `MaximumParallelMessages` — doubled so a lane never starves.
+* **A dying node loses nothing.** Anything queued but not yet completed is still unacknowledged, so closing
+  the channel or crashing hands every one of those deliveries back to the broker.
+* **Shutdown trades duplicates for safety.** Graceful drain processes what it can within the drain timeout;
+  whatever it cannot is simply never settled and gets redelivered. A rolling deploy therefore produces
+  duplicate deliveries bounded by the prefetch depth. Your handlers should already be idempotent under
+  at-least-once delivery, but it is worth knowing the number is not zero.
+
+**Transport support is opt-in and default-closed.** A transport must settle each delivery individually *and*
+tolerate settling out of order, because the execution block completes messages in handler-completion order
+rather than delivery order. RabbitMQ queues qualify and are supported today. Kafka cannot and is out of
+scope: a cumulative offset commit has no way to express a gap. Calling
+`ProcessInParallelWithNativeAcks()` on a transport that has not opted in throws at configuration time rather
+than degrading silently.
+
 ## Buffered Endpoints
 
 ::: tip
@@ -189,15 +243,15 @@ queue that `BufferedInMemory` and `Durable` endpoints put between the transport 
 An `Inline` endpoint has no such block: it executes each message directly on the transport's listening
 callback. Settings that size or shard that block therefore do nothing on an `Inline` endpoint.
 
-| Setting | `Inline` | `BufferedInMemory` | `Durable` |
-| --- | --- | --- | --- |
-| `MaximumParallelMessages(n)` / `Sequential()` | ignored (warns) | ✔️ | ✔️ |
-| `PartitionProcessingByGroupId(slots)` | **throws at startup** | ✔️ | ✔️ |
-| `BufferedInMemory(limits)` / `UseDurableInbox(limits)` back pressure | ignored (warns) | ✔️ | ✔️ |
-| `ListenerCount(n)` | ✔️ | ✔️ | ✔️ |
-| `ListenWithStrictOrdering()` / `ListenOnlyAtLeader()` | ✔️ (exclusivity only) | ✔️ | ✔️ |
-| `ExclusiveNodeWithParallelism(n)` | ✔️ exclusivity, parallelism ignored (warns) | ✔️ | ✔️ |
-| `CircuitBreaker()` | ✔️ | ✔️ | ✔️ |
+| Setting | `Inline` | `NativeAck` | `BufferedInMemory` | `Durable` |
+| --- | --- | --- | --- | --- |
+| `MaximumParallelMessages(n)` / `Sequential()` | ignored (warns) | ✔️ | ✔️ | ✔️ |
+| `PartitionProcessingByGroupId(slots)` | **throws at startup** | ✔️ | ✔️ | ✔️ |
+| `BufferedInMemory(limits)` / `UseDurableInbox(limits)` back pressure | ignored (warns) | n/a — broker prefetch | ✔️ | ✔️ |
+| `ListenerCount(n)` | ✔️ | ✔️ | ✔️ | ✔️ |
+| `ListenWithStrictOrdering()` / `ListenOnlyAtLeader()` | ✔️ (exclusivity only) | ✔️ | ✔️ | ✔️ |
+| `ExclusiveNodeWithParallelism(n)` | ✔️ exclusivity, parallelism ignored (warns) | ✔️ | ✔️ | ✔️ |
+| `CircuitBreaker()` | ✔️ | ✔️ | ✔️ | ✔️ |
 
 As of Wolverine 6.30, these combinations are no longer silently accepted:
 

--- a/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
+++ b/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
@@ -43,7 +43,9 @@ public class listener_configuration_validation
         problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
         problem.Message.ShouldContain("PartitionProcessingByGroupId()");
         problem.Message.ShouldContain("stub://one");
-        problem.Message.ShouldContain("BufferedInMemory or Durable");
+        // GH-3708: the message now points at the mode that exists for exactly this combination
+        problem.Message.ShouldContain("ProcessInParallelWithNativeAcks()");
+        problem.Message.ShouldContain("BufferedInMemory()");
     }
 
     [Fact]

--- a/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
+++ b/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
@@ -114,8 +114,18 @@ public class native_ack_mode_gate
     {
         var topology = new GlobalPartitionedMessageTopology(new WolverineOptions());
 
-        var ex = Should.Throw<ArgumentOutOfRangeException>(() => topology.Mode(EndpointMode.NativeAck));
-        ex.Message.ShouldContain("companion local queue");
+        var nativeAck = Should.Throw<ArgumentOutOfRangeException>(() => topology.Mode(EndpointMode.NativeAck));
+        var inline = Should.Throw<ArgumentOutOfRangeException>(() => topology.Mode(EndpointMode.Inline));
+
+        nativeAck.ParamName.ShouldBe("mode");
+
+        // Assert on the MODE NAME, not on the prose. The original version of this test asserted the phrase
+        // "companion local queue", which appears in the Inline rejection as well -- so it could not tell the two
+        // branches apart and would have passed even if NativeAck fell through to the Inline guard. Requiring the
+        // two messages to differ is what actually pins "this mode has its own rejection", and it survives any
+        // rewording of either one.
+        nativeAck.Message.ShouldContain(nameof(EndpointMode.NativeAck));
+        nativeAck.Message.ShouldNotBe(inline.Message);
     }
 
     [Fact]

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_enqueue_directly_4011.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_enqueue_directly_4011.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4011. ListeningAgent.EnqueueDirectlyAsync is a type-switch over receiver implementations with a throwing
+/// fallthrough. Every receiver that existed before GH-3708 had a branch, so the fallthrough was unreachable --
+/// adding a fourth receiver type made it reachable. This is the durability agent's re-entry point (DLQ replay
+/// per GH-1942, scheduled-message firing), so without a branch a NativeAck endpoint in an application that also
+/// has persistence configured threw on any replay targeting it.
+/// </summary>
+public class native_ack_enqueue_directly_4011 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IWolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        NativeAckPingHandler.Handled.Clear();
+        NativeAckPingHandler.Gate = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task enqueue_directly_reaches_a_native_ack_receiver_instead_of_throwing()
+    {
+        var endpoint = new NativeAckStubEndpoint("na-4011", new StubTransport())
+        {
+            IsListener = true
+        };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+
+        await using var agent = new ListeningAgent(endpoint, (WolverineRuntime)theRuntime);
+        await agent.StartAsync();
+
+        // Guard against a vacuous pass: if this were a BufferedReceiver the existing first branch would have
+        // handled it and the test would prove nothing about GH-4011.
+        receiverOf(agent).ShouldBeOfType<NativeAckReceiver>();
+
+        var envelope = new Envelope(new NativeAckPing("replayed"))
+        {
+            MessageType = typeof(NativeAckPing).ToMessageTypeName()
+        };
+
+        // Pre-GH-4011 this threw InvalidOperationException("There is no active, local queue for this listening
+        // endpoint at ...") because NativeAckReceiver matched none of the branches.
+        await agent.EnqueueDirectlyAsync([envelope]);
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!NativeAckPingHandler.Handled.Contains("replayed") && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Yield();
+        }
+
+        NativeAckPingHandler.Handled.ShouldContain("replayed");
+    }
+
+    private static IReceiver receiverOf(ListeningAgent agent)
+    {
+        var field = typeof(ListeningAgent).GetField("_receiver", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IReceiver)field.GetValue(agent)!;
+    }
+}

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_receiver.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_receiver.cs
@@ -1,0 +1,220 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using JasperFx.Core;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+#region test message + handler
+
+public record NativeAckPing(string Name);
+
+public class NativeAckPingHandler
+{
+    public static readonly ConcurrentBag<string> Handled = new();
+
+    /// <summary>Gate so a test can observe the receiver mid-flight without Task.Delay. </summary>
+    public static TaskCompletionSource? Gate;
+
+    public async Task Handle(NativeAckPing message)
+    {
+        if (Gate != null)
+        {
+            await Gate.Task;
+        }
+
+        Handled.Add(message.Name);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// GH-3708. The defining behaviour of EndpointMode.NativeAck: the broker delivery is NOT settled at receipt,
+/// only when the handler pipeline reaches a terminal.
+/// </summary>
+public class native_ack_receiver : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IWolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        NativeAckPingHandler.Handled.Clear();
+        NativeAckPingHandler.Gate = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        NativeAckPingHandler.Gate = null;
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private NativeAckReceiver receiverFor(Action<Endpoint>? configure = null)
+    {
+        var endpoint = new NativeAckStubEndpoint("native-ack", new StubTransport());
+        configure?.Invoke(endpoint);
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+
+        return new NativeAckReceiver(endpoint, theRuntime, new HandlerPipeline((WolverineRuntime)theRuntime, (WolverineRuntime)theRuntime, endpoint));
+    }
+
+    private static Envelope pingEnvelope(string name = "one")
+    {
+        return new Envelope(new NativeAckPing(name)) { MessageType = typeof(NativeAckPing).ToMessageTypeName() };
+    }
+
+    [Fact]
+    public async Task settles_exactly_once_and_only_after_the_handler_succeeds()
+    {
+        var receiver = receiverFor();
+        var listener = new RecordingListener();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        NativeAckPingHandler.Gate = gate;
+
+        await receiver.ReceivedAsync(listener, pingEnvelope());
+
+        // Mid-flight: the delivery has been received and enqueued, and is deliberately still unacknowledged.
+        // This is the entire difference from BufferedInMemory, which acks right here.
+        await listener.WaitUntilAtLeast(0);
+        listener.Completed.Count.ShouldBe(0);
+        listener.Deferred.Count.ShouldBe(0);
+
+        gate.SetResult();
+
+        await listener.WaitForSettlement();
+
+        listener.Completed.Count.ShouldBe(1);
+        listener.Deferred.Count.ShouldBe(0);
+        NativeAckPingHandler.Handled.ShouldContain("one");
+    }
+
+    [Fact]
+    public async Task an_expired_envelope_is_settled_without_ever_reaching_the_handler()
+    {
+        var receiver = receiverFor();
+        var listener = new RecordingListener();
+
+        var envelope = pingEnvelope("expired");
+        envelope.DeliverBy = DateTimeOffset.UtcNow.Subtract(1.Minutes());
+
+        await receiver.ReceivedAsync(listener, envelope);
+        await receiver.DrainAsync();
+
+        // Acked so the broker stops redelivering something nobody will ever process
+        listener.Completed.Count.ShouldBe(1);
+        NativeAckPingHandler.Handled.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_latched_receiver_hands_the_delivery_back_to_the_broker()
+    {
+        var receiver = receiverFor();
+        var listener = new RecordingListener();
+
+        receiver.Latch();
+        await receiver.ReceivedAsync(listener, pingEnvelope("latched"));
+        await receiver.DrainAsync();
+
+        listener.Deferred.Count.ShouldBe(1);
+        listener.Completed.Count.ShouldBe(0);
+        NativeAckPingHandler.Handled.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The reason GH-4013 added the per-envelope channel-source overload. With ListenerCount > 1 the receiver
+    /// is shared across listeners, so a single bound IChannelCallback would settle the wrong delivery.
+    /// </summary>
+    [Fact]
+    public async Task each_delivery_settles_against_its_own_listener()
+    {
+        var receiver = receiverFor();
+        var listenerA = new RecordingListener();
+        var listenerB = new RecordingListener();
+
+        await receiver.ReceivedAsync(listenerA, pingEnvelope("a"));
+        await receiver.ReceivedAsync(listenerB, pingEnvelope("b"));
+
+        // NOT DrainAsync() here: an unlatched drain deliberately does not wait on the block (the same
+        // re-entrancy guard BufferedReceiver has, so a pipeline-triggered pause cannot deadlock itself).
+        await listenerA.WaitForSettlement();
+        await listenerB.WaitForSettlement();
+
+        listenerA.Completed.Count.ShouldBe(1);
+        listenerB.Completed.Count.ShouldBe(1);
+        listenerA.Completed.Single().Message.ShouldBeOfType<NativeAckPing>().Name.ShouldBe("a");
+        listenerB.Completed.Single().Message.ShouldBeOfType<NativeAckPing>().Name.ShouldBe("b");
+    }
+
+    [Fact]
+    public void back_pressure_is_the_brokers_prefetch_window_not_an_agent()
+    {
+        var endpoint = new NativeAckStubEndpoint("native-ack", new StubTransport());
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+    }
+}
+
+/// <summary>Stands in for RabbitMQ until it opts in.</summary>
+internal class NativeAckStubEndpoint : StubEndpoint
+{
+    public NativeAckStubEndpoint(string queueName, StubTransport transport) : base(queueName, transport)
+    {
+    }
+
+    protected override bool supportsNativeAck => true;
+}
+
+/// <summary>Records how each delivery was settled, and by which listener.</summary>
+internal class RecordingListener : IListener
+{
+    public ConcurrentBag<Envelope> Completed { get; } = new();
+    public ConcurrentBag<Envelope> Deferred { get; } = new();
+
+    public Uri Address { get; } = new("stub://native-ack");
+    public IHandlerPipeline? Pipeline => null;
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        Completed.Add(envelope);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DeferAsync(Envelope envelope)
+    {
+        Deferred.Add(envelope);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask StopAsync() => ValueTask.CompletedTask;
+
+    public async Task WaitUntilAtLeast(int settled)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (Completed.Count + Deferred.Count < settled && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Yield();
+        }
+    }
+
+    public Task WaitForSettlement() => WaitUntilAtLeast(1);
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_mode.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_mode.cs
@@ -1,0 +1,180 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+#region messages and handler
+
+public record NativeAckWork(int Number);
+
+public static class NativeAckWorkTracking
+{
+    public static readonly ConcurrentBag<int> Handled = new();
+
+    /// <summary>When set, handlers park here forever -- standing in for a node that dies mid-flight.</summary>
+    public static TaskCompletionSource? Block;
+
+    public static void Reset()
+    {
+        Handled.Clear();
+        Block = null;
+    }
+}
+
+public class NativeAckWorkHandler
+{
+    public async Task Handle(NativeAckWork message)
+    {
+        if (NativeAckWorkTracking.Block != null)
+        {
+            await NativeAckWorkTracking.Block.Task;
+        }
+
+        NativeAckWorkTracking.Handled.Add(message.Number);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// GH-3708. RabbitMQ is the first transport to opt into EndpointMode.NativeAck. The guarantee under test is the
+/// one the mode exists for: Buffered's throughput with Inline's no-loss behaviour.
+/// </summary>
+public class native_ack_mode : IAsyncLifetime
+{
+    // A queue per test. These share one static tracking bag and one broker, so a single queue let the
+    // redelivery test's messages land in another test's assertion.
+    private const string ModeQueue = "native-ack-3708-mode";
+    private const string EndToEndQueue = "native-ack-3708-e2e";
+    private const string RedeliveryQueue = "native-ack-3708-redelivery";
+
+    public ValueTask InitializeAsync()
+    {
+        NativeAckWorkTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        NativeAckWorkTracking.Block?.TrySetResult();
+        NativeAckWorkTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    private static Task<IHost> startHostAsync(string queueName)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRabbitMq("host=localhost;port=5672").AutoProvision();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeAckWorkHandler>();
+
+                opts.ListenToRabbitQueue(queueName)
+                    .Named(queueName)
+                    .ProcessInParallelWithNativeAcks();
+
+                opts.PublishMessage<NativeAckWork>().ToRabbitQueue(queueName);
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task the_endpoint_really_is_in_native_ack_mode_with_a_native_ack_receiver()
+    {
+        using var host = await startHostAsync(ModeQueue);
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = runtime.Endpoints.EndpointByName(ModeQueue).ShouldNotBeNull();
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+
+        // Prefetch IS the back pressure for this mode, so it must cover every lane that can be busy
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task messages_are_processed_end_to_end()
+    {
+        using var host = await startHostAsync(EndToEndQueue);
+        var bus = host.MessageBus();
+
+        for (var i = 0; i < 10; i++)
+        {
+            await bus.SendAsync(new NativeAckWork(i));
+        }
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (handledInRange(0, 10).Count() < 10 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        handledInRange(0, 10).ShouldBe(Enumerable.Range(0, 10));
+    }
+
+    /// <summary>
+    /// The whole point of the mode. Under BufferedInMemory these messages are acked the instant they arrive, so
+    /// a node that dies before the handler finishes loses every one of them. Under NativeAck nothing is acked
+    /// until the handler succeeds, so closing the channel hands them all back to the broker.
+    /// </summary>
+    [Fact]
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    {
+        NativeAckWorkTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstHost = await startHostAsync(RedeliveryQueue);
+        var bus = firstHost.MessageBus();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await bus.SendAsync(new NativeAckWork(100 + i));
+        }
+
+        // Let the deliveries actually reach the parked handlers before killing the node
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (queueCount(firstHost, RedeliveryQueue) == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        // The node dies mid-flight, having acked nothing
+        firstHost.Dispose();
+
+        handledInRange(100, 5).ShouldBeEmpty();
+
+        // A fresh node picks up every redelivered message
+        NativeAckWorkTracking.Block!.TrySetResult();
+        NativeAckWorkTracking.Block = null;
+
+        using var secondHost = await startHostAsync(RedeliveryQueue);
+
+        deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (handledInRange(100, 5).Count() < 5 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        handledInRange(100, 5).ShouldBe(Enumerable.Range(100, 5));
+    }
+
+    private static IEnumerable<int> handledInRange(int start, int count)
+    {
+        return NativeAckWorkTracking.Handled
+            .Where(x => x >= start && x < start + count)
+            .Distinct()
+            .OrderBy(x => x);
+    }
+
+    private static int queueCount(IHost host, string queueName)
+    {
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var circuit = runtime.Endpoints.FindListenerCircuit(new Uri($"rabbitmq://queue/{queueName}"));
+        return circuit?.QueueCount ?? 0;
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -76,6 +76,20 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     public ushort? ConsumerDispatchConcurrency { get; set; }
 
     /// <summary>
+    /// GH-3708. RabbitMQ is the first transport to accept <see cref="EndpointMode.NativeAck"/>. It qualifies on
+    /// both counts the mode requires: deliveries are settled individually -- GH-3706 made every ack
+    /// <c>multiple: false</c>, which matters because under <c>multiple: true</c> an out-of-order completion
+    /// would silently ack every lower delivery tag still in flight -- and GH-3687's <c>DeliveredOn</c> /
+    /// <c>CanSettle</c> plumbing already makes a completion-time ack safe when it arrives from an arbitrary
+    /// worker thread rather than the consumer callback.
+    ///
+    /// <para>
+    /// Only queues, not exchanges or topics: native acks are a listening concept, and RabbitMQ listens on queues.
+    /// </para>
+    /// </summary>
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
     ///     The number of unacknowledged messages that can be processed concurrently
     /// </summary>
     public ushort PreFetchCount

--- a/src/Wolverine/Configuration/IEndpointPolicy.cs
+++ b/src/Wolverine/Configuration/IEndpointPolicy.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Wolverine.Runtime;
 
 namespace Wolverine.Configuration;
@@ -13,10 +14,18 @@ internal class ServerlessEndpointsMustBeInlinePolicy : IEndpointPolicy
     {
         try
         {
-            // GH-3708: this silently downgrades a NativeAck endpoint to Inline, which drops its partitioning and
-            // parallelism. Correct for Serverless -- there is no long-running process to hold an execution block --
-            // but it should say so out loud once a transport can actually opt into NativeAck. Tracked with the
-            // fluent API work rather than here, because nothing can reach this state yet.
+            // GH-3708. Coercing NativeAck to Inline is correct for Serverless -- there is no long-running process
+            // to hold an execution block -- but it silently drops the endpoint's partitioning and parallelism, and
+            // partitioned processing is a GUARANTEE the user asked for. Say so rather than degrading in silence.
+            if (endpoint.Mode == EndpointMode.NativeAck)
+            {
+                runtime.Logger.LogWarning(
+                    "Endpoint {Uri} was configured with ProcessInParallelWithNativeAcks(), but Serverless mode requires every endpoint to be Inline. "
+                    + "Wolverine has downgraded it, which means its parallelism and any PartitionProcessingByGroupId() grouping no longer apply. "
+                    + "Messages are still settled natively; they are simply processed one at a time on the transport's listening callback.",
+                    endpoint.Uri);
+            }
+
             endpoint.Mode = EndpointMode.Inline;
         }
         catch (Exception e)

--- a/src/Wolverine/Configuration/IListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/IListenerConfiguration.cs
@@ -108,6 +108,12 @@ public interface IListenerConfiguration<T> : IEndpointConfiguration<T>
     ///     Force any messages enqueued to this worker queue to be durable
     /// </summary>
     /// <returns></returns>
+    /// <summary>
+    /// Hold each broker delivery unacknowledged while it flows through an in-memory, optionally
+    /// group-partitioned execution block, and settle it natively when the handler finishes. See GH-3708.
+    /// </summary>
+    T ProcessInParallelWithNativeAcks();
+
     T UseDurableInbox(BufferingLimits limits);
 
     /// <summary>

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -407,6 +407,37 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
     /// Not valid on a local queue, which has no transport listener to be inline with -- that combination
     /// throws here rather than at the first send. See GH-4022.
     /// </summary>
+    /// <summary>
+    /// Process incoming messages through an in-memory execution block -- optionally group-partitioned via
+    /// <see cref="PartitionProcessingByGroupId"/> -- while holding the broker delivery unacknowledged, settling it
+    /// natively only when the handler pipeline reaches a terminal. Buffered's throughput and partitioning with
+    /// Inline's no-loss guarantee, and no database involvement. See GH-3708.
+    ///
+    /// <para>
+    /// Requires a transport whose deliveries are settled individually and can be settled out of order; a
+    /// transport that does not qualify throws at configuration time rather than silently degrading. RabbitMQ
+    /// queues qualify today.
+    /// </para>
+    ///
+    /// <para>
+    /// Back pressure is the broker's prefetch window rather than <see cref="BufferingLimits"/>, and the ordering
+    /// guarantee is that messages sharing a group id never run concurrently -- NOT that they run in original
+    /// delivery order, which no native-ack retry scheme can promise. Use the durable inbox if you need that.
+    /// </para>
+    /// </summary>
+    public TSelf ProcessInParallelWithNativeAcks()
+    {
+        if (_endpoint is LocalQueue)
+        {
+            throw new NotSupportedException(
+                $"Wolverine cannot use the {nameof(ProcessInParallelWithNativeAcks)} option for local queues. Native acks "
+                + "settle a delivery back to a message broker, and a local queue has no broker to settle against.");
+        }
+
+        add(e => e.Mode = EndpointMode.NativeAck);
+        return this.As<TSelf>();
+    }
+
     public TSelf ProcessInline()
     {
         if (_endpoint is LocalQueue)

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -105,9 +105,11 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
     /// GroupIds. The number of "slots" reflects the maximum number of parallel messages
     /// that can be handled concurrently.
     ///
-    /// Requires a BufferedInMemory or Durable endpoint. Combining this with ProcessInline()
+    /// Requires a BufferedInMemory, Durable, or NativeAck endpoint. Combining this with ProcessInline()
     /// throws at bootstrap, because an Inline endpoint has no local execution block to shard
-    /// and the group id guarantee would silently not exist. See GH-3712.
+    /// and the group id guarantee would silently not exist. See GH-3712. If you want partitioned
+    /// processing together with native broker acks, that is what
+    /// <see cref="ProcessInParallelWithNativeAcks"/> is for -- see GH-3708.
     /// </summary>
     /// <param name="numberOfSlots"></param>
     /// <returns></returns>

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -63,6 +63,8 @@ internal static class ListenerConfigurationValidator
             yield break;
         }
 
+        // NativeAck reaches none of the checks below and must not: partitioned processing plus real parallelism
+        // is the entire point of that mode. It is Inline -- and only Inline -- that has no execution block.
         var name = describe(endpoint);
 
         if (endpoint is LocalQueue)
@@ -90,8 +92,9 @@ internal static class ListenerConfigurationValidator
                 $"Invalid listener configuration for {name}: PartitionProcessingByGroupId() was configured on an Inline endpoint. " +
                 "Partitioned processing is implemented by Wolverine's local execution block, and an Inline endpoint executes each message " +
                 "directly on the transport's listening callback without one -- so the group id ordering guarantee would silently not exist. " +
-                "Either remove ProcessInline() (partitioned processing requires BufferedInMemory or Durable), or remove " +
-                "PartitionProcessingByGroupId() from this endpoint.");
+                "If you want partitioned processing AND native broker acks, use ProcessInParallelWithNativeAcks() " +
+                "instead of ProcessInline() -- that mode exists for exactly this combination (GH-3708). Otherwise use " +
+                "BufferedInMemory() or UseDurableInbox(), or remove PartitionProcessingByGroupId() from this endpoint.");
         }
 
         if (endpoint.DiscardedMaxDegreeOfParallelism is { } discarded)

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -1,0 +1,290 @@
+using JasperFx.Blocks;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Transports;
+
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3708. The receiver for <see cref="EndpointMode.NativeAck"/>: BufferedReceiver's execution block with
+/// Inline's channel wiring. An incoming delivery is enqueued into an in-memory (optionally group-partitioned)
+/// block and <b>deliberately not settled</b>; the broker delivery stays unacknowledged until the handler
+/// pipeline reaches a terminal, at which point the completion continuation settles it natively against the
+/// listener -- ack on success, nack or dead-letter on terminal failure.
+///
+/// <para>
+/// Two consequences follow from never acking at receipt, and both are the point rather than side effects:
+/// </para>
+/// <list type="bullet">
+/// <item>There is no loss window. Anything queued but not yet completed is still unacknowledged, so a crash
+/// or a closed channel makes the broker redeliver it. That is also why <see cref="DrainAsync"/> does not need
+/// to guarantee it finishes -- whatever it cannot drain in time is simply never settled.</item>
+/// <item>Back pressure is the broker's prefetch window rather than an in-process BackPressureAgent: the broker
+/// stops delivering once its unacked ceiling is reached. See <see cref="Endpoint.ShouldEnforceBackPressure"/>.</item>
+/// </list>
+///
+/// <para>
+/// Scheduling and dead-lettering are the <i>listener's</i> capabilities in this mode, not this receiver's,
+/// because the pipeline channel is the listener -- exactly as in <see cref="InlineReceiver"/>. This receiver
+/// deliberately does not implement ISupportNativeScheduling or ISupportDeadLetterQueue; doing so would route
+/// those terminals through an in-memory structure whose contents a crash would lose, which is the guarantee
+/// this mode exists to provide.
+/// </para>
+/// </summary>
+internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
+{
+    private readonly RetryBlock<Envelope> _completeBlock;
+    private readonly RetryBlock<Envelope> _deferBlock;
+    private readonly Endpoint _endpoint;
+    private readonly ILogger _logger;
+    private readonly IBlock<Envelope> _receivingBlock;
+    private readonly DurabilitySettings _settings;
+    private bool _latched;
+
+    public NativeAckReceiver(Endpoint endpoint, IWolverineRuntime runtime, IHandlerPipeline pipeline)
+    {
+        _endpoint = endpoint;
+        Uri = endpoint.Uri;
+        _logger = runtime.LoggerFactory.CreateLogger<NativeAckReceiver>();
+        _settings = runtime.DurabilitySettings;
+        Pipeline = pipeline;
+
+        // Guard against a listener-less envelope reaching either retry block -- env.Listener is null for the
+        // all-zero system handshake envelope, and an unguarded deref NREs into the retry loop. GH-3013.
+        _deferBlock = new RetryBlock<Envelope>(
+            (env, _) => env.Listener is { } l ? l.DeferAsync(env).AsTask() : Task.CompletedTask, runtime.Logger,
+            runtime.Cancellation);
+
+        // Unlike BufferedReceiver, this block is NOT posted to on receipt. It exists only for envelopes that
+        // never reach the handler pipeline at all -- an already-expired delivery, which has to be acked so the
+        // broker stops redelivering something nobody will ever process.
+        _completeBlock = new RetryBlock<Envelope>(
+            (env, _) => env.Listener is { } l ? l.CompleteAsync(env).AsTask() : Task.CompletedTask, runtime.Logger,
+            runtime.Cancellation);
+
+        if (endpoint.GroupShardingSlotNumber == null)
+        {
+            _receivingBlock = new Block<Envelope>(endpoint.MaxDegreeOfParallelism,
+                Block<Envelope>.DefaultBoundedCapacity, executeAsync);
+        }
+        else
+        {
+            var sharded = new ShardedExecutionBlock((int)endpoint.GroupShardingSlotNumber,
+                runtime.Options.MessagePartitioning, Block<Envelope>.DefaultBoundedCapacity, executeAsync,
+                // GH-3899: message types exempted from partitioned processing run at the endpoint's normal
+                // parallelism instead of a sequential GroupId slot
+                endpoint.MaxDegreeOfParallelism);
+            sharded.OnError = onBlockError;
+
+            // GH-4013 built this overload for exactly this mode: the channel has to be resolved PER ENVELOPE,
+            // because each delivery settles against the listener that delivered it. Binding a single
+            // IChannelCallback for the whole block -- which is all BufferedReceiver ever needed, since its
+            // completions are no-ops -- would ack the wrong delivery under ListenerCount > 1.
+            _receivingBlock = sharded.DeserializeFirst(pipeline, runtime, channelFor);
+        }
+
+        _receivingBlock.OnError = onBlockError;
+    }
+
+    public Uri Uri { get; }
+
+    public IHandlerPipeline Pipeline { get; }
+
+    public int QueueCount => (int)_receivingBlock.Count;
+
+    /// <summary>CritterWatch#942 -- set when the receiving block faults terminally (jasperfx#506).</summary>
+    public bool HasFaulted { get; private set; }
+
+    public void Dispose()
+    {
+        _receivingBlock.Complete();
+        _completeBlock.Dispose();
+        _deferBlock.Dispose();
+    }
+
+    public async ValueTask ReceivedAsync(IListener listener, Envelope[] messages)
+    {
+        if (messages.Length == 0) return;
+
+        if (_settings.Cancellation.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        var now = DateTimeOffset.Now;
+
+        foreach (var envelope in messages)
+        {
+            await receiveOneAsync(listener, envelope, now).ConfigureAwait(false);
+        }
+
+        _logger.IncomingBatchReceived(Uri, messages);
+    }
+
+    public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
+    {
+        await receiveOneAsync(listener, envelope, DateTimeOffset.Now).ConfigureAwait(false);
+        _logger.IncomingReceived(envelope, Uri);
+    }
+
+    private async ValueTask receiveOneAsync(IListener listener, Envelope envelope, DateTimeOffset now)
+    {
+        if (envelope.IsPing()) return;
+
+        envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
+
+        if (envelope.IsExpired())
+        {
+            // Nothing will ever handle it, so settle it rather than leaving the broker to redeliver forever.
+            await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+            return;
+        }
+
+        var activity = _endpoint.TelemetryEnabled ? WolverineTracing.StartReceiving(envelope) : null;
+
+        // NOTE the absence of a _completeBlock.PostAsync here. That single line is what separates this mode
+        // from BufferedInMemory: the delivery stays unacknowledged until the pipeline settles it.
+        await _receivingBlock.PostAsync(envelope).ConfigureAwait(false);
+
+        activity?.Stop();
+    }
+
+    internal async Task executeAsync(Envelope envelope, CancellationToken _)
+    {
+        if (_latched && envelope.Listener != null)
+        {
+            // Latched before this one started: hand it straight back to the broker instead of holding an
+            // unacked delivery that nothing is going to process.
+            await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            if (envelope.ContentType.IsEmpty())
+            {
+                envelope.ContentType = EnvelopeConstants.JsonContentType;
+            }
+
+            // The channel is the LISTENER, which is what makes every terminal settle natively.
+            await Pipeline.InvokeAsync(envelope, channelFor(envelope)).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            try
+            {
+                _logger.LogError(e, "Unexpected error in Pipeline invocation for {Uri}", Uri);
+            }
+            catch
+            {
+                // CritterWatch#942 -- an exception escaping here faults the block terminally via Block's error
+                // rung, and a faulted block never recovers. Swallow: the message fails, the listener survives.
+            }
+
+            // The pipeline did not settle it, so the broker still owns it. Nack rather than leaving the
+            // delivery dangling until the connection drops.
+            try
+            {
+                await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error trying to defer envelope {EnvelopeId} back to the broker", envelope.Id);
+            }
+        }
+    }
+
+    private IChannelCallback channelFor(Envelope envelope)
+    {
+        // Envelope.Listener is assigned by MarkReceived on every path into this receiver.
+        return envelope.Listener is { } listener ? listener : NullChannelCallback.Instance;
+    }
+
+    public void Latch()
+    {
+        _latched = true;
+    }
+
+    public async ValueTask DrainAsync()
+    {
+        // Same re-entrancy guard as the other receivers: a drain triggered from INSIDE the pipeline (a rate
+        // limiting pause, say) must not wait on the block, because the current message's execute function is
+        // still on the call stack and would deadlock.
+        var waitForCompletion = _latched;
+        _latched = true;
+        _receivingBlock.Complete();
+
+        if (waitForCompletion)
+        {
+            try
+            {
+                var completion = _receivingBlock.WaitForCompletionAsync();
+                await Task.WhenAny(completion, Task.Delay(_settings.DrainTimeout)).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error waiting for in-flight message processing to complete at {Uri}", Uri);
+            }
+        }
+
+        // Deliberately NOT a correctness requirement that the block emptied. Anything still queued was never
+        // acked, so closing the channel hands it back to the broker. The cost is redelivery -- bounded by the
+        // prefetch window -- not loss. Quantifying that duplicate count under a rolling deploy is GH-3713.
+        await _completeBlock.DrainAsync().ConfigureAwait(false);
+        await _deferBlock.DrainAsync().ConfigureAwait(false);
+    }
+
+    private void onBlockError(Envelope? envelope, Exception ex)
+    {
+        if (envelope == null)
+        {
+            HasFaulted = true;
+            try
+            {
+                _logger.LogCritical(ex,
+                    "The native-ack worker queue for {Uri} has faulted and stopped processing. Messages already delivered but not yet settled will be redelivered by the broker",
+                    Uri);
+            }
+            catch
+            {
+                // Flag is already set; recovery does not depend on this line landing.
+            }
+
+            return;
+        }
+
+        try
+        {
+            _logger.LogError(ex, "Error processing envelope {EnvelopeId} ({MessageType}) in the native-ack queue for {Uri}",
+                envelope.Id, envelope.MessageType, Uri);
+        }
+        catch
+        {
+            // Swallow: an escape here would fault the block terminally.
+        }
+    }
+}
+
+/// <summary>
+/// GH-3708. Stand-in for the vanishingly rare envelope that reaches the native-ack receiver without a listener
+/// attached. Settling is a no-op because there is no broker delivery to settle.
+/// </summary>
+internal class NullChannelCallback : IChannelCallback
+{
+    internal static readonly NullChannelCallback Instance = new();
+
+    public IHandlerPipeline? Pipeline => null;
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DeferAsync(Envelope envelope)
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -592,11 +592,7 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
                 return new BufferedReceiver(Endpoint, _runtime, _pipeline);
 
             case EndpointMode.NativeAck:
-                // GH-3708. The enum member and its transport opt-in gate landed ahead of the receiver so that the
-                // mode is never briefly default-open. Unreachable today: no transport overrides supportsNativeAck,
-                // so Endpoint.Mode cannot be set to this value. NativeAckReceiver replaces this arm.
-                throw new NotSupportedException(
-                    $"EndpointMode.NativeAck is not implemented yet for {Endpoint.Uri}. See https://github.com/JasperFx/wolverine/issues/3708");
+                return new NativeAckReceiver(Endpoint, _runtime, _pipeline);
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(Endpoint.Mode), Endpoint.Mode,

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -208,6 +208,18 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             // Agent is latched if listener is null
             await inline.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
         }
+        else if (_receiver is NativeAckReceiver nativeAck)
+        {
+            // GH-4011. Same shape as the InlineReceiver case above, and for the same reason: a receiver whose
+            // settlement rides the listener rather than a local queue. These envelopes come from the message
+            // store (DLQ replay per GH-1942, scheduled-message firing), not from a broker delivery, so there is
+            // no delivery tag to ack -- RetryOnInlineChannelCallback marks the inbox row handled and only then
+            // forwards to the real listener. Without this branch a NativeAck endpoint in an application that
+            // also has persistence configured -- durable outbox for sending, native acks on one flooding
+            // listener, a perfectly legitimate combination -- threw on any DLQ replay targeting it.
+            // Agent is latched if listener is null
+            await nativeAck.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
+        }
         else if (_receiver is GlobalPartitionedReceiverBridge bridge)
         {
             // Forward to the companion local queue for sequential processing


### PR DESCRIPTION
Completes https://github.com/JasperFx/wolverine/issues/3708 (steps 3-6 of the [build order](https://github.com/JasperFx/wolverine/issues/3708#issuecomment-5387782934); step 1-2 landed in #4032). Also closes #4011.

Fills the empty cell in the mode matrix: **Buffered's throughput and partitioning with Inline's no-loss guarantee, and no database involvement.**

| | Broker ack timing | Loss window | Parallelism | Group partitioning | DB cost |
| --- | --- | --- | --- | --- | --- |
| `Inline` | after handler success | none | `ListenerCount` only | none | none |
| **`NativeAck`** | after handler success | **none** | `MaximumParallelMessages` | ✔️ | none |
| `BufferedInMemory` | at receipt, **before** the handler | crash loses buffered messages | `MaximumParallelMessages` | ✔️ | none |
| `Durable` | after the inbox insert | none | `MaximumParallelMessages` | ✔️ | inbox insert + mark-handled |

```csharp
opts.ListenToRabbitQueue("webhooks")
    .ProcessInParallelWithNativeAcks()
    .PartitionProcessingByGroupId(PartitionSlots.Five)
    .MaximumParallelMessages(10);
```

## `NativeAckReceiver`

BufferedReceiver's execution block with InlineReceiver's channel wiring. The single line that defines the mode is the **absence** of a `_completeBlock.PostAsync()` on receipt — the delivery stays unacknowledged until the pipeline settles it.

Three decisions worth review attention:

- **The channel is resolved per envelope**, via #4013's `DeserializeFirst(pipeline, runtime, channelSource)` overload rather than one bound `IChannelCallback`. With `ListenerCount > 1` the receiver is shared across listeners, so a single bound channel would ack the wrong delivery. There is a test for it.
- **No `ISupportNativeScheduling` / `ISupportDeadLetterQueue` on the receiver.** The channel is the listener, so those are the listener's native capabilities, exactly as for `InlineReceiver`. Implementing them here would route a terminal through in-memory state a crash would lose — which is the guarantee this mode exists to provide.
- **`_completeBlock` survives, but only for already-expired deliveries.** Something no handler will ever process still has to be acked so the broker stops redelivering it.

## RabbitMQ opts in

`RabbitMqQueue` is the first transport to override `supportsNativeAck`, and it qualifies on both counts the mode requires:

- **Deliveries settle individually.** #3706 made every ack `multiple: false`, which is load-bearing here — under `multiple: true` an out-of-order completion would silently ack every lower delivery tag still in flight, turning the no-loss guarantee into silent loss.
- **Completion-time acks are already safe from arbitrary threads.** #3687's `DeliveredOn` / `CanSettle` plumbing refuses to settle against a stale or closed channel.

Queues only, not exchanges or topics — native acks are a listening concept.

## `ProcessInParallelWithNativeAcks()`

Pulled forward from step 6 into step 5 out of necessity: without it the opt-in is unreachable. There is no fluent `Mode()` on listener configuration, and the first cut of the RabbitMQ test cast through `IRabbitMqQueue` to set `Mode` directly — which documents a missing API rather than a working one.

It throws eagerly for a local queue, matching `ProcessInline()`'s guard from #4027. The lazily-sourced `LocalQueueConfiguration(Func<LocalQueue>)` path that guard cannot see is already covered: `LocalQueue` does not override `supportsNativeAck`, so the `Mode` setter rejects it with a real message.

## GH-4011

`ListeningAgent.EnqueueDirectlyAsync` is a type-switch ending in a throwing fallthrough. Every receiver that existed before this PR had a branch, so the fallthrough was unreachable; `NativeAckReceiver` made it reachable. This is the durability agent's re-entry point — DLQ replay (#1942), scheduled-message firing — so without a branch, a NativeAck endpoint in an application that *also* has persistence configured threw on any replay targeting it. Durable outbox for sending plus native acks on one flooding listener is a legitimate combination, not an exotic one.

**The test was red-baselined** against the exact `InvalidOperationException("There is no active, local queue ...")` before the branch was added, and asserts the receiver really is a `NativeAckReceiver` so it cannot pass vacuously through the `BufferedReceiver` branch.

## Repaying the GH-3712 debt

#4017 landed a bootstrap validator and a per-mode settings matrix written for a three-mode world; both were wrong the moment a fourth mode existed.

- The validator's fatal message for `Inline` + `PartitionProcessingByGroupId()` now points at `ProcessInParallelWithNativeAcks()` — the mode that exists for exactly the combination the user was reaching for — instead of only offering the two modes that mean giving up native acks. The CoreTests assertion pinning that text is updated; it is precisely the debt #4017 predicted.
- `ServerlessEndpointsMustBeInlinePolicy` now **warns** before downgrading a NativeAck endpoint. Coercion is correct for Serverless, but partitioned processing is a guarantee the user asked for, and dropping it in silence is the exact failure mode GH-3712 exists to prevent.
- The listener docs gain a `NativeAck` column and a section for the mode.

## The guarantee, stated exactly

**Protection against intra-group concurrency is the hard guarantee. Strict sequential processing in original delivery order is not.** A failed or redelivered message re-enters its lane later, never concurrently. That is the honest contract for native-ack retry semantics on every broker; users needing strict order under failure keep the durable inbox. This is in the docs in those words.

Also documented rather than left to be discovered: **a rolling deploy produces duplicate deliveries bounded by prefetch depth.** Graceful drain processes what it can within the drain timeout; whatever it cannot is never settled and gets redelivered. Handlers should already be idempotent under at-least-once, but the number is not zero. Quantifying it under chaos is #3713.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors
- CoreTests — 2539 total, 0 failed, 2 skipped
- **RabbitMQ tests run against a real broker**, including the one that matters: a node dies mid-flight having acked nothing, and a fresh node picks up all five messages on redelivery. Under `BufferedInMemory` those five are gone.

That redelivery test initially "failed" by proving itself — its redelivered messages showed up in a *different* test's assertion, because the tracking bag is static and all three tests shared one queue while the broker outlives the host. Each test now owns its queue.

## Not in this PR

#3715 (NativeAck for other transports — ASB, SQS, Pub/Sub, NATS JetStream, Redis Streams and Pulsar are all natural fits), #3713 (the 5-node chaos reproduction), and #3709, whose premise needs re-scoping against what actually landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)