### PR TITLE
docs: the perf rig is multi-transport now; record its ground rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,23 @@ WolverineOptions uses partial classes to organize concerns:
 | GCP Pub/Sub | 8085 |
 | Pulsar | 6650 |
 
+## Performance Rig (`src/Testing/KafkaPerfRig`)
+
+Multi-transport load rig (Kafka, RabbitMQ, NATS JetStream, Pulsar + native twins) used for the
+GH-3490/3492/4026/4039 perf waves. Outside both solutions and CI — build/run standalone via
+`rig.sh` / `cells*.sh` in that folder; see its README for roles, knobs, and required brokers.
+Ground rules when measuring:
+
+- **No perf claim without rig numbers**: interleaved runs, "before" pinned in the same build
+  (`RIG_MAX_RECEIVE=1`-style knobs) or **two independently built worktrees** once the change is
+  committed — `git stash push` of committed paths silently stashes nothing and measures
+  fix-vs-fix.
+- Trust the hygiene in `rig.sh` (per-run schema drop + broker cleanup) and keep it working —
+  leftover inbox rows/stream backlogs have produced multi-x measurement errors and hosts that
+  fail to start. Build with `MSBUILDDISABLENODEREUSE=1`.
+- Negative results go in the ledger too (ack coalescing was measured at −10% on RabbitMQ and
+  is a standing "do not revisit").
+
 ## Additional Documentation
 
 When working on specific areas, consult these files:

--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -1,15 +1,18 @@
 # KafkaPerfRig
 
