### PR TITLE
GH-3531: cover EF Core + Marten conjoined tenancy in one database

### DIFF
--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/MixedConjoinedTenancyModel.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/MixedConjoinedTenancyModel.cs
@@ -1,0 +1,53 @@
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.Attributes;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+// GH-3531. The EF half of a database shared with Marten. Deliberately in its own schema so the
+// assertions can say WHICH engine owns a given table rather than inferring it from a name.
+public class MixedItem : ITenanted
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? TenantId { get; set; }
+}
+
+public record CreateMixedItem(Guid Id, string Name);
+
+[WolverineIgnore]
+public class MixedItemHandler
+{
+    public static void Handle(CreateMixedItem command, MixedItemsDbContext db)
+    {
+        db.Items.Add(new MixedItem { Id = command.Id, Name = command.Name });
+    }
+}
+
+public class MixedItemsDbContext : DbContext
+{
+    public const string SchemaName = "mixed_ef";
+
+    public MixedItemsDbContext(DbContextOptions<MixedItemsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<MixedItem> Items { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MixedItem>(map =>
+        {
+            map.ToTable("mixed_items", SchemaName);
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+        });
+    }
+}
+
+// The Marten half of the same database.
+public class MixedDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/mixed_efcore_and_marten_conjoined_tenancy.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/mixed_efcore_and_marten_conjoined_tenancy.cs
@@ -1,0 +1,262 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.MultiTenancy;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Internals;
+using Wolverine.Marten;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+/// <summary>
+/// GH-3531. Wolverine-managed conjoined EF Core tenancy and Marten conjoined tenancy sharing ONE
+/// physical Postgres database, which is what a real Critter Stack app hits and what every existing
+/// conjoined battery avoids by giving EF the database to itself.
+///
+/// <para>The question these ask is ownership: two engines each manage their own partitions and their
+/// own tenant registry against the same server, and neither may create, drop or claim the other's.
+/// Deliberately asserted against pg_catalog rather than against either engine's own API, because an
+/// engine reporting on its own partitions cannot show that it left the other alone.</para>
+/// </summary>
+[Collection("multi-tenancy")]
+public class mixed_efcore_and_marten_conjoined_tenancy : IAsyncLifetime
+{
+    private const string MartenSchema = "mixed_marten";
+    private const string WolverineSchema = "mixed_wolverine";
+    private const string TenantRed = "red";
+    private const string TenantBlue = "blue";
+
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+    private IConjoinedTenantPartitions<MixedItemsDbContext> thePartitions = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await dropSchemasAsync();
+
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<MixedItemHandler>();
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, WolverineSchema);
+
+                opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<MixedItemsDbContext>(
+                    (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                    AutoCreate.CreateOrUpdate,
+                    tenancy => tenancy.PartitionPerTenant());
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = MartenSchema;
+                    m.DisableNpgsqlLogging = true;
+                    // Marten manages its OWN per-tenant partitions here, which is the half of the
+                    // scenario that matters: two engines each partitioning their own tables in one DB
+                    m.Policies.PartitionMultiTenantedDocumentsUsingMartenManagement(MartenSchema);
+
+                    m.Schema.For<MixedDoc>().MultiTenanted();
+                }).ApplyAllDatabaseChangesOnStartup();
+
+                // NOTE: deliberately NOT .IntegrateWithWolverine() here -- see GH-3531. Handing the
+                // Wolverine message store to Marten leaves the conjoined EF builder unable to resolve
+                // a connection string ("Unable to determine the database connection string for the
+                // conjoined multi-tenanted DbContext"), because it reads it from the message store's
+                // database settings and Marten's store does not surface one. That interaction is a
+                // finding in its own right; these tests are about partition and tenant OWNERSHIP
+                // between the two engines, which does not depend on who owns envelope storage.
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddResourceSetupOnStartup();
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+        thePartitions = theHost.Services.GetRequiredService<IConjoinedTenantPartitions<MixedItemsDbContext>>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private static async Task dropSchemasAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"DROP SCHEMA IF EXISTS {MixedItemsDbContext.SchemaName} CASCADE; " +
+            $"DROP SCHEMA IF EXISTS {MartenSchema} CASCADE; " +
+            $"DROP SCHEMA IF EXISTS {WolverineSchema} CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task each_engine_keeps_its_control_tables_in_its_own_schema()
+    {
+        var wolverineTables = await tablesInAsync(WolverineSchema);
+        var martenTables = await tablesInAsync(MartenSchema);
+        var efTables = await tablesInAsync(MixedItemsDbContext.SchemaName);
+
+        // Wolverine's conjoined bookkeeping -- the tenant registry and the partition control table
+        wolverineTables.ShouldContain("wolverine_tenants");
+        wolverineTables.ShouldContain("wolverine_tenant_partitions");
+
+        // ...and it stays out of the other two schemas entirely
+        martenTables.ShouldNotContain("wolverine_tenants");
+        martenTables.ShouldNotContain("wolverine_tenant_partitions");
+        efTables.ShouldNotContain("wolverine_tenants");
+        efTables.ShouldNotContain("wolverine_tenant_partitions");
+
+        // Marten's own partition control table -- the counterpart the issue names -- lives in
+        // Marten's schema and nowhere else
+        martenTables.ShouldContain("mt_tenant_partitions");
+        wolverineTables.ShouldNotContain("mt_tenant_partitions");
+        efTables.ShouldNotContain("mt_tenant_partitions");
+
+        // Marten's document storage stays in Marten's schema, and the EF entity in EF's
+        martenTables.ShouldContain(x => x.StartsWith("mt_doc_"));
+        efTables.ShouldContain("mixed_items");
+        efTables.ShouldNotContain(x => x.StartsWith("mt_doc_"));
+    }
+
+    [Fact]
+    public async Task registering_a_tenant_with_wolverine_partitions_only_the_ef_table()
+    {
+        var martenBefore = await partitionsOfAsync(MartenSchema, "mt_doc_mixeddoc");
+
+        await theHost.AddWolverineManagedTenantsAsync<MixedItemsDbContext>(TenantRed);
+
+        var efAfter = await partitionsOfAsync(MixedItemsDbContext.SchemaName, "mixed_items");
+        efAfter.ShouldContain(x => x.Contains(TenantRed));
+
+        // The whole point: Wolverine created a partition on ITS table and left Marten's alone
+        var martenAfter = await partitionsOfAsync(MartenSchema, "mt_doc_mixeddoc");
+        martenAfter.ShouldBe(martenBefore);
+        martenAfter.ShouldNotContain(x => x.Contains(TenantRed));
+    }
+
+    [Fact]
+    public async Task registering_a_tenant_with_marten_does_not_partition_the_ef_table()
+    {
+        var efBefore = await partitionsOfAsync(MixedItemsDbContext.SchemaName, "mixed_items");
+
+        await theStore.Advanced.AddMartenManagedTenantsAsync(TestContext.Current.CancellationToken,
+            new Dictionary<string, string> { [TenantBlue] = TenantBlue });
+
+        var martenAfter = await partitionsOfAsync(MartenSchema, "mt_doc_mixeddoc");
+        martenAfter.ShouldContain(x => x.Contains(TenantBlue));
+
+        // ...and Marten left the EF table exactly as it found it
+        var efAfter = await partitionsOfAsync(MixedItemsDbContext.SchemaName, "mixed_items");
+        efAfter.ShouldBe(efBefore);
+        efAfter.ShouldNotContain(x => x.Contains(TenantBlue));
+    }
+
+    [Fact]
+    public async Task cross_tenant_isolation_holds_for_both_engines_in_one_database()
+    {
+        await theHost.AddWolverineManagedTenantsAsync<MixedItemsDbContext>(TenantRed, TenantBlue);
+        await theStore.Advanced.AddMartenManagedTenantsAsync(TestContext.Current.CancellationToken,
+            new Dictionary<string, string> { [TenantRed] = TenantRed, [TenantBlue] = TenantBlue });
+
+        var redItem = Guid.NewGuid();
+        var blueItem = Guid.NewGuid();
+
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync(TenantRed, new CreateMixedItem(redItem, "red-item")));
+        await theHost.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync(TenantBlue, new CreateMixedItem(blueItem, "blue-item")));
+
+        await using (var redSession = theStore.LightweightSession(TenantRed))
+        {
+            redSession.Store(new MixedDoc { Id = redItem, Name = "red-doc" });
+            await redSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var blueSession = theStore.LightweightSession(TenantBlue))
+        {
+            blueSession.Store(new MixedDoc { Id = blueItem, Name = "blue-doc" });
+            await blueSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // EF entities: each tenant sees only its own row
+        var builder = theHost.Services.GetRequiredService<IDbContextBuilder<MixedItemsDbContext>>();
+        await using (var red = await builder.BuildAsync(TenantRed, TestContext.Current.CancellationToken))
+        {
+            // Both Marten and EF Core ship an AnyAsync extension, and this file sees both -- qualify
+            // so the EF one is unambiguously the one querying an EF DbSet
+            (await EntityFrameworkQueryableExtensions.AnyAsync(
+                red.Items, x => x.Id == redItem, TestContext.Current.CancellationToken)).ShouldBeTrue();
+            (await EntityFrameworkQueryableExtensions.AnyAsync(
+                red.Items, x => x.Id == blueItem, TestContext.Current.CancellationToken)).ShouldBeFalse();
+        }
+
+        // Marten documents: the same isolation, from the same database
+        await using (var red = theStore.QuerySession(TenantRed))
+        {
+            (await red.LoadAsync<MixedDoc>(redItem, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+            (await red.LoadAsync<MixedDoc>(blueItem, TestContext.Current.CancellationToken)).ShouldBeNull();
+        }
+
+        await using (var blue = theStore.QuerySession(TenantBlue))
+        {
+            (await blue.LoadAsync<MixedDoc>(blueItem, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+            (await blue.LoadAsync<MixedDoc>(redItem, TestContext.Current.CancellationToken)).ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// Child partitions of a table, straight from pg_catalog -- neither engine's own bookkeeping.
+    /// </summary>
+    private static async Task<IReadOnlyList<string>> partitionsOfAsync(string schema, string table)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+                          select child.relname
+                          from pg_inherits
+                             join pg_class parent on pg_inherits.inhparent = parent.oid
+                             join pg_class child on pg_inherits.inhrelid = child.oid
+                             join pg_namespace n on parent.relnamespace = n.oid
+                          where n.nspname = :schema and parent.relname = :table
+                          order by child.relname;
+                          """;
+        cmd.Parameters.AddWithValue("schema", schema);
+        cmd.Parameters.AddWithValue("table", table);
+
+        var names = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) names.Add(reader.GetString(0));
+        return names;
+    }
+
+    private static async Task<IReadOnlyList<string>> tablesInAsync(string schema)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select tablename from pg_tables where schemaname = :schema order by tablename;";
+        cmd.Parameters.AddWithValue("schema", schema);
+
+        var names = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) names.Add(reader.GetString(0));
+        return names;
+    }
+}


### PR DESCRIPTION
Covers scenario 1 of #3531.

Every existing conjoined battery gives EF Core the database to itself. A real Critter Stack app does not. This adds the mixed-persistence coverage the issue asks for: **Wolverine-managed conjoined EF tenancy with `PartitionPerTenant`, and Marten conjoined tenancy with Marten-managed partitioning, against one Postgres database**, each in its own schema.

## Asserted against `pg_catalog`, not against either engine

This is the design decision worth reviewing. Every assertion reads `pg_inherits` / `pg_tables` directly rather than asking Wolverine or Marten what they think they did — because **an engine reporting on its own partitions cannot show that it left the other one alone**, which is the entire question the issue poses.

| test | what it pins |
|---|---|
| `each_engine_keeps_its_control_tables_in_its_own_schema` | `wolverine_tenants` + `wolverine_tenant_partitions` in the Wolverine schema, `mt_tenant_partitions` in Marten's, neither in the other's or in EF's |
| `registering_a_tenant_with_wolverine_partitions_only_the_ef_table` | `AddWolverineManagedTenantsAsync` partitions `mixed_items` and leaves Marten's document table exactly as it was |
| `registering_a_tenant_with_marten_does_not_partition_the_ef_table` | the mirror, through `AddMartenManagedTenantsAsync` |
| `cross_tenant_isolation_holds_for_both_engines_in_one_database` | an EF entity and a Marten document written per tenant, each readable only by its own tenant, from the same database |

## A finding that probably wants its own issue

**`.IntegrateWithWolverine()` cannot currently be combined with conjoined EF tenancy.** Handing envelope storage to Marten leaves `ConjoinedDbContextBuilder` unable to resolve a connection string — it reads `_database.Settings.ConnectionString` from the Wolverine message store, and Marten's store surfaces none — so the host dies at startup with:

> `Unable to determine the database connection string for the conjoined multi-tenanted DbContext ...`

That is a plausible real-world combination (Marten for envelopes + conjoined EF for entities), so it looks like a genuine gap rather than an unsupported pairing. These tests therefore keep Wolverine on its own Postgres message store, which does not weaken them — they are about partition and tenant **ownership** between the engines, not about who owns envelope storage. The constraint is recorded in a comment at the exact place the next reader will hit it. Happy to file it separately.

## Scenario 2 (EF + Polecat) is not here

Its stated gate, JasperFx/polecat#335, **has since closed**, so it is genuinely unblocked now. But it needs a `Wolverine.Polecat` reference this test project does not carry, and it is better as its own change than bolted onto this one.

## Verified

- `EfCoreTests.MultiTenancy`: **197 tests, 0 failed** (193 before these four).
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.
- **No new CI target needed** — this project already runs under `CIEfCore` and already referenced `Wolverine.Marten`, so nothing has to be wired into a workflow (and #4037's guard would have caught it if it did).

Two notes from building it, in case they save someone time later: `MixedDoc` needs `m.Schema.For<MixedDoc>().MultiTenanted()` — with only `RegisterDocumentType` it is single-tenant, so Marten creates no partitions and isolation silently does not apply. And Marten and EF Core both ship an `AnyAsync` extension, so a file that sees both must qualify the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
