### PR TITLE
GH-3540: move the Npgsql-EF projects to net10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -170,9 +170,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
@@ -184,7 +185,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.2" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
   </ItemGroup>
   <!-- TFM-conditional EF Core ecosystem -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenancyCompliance.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/ConjoinedTenancyCompliance.cs
@@ -95,12 +95,25 @@ public abstract class ConjoinedTenancyCompliance : IAsyncLifetime
         property.GetColumnName().ShouldBe(StorageConstants.TenantIdColumn);
         property.GetDefaultValue().ShouldBe(StorageConstants.DefaultTenantId);
         entityType.GetIndexes().ShouldContain(x => x.Properties.Any(p => p.Name == nameof(ConjoinedItem.TenantId)));
+        // EF 10 replaced the single anonymous filter with NAMED filters, and the customizer
+        // registers under ConjoinedTenancy.QueryFilterName there -- so GetQueryFilter(), the EF 8/9
+        // accessor, reads null on EF 10 even though the filter is applied. Asserting through the
+        // old accessor on net10 reports a broken feature that works. GH-3540.
+#if NET10_0_OR_GREATER
+        entityType.GetDeclaredQueryFilters()
+            .ShouldContain(x => x.Key == Wolverine.EntityFrameworkCore.Internals.ConjoinedTenancy.QueryFilterName);
+#else
         entityType.GetQueryFilter().ShouldNotBeNull();
+#endif
 
         // And an unmarked entity is left completely alone
         var globalType = context.Model.FindEntityType(typeof(GlobalThing))!;
         globalType.FindProperty(nameof(ConjoinedItem.TenantId)).ShouldBeNull();
+#if NET10_0_OR_GREATER
+        globalType.GetDeclaredQueryFilters().ShouldBeEmpty();
+#else
         globalType.GetQueryFilter().ShouldBeNull();
+#endif
     }
 
     [Fact]

--- a/src/Persistence/EfCoreTests.MultiTenancy/EfCoreTests.MultiTenancy.csproj
+++ b/src/Persistence/EfCoreTests.MultiTenancy/EfCoreTests.MultiTenancy.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <NoWarn>$(NoWarn);CS0436</NoWarn>
     </PropertyGroup>
 

--- a/src/Persistence/EfCoreTests/EfCoreTests.csproj
+++ b/src/Persistence/EfCoreTests/EfCoreTests.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Persistence/MultiTenantedEfCoreWithPostgreSQL/MultiTenantedEfCoreWithPostgreSQL.csproj
+++ b/src/Persistence/MultiTenantedEfCoreWithPostgreSQL/MultiTenantedEfCoreWithPostgreSQL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/Persistence/MultiTenantedEfCoreWithSqlServer/MultiTenantedEfCoreWithSqlServer.csproj
+++ b/src/Persistence/MultiTenantedEfCoreWithSqlServer/MultiTenantedEfCoreWithSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/Samples/ConjoinedMultiTenantedEfCore/ConjoinedMultiTenantedEfCore.csproj
+++ b/src/Samples/ConjoinedMultiTenantedEfCore/ConjoinedMultiTenantedEfCore.csproj
@@ -4,7 +4,7 @@
         <!-- net9.0 only for now: every project using the Npgsql EF provider in this
              repo is net9.0-only until Npgsql.EntityFrameworkCore.PostgreSQL 10 GA
              (the rc pin conflicts with Microsoft.EntityFrameworkCore 10.0.2) -->
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes #3540.

Npgsql.EntityFrameworkCore.PostgreSQL 10 GA has shipped, so the `rc.2` pin that kept every Npgsql-EF project net9-only can go.

## The blocker moved rather than disappeared

The issue records rc.2 hard-pinning EF Core `10.0.0-rc.2` against the repo's `10.0.2`. **GA is stricter, not looser:** Npgsql EF 10.0.1+ requires `Microsoft.EntityFrameworkCore [10.0.4, 11.0.0)`. So this is a coordinated bump of both — EF Core `10.0.2 → 10.0.4` and Npgsql EF `rc.2 → 10.0.3` in the net10 block — not the one-line version change the issue implies.

`Microsoft.EntityFrameworkCore.InMemory` also had **no net10 pin at all** (declared only for net9), which surfaces as `NU1010` the moment `EfCoreTests` multi-targets. Added.

## Running on net10 found a real defect — in the test, not the product

This is the part worth reviewing. EF 10 replaced the single anonymous query filter with **named** filters. `ConjoinedTenancyModelCustomizer` already handles that:

```csharp
#if NET10_0_OR_GREATER
    entity.HasQueryFilter(ConjoinedTenancy.QueryFilterName, filter);
#else
    entity.HasQueryFilter(filter);
#endif
```

The compliance assertion did not. It calls `IEntityType.GetQueryFilter()` — the EF 8/9 accessor — which reads **null** on EF 10 even though the filter is registered and working. So the first net10 run failed `tenanted_entities_are_mapped_with_tenant_id_column_filter_and_index` on both Postgres and SQL Server, and left alone it would have reported a healthy feature as broken. The assertion now mirrors the customizer's own split.

`DbContextUsageSource` already documents this exact EF 8/9-vs-10 accessor difference and reflects over both, which is what identified the test as the stale side rather than the product.

## Three Npgsql-EF projects deliberately NOT moved

The pin was not what was holding them, and folding their problems in here would bury the change:

- **WolverineWebApi** and **Wolverine.Http.Tests** — blocked on **Microsoft.OpenApi 2.x**, which removed the `Microsoft.OpenApi.Any` and `Microsoft.OpenApi.Models` namespaces they use. Moving them also trips `NU1510` for a `Microsoft.AspNetCore.SignalR` reference that net10 prunes. That is an OpenApi migration and wants its own PR.
- **PausingAndRestartingListener** — **already broken on net9 on `main`**: it imports `Oakton` with no package reference for it. It is in neither solution file and no build target, so nothing has compiled it in a long time. Worth its own issue; I did not touch it.

## CI cost: none

`tests.yml` passes `--framework net9.0`, and both `frameworksBuiltFor` and `BuildTestProjectsWithFramework` honour it, so the added TFM adds no CI time — neither build nor test.

## Verified

| suite | net9.0 | net10.0 |
|---|--:|--:|
| `EfCoreTests.MultiTenancy` | 193 tests, **0 failed** | 193 tests, **0 failed** |
| `EfCoreTests` | 205 tests, **0 failed** | 205 tests, **0 failed** |

Plus `dotnet build wolverine.slnx -c Release -f net9.0` clean.

One note on how that green was reached, since the first run was not: the initial net10 run showed 54 failures and net9 showed 52. Diffing the failure *sets* rather than the counts isolated the two genuine net10 regressions above; the other 52 were one stale local SQL Server table (`mt_items.items`, left over from an older model, failing every SQL-Server-backed class with the same `Cannot insert the value NULL into column 'Name'`). Dropping it took both frameworks to zero. Counts alone would have hidden the two that mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