-Load-test rig for [GH-3490](https://github.com/JasperFx/wolverine/issues/3490) — the Kafka
-performance deep dive. Deliberately **not** part of either `.slnx` solution or CI.
+Load-test rig for the transport performance deep dives — GH-3490 (Kafka), GH-3492 (RabbitMQ),
+GH-4026/GH-4039 (Kafka topic groups, NATS JetStream, Pulsar). Despite the name it is now a
+multi-transport rig. Deliberately **not** part of either `.slnx` solution or CI.
 
-Two twin harnesses generate identical traffic and share one monotonic stage clock
-(`Stopwatch.GetTimestamp`, valid across processes on one box):
+Harnesses generate identical traffic (shared corpus, rate loops, and recorder) and share one
+monotonic stage clock (`Stopwatch.GetTimestamp`, valid across processes on one box):
 
-- **wolverine**: `WolverinePublisher` / `WolverineConsumer` (`UseKafka`, configurable endpoint
-  modes, batching, sequencing)
-- **native**: raw Confluent.Kafka producer + sequential consumer with the same
-  store-after-process offset semantics
+| Roles | Harness | Notes |
+|---|---|---|
+| `wolverine-{publisher,consumer}` | Kafka (`UseKafka`) | plus a **native** twin: raw Confluent.Kafka (`native-{publisher,consumer}`) |
+| `rabbit-{publisher,consumer}` | RabbitMQ | plus a native RabbitMQ.Client twin (`native-rabbit-*`) |
+| `nats-{publisher,consumer}` | NATS JetStream | deletes its per-run stream on shutdown |
+| `pulsar-{publisher,consumer}` | Pulsar | per-run topics deleted via the admin API in `rig.sh` |
 
 Stages recorded per message: `t0` publish call → `t2` consume return/envelope mapping →
 `t3` handler entry → `t4` handler exit. Results land as raw CSV + p50/p95/p99 JSON.
@@ -17,17 +20,43 @@ Stages recorded per message: `t0` publish call → `t2` consume return/envelope 
 ## Running
 
 ```bash
-docker compose up -d kafka postgresql   # from the repo root
+docker compose up -d kafka rabbitmq nats pulsar postgresql   # whichever brokers the cells need
 
 ./rig.sh wolverine baseline             # one scenario (client-shaped defaults)
 ./rig.sh native native-anchor           # the native twin
-./cells.sh                              # the full experiment sweep
-./cells.sh baseline send-inline         # selected cells only
+./cells.sh                              # Kafka sweep (incl. max-durable-group cells)
+./cells-rabbit.sh r-max-durable         # RabbitMQ cells, selected
+./cells-nats.sh                         # NATS JetStream cells
+./cells-pulsar.sh                       # Pulsar cells
 ```
 
 Scenario knobs are `RIG_*` env vars — see `RigConfig.cs`. The defaults reproduce the
 GH-3490 report shape: 1Kb flow @ 8/s + 100Kb flow @ 0.6/s, buffered listeners, sender
-batching (10, 10ms), per-game semaphore sequencing, ~9ms simulated handler.
+batching (10, 10ms), per-game semaphore sequencing, ~9ms simulated handler. Notable later
+additions: `RIG_KAFKA_TOPIC_GROUP=1` (one `ListenToKafkaTopics` consumer over both topics),
+`RIG_MAX_RECEIVE=n` (pin `MaximumMessagesToReceive`; `1` reproduces pre-batching behavior
+inside the same build), `RIG_PUBLISHERS=n` (concurrent max-throughput publish loops — one
+awaited DotPulsar produce is ~2ms, so a single loop publisher-bounds every Pulsar cell at
+~450/s), `RIG_LOG_LISTENER=1` (surface back-pressure pause/restart logs, which are
+Information-level and otherwise filtered).
 
-Measured findings and the experiment ledger live in the issue and
-`KAFKA-PERF-DEEP-DIVE-PLAN.md` (repo root, session artifact).
+## Hygiene — believe no number without it
+
+Max-throughput cells publish millions of messages per run and the consumer keeps only a
+fraction; the leftovers poison every later run:
+
+- `rig.sh` **drops the rig's Postgres schema before each run** — 6M leftover inbox rows once
+  made Wolverine's startup recovery time out, so consumer hosts failed to start and cells
+  "measured" a dead host.
+- Per-run Kafka topics / Rabbit queues / Pulsar topics are deleted by `rig.sh`; the NATS
+  consumer deletes its own per-run stream (67M messages / 101 GB had accumulated in the broker
+  container in one afternoon).
+- Build with `MSBUILDDISABLENODEREUSE=1`: a day of builds leaves hundreds of idle MSBuild
+  nodes holding tens of GB, which starves the brokers and skews cells.
+- **A/B after the change is committed needs two worktrees built independently.** `git stash
+  push` of already-committed paths exits 0 with nothing stashed — a stash-based A/B then
+  silently measures fix-vs-fix.
+
+Measured findings and the experiment ledgers live in the deep-dive issues (GH-3490/3492/3493/
+3494, all closed with their ledgers) and the `*-PERF-DEEP-DIVE-PLAN.md` documents at the repo
+root (session artifacts).


### PR DESCRIPTION
Docs only, two files.

- **`src/Testing/KafkaPerfRig/README.md`** still described a Kafka-only rig. It has carried RabbitMQ roles since GH-3492 and gained NATS JetStream and Pulsar harnesses in the GH-4026/GH-4039 waves. Now documents: the role table per transport (with native twins), the `cells*.sh` sweeps, the newer knobs (`RIG_KAFKA_TOPIC_GROUP`, `RIG_MAX_RECEIVE`, `RIG_PUBLISHERS`, `RIG_LOG_LISTENER`), and a **Hygiene** section with the lessons the 8/23 wave paid for: per-run Postgres schema drop + broker cleanup (6M leftover inbox rows made consumer hosts fail to start and cells "measure" a dead host; 67M leftover JetStream messages / 101 GB degraded every later cell), `MSBUILDDISABLENODEREUSE=1`, and the stash trap — `git stash push` of already-committed paths exits 0 with nothing stashed, so a stash-based A/B after commit silently measures fix-vs-fix; use two independently built worktrees.
- **`CLAUDE.md`** gains a short "Performance Rig" section with the same ground rules (no perf claim without rig numbers, hygiene, negative results go in the ledger — the −10% ack-coalescing result stays a standing "do not revisit"), so they're in front of anyone measuring rather than buried in the rig folder.

No code, no behavior. Numbers referenced are from today's merged PRs (#4025/#4029/#4039).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
