### PR TITLE
GH-3708: document NativeAck in the RabbitMQ and partitioning guides

### DIFF
--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -366,6 +366,24 @@ builder.UseWolverine(opts =>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/PartitioningSamples.cs#L14-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_partitioned_processing_on_any_listener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: tip Partitioned processing without the database <Badge type="tip" text="6.30" />
+The example above uses the listener's default mode. Note what each mode costs you here:
+
+* **Durable** gives you no-loss partitioned processing, but every message pays an inbox insert and a
+  mark-as-handled update.
+* **BufferedInMemory** removes the database cost, but acknowledges each message to the broker *before* the
+  handler runs — so a node that dies mid-flight loses whatever was buffered.
+* **`ProcessInParallelWithNativeAcks()`** gives you partitioned processing with neither cost: the broker
+  delivery is held unacknowledged until the handler succeeds, so a dying node loses nothing and no database is
+  involved. See [Native Ack Endpoints](/guide/messaging/listeners#native-ack-endpoints).
+* **`ProcessInline()`** cannot do partitioned processing at all, and Wolverine now **throws at startup** rather
+  than silently ignoring `PartitionProcessingByGroupId()` on an inline endpoint.
+
+The ordering guarantee is the same in every mode that supports it: messages sharing a group id never execute
+concurrently. Strict processing in original delivery order is *not* promised under failure or redelivery in any
+non-durable mode.
+:::
+
 ## Exempting Message Types from Partitioned Processing <Badge type="tip" text="6.26" />
 
 `PartitionProcessingByGroupId()` routes **every** message on the listener through a GroupId-keyed slot. That's

--- a/docs/guide/messaging/transports/rabbitmq/performance.md
+++ b/docs/guide/messaging/transports/rabbitmq/performance.md
@@ -61,6 +61,13 @@ was measured at roughly **10% slower** and rejected (GH-3492).
 - **Buffered**: messages are acked **as soon as they are buffered in memory**, before handling —
   an ungraceful shutdown loses whatever was buffered (at-most-once on crash). Fastest mode;
   use with idempotent handlers or tolerable-loss workloads.
+- **NativeAck** <Badge type="tip" text="6.30" />: the delivery is held **unacknowledged** while the message
+  flows through an in-memory, optionally group-partitioned execution block, and is acked only when the handler
+  succeeds. Buffered's throughput and partitioning with Inline's no-loss behaviour, and no database. Configure
+  with `.ProcessInParallelWithNativeAcks()`; see
+  [Native Ack Endpoints](/guide/messaging/listeners#native-ack-endpoints). This is the mode to reach for when
+  Inline is too slow *because* it is single-threaded per listener and Durable is too expensive under a flood.
+  RabbitMQ is the first transport to support it, and per-message acks (below) are exactly why it can.
 - **Durable**: each message is written to the database inbox before it is acked, and handled
   from there. The consumer coalesces prefetched deliveries for up to 5ms into a single batched
   inbox insert (up to `MaximumMessagesToReceive`, default 100), so under load the write cost is
@@ -75,8 +82,15 @@ was measured at roughly **10% slower** and rejected (GH-3492).
 ## Prefetch
 
 Wolverine sets the channel prefetch (`basic.qos`) automatically: for Buffered/Durable endpoints
-it defaults to `2 × MaximumParallelMessages`, and for Inline endpoints to 100. Override with
-`.PreFetchCount(...)` on the listener. For Inline endpoints prefetch mostly just hides network
+it defaults to `2 × MaximumParallelMessages`, and for Inline endpoints to 100. For **NativeAck**
+endpoints it covers every lane that can be busy at once — the partition slot count when the endpoint is
+group-partitioned, otherwise `MaximumParallelMessages` — doubled so a lane never starves waiting on the
+next delivery. Override with `.PreFetchCount(...)` on the listener.
+
+For a NativeAck endpoint the prefetch window **is** the back pressure, since nothing is acked until a handler
+succeeds: the broker simply stops delivering once the unacked ceiling is reached. That is also the bound on
+how many deliveries a dying node hands back, so raising it trades smoother throughput for more redelivery
+after a crash or a rolling deploy. For Inline endpoints prefetch mostly just hides network
 latency between messages; for Buffered/Durable it controls how far the broker can run ahead of
 your workers — higher values smooth throughput at the cost of more unacked messages redelivered
 if the node dies.


### PR DESCRIPTION
Docs-only follow-up to #4040.

#4040 documents `EndpointMode.NativeAck` in `listeners.md` — the settings-matrix column and the mode's own section. Two other pages discuss exactly the trade-off this mode changes and did not know it existed.

**RabbitMQ performance guide.** `NativeAck` joins "Choosing the endpoint mode", positioned as what to reach for when Inline is too slow *because* it is single-threaded per listener and Durable is too expensive under a flood. The prefetch section gains the mode's sizing rule and, more usefully, the consequence: for a NativeAck endpoint the prefetch window **is** the back pressure — nothing is acked until a handler succeeds, so the broker stops delivering at the unacked ceiling — and it is simultaneously the bound on how many deliveries a dying node hands back. Raising it trades smoother throughput for more redelivery after a crash or rolling deploy. That is a real dial with two opposed effects and it should be documented as one.

**Partitioning guide.** A tip on "Partitioned Processing at any Endpoint" spelling out what each mode actually costs for partitioned work, since that page previously implied the choice was free: Durable pays an inbox insert plus a mark-as-handled update per message; BufferedInMemory removes the database cost but acks before the handler runs, so a node dying mid-flight loses what was buffered; `ProcessInParallelWithNativeAcks()` pays neither; and `ProcessInline()` cannot do it at all and now throws at startup rather than silently ignoring `PartitionProcessingByGroupId()` (GH-3712).

It also repeats the ordering guarantee in the place where someone configuring partitioning will actually read it: messages sharing a group id never execute concurrently, but strict processing in original delivery order is **not** promised under failure or redelivery in any non-durable mode.

## Ordering

No file overlap with #4040 — that PR touches `listeners.md`, this touches `partitioning.md` and `rabbitmq/performance.md`. The only dependency is a cross-reference: both new sections link to `/guide/messaging/listeners#native-ack-endpoints`, which #4040 creates. **Merge #4040 first** or those two anchors dangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)