### PR TITLE
GH-3710: opt-in in-memory idempotency guard for non-durable endpoints

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -138,7 +138,9 @@ Three consequences follow from never acking at receipt, and all three are the po
 * **Shutdown trades duplicates for safety.** Graceful drain processes what it can within the drain timeout;
   whatever it cannot is simply never settled and gets redelivered. A rolling deploy therefore produces
   duplicate deliveries bounded by the prefetch depth. Your handlers should already be idempotent under
-  at-least-once delivery, but it is worth knowing the number is not zero.
+  at-least-once delivery, but it is worth knowing the number is not zero. The
+  [in-memory idempotency guard](#in-memory-idempotency-guard) below takes the edge off that for a *running*
+  process.
 
 **Transport support is opt-in and default-closed.** A transport must settle each delivery individually *and*
 tolerate settling out of order, because the execution block completes messages in handler-completion order
@@ -146,6 +148,101 @@ rather than delivery order. RabbitMQ queues qualify and are supported today. Kaf
 scope: a cumulative offset commit has no way to express a gap. Calling
 `ProcessInParallelWithNativeAcks()` on a transport that has not opted in throws at configuration time rather
 than degrading silently.
+
+## In-Memory Idempotency Guard <Badge type="tip" text="6.30" />
+
+The [durable inbox](/guide/durability) deduplicates incoming messages on the primary key of its incoming
+table: a redelivery of a message id it has already stored is acked back to the broker and never executed
+again. `NativeAck`, `BufferedInMemory`, and `Inline` endpoints have no such table, and `NativeAck` in
+particular is *at-least-once by design* — every rolling deploy leaves whatever the drain could not finish
+unsettled, and the broker redelivers it.
+
+`WithInMemoryIdempotency()` is the non-durable analogue: an opt-in, bounded, in-memory set of the message ids
+this process has already handled on this endpoint. A redelivery of one is settled with the broker and dropped
+without ever reaching your handler — the same outcome as the durable path, minus the database.
+
+```csharp
+opts.ListenToRabbitQueue("webhooks")
+    .ProcessInParallelWithNativeAcks()
+    .PartitionProcessingByGroupId(PartitionSlots.Five)
+
+    // Opt in. Both arguments are optional; these are the defaults.
+    .WithInMemoryIdempotency(window: 5.Minutes(), maxTracked: 100_000);
+```
+
+To turn it on everywhere rather than endpoint by endpoint, use a policy:
+
+```csharp
+opts.Policies.AllListeners(x => x.WithInMemoryIdempotency());
+```
+
+### What it does and does not promise
+
+::: warning An in-memory guard does not survive a restart
+The guard is **per process and in memory**. Three limits follow, and none of them is a bug:
+
+* **A restart forgets everything.** The very deploy that produces the redelivery burst also empties the guard
+  on the node that starts up. It protects a *running* process against a redelivery it saw itself.
+* **A second node never knew.** With competing consumers, a redelivery can land on a different node than the
+  original. With an exclusive listener (including the [partitioned topology](/guide/messaging/partitioning)
+  story) redeliveries land on the node that owns the listener — the same node whose guard saw the original —
+  so the guard is effective in steady state, but a failover hands the queue to a node starting from empty.
+* **Eviction is generational, not exact.** An id is remembered for at least half the window and at most the
+  whole window, and less than that when a flood of unique ids hits `maxTracked` first.
+
+The promise is **at-least-once delivery with best-effort deduplication**, not exactly-once. If you need hard
+deduplication that holds across restarts and across nodes, use the durable inbox. Handlers should still be
+written to tolerate a duplicate.
+:::
+
+Note that duplicate *processing* under `NativeAck` is a cost and liveness concern rather than a correctness
+one for group ordering: even a duplicate that slips past the guard runs in its group's sequential lane, so
+the intra-group concurrency guarantee holds either way.
+
+### Bounding and tuning
+
+Memory is bounded by construction, which matters because the workload `NativeAck` exists for is exactly the
+one that would make an unbounded set of seen ids a leak. Two hash sets — a current generation and the
+previous one — are kept and both are consulted on lookup. The pair rotates on whichever comes first:
+
+| Trigger | Effect |
+| --- | --- |
+| `window / 2` elapsed | current generation becomes previous, previous is dropped |
+| `maxTracked / 2` ids in the current generation | same rotation, early — a flood of unique ids evicts by size rather than growing |
+
+So the ceiling really is `maxTracked` ids, roughly single-digit megabytes at the 100,000 default, with no
+per-entry timestamps and no LRU bookkeeping. Size the `window` to cover the redelivery burst you actually
+expect — for `NativeAck` that is the drain timeout plus the broker's redelivery latency, seconds rather than
+minutes — and leave `maxTracked` alone unless you are running a flood at a sustained rate where
+`maxTracked / peak messages per second` would fall below that window.
+
+### Where it applies
+
+| Mode | Guard |
+| --- | --- |
+| `NativeAck` | ✔️ — the primary use case |
+| `BufferedInMemory` | ✔️ |
+| `Inline` | ✔️ |
+| `Durable` | ignored (warns at startup) — the inbox already deduplicates, and does it better |
+| Local queues | `NotSupportedException` — nothing redelivers to a local queue |
+
+A message that fails and is handed *back* to the broker — nacked, requeued, or deferred during a drain — is
+deliberately **not** remembered, because remembering it would suppress its own retry and turn a failure into
+a lost message. Only a delivery that reached a terminal the broker will not undo (handler success, or a
+native dead-letter move) is recorded. Duplicate drops are logged at `Debug`, not `Error`: in a mode that
+never settles at receipt, redelivery is expected operational noise rather than a sign that something is wrong.
+
+### Prefer broker-side deduplication where it exists
+
+Some transports can deduplicate at the broker, which is strictly better than anything an in-process guard can
+do — it survives restarts and spans nodes:
+
+* **NATS JetStream** — a stream's `duplicate_window` deduplicates on the `Nats-Msg-Id` header.
+* **SQS FIFO queues** — `MessageDeduplicationId`, with a five-minute window.
+* **Google Cloud Pub/Sub** — subscription-level deduplication on a publisher-supplied `deduplication-id`.
+
+Use those where they are available. This guard is chiefly for RabbitMQ classic and quorum queues, which have
+nothing of the kind.
 
 ## Buffered Endpoints
 
@@ -167,6 +264,10 @@ With `Buffered` endpoints, you can:
   acceptable level
 
 Requeue error actions just put the failed message back into the in memory queue at the back of the queue.
+
+Because the broker ack happens at receipt, a `Buffered` endpoint sees a redelivery only when the broker itself
+resends one (a closed channel with the ack still in flight, say). The
+[in-memory idempotency guard](#in-memory-idempotency-guard) is available here too if that matters to you.
 
 ## Durable Endpoints
 
@@ -252,6 +353,7 @@ callback. Settings that size or shard that block therefore do nothing on an `Inl
 | `ListenWithStrictOrdering()` / `ListenOnlyAtLeader()` | ✔️ (exclusivity only) | ✔️ | ✔️ | ✔️ |
 | `ExclusiveNodeWithParallelism(n)` | ✔️ exclusivity, parallelism ignored (warns) | ✔️ | ✔️ | ✔️ |
 | `CircuitBreaker()` | ✔️ | ✔️ | ✔️ | ✔️ |
+| [`WithInMemoryIdempotency()`](#in-memory-idempotency-guard) | ✔️ | ✔️ | ✔️ | ignored (warns) |
 
 As of Wolverine 6.30, these combinations are no longer silently accepted:
 

--- a/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
+++ b/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
@@ -1,7 +1,9 @@
+using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Wolverine.Configuration;
+using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Runtime;
 using Wolverine.Transports;
 using Wolverine.Transports.Local;
@@ -271,6 +273,82 @@ public class listener_configuration_validation
         ListenerConfigurationValidator.Validate(endpoint).Single()
             .Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
     }
+
+    #region GH-3710 in-memory idempotency guard
+
+    [Fact]
+    public void the_in_memory_idempotency_guard_is_opt_in()
+    {
+        var endpoint = compiledEndpoint(opts => opts.ListenForMessagesFrom("stub://one"));
+
+        endpoint.InMemoryIdempotency.ShouldBeNull();
+        endpoint.IdempotencyGuard.ShouldBeNull();
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void opting_in_builds_the_guard_with_the_configured_tuning()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .BufferedInMemory()
+                .WithInMemoryIdempotency(30.Seconds(), 5000);
+        });
+
+        endpoint.InMemoryIdempotency!.Window.ShouldBe(30.Seconds());
+        endpoint.InMemoryIdempotency.MaxTracked.ShouldBe(5000);
+        endpoint.IdempotencyGuard.ShouldNotBeNull();
+
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_defaults_are_five_minutes_and_a_hundred_thousand_ids()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one").WithInMemoryIdempotency();
+        });
+
+        endpoint.InMemoryIdempotency!.Window.ShouldBe(InMemoryIdempotencySettings.DefaultWindow);
+        endpoint.InMemoryIdempotency.MaxTracked.ShouldBe(InMemoryIdempotencySettings.DefaultMaxTracked);
+    }
+
+    [Fact]
+    public void the_guard_is_inert_and_warns_on_a_durable_endpoint()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.ListenForMessagesFrom("stub://one")
+                .UseDurableInbox()
+                .WithInMemoryIdempotency();
+        });
+
+        // The inbox primary key already does this, across restarts and across nodes
+        endpoint.IdempotencyGuard.ShouldBeNull();
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).Single();
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+        problem.Message.ShouldContain("WithInMemoryIdempotency()");
+        problem.Message.ShouldContain("durable");
+    }
+
+    [Fact]
+    public void cannot_use_the_guard_on_a_local_queue()
+    {
+        var ex = Should.Throw<NotSupportedException>(() =>
+        {
+            using var host = Host.CreateDefaultBuilder().UseWolverine(opts =>
+            {
+                opts.LocalQueue("idempotent-local").WithInMemoryIdempotency();
+            }).Build();
+        });
+
+        ex.Message.ShouldContain("WithInMemoryIdempotency");
+    }
+
+    #endregion
 }
 
 public record InlineLocalQueueMessage(string Name);

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/generational_idempotency_guard.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/generational_idempotency_guard.cs
@@ -1,0 +1,252 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime.WorkerQueues;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3710. Unit tests for the default in-memory idempotency guard. The rotation policy is tested against an
+/// injected clock rather than Task.Delay -- the whole point of the generational scheme is that eviction is
+/// decided by two cheap comparisons, so there is nothing here that needs real time to pass.
+/// </summary>
+public class generational_idempotency_guard
+{
+    private DateTimeOffset theTime = new(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
+
+    private GenerationalIdempotencyGuard guardFor(TimeSpan? window = null, int? maxTracked = null,
+        MessageIdentity identity = MessageIdentity.IdOnly)
+    {
+        var settings = new InMemoryIdempotencySettings();
+        if (window.HasValue) settings.Window = window.Value;
+        if (maxTracked.HasValue) settings.MaxTracked = maxTracked.Value;
+
+        return new GenerationalIdempotencyGuard(settings, identity, () => theTime);
+    }
+
+    private static Envelope envelopeFor(Guid? id = null, string destination = "stub://one")
+    {
+        return new Envelope
+        {
+            Id = id ?? Guid.NewGuid(),
+            Destination = new Uri(destination)
+        };
+    }
+
+    [Fact]
+    public void first_time_through_is_always_allowed()
+    {
+        var guard = guardFor();
+        guard.TryBeginProcessing(envelopeFor()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_duplicate_of_an_in_flight_message_is_rejected()
+    {
+        var guard = guardFor();
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+
+        // The original has NOT completed. The duplicate still has to be turned away, or it would sit in the
+        // execution block waiting to run the same message a second time.
+        guard.TryBeginProcessing(envelopeFor(envelope.Id)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_duplicate_of_a_processed_message_is_rejected()
+    {
+        var guard = guardFor();
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.MarkProcessed(envelope);
+
+        guard.TryBeginProcessing(envelopeFor(envelope.Id)).ShouldBeFalse();
+        guard.InFlightCount.ShouldBe(0);
+        guard.TrackedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void a_released_message_is_not_remembered_and_can_run_again()
+    {
+        var guard = guardFor();
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+
+        // The failure path: nacked or requeued, so the broker is going to send it again and the retry must
+        // be allowed to execute.
+        guard.Release(envelope);
+
+        guard.TrackedCount.ShouldBe(0);
+        guard.InFlightCount.ShouldBe(0);
+        guard.TryBeginProcessing(envelopeFor(envelope.Id)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void releasing_after_a_previous_success_forgets_the_id_entirely()
+    {
+        var guard = guardFor();
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.MarkProcessed(envelope);
+        guard.Release(envelope);
+
+        guard.TryBeginProcessing(envelopeFor(envelope.Id)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_id_survives_the_first_generation_rotation()
+    {
+        var guard = guardFor(10.Minutes());
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.MarkProcessed(envelope);
+
+        // One rotation moves it into the previous generation, where membership is still checked. This is the
+        // "at least Window / 2" half of the promise.
+        theTime = theTime.Add(6.Minutes());
+
+        guard.TryBeginProcessing(envelopeFor(envelope.Id)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_id_ages_out_after_both_generations_rotate()
+    {
+        var guard = guardFor(10.Minutes());
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.MarkProcessed(envelope);
+
+        theTime = theTime.Add(6.Minutes());
+        guard.TryBeginProcessing(envelopeFor(Guid.NewGuid())).ShouldBeTrue(); // forces the first rotation
+
+        theTime = theTime.Add(6.Minutes());
+
+        // Second rotation drops the generation the id was in -- it is genuinely forgotten now, which is what
+        // keeps this from being an unbounded set.
+        guard.TryBeginProcessing(envelopeFor(envelope.Id)).ShouldBeTrue();
+        guard.TrackedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void memory_stays_bounded_under_a_sustained_flood_of_unique_ids()
+    {
+        // Deliberately a tiny ceiling and a window long enough that time-based rotation never fires: the only
+        // thing keeping this bounded is the size trigger.
+        var guard = guardFor(1.Hours(), 100);
+
+        for (var i = 0; i < 50_000; i++)
+        {
+            var envelope = envelopeFor();
+            guard.TryBeginProcessing(envelope).ShouldBeTrue();
+            guard.MarkProcessed(envelope);
+
+            guard.TrackedCount.ShouldBeLessThanOrEqualTo(100);
+        }
+
+        guard.TrackedCount.ShouldBeLessThanOrEqualTo(100);
+        guard.InFlightCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void in_flight_ids_are_bounded_too_even_if_nothing_ever_completes()
+    {
+        // The receivers release everything they claim, but a guard that could grow without limit when they
+        // did not would be a memory leak on exactly the flood workload this feature exists for.
+        var guard = guardFor(1.Hours(), 100);
+
+        for (var i = 0; i < 50_000; i++)
+        {
+            guard.TryBeginProcessing(envelopeFor()).ShouldBeTrue();
+        }
+
+        guard.InFlightCount.ShouldBeLessThanOrEqualTo(100);
+    }
+
+    [Fact]
+    public void size_based_eviction_uses_the_configured_ceiling()
+    {
+        var guard = guardFor(1.Hours(), 1000);
+
+        for (var i = 0; i < 10_000; i++)
+        {
+            var envelope = envelopeFor();
+            guard.TryBeginProcessing(envelope);
+            guard.MarkProcessed(envelope);
+        }
+
+        guard.TrackedCount.ShouldBeLessThanOrEqualTo(1000);
+
+        // ...and it really is tracking, not just throwing everything away
+        guard.TrackedCount.ShouldBeGreaterThan(100);
+    }
+
+    [Fact]
+    public void honors_MessageIdentity_IdOnly_across_destinations()
+    {
+        var guard = guardFor(identity: MessageIdentity.IdOnly);
+        var id = Guid.NewGuid();
+
+        guard.TryBeginProcessing(envelopeFor(id, "stub://one")).ShouldBeTrue();
+        guard.TryBeginProcessing(envelopeFor(id, "stub://two")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void honors_MessageIdentity_IdAndDestination()
+    {
+        var guard = guardFor(identity: MessageIdentity.IdAndDestination);
+        var id = Guid.NewGuid();
+
+        // The Modular Monolith shape: the same message id received at two different listening endpoints of
+        // one process is two messages, not a duplicate.
+        guard.TryBeginProcessing(envelopeFor(id, "stub://one")).ShouldBeTrue();
+        guard.TryBeginProcessing(envelopeFor(id, "stub://two")).ShouldBeTrue();
+
+        guard.TryBeginProcessing(envelopeFor(id, "stub://one")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task exactly_one_caller_wins_each_id_under_concurrency()
+    {
+        var guard = new GenerationalIdempotencyGuard(new InMemoryIdempotencySettings(), MessageIdentity.IdOnly);
+
+        var ids = Enumerable.Range(0, 200).Select(_ => Guid.NewGuid()).ToArray();
+        var winners = new System.Collections.Concurrent.ConcurrentDictionary<Guid, int>();
+
+        // Every id is offered to the guard by 8 threads at once. Duplicate suppression is only worth
+        // anything if exactly one of them is told to go ahead.
+        await Parallel.ForEachAsync(Enumerable.Range(0, 8), async (_, _) =>
+        {
+            await Task.Yield();
+
+            foreach (var id in ids)
+            {
+                if (guard.TryBeginProcessing(envelopeFor(id)))
+                {
+                    winners.AddOrUpdate(id, 1, (_, count) => count + 1);
+                }
+            }
+        });
+
+        winners.Count.ShouldBe(ids.Length);
+        winners.Values.ShouldAllBe(x => x == 1);
+    }
+
+    [Fact]
+    public void the_window_has_to_be_positive()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryIdempotencySettings { Window = TimeSpan.Zero });
+    }
+
+    [Fact]
+    public void has_to_be_allowed_to_track_something()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryIdempotencySettings { MaxTracked = 1 });
+    }
+}

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/in_memory_idempotency_guard_on_receivers.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/in_memory_idempotency_guard_on_receivers.cs
@@ -1,0 +1,233 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3710. The opt-in in-memory guard as the receivers see it. The behaviour deliberately mirrors
+/// <c>when_durable_receiver_detects_duplicate_incoming_envelope</c>: a duplicate is settled with the broker
+/// so it stops coming back, and it never reaches the handler.
+/// </summary>
+public class in_memory_idempotency_guard_on_receivers : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IWolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        NativeAckPingHandler.Handled.Clear();
+        NativeAckPingHandler.Gate = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        NativeAckPingHandler.Gate = null;
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private Endpoint nativeAckEndpoint(bool withGuard)
+    {
+        var endpoint = new NativeAckStubEndpoint("native-ack-idempotency", new StubTransport());
+        if (withGuard)
+        {
+            endpoint.InMemoryIdempotency = new InMemoryIdempotencySettings();
+        }
+
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+
+        return endpoint;
+    }
+
+    private NativeAckReceiver nativeAckReceiver(Endpoint endpoint)
+    {
+        return new NativeAckReceiver(endpoint, theRuntime,
+            new HandlerPipeline((WolverineRuntime)theRuntime, (WolverineRuntime)theRuntime, endpoint));
+    }
+
+    private BufferedReceiver bufferedReceiver(bool withGuard)
+    {
+        var endpoint = new StubEndpoint("buffered-idempotency", new StubTransport());
+        if (withGuard)
+        {
+            endpoint.InMemoryIdempotency = new InMemoryIdempotencySettings();
+        }
+
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+        endpoint.Compile(theRuntime);
+
+        return new BufferedReceiver(endpoint, theRuntime,
+            new HandlerPipeline((WolverineRuntime)theRuntime, (WolverineRuntime)theRuntime, endpoint));
+    }
+
+    private static Envelope pingEnvelope(string name, Guid? id = null)
+    {
+        var envelope = new Envelope(new NativeAckPing(name))
+            { MessageType = typeof(NativeAckPing).ToMessageTypeName() };
+
+        if (id.HasValue) envelope.Id = id.Value;
+
+        return envelope;
+    }
+
+    [Fact]
+    public void the_guard_is_off_unless_you_ask_for_it()
+    {
+        nativeAckEndpoint(false).IdempotencyGuard.ShouldBeNull();
+        nativeAckEndpoint(true).IdempotencyGuard.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_redelivery_is_acked_and_never_executed_in_native_ack_mode()
+    {
+        var receiver = nativeAckReceiver(nativeAckEndpoint(true));
+        var listener = new RecordingListener();
+
+        var first = pingEnvelope("one");
+        await receiver.ReceivedAsync(listener, first);
+        await listener.WaitUntilAtLeast(1);
+
+        // Same message id, brand new delivery -- exactly what a rolling deploy produces when the drain
+        // timeout expires with deliveries still unsettled.
+        await receiver.ReceivedAsync(listener, pingEnvelope("one", first.Id));
+        await listener.WaitUntilAtLeast(2);
+
+        NativeAckPingHandler.Handled.Count.ShouldBe(1);
+
+        // Both deliveries settled: the duplicate is acked-and-dropped rather than left to be redelivered
+        // forever, which is what DurableReceiver does when the inbox INSERT hits the primary key.
+        listener.Completed.Count.ShouldBe(2);
+        listener.Deferred.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task without_the_guard_a_redelivery_runs_again()
+    {
+        var receiver = nativeAckReceiver(nativeAckEndpoint(false));
+        var listener = new RecordingListener();
+
+        var first = pingEnvelope("one");
+        await receiver.ReceivedAsync(listener, first);
+        await listener.WaitUntilAtLeast(1);
+
+        await receiver.ReceivedAsync(listener, pingEnvelope("one", first.Id));
+        await listener.WaitUntilAtLeast(2);
+
+        NativeAckPingHandler.Handled.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_concurrent_duplicate_is_dropped_rather_than_queued_up_to_run_again()
+    {
+        var receiver = nativeAckReceiver(nativeAckEndpoint(true));
+        var listener = new RecordingListener();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        NativeAckPingHandler.Gate = gate;
+
+        var first = pingEnvelope("one");
+        await receiver.ReceivedAsync(listener, first);
+
+        // The original is parked inside the handler. The duplicate has to be turned away on the in-flight
+        // set, not merely on the processed set.
+        await receiver.ReceivedAsync(listener, pingEnvelope("one", first.Id));
+        await listener.WaitUntilAtLeast(1);
+
+        listener.Completed.Count.ShouldBe(1);
+        NativeAckPingHandler.Handled.ShouldBeEmpty();
+
+        gate.SetResult();
+        await listener.WaitUntilAtLeast(2);
+
+        NativeAckPingHandler.Handled.Count.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// The failure path, and the reason the guard has a Release() at all: a delivery handed back to the
+    /// broker WILL come back, and suppressing that redelivery would convert a retry into a lost message.
+    /// This also covers the guard living on the endpoint rather than the receiver -- the second receiver is
+    /// a rebuild of the first, which is what a listener restart or back-pressure recovery does.
+    /// </summary>
+    [Fact]
+    public async Task a_deferred_delivery_is_not_remembered_and_still_runs_when_it_comes_back()
+    {
+        var endpoint = nativeAckEndpoint(true);
+
+        var latched = nativeAckReceiver(endpoint);
+        var listener = new RecordingListener();
+        latched.Latch();
+
+        var envelope = pingEnvelope("one");
+        await latched.ReceivedAsync(listener, envelope);
+        await latched.DrainAsync();
+
+        listener.Deferred.Count.ShouldBe(1);
+        NativeAckPingHandler.Handled.ShouldBeEmpty();
+
+        var rebuilt = nativeAckReceiver(endpoint);
+        await rebuilt.ReceivedAsync(listener, pingEnvelope("one", envelope.Id));
+        await listener.WaitUntilAtLeast(2);
+
+        NativeAckPingHandler.Handled.Count.ShouldBe(1);
+        listener.Completed.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_redelivery_is_acked_and_never_executed_in_buffered_mode()
+    {
+        var receiver = bufferedReceiver(true);
+        var listener = new RecordingListener();
+
+        var first = pingEnvelope("one");
+        await ((IReceiver)receiver).ReceivedAsync(listener, first);
+
+        // Buffered acks at receipt, so settlement says nothing about the handler. Wait on the handler.
+        await waitForHandledCount(1);
+
+        // The duplicate is dropped synchronously inside ReceivedAsync, so there is no race to wait out here.
+        await ((IReceiver)receiver).ReceivedAsync(listener, pingEnvelope("one", first.Id));
+
+        NativeAckPingHandler.Handled.Count.ShouldBe(1);
+        listener.Completed.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task without_the_guard_buffered_mode_runs_a_redelivery_again()
+    {
+        var receiver = bufferedReceiver(false);
+        var listener = new RecordingListener();
+
+        var first = pingEnvelope("one");
+        await ((IReceiver)receiver).ReceivedAsync(listener, first);
+        await listener.WaitUntilAtLeast(1);
+
+        await ((IReceiver)receiver).ReceivedAsync(listener, pingEnvelope("one", first.Id));
+        await listener.WaitUntilAtLeast(2);
+
+        await waitForHandledCount(2);
+        NativeAckPingHandler.Handled.Count.ShouldBe(2);
+    }
+
+    private static async Task waitForHandledCount(int count)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (NativeAckPingHandler.Handled.Count < count && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Yield();
+        }
+    }
+}

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -14,6 +14,7 @@ using Wolverine.Runtime.Interop;
 using Wolverine.Runtime.Routing;
 using Wolverine.Runtime.Scheduled;
 using Wolverine.Runtime.Serialization;
+using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Transports;
 using Wolverine.Transports.Sending;
 
@@ -427,6 +428,23 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
         }
     }
 
+    /// <summary>
+    /// GH-3710. When set, this listening endpoint drops -- and immediately settles -- a redelivery of a
+    /// message id it has already seen within the configured window. Opt in with
+    /// <c>IListenerConfiguration.WithInMemoryIdempotency()</c>; null means the guard does not exist for this
+    /// endpoint and costs nothing. Inert on a <see cref="EndpointMode.Durable"/> endpoint, whose inbox
+    /// already deduplicates by primary key.
+    /// </summary>
+    public InMemoryIdempotencySettings? InMemoryIdempotency { get; internal set; }
+
+    /// <summary>
+    /// GH-3710. Built once in <see cref="Compile"/> and deliberately owned by the ENDPOINT rather than the
+    /// receiver: a receiver is rebuilt on back pressure recovery and on every listener restart, and those are
+    /// precisely the moments that produce redeliveries. A guard scoped to the receiver would forget its
+    /// contents at the one instant it is most needed.
+    /// </summary>
+    internal IIncomingIdempotencyGuard? IdempotencyGuard { get; private set; }
+
     public RoutingMode RoutingType { get; set; } = RoutingMode.Static;
 
 
@@ -669,6 +687,16 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
         }
 
         normalizeForMode();
+
+        // GH-3710. Durable endpoints deduplicate through the inbox's primary key, so a second, weaker
+        // in-memory guard in front of it would only add memory. ListenerConfigurationValidator says so in
+        // the log rather than leaving it silently inert.
+        if (InMemoryIdempotency != null && IdempotencyGuard == null && Mode != EndpointMode.Durable &&
+            this is not Transports.Local.LocalQueue)
+        {
+            IdempotencyGuard =
+                new GenerationalIdempotencyGuard(InMemoryIdempotency, runtime.DurabilitySettings.MessageIdentity);
+        }
 
         _hasCompiled = true;
     }

--- a/src/Wolverine/Configuration/IListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/IListenerConfiguration.cs
@@ -114,6 +114,22 @@ public interface IListenerConfiguration<T> : IEndpointConfiguration<T>
     /// </summary>
     T ProcessInParallelWithNativeAcks();
 
+    /// <summary>
+    /// GH-3710. Opt in to a bounded, in-memory guard that drops -- and immediately settles -- a redelivery
+    /// of a message id this process has already handled on this endpoint within the window. The non-durable
+    /// analogue of the durable inbox's duplicate detection, for <c>ProcessInParallelWithNativeAcks()</c>,
+    /// <c>BufferedInMemory()</c>, and <c>ProcessInline()</c> endpoints.
+    ///
+    /// <para>
+    /// Best-effort by construction: the guard lives in memory in ONE process, so a restart forgets
+    /// everything it knew and a second node never knew it. Read the "In-Memory Idempotency Guard" section of
+    /// the listener docs before relying on it, and keep the durable inbox if you need hard deduplication.
+    /// </para>
+    /// </summary>
+    /// <param name="window">How long a handled message id is remembered. Defaults to 5 minutes.</param>
+    /// <param name="maxTracked">Ceiling on remembered ids, after which the oldest generation is evicted early. Defaults to 100,000.</param>
+    T WithInMemoryIdempotency(TimeSpan? window = null, int? maxTracked = null);
+
     T UseDurableInbox(BufferingLimits limits);
 
     /// <summary>

--- a/src/Wolverine/Configuration/ListenerConfiguration.cs
+++ b/src/Wolverine/Configuration/ListenerConfiguration.cs
@@ -5,6 +5,7 @@ using Wolverine.Runtime;
 using Wolverine.Runtime.Interop;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Runtime.Serialization.Encryption;
+using Wolverine.Runtime.WorkerQueues;
 using Wolverine.Transports;
 using Wolverine.Transports.Local;
 
@@ -437,6 +438,46 @@ public class ListenerConfiguration<TSelf, TEndpoint> : DelayedEndpointConfigurat
         }
 
         add(e => e.Mode = EndpointMode.NativeAck);
+        return this.As<TSelf>();
+    }
+
+    /// <summary>
+    /// GH-3710. Remember the message ids this process has already handled on this endpoint, and drop --
+    /// after settling -- any redelivery of one within the window. This is the non-durable analogue of the
+    /// durable inbox's duplicate detection: same outcome (ack the duplicate, never execute it), no database.
+    ///
+    /// <para>
+    /// Chiefly for <see cref="ProcessInParallelWithNativeAcks"/>, which is at-least-once by design and
+    /// deliberately produces a burst of redeliveries -- bounded by the broker's prefetch depth -- on every
+    /// rolling deploy. Also valid on <see cref="BufferedInMemory()"/> and <see cref="ProcessInline"/>.
+    /// Inert on <see cref="UseDurableInbox()"/>, whose inbox primary key already does this properly.
+    /// </para>
+    ///
+    /// <para>
+    /// The guard is per-process and in memory, and the docs say so out loud: a restart forgets every id it
+    /// ever saw, and a sibling node -- or the new owner after an exclusive-listener failover -- starts empty.
+    /// The promise is "at-least-once with best-effort dedup", not exactly-once. Where the broker has a real
+    /// dedup window (NATS JetStream's <c>Nats-Msg-Id</c>, SQS FIFO's <c>MessageDeduplicationId</c>, Pub/Sub's
+    /// <c>deduplication-id</c>), prefer that.
+    /// </para>
+    /// </summary>
+    /// <param name="window">How long a handled message id is remembered. Defaults to 5 minutes.</param>
+    /// <param name="maxTracked">Ceiling on remembered ids. Defaults to 100,000.</param>
+    public TSelf WithInMemoryIdempotency(TimeSpan? window = null, int? maxTracked = null)
+    {
+        if (_endpoint is LocalQueue)
+        {
+            throw new NotSupportedException(
+                $"Wolverine cannot use the {nameof(WithInMemoryIdempotency)} option for local queues. The guard "
+                + "deduplicates redeliveries from a message broker, and a local queue has no broker to redeliver "
+                + "anything -- messages reach it from inside this same process.");
+        }
+
+        var settings = new InMemoryIdempotencySettings();
+        if (window.HasValue) settings.Window = window.Value;
+        if (maxTracked.HasValue) settings.MaxTracked = maxTracked.Value;
+
+        add(e => e.InMemoryIdempotency = settings);
         return this.As<TSelf>();
     }
 

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -58,6 +58,28 @@ internal static class ListenerConfigurationValidator
             yield break;
         }
 
+        // GH-3710. The in-memory guard applies to every non-durable listening mode, so this check sits
+        // ahead of the Inline-only block below.
+        if (endpoint.InMemoryIdempotency != null)
+        {
+            if (endpoint.Mode == EndpointMode.Durable)
+            {
+                yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Warning,
+                    $"Ignored listener configuration for {describe(endpoint)}: WithInMemoryIdempotency() was configured on a " +
+                    "durable endpoint, and Wolverine has not built the guard. The durable inbox already rejects a duplicate " +
+                    "message id on the primary key of the incoming table, across restarts and across every node -- which is " +
+                    "strictly stronger than an in-memory, per-process guard. Remove WithInMemoryIdempotency(), or remove " +
+                    "UseDurableInbox() if what you wanted was best-effort dedup without a database.");
+            }
+            else if (endpoint is LocalQueue)
+            {
+                yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Warning,
+                    $"Ignored listener configuration for {describe(endpoint)}: WithInMemoryIdempotency() was configured on a " +
+                    "local queue. The guard deduplicates redeliveries from a message broker, and nothing is ever redelivered " +
+                    "to a local queue -- its messages are enqueued from inside this same process.");
+            }
+        }
+
         if (endpoint.Mode != EndpointMode.Inline)
         {
             yield break;

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -26,6 +26,14 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
     private readonly IBlock<Envelope> _receivingBlock;
     private readonly InMemoryScheduledJobProcessor _scheduler;
     private readonly DurabilitySettings _settings;
+
+    /// <summary>
+    /// GH-3710. Null unless the endpoint opted in with WithInMemoryIdempotency(). Only consulted on the
+    /// IReceiver.ReceivedAsync paths -- deliveries that came from a broker. Envelopes enqueued locally
+    /// (cascading messages, an in-process retry, a scheduled job firing) never pass through it, because
+    /// nothing redelivers those.
+    /// </summary>
+    private readonly IIncomingIdempotencyGuard? _idempotency;
     private bool _latched;
 
     public BufferedReceiver(Endpoint endpoint, IWolverineRuntime runtime, IHandlerPipeline pipeline)
@@ -46,6 +54,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         Uri = endpoint.Uri;
         _logger = runtime.LoggerFactory.CreateLogger<BufferedReceiver>();
         _settings = runtime.DurabilitySettings;
+        _idempotency = endpoint.IdempotencyGuard;
         Pipeline = pipeline;
 
         _scheduler = new InMemoryScheduledJobProcessor(this, _logger);
@@ -135,6 +144,9 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
     {
         if (_latched && envelope.Listener != null)
         {
+            // GH-3710: deferring hands the delivery back to the broker, which may redeliver it. Forget the
+            // id, or that redelivery would be dropped as a duplicate of a message that never ran.
+            _idempotency?.Release(envelope);
             await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
             return;
         }
@@ -147,9 +159,18 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
             }
 
             await Pipeline!.InvokeAsync(envelope, this).ConfigureAwait(false);
+
+            // GH-3710. HasBeenAcked answers "did this reach a terminal the broker will not undo?" --
+            // MessageContext.CompleteAsync sets it on success and on a native dead-letter move, while a
+            // requeue back to the broker (IChannelCallback.DeferAsync -> TryRequeueAsync) does not. Only the
+            // former may be remembered; remembering a requeued id would silently discard its redelivery.
+            recordOutcome(envelope);
         }
         catch (Exception? e)
         {
+            // GH-3710: the pipeline never reached a terminal, so nothing about this id may be remembered.
+            _idempotency?.Release(envelope);
+
             // This *should* never happen, but of course it will
             try
             {
@@ -162,6 +183,20 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
                 // via Block's error rung, and a faulted block never recovers. Swallowing is the
                 // lesser evil: the message fails, the listener survives.
             }
+        }
+    }
+
+    private void recordOutcome(Envelope envelope)
+    {
+        if (_idempotency == null) return;
+
+        if (envelope.HasBeenAcked)
+        {
+            _idempotency.MarkProcessed(envelope);
+        }
+        else
+        {
+            _idempotency.Release(envelope);
         }
     }
 
@@ -296,7 +331,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         foreach (var envelope in messages)
         {
             envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
-            if (!envelope.IsExpired())
+            if (!envelope.IsExpired() && !isDuplicate(envelope))
             {
                 await EnqueueAsync(envelope).ConfigureAwait(false);
             }
@@ -318,6 +353,14 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
             return;
         }
 
+        if (isDuplicate(envelope))
+        {
+            // Already acked by the _completeBlock post below, exactly as the durable path acks-and-drops a
+            // duplicate incoming envelope.
+            await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+            return;
+        }
+
         if (envelope.Status == EnvelopeStatus.Scheduled)
         {
             _scheduler.Enqueue(envelope.ScheduledTime!.Value, envelope);
@@ -330,6 +373,22 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
         await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
 
         _logger.IncomingReceived(envelope, Uri);
+    }
+
+    /// <summary>
+    /// GH-3710. Claim this broker delivery for the in-memory idempotency guard, answering true when it is a
+    /// redelivery of something already handled (or in flight) within the window. Always false when the
+    /// endpoint did not opt in.
+    /// </summary>
+    private bool isDuplicate(Envelope envelope)
+    {
+        if (_idempotency == null || _idempotency.TryBeginProcessing(envelope)) return false;
+
+        _logger.LogDebug(
+            "Discarding duplicate delivery of envelope {EnvelopeId} ({MessageType}) at {Uri}; it was already handled within the in-memory idempotency window",
+            envelope.Id, envelope.MessageType, Uri);
+
+        return true;
     }
 
     public void Dispose()

--- a/src/Wolverine/Runtime/WorkerQueues/GenerationalIdempotencyGuard.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/GenerationalIdempotencyGuard.cs
@@ -1,0 +1,163 @@
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3710. The default <see cref="IIncomingIdempotencyGuard"/>: a <b>generational</b> set of recently seen
+/// message ids.
+///
+/// <para>
+/// Two hash sets per category are kept, a current generation and the previous one, and membership is checked
+/// across both. Rotation -- previous is dropped, current becomes previous, a fresh current is started --
+/// happens on whichever comes first of half the configured window elapsing or the tracked count reaching half
+/// of <see cref="InMemoryIdempotencySettings.MaxTracked"/>. That is the whole eviction policy, and it is
+/// deliberately cruder than an LRU: no per-entry timestamps, no per-entry bookkeeping, O(1) on every
+/// operation, and a hard ceiling on memory. The price is that an id's lifetime is a range rather than a
+/// number -- remembered for at least <c>Window / 2</c> and at most <c>Window</c>, and less than that under a
+/// flood of unique ids, which is exactly the workload where bounded memory matters more than a precise
+/// window.
+/// </para>
+///
+/// <para>
+/// In-flight ids are tracked separately from processed ids so that a duplicate arriving <i>while</i> the
+/// original is still executing is dropped rather than queued up to run again. In-flight ids are generational
+/// too, purely as a leak stop: every receiver path releases what it claims, but an id that somehow never
+/// reaches a terminal still ages out instead of accumulating forever.
+/// </para>
+///
+/// <para>
+/// Locking is a plain <c>lock</c> rather than <c>ImHashMap</c> swap-on-write. This is not a per-dispatch
+/// dictionary lookup on the hot path -- it runs once per broker delivery, alongside deserialization and a
+/// network settle -- and a mutating set with a read-modify-write on every call is the shape a copy-on-write
+/// trie is worst at.
+/// </para>
+/// </summary>
+internal class GenerationalIdempotencyGuard : IIncomingIdempotencyGuard
+{
+    private readonly int _generationLimit;
+    private readonly MessageIdentity _identity;
+    private readonly object _locker = new();
+    private readonly Func<DateTimeOffset> _now;
+    private readonly TimeSpan _rotation;
+
+    private HashSet<IdempotencyKey> _currentInFlight = new();
+    private HashSet<IdempotencyKey> _currentProcessed = new();
+    private DateTimeOffset _nextRotation;
+    private HashSet<IdempotencyKey> _previousInFlight = new();
+    private HashSet<IdempotencyKey> _previousProcessed = new();
+
+    public GenerationalIdempotencyGuard(InMemoryIdempotencySettings settings, MessageIdentity identity)
+        : this(settings, identity, () => DateTimeOffset.UtcNow)
+    {
+    }
+
+    /// <param name="now">Seam for deterministic tests of the rotation policy. Production uses the system clock.</param>
+    internal GenerationalIdempotencyGuard(InMemoryIdempotencySettings settings, MessageIdentity identity,
+        Func<DateTimeOffset> now)
+    {
+        Settings = settings;
+        _identity = identity;
+        _now = now;
+
+        // Half the window, because an id has to survive BOTH generations to be forgotten -- rotating on the
+        // full window would remember every id for up to twice as long as advertised.
+        _rotation = TimeSpan.FromTicks(Math.Max(1, settings.Window.Ticks / 2));
+        _generationLimit = Math.Max(1, settings.MaxTracked / 2);
+        _nextRotation = now().Add(_rotation);
+    }
+
+    public InMemoryIdempotencySettings Settings { get; }
+
+    /// <summary>Number of ids currently remembered as processed, across both generations. Test seam.</summary>
+    internal int TrackedCount
+    {
+        get
+        {
+            lock (_locker)
+            {
+                return _currentProcessed.Count + _previousProcessed.Count;
+            }
+        }
+    }
+
+    /// <summary>Number of ids currently claimed but not yet terminal, across both generations. Test seam.</summary>
+    internal int InFlightCount
+    {
+        get
+        {
+            lock (_locker)
+            {
+                return _currentInFlight.Count + _previousInFlight.Count;
+            }
+        }
+    }
+
+    public bool TryBeginProcessing(Envelope envelope)
+    {
+        var key = IdempotencyKey.For(envelope, _identity);
+
+        lock (_locker)
+        {
+            rotateIfNecessary();
+
+            if (_currentInFlight.Contains(key) || _previousInFlight.Contains(key)
+                                               || _currentProcessed.Contains(key) ||
+                                               _previousProcessed.Contains(key))
+            {
+                return false;
+            }
+
+            _currentInFlight.Add(key);
+            return true;
+        }
+    }
+
+    public void MarkProcessed(Envelope envelope)
+    {
+        var key = IdempotencyKey.For(envelope, _identity);
+
+        lock (_locker)
+        {
+            _currentInFlight.Remove(key);
+            _previousInFlight.Remove(key);
+
+            _currentProcessed.Add(key);
+
+            rotateIfNecessary();
+        }
+    }
+
+    public void Release(Envelope envelope)
+    {
+        var key = IdempotencyKey.For(envelope, _identity);
+
+        lock (_locker)
+        {
+            _currentInFlight.Remove(key);
+            _previousInFlight.Remove(key);
+
+            // Deliberately also removes any processed record of this id. The failure path means the broker
+            // is going to redeliver, and remembering the id would silently discard the retry.
+            _currentProcessed.Remove(key);
+            _previousProcessed.Remove(key);
+        }
+    }
+
+    private void rotateIfNecessary()
+    {
+        var now = _now();
+        var byTime = now >= _nextRotation;
+        var bySize = _currentProcessed.Count + _currentInFlight.Count >= _generationLimit;
+
+        if (!byTime && !bySize)
+        {
+            return;
+        }
+
+        _previousProcessed = _currentProcessed;
+        _currentProcessed = new HashSet<IdempotencyKey>();
+
+        _previousInFlight = _currentInFlight;
+        _currentInFlight = new HashSet<IdempotencyKey>();
+
+        _nextRotation = now.Add(_rotation);
+    }
+}

--- a/src/Wolverine/Runtime/WorkerQueues/IIncomingIdempotencyGuard.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/IIncomingIdempotencyGuard.cs
@@ -1,0 +1,129 @@
+using JasperFx.Core;
+
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3710. Opt-in, per-process, bounded duplicate detection for endpoints that have no durable inbox.
+///
+/// <para>
+/// The durable inbox deduplicates by the primary key of <c>wolverine_incoming</c>, which is why a
+/// <see cref="Configuration.EndpointMode.Durable"/> endpoint never needs this. Every other mode --
+/// <see cref="Configuration.EndpointMode.NativeAck"/> above all, which deliberately leaves deliveries
+/// unacknowledged and therefore *expects* redelivery on any rolling deploy -- has nothing at all. This is
+/// the in-memory analogue: recognisably the same feature as
+/// <c>DurableReceiver.handleDuplicateIncomingEnvelope</c> (ack the duplicate delivery, drop it, do not
+/// execute it) minus the database.
+/// </para>
+///
+/// <para>
+/// The honest limit, which the docs state plainly: this is per-process and in memory. A restart forgets
+/// everything, and a second node (or a slot failover to one) starts empty. The promise is
+/// "at-least-once with best-effort dedup", not exactly-once. Anyone needing hard dedup keeps the durable
+/// inbox, or leans on a broker that has its own dedup window (NATS JetStream's <c>Nats-Msg-Id</c>, SQS
+/// FIFO's <c>MessageDeduplicationId</c>, Pub/Sub's <c>deduplication-id</c>).
+/// </para>
+/// </summary>
+internal interface IIncomingIdempotencyGuard
+{
+    /// <summary>
+    /// Claim this envelope for processing. Returns <c>false</c> when the id is already in flight or was
+    /// already processed within the window, in which case the caller settles the delivery and drops it.
+    /// </summary>
+    bool TryBeginProcessing(Envelope envelope);
+
+    /// <summary>
+    /// Move an id from in-flight to processed. Call this only when the delivery reached a terminal the
+    /// broker will not redeliver.
+    /// </summary>
+    void MarkProcessed(Envelope envelope);
+
+    /// <summary>
+    /// Drop an id from the in-flight set WITHOUT marking it processed. This is the failure path: a
+    /// nacked or requeued delivery is coming back, and suppressing it would turn a retry into a message
+    /// loss.
+    /// </summary>
+    void Release(Envelope envelope);
+}
+
+/// <summary>
+/// GH-3710. Identity of a received delivery for duplicate detection purposes, honoring
+/// <see cref="DurabilitySettings.MessageIdentity"/>: under
+/// <see cref="Wolverine.MessageIdentity.IdAndDestination"/> the same message id arriving at two different
+/// listening endpoints of one process (the Modular Monolith shape) is two distinct messages, not a duplicate.
+/// </summary>
+internal readonly record struct IdempotencyKey(Guid Id, Uri? Destination)
+{
+    public static IdempotencyKey For(Envelope envelope, MessageIdentity identity)
+    {
+        return identity == MessageIdentity.IdAndDestination
+            ? new IdempotencyKey(envelope.Id, envelope.Destination)
+            : new IdempotencyKey(envelope.Id, null);
+    }
+}
+
+/// <summary>
+/// GH-3710. Tuning for the opt-in in-memory idempotency guard on a non-durable listening endpoint.
+/// </summary>
+public class InMemoryIdempotencySettings
+{
+    /// <summary>
+    /// The default duplicate-suppression window, 5 minutes. Comfortably longer than the redelivery burst
+    /// a rolling deploy produces on a <see cref="Configuration.EndpointMode.NativeAck"/> endpoint, which is
+    /// bounded by the broker's prefetch depth and settles within seconds.
+    /// </summary>
+    public static readonly TimeSpan DefaultWindow = 5.Minutes();
+
+    /// <summary>
+    /// The default ceiling on tracked message ids, 100,000. At 16 bytes of Guid plus hash set overhead this
+    /// is single-digit megabytes, and it is a hard ceiling rather than a target: a sustained flood of unique
+    /// ids evicts by size long before the window elapses.
+    /// </summary>
+    public const int DefaultMaxTracked = 100_000;
+
+    private TimeSpan _window = DefaultWindow;
+    private int _maxTracked = DefaultMaxTracked;
+
+    /// <summary>
+    /// How long a completed message id is remembered. Eviction is generational rather than per-entry, so
+    /// an id is remembered for at least half this window and at most all of it.
+    /// </summary>
+    public TimeSpan Window
+    {
+        get => _window;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Window),
+                    "The in-memory idempotency window must be greater than zero");
+            }
+
+            _window = value;
+        }
+    }
+
+    /// <summary>
+    /// The maximum number of completed message ids held in memory. Reaching this rotates the generations
+    /// early, so memory stays bounded under a sustained flood of unique ids at the cost of a shorter
+    /// effective window.
+    /// </summary>
+    public int MaxTracked
+    {
+        get => _maxTracked;
+        set
+        {
+            if (value < 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaxTracked),
+                    "The in-memory idempotency guard must be allowed to track at least 2 message ids");
+            }
+
+            _maxTracked = value;
+        }
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(Window)}: {Window}, {nameof(MaxTracked)}: {MaxTracked}";
+    }
+}

--- a/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
@@ -14,6 +14,11 @@ internal class InlineReceiver : IReceiver
     private readonly IHandlerPipeline _pipeline;
     private readonly DurabilitySettings _settings;
 
+    /// <summary>
+    /// GH-3710. Null unless the endpoint opted in with WithInMemoryIdempotency().
+    /// </summary>
+    private readonly IIncomingIdempotencyGuard? _idempotency;
+
     private int _inFlightCount;
     private readonly TaskCompletionSource _drainComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private volatile bool _latched;
@@ -24,6 +29,7 @@ internal class InlineReceiver : IReceiver
         _pipeline = pipeline;
         _logger = runtime.LoggerFactory.CreateLogger<InlineReceiver>();
         _settings = runtime.DurabilitySettings;
+        _idempotency = endpoint.IdempotencyGuard;
     }
 
     public IHandlerPipeline Pipeline => _pipeline;
@@ -118,7 +124,24 @@ internal class InlineReceiver : IReceiver
         try
         {
             envelope.MarkReceived(listener, DateTimeOffset.UtcNow, _settings, _endpoint.WireTap);
+
+            // GH-3710. Ack-and-drop a redelivery of something already handled within the window, the
+            // non-durable analogue of DurableReceiver.handleDuplicateIncomingEnvelope.
+            if (_idempotency != null && !_idempotency.TryBeginProcessing(envelope))
+            {
+                _logger.LogDebug(
+                    "Discarding duplicate delivery of envelope {EnvelopeId} ({MessageType}) at {Uri}; it was already handled within the in-memory idempotency window",
+                    envelope.Id, envelope.MessageType, listener.Address);
+
+                await listener.CompleteAsync(envelope);
+                return;
+            }
+
             await _pipeline.InvokeAsync(envelope, listener, activity!);
+
+            // GH-3710. Only a delivery the broker will not redeliver -- acked, or natively dead lettered --
+            // may be remembered. A nack or requeue releases the id so the redelivery still runs.
+            recordOutcome(envelope);
             _logger.IncomingReceived(envelope, listener.Address);
 
             // Don't clobber an Error status already set by the HandlerPipeline / Executor.
@@ -133,6 +156,8 @@ internal class InlineReceiver : IReceiver
         }
         catch (Exception? e)
         {
+            _idempotency?.Release(envelope);
+
             activity?.SetStatus(ActivityStatusCode.Error, e.GetType().Name);
             _logger.LogError(e, "Failure to receive an incoming message for envelope {EnvelopeId}", envelope.Id);
 
@@ -150,6 +175,20 @@ internal class InlineReceiver : IReceiver
         finally
         {
             activity?.Stop();
+        }
+    }
+
+    private void recordOutcome(Envelope envelope)
+    {
+        if (_idempotency == null) return;
+
+        if (envelope.HasBeenAcked)
+        {
+            _idempotency.MarkProcessed(envelope);
+        }
+        else
+        {
+            _idempotency.Release(envelope);
         }
     }
 

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -42,6 +42,15 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
     private readonly ILogger _logger;
     private readonly IBlock<Envelope> _receivingBlock;
     private readonly DurabilitySettings _settings;
+
+    /// <summary>
+    /// GH-3710. Null unless the endpoint opted in with WithInMemoryIdempotency(), which is what makes the
+    /// guard zero-cost by default: one null check per delivery and nothing else. Owned by the endpoint rather
+    /// than by this receiver, so its contents survive the receiver rebuilds -- back pressure recovery, listener
+    /// restart -- that are themselves a source of redeliveries.
+    /// </summary>
+    private readonly IIncomingIdempotencyGuard? _idempotency;
+
     private bool _latched;
 
     public NativeAckReceiver(Endpoint endpoint, IWolverineRuntime runtime, IHandlerPipeline pipeline)
@@ -50,6 +59,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
         Uri = endpoint.Uri;
         _logger = runtime.LoggerFactory.CreateLogger<NativeAckReceiver>();
         _settings = runtime.DurabilitySettings;
+        _idempotency = endpoint.IdempotencyGuard;
         Pipeline = pipeline;
 
         // Guard against a listener-less envelope reaching either retry block -- env.Listener is null for the
@@ -143,6 +153,21 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
             return;
         }
 
+        // GH-3710. Ack-and-drop a redelivery of something this process already handled (or is handling right
+        // now), which is exactly what DurableReceiver.handleDuplicateIncomingEnvelope does when the inbox
+        // INSERT hits the primary key -- minus the database. Debug rather than Error, unlike the durable path:
+        // in a mode that never settles on receipt, redelivery after a rolling deploy is expected operational
+        // noise rather than a sign that something went wrong.
+        if (_idempotency != null && !_idempotency.TryBeginProcessing(envelope))
+        {
+            _logger.LogDebug(
+                "Discarding duplicate delivery of envelope {EnvelopeId} ({MessageType}) at {Uri}; it was already handled within the in-memory idempotency window",
+                envelope.Id, envelope.MessageType, Uri);
+
+            await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
+            return;
+        }
+
         var activity = _endpoint.TelemetryEnabled ? WolverineTracing.StartReceiving(envelope) : null;
 
         // NOTE the absence of a _completeBlock.PostAsync here. That single line is what separates this mode
@@ -157,7 +182,9 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
         if (_latched && envelope.Listener != null)
         {
             // Latched before this one started: hand it straight back to the broker instead of holding an
-            // unacked delivery that nothing is going to process.
+            // unacked delivery that nothing is going to process. The broker WILL redeliver it, so the guard
+            // has to forget the id or the redelivery would be dropped as a duplicate of a message that never ran.
+            _idempotency?.Release(envelope);
             await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
             return;
         }
@@ -171,6 +198,13 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
 
             // The channel is the LISTENER, which is what makes every terminal settle natively.
             await Pipeline.InvokeAsync(envelope, channelFor(envelope)).ConfigureAwait(false);
+
+            // GH-3710. Envelope.HasBeenAcked is the precise question the guard needs answered: was this
+            // delivery settled in a way the broker will not undo? Success acks it through
+            // MessageContext.CompleteAsync, and so does a native dead-letter move. A requeue or a nack does
+            // NOT set it, and those are the cases where remembering the id would turn a retry into a lost
+            // message -- so anything else releases.
+            recordOutcome(envelope);
         }
         catch (Exception e)
         {
@@ -184,8 +218,11 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
                 // rung, and a faulted block never recovers. Swallow: the message fails, the listener survives.
             }
 
-            // The pipeline did not settle it, so the broker still owns it. Nack rather than leaving the
-            // delivery dangling until the connection drops.
+            // The pipeline did not settle it, so the broker still owns it and will redeliver. Nack rather
+            // than leaving the delivery dangling until the connection drops, and forget the id so the
+            // redelivery is allowed to run.
+            _idempotency?.Release(envelope);
+
             try
             {
                 await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
@@ -194,6 +231,20 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
             {
                 _logger.LogError(ex, "Error trying to defer envelope {EnvelopeId} back to the broker", envelope.Id);
             }
+        }
+    }
+
+    private void recordOutcome(Envelope envelope)
+    {
+        if (_idempotency == null) return;
+
+        if (envelope.HasBeenAcked)
+        {
+            _idempotency.MarkProcessed(envelope);
+        }
+        else
+        {
+            _idempotency.Release(envelope);
         }
     }
 


### PR DESCRIPTION
Closes #3710

## What

The durable inbox deduplicates incoming messages on the primary key of `wolverine_incoming`. Every non-durable mode had nothing at all — verified in the issue, and still true. #3708's `EndpointMode.NativeAck` makes that gap matter: it is at-least-once *by design* and produces a burst of duplicate deliveries — bounded by the broker's prefetch depth — on every rolling deploy, because whatever graceful drain cannot finish within the drain timeout is simply never settled.

This adds `IIncomingIdempotencyGuard` plus a generational default implementation, opted into per endpoint:

```csharp
opts.ListenToRabbitQueue("webhooks")
    .ProcessInParallelWithNativeAcks()
    .PartitionProcessingByGroupId(PartitionSlots.Five)
    .WithInMemoryIdempotency(window: 5.Minutes(), maxTracked: 100_000); // both optional, these are the defaults
```

Default **off**. When it is off, the receivers pay one null check per delivery and nothing else.

## Design notes

**Where it sits.** Same semantics as the durable path, minus the database: a duplicate is settled with the broker and dropped without reaching the handler, exactly like `DurableReceiver.handleDuplicateIncomingEnvelope` does when the inbox INSERT hits the primary key. Logged at `Debug` rather than `Error` — in a mode that never settles at receipt, redelivery is expected operational noise.

**Bounding.** An unbounded set of seen ids would be a leak on precisely the flood workload `NativeAck` exists for. Eviction is generational: two hash sets, both consulted on lookup, rotated on whichever comes first of `window / 2` elapsing or `maxTracked / 2` ids landing in the current generation. Hard ceiling of `maxTracked`, no per-entry timestamps, no LRU bookkeeping, O(1) everywhere. The price — stated in the docs — is that an id's lifetime is a range (at least `window / 2`, at most `window`, less under a flood) rather than a number.

**In-flight vs processed.** Tracked separately, so a duplicate arriving *while* the original is still executing is dropped rather than queued to run again. In-flight ids are generational too, purely as a leak stop.

**Success vs failure.** Only a delivery that reached a terminal the broker will not undo is remembered — `Envelope.HasBeenAcked`, which `MessageContext.CompleteAsync` sets on handler success and which a native dead-letter move also sets. Anything nacked, requeued, or deferred during a drain **releases** the id, because remembering it would suppress its own retry and turn a failure into a lost message.

**Per-endpoint, and it survives receiver rebuilds.** The guard is owned by the `Endpoint`, not the receiver: receivers are rebuilt on listener restart and back-pressure recovery, and those are exactly the moments that produce redeliveries. Global opt-in is the existing `opts.Policies.AllListeners(x => x.WithInMemoryIdempotency())`.

**Honors `DurabilitySettings.MessageIdentity`** — under `IdAndDestination` the key includes the destination, so the Modular Monolith shape (one process, same id at two listeners) still works.

**Refused or inert where it is meaningless.** `Durable` builds no guard and warns at startup (the inbox already does this, across restarts and across nodes). Local queues throw `NotSupportedException` where you call it, with a lazily-resolved fallback warning in `ListenerConfigurationValidator`.

**JetStream and friends.** Not implemented here, per the issue. The docs point at broker-side dedup where it exists — JetStream's `Nats-Msg-Id` duplicate window, SQS FIFO's `MessageDeduplicationId`, Pub/Sub's `deduplication-id` — as strictly better than an in-process guard, and note that this guard is chiefly for RabbitMQ classic/quorum queues, which have nothing.

## The honest limit, and where it is documented

New "In-Memory Idempotency Guard" section in `docs/guide/messaging/listeners.md`, sitting between the `NativeAck` and `Buffered` sections so a user choosing a non-durable mode reads it in place, plus a row in the "which settings apply in which mode" matrix and pointers from the `NativeAck` shutdown bullet and the `Buffered` section.

It says out loud, in a warning block, that **an in-memory guard does not survive a restart**: the deploy that causes the redelivery burst also empties the guard on the node that starts up, a sibling node never knew, and a slot failover hands the queue to a node starting empty. The promise is *at-least-once with best-effort dedup*, not exactly-once; hard dedup means the durable inbox. It also notes that a duplicate slipping through is a cost/liveness issue rather than a correctness one for #3708's ordering guarantee — a duplicate still runs in its group's sequential lane.

## Tests

- `generational_idempotency_guard` — rotation across both generations against an injected clock (survives one rotation, forgotten after two); bounded memory under 50,000 unique ids with a ceiling of 100; in-flight ids bounded even when nothing ever completes; in-flight duplicate rejected; released id re-runnable; both `MessageIdentity` modes; and a concurrency hammer asserting exactly one winner per id across 8 threads.
- `in_memory_idempotency_guard_on_receivers` — redelivery acked and never executed under `NativeAck` and under `BufferedInMemory`; both modes run the duplicate again with the guard off; concurrent duplicate dropped while the original is parked in the handler; and a deferred delivery not remembered, re-run through a *rebuilt* receiver on the same endpoint.
- `listener_configuration_validation` — opt-in only, tuning flows through to the guard, the defaults, the durable warning, and the local-queue refusal.

Broker-level redelivery integration testing on RabbitMQ (forcing a redelivery by closing the connection with unacked deliveries) is not in this PR.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings.
- Full CoreTests: 2566 total, 0 failed, 2 skipped (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)