### PR TITLE
GH-4046: EndpointMode.NativeAck for Redis Streams

### DIFF
--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -378,6 +378,47 @@ RabbitMQ, Kafka or SQS. If what you actually wanted was Redis-native scheduled r
 use the default `BufferedInMemory()` (or `ProcessInline()`) listener: those schedule natively in Redis.
 :::
 
+## Native Acks with Parallel Processing <Badge type="tip" text="6.30" />
+
+Redis stream listeners support `EndpointMode.NativeAck` (see [GH-3708](https://github.com/JasperFx/wolverine/issues/3708)),
+which combines `BufferedInMemory`'s parallelism and group partitioning with `Inline`'s no-loss behavior, and needs no
+database at all:
+
+```csharp
+opts.ListenToRedisStream("webhooks", "webhook-processors")
+    .ProcessInParallelWithNativeAcks()
+    .PartitionProcessingByGroupId(PartitionSlots.Seven)
+
+    // XAUTOCLAIM is what recovers entries a dead node left pending
+    .EnableAutoClaim(period: TimeSpan.FromSeconds(30), minIdle: TimeSpan.FromMinutes(2));
+```
+
+Incoming entries flow through an in-memory (optionally group-partitioned) execution block while the stream entry is
+held **unacknowledged**, and are settled natively — `XACK` on handler success, dead-lettered or requeued on terminal
+failure — from the completion continuation. Redis qualifies for this mode because `XACK` names a single entry id that
+Wolverine carries on the envelope itself, so one delivery can be settled, out of order, from whichever worker thread
+finished it.
+
+The guarantee is exactly the one the mode promises everywhere: **messages sharing a group id never execute
+concurrently**, and nothing is acknowledged until its handler succeeds. Processing in original delivery order is
+*best effort*, not promised — a failed or reclaimed message re-enters its lane later, never concurrently. Use
+`UseDurableInbox()` if you need strict ordering under failure.
+
+Two things to know that are specific to Redis:
+
+* **Recovery of a dead node's entries is opt-in.** Redis does not hand unacknowledged entries back when a connection
+  drops the way RabbitMQ does; they stay in the consumer group's pending entries list until some consumer runs
+  `XAUTOCLAIM`. That means `EnableAutoClaim()`. This is true of `Inline` and `BufferedInMemory` listeners as well.
+* **Size `minIdle` above your slowest lane, not your slowest handler.** This mode holds an entry from the moment it is
+  read until its handler finishes, including time spent queued in a lane. A `minIdle` shorter than the worst-case lane
+  residency lets a consumer re-claim an entry it is still working on, and process it twice.
+
+The read batch size is this transport's prefetch equivalent, and in this mode it defaults to twice the number of lanes
+that can be busy at once — the partition slot count when `PartitionProcessingByGroupId()` is used, otherwise
+`MaximumParallelMessages()` — instead of the usual 10. `BatchSize()` still overrides it. Note that unlike RabbitMQ's
+prefetch, it does not cap how many entries can be unacknowledged: the bounded execution block is what applies back
+pressure, and the consumer loop stops reading once that block is full.
+
 ## Scheduled Messaging <Badge type="tip" text="5.10" />
 
 The Redis transport supports native Redis message scheduling for delayed or scheduled delivery. There's no configuration

--- a/src/Transports/Redis/Wolverine.Redis.Tests/native_ack_mode.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/native_ack_mode.cs
@@ -1,0 +1,410 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using StackExchange.Redis;
+using Wolverine.Configuration;
+using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+#region messages and handler
+
+public record RedisNativeAckWork(Guid SessionId, int Number, string Group);
+
+/// <summary>
+/// Tracking state is keyed by a session id carried on the message itself rather than living in one static
+/// bag. Every test here gets its own stream, its own consumer group AND its own session, because the
+/// RabbitMQ suite showed what happens otherwise: a redelivery test's messages arriving late land in the
+/// next test's assertions.
+/// </summary>
+public class RedisNativeAckSession
+{
+    public ConcurrentBag<int> Handled { get; } = new();
+
+    /// <summary>When set, handlers park here -- standing in for a node that dies mid-flight.</summary>
+    public TaskCompletionSource? Block { get; set; }
+
+    /// <summary>Per-message gates, so one message can be held while the ones behind it finish.</summary>
+    public ConcurrentDictionary<int, TaskCompletionSource> Gates { get; } = new();
+
+    public ConcurrentDictionary<string, int> ActiveByGroup { get; } = new();
+    public int MaxConcurrencyWithinAGroup;
+    public int MaxConcurrencyOverall;
+    private int _active;
+
+    public TaskCompletionSource GateFor(int number)
+    {
+        return Gates.GetOrAdd(number, _ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+    }
+
+    public async Task HandleAsync(RedisNativeAckWork message)
+    {
+        if (Gates.TryGetValue(message.Number, out var gate))
+        {
+            await gate.Task;
+        }
+
+        var block = Block;
+        if (block != null)
+        {
+            await block.Task;
+        }
+
+        var overall = Interlocked.Increment(ref _active);
+        var withinGroup = ActiveByGroup.AddOrUpdate(message.Group, 1, (_, current) => current + 1);
+
+        trackMaximum(ref MaxConcurrencyOverall, overall);
+        trackMaximum(ref MaxConcurrencyWithinAGroup, withinGroup);
+
+        try
+        {
+            // Long enough that two messages of the same group WOULD overlap if nothing prevented it
+            await Task.Delay(75);
+            Handled.Add(message.Number);
+        }
+        finally
+        {
+            ActiveByGroup.AddOrUpdate(message.Group, 0, (_, current) => current - 1);
+            Interlocked.Decrement(ref _active);
+        }
+    }
+
+    private static void trackMaximum(ref int target, int candidate)
+    {
+        var current = Volatile.Read(ref target);
+        while (candidate > current)
+        {
+            var previous = Interlocked.CompareExchange(ref target, candidate, current);
+            if (previous == current) return;
+            current = previous;
+        }
+    }
+
+    public void ReleaseEverything()
+    {
+        Block?.TrySetResult();
+        foreach (var gate in Gates.Values)
+        {
+            gate.TrySetResult();
+        }
+    }
+}
+
+public static class RedisNativeAckTracking
+{
+    private static readonly ConcurrentDictionary<Guid, RedisNativeAckSession> _sessions = new();
+
+    public static RedisNativeAckSession Start(Guid id)
+    {
+        var session = new RedisNativeAckSession();
+        _sessions[id] = session;
+        return session;
+    }
+
+    public static RedisNativeAckSession For(Guid id)
+    {
+        return _sessions.GetOrAdd(id, _ => new RedisNativeAckSession());
+    }
+}
+
+public class RedisNativeAckWorkHandler
+{
+    public Task Handle(RedisNativeAckWork message)
+    {
+        return RedisNativeAckTracking.For(message.SessionId).HandleAsync(message);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// GH-4046. Redis Streams opting into <see cref="EndpointMode.NativeAck"/>. What is under test is the
+/// guarantee the mode exists for -- Buffered's throughput and partitioning with Inline's no-loss behaviour --
+/// expressed in Redis's own terms: the pending entries list. Nothing is XACKed until a handler succeeds, so
+/// "unacked" here is directly observable as an entry still sitting in the group's PEL.
+/// </summary>
+public class native_ack_mode : IAsyncLifetime
+{
+    private readonly List<RedisNativeAckSession> _sessions = new();
+    private IConnectionMultiplexer _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = await ConnectionMultiplexer.ConnectAsync(RedisContainerFixture.ConnectionString);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var session in _sessions)
+        {
+            session.ReleaseEverything();
+        }
+
+        await _connection.DisposeAsync();
+    }
+
+    private RedisNativeAckSession startSession(Guid id)
+    {
+        var session = RedisNativeAckTracking.Start(id);
+        _sessions.Add(session);
+        return session;
+    }
+
+    private Task<IHost> startHostAsync(string streamKey, string consumerGroup,
+        Action<RedisListenerConfiguration>? configure = null, string? consumerName = null)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<RedisNativeAckWorkHandler>();
+
+                // Group id for the partitioned lanes comes off the message body
+                opts.MessagePartitioning.ByMessage<RedisNativeAckWork>(x => x.Group);
+
+                var listener = opts.ListenToRedisStream(streamKey, consumerGroup)
+                    .Named(streamKey)
+                    .ProcessInParallelWithNativeAcks()
+                    .BlockTimeout(100.Milliseconds())
+                    .StartFromBeginning();
+
+                if (consumerName != null)
+                {
+                    listener.ConsumerName(consumerName);
+                }
+
+                configure?.Invoke(listener);
+
+                // NOTE: deliberately NOT SendInline(). Listener and subscriber share one Endpoint object here,
+                // so SendInline() would set Mode = Inline on the very endpoint this suite is testing.
+                opts.PublishMessage<RedisNativeAckWork>().ToRedisStream(streamKey);
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task the_endpoint_really_is_in_native_ack_mode_with_a_native_ack_receiver()
+    {
+        var streamKey = $"native-ack-4046-mode-{Guid.NewGuid():N}";
+        using var host = await startHostAsync(streamKey, "mode-group");
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = runtime.Endpoints.EndpointByName(streamKey).ShouldNotBeNull().ShouldBeOfType<RedisStreamEndpoint>();
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+
+        // Back pressure is the execution block plus the read batch, not a BackPressureAgent
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+
+        // ...and the read batch, this transport's prefetch equivalent, has to cover every lane
+        endpoint.BatchSize.ShouldBe(endpoint.MaxDegreeOfParallelism * 2);
+    }
+
+    [Fact]
+    public void batch_size_default_covers_every_lane_that_can_be_busy()
+    {
+        var transport = new RedisTransport(RedisContainerFixture.ConnectionString);
+
+        var buffered = transport.StreamEndpoint("batch-size-buffered");
+        buffered.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        buffered.BatchSize.ShouldBe(10);
+
+        // Not partitioned: the lanes are MaxDegreeOfParallelism
+        var parallel = transport.StreamEndpoint("batch-size-parallel");
+        parallel.MaxDegreeOfParallelism = 6;
+        parallel.Mode = EndpointMode.NativeAck;
+        parallel.BatchSize.ShouldBe(12);
+
+        // Partitioned: the lanes are the slots, and GH-3899's exempt types still run at
+        // MaxDegreeOfParallelism, so the batch covers whichever is larger
+        var partitioned = transport.StreamEndpoint("batch-size-partitioned");
+        partitioned.MaxDegreeOfParallelism = 3;
+        partitioned.GroupShardingSlotNumber = PartitionSlots.Nine;
+        partitioned.Mode = EndpointMode.NativeAck;
+        partitioned.BatchSize.ShouldBe(18);
+
+        partitioned.MaxDegreeOfParallelism = 20;
+        partitioned.BatchSize.ShouldBe(40);
+
+        // An explicit setting always wins over the mode default
+        var explicitly = transport.StreamEndpoint("batch-size-explicit");
+        explicitly.Mode = EndpointMode.NativeAck;
+        explicitly.BatchSize = 3;
+        explicitly.BatchSize.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task messages_are_processed_end_to_end()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = startSession(sessionId);
+        var streamKey = $"native-ack-4046-e2e-{Guid.NewGuid():N}";
+
+        using var host = await startHostAsync(streamKey, "e2e-group");
+        var bus = host.MessageBus();
+
+        for (var i = 0; i < 10; i++)
+        {
+            await bus.SendAsync(new RedisNativeAckWork(sessionId, i, "e2e"));
+        }
+
+        await waitFor(() => session.Handled.Distinct().Count() >= 10, 30.Seconds());
+
+        session.Handled.Distinct().OrderBy(x => x).ShouldBe(Enumerable.Range(0, 10));
+
+        // Every delivery settled: the pending entries list is what "acked" means on this transport
+        await waitFor(async () => await pendingCountAsync(streamKey, "e2e-group") == 0, 15.Seconds());
+    }
+
+    /// <summary>
+    /// The per-entry settlement property that lets this transport qualify at all. XACK names one entry id, so
+    /// a message whose handler finishes early settles ITSELF and nothing else -- the entry ahead of it in the
+    /// stream stays pending. A cumulative settle model (a Kafka offset commit, a RabbitMQ ack with
+    /// multiple:true) would have silently acked the still-running message here, which is exactly the loss the
+    /// mode is supposed to prevent.
+    /// </summary>
+    [Fact]
+    public async Task only_the_completed_entry_is_settled_when_completion_is_out_of_order()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = startSession(sessionId);
+        var streamKey = $"native-ack-4046-ooo-{Guid.NewGuid():N}";
+        const string group = "ooo-group";
+
+        // Message 0 -- the FIRST entry in the stream -- is held while 1 and 2 sail past it
+        var gate = session.GateFor(0);
+
+        using var host = await startHostAsync(streamKey, group);
+        var bus = host.MessageBus();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await bus.SendAsync(new RedisNativeAckWork(sessionId, i, "ooo"));
+        }
+
+        await waitFor(() => session.Handled.Contains(1) && session.Handled.Contains(2), 30.Seconds());
+
+        // The two later entries are settled; the earlier one is still held, and still pending
+        await waitFor(async () => await pendingCountAsync(streamKey, group) == 1, 15.Seconds());
+        session.Handled.ShouldNotContain(0);
+
+        gate.TrySetResult();
+
+        await waitFor(() => session.Handled.Contains(0), 30.Seconds());
+        await waitFor(async () => await pendingCountAsync(streamKey, group) == 0, 15.Seconds());
+    }
+
+    /// <summary>
+    /// The whole point of the mode. Under BufferedInMemory these entries are XACKed the instant they are read,
+    /// so a node that dies before the handler finishes loses every one of them. Under NativeAck nothing is
+    /// acked until the handler succeeds, so they are all still in the consumer group's pending entries list
+    /// when the node dies, and XAUTOCLAIM hands them to the node that replaces it.
+    /// </summary>
+    [Fact]
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = startSession(sessionId);
+        var streamKey = $"native-ack-4046-redelivery-{Guid.NewGuid():N}";
+        const string group = "redelivery-group";
+
+        // Every handler on the first node parks here and never comes back -- a node that dies mid-flight
+        session.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstHost = await startHostAsync(streamKey, group, consumerName: "node-1");
+        var bus = firstHost.MessageBus();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await bus.SendAsync(new RedisNativeAckWork(sessionId, 100 + i, $"g{i}"));
+        }
+
+        // Let the entries actually reach the parked handlers before killing the node
+        await waitFor(async () => await pendingCountAsync(streamKey, group) == 5, 30.Seconds());
+
+        // The node dies mid-flight, having acked nothing
+        firstHost.Dispose();
+
+        session.Handled.ShouldBeEmpty();
+
+        // Still unacked with the node gone -- nothing was settled on receipt, and node 1's handlers stay
+        // parked forever so they can never settle anything either
+        (await pendingCountAsync(streamKey, group)).ShouldBe(5);
+
+        // New handler invocations on the replacement node do not park
+        session.Block = null;
+
+        // A fresh node claims every pending entry out of the dead consumer's PEL. XAUTOCLAIM is the
+        // redelivery mechanism here -- XREADGROUP ">" only ever returns never-delivered entries.
+        using var secondHost = await startHostAsync(streamKey, group,
+            listener => listener.EnableAutoClaim(250.Milliseconds(), 250.Milliseconds()),
+            consumerName: "node-2");
+
+        await waitFor(() => session.Handled.Distinct().Count() >= 5, 60.Seconds());
+
+        session.Handled.Distinct().OrderBy(x => x).ShouldBe(Enumerable.Range(100, 5));
+        await waitFor(async () => await pendingCountAsync(streamKey, group) == 0, 30.Seconds());
+    }
+
+    /// <summary>
+    /// The hard guarantee of the mode: messages sharing a group id never execute concurrently, while the
+    /// endpoint as a whole still runs several at once. Original delivery order is explicitly NOT promised.
+    /// </summary>
+    [Fact]
+    public async Task messages_sharing_a_group_id_never_execute_concurrently()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = startSession(sessionId);
+        var streamKey = $"native-ack-4046-partitioned-{Guid.NewGuid():N}";
+        const string group = "partitioned-group";
+
+        using var host = await startHostAsync(streamKey, group,
+            listener => listener.PartitionProcessingByGroupId(PartitionSlots.Nine));
+
+        var bus = host.MessageBus();
+
+        var number = 0;
+        for (var g = 0; g < 6; g++)
+        {
+            for (var i = 0; i < 4; i++)
+            {
+                await bus.SendAsync(new RedisNativeAckWork(sessionId, number++, $"group-{g}"));
+            }
+        }
+
+        await waitFor(() => session.Handled.Distinct().Count() >= 24, 60.Seconds());
+
+        session.MaxConcurrencyWithinAGroup.ShouldBe(1);
+        session.MaxConcurrencyOverall.ShouldBeGreaterThan(1);
+
+        await waitFor(async () => await pendingCountAsync(streamKey, group) == 0, 30.Seconds());
+    }
+
+    private async Task<long> pendingCountAsync(string streamKey, string consumerGroup)
+    {
+        var pending = await _connection.GetDatabase().StreamPendingAsync(streamKey, consumerGroup);
+        return pending.PendingMessageCount;
+    }
+
+    private static Task waitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        return waitFor(() => Task.FromResult(condition()), timeout);
+    }
+
+    private static async Task waitFor(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (!await condition())
+        {
+            if (DateTimeOffset.UtcNow > deadline)
+            {
+                throw new TimeoutException("Condition was not met in time");
+            }
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
@@ -15,6 +15,7 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
     IStorageBackedQueue
 {
     private readonly RedisTransport _transport;
+    private int? _batchSize;
 
     internal bool SupportsNativeScheduledSend { get; set; } = true;
     
@@ -74,9 +75,78 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
     public string? ConsumerGroup { get; set; }
     
     /// <summary>
-    /// Maximum number of messages to read in a single batch from Redis Stream
+    /// GH-4046. Redis Streams is the second transport to accept <see cref="EndpointMode.NativeAck" />, and it
+    /// qualifies on both counts the mode requires.
+    ///
+    /// <para>
+    /// <b>Settlement is per entry.</b> <c>RedisStreamListener.CompleteAsync</c> acks with
+    /// <c>XACK streamKey consumerGroup entryId</c>, where the entry id rides along on the envelope itself in the
+    /// <c>RedisEnvelopeMapper.RedisEntryIdHeader</c> header. The delivery identity therefore travels with the
+    /// envelope rather than living in the read loop's stack frame, so an arbitrary worker thread can settle one
+    /// delivery -- and only that one -- whenever its handler finishes. There is no cumulative form to get wrong:
+    /// unlike a Kafka offset commit, acking entry 5 says nothing about entries 1-4, which is exactly what
+    /// out-of-order completion out of a partitioned execution block needs.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Redelivery does not depend on a lease clock.</b> An entry that is read but never acked stays in the
+    /// consumer group's pending entries list, and <c>XAUTOCLAIM</c> is what hands it to another consumer. Nothing
+    /// expires on a timer while an envelope waits its turn in a lane, so -- unlike SQS visibility timeouts, Azure
+    /// Service Bus lock durations, Pub/Sub ack deadlines or JetStream <c>AckWait</c> -- there is no deadline to
+    /// renew for the (unbounded) time an envelope sits queued. That is what makes this the cheapest adopter.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Two operational caveats, neither a correctness hole in the mode itself.</b> First, PEL recovery is
+    /// opt-in on this transport: a node that dies holding unacked entries leaves them pending, and they come back
+    /// only when some consumer runs <c>XAUTOCLAIM</c>, which means <c>EnableAutoClaim()</c>. That is true of Inline
+    /// and Buffered listeners here too, not something this mode introduces. Second, once auto-claim IS on,
+    /// <see cref="AutoClaimMinIdle" /> behaves as a de facto lease: this mode holds a delivery for lane queue time
+    /// plus handler time rather than handler time alone, so a min-idle shorter than the worst-case lane residency
+    /// lets a consumer re-claim an entry it is still working on and process it twice. Size it above the slowest
+    /// lane, not just the slowest handler.
+    /// </para>
     /// </summary>
-    public int BatchSize { get; set; } = 10;
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
+    /// Maximum number of messages to read in a single batch from Redis Stream (XREADGROUP / XAUTOCLAIM count).
+    /// Defaults to 10, or to twice the number of concurrently-busy lanes when this endpoint is in
+    /// <see cref="EndpointMode.NativeAck" /> mode.
+    /// </summary>
+    public int BatchSize
+    {
+        get
+        {
+            if (_batchSize.HasValue)
+            {
+                return _batchSize.Value;
+            }
+
+            if (Mode == EndpointMode.NativeAck)
+            {
+                // GH-4046. The read batch is this transport's prefetch equivalent, and it has to cover every lane
+                // that can be busy at once -- the partition slot count when the endpoint is group-partitioned and
+                // MaxDegreeOfParallelism otherwise (whichever is larger, since GH-3899 exempted message types run
+                // at the endpoint's parallelism rather than in a slot), doubled so a lane is never left idle
+                // waiting on the next poll. Ten -- the default for the other modes -- would starve a default
+                // MaxDegreeOfParallelism of Environment.ProcessorCount on any decent box.
+                //
+                // Note what this is NOT: unlike RabbitMQ's PreFetchCount it does not cap the unacked window.
+                // Redis has no unacked ceiling, and the consumer loop polls again the moment it has posted a
+                // batch, so what bounds the in-flight set is the bounded execution block -- the loop's
+                // ReceivedAsync await stops pulling entries once the block's channel is full.
+                var lanes = GroupShardingSlotNumber.HasValue
+                    ? Math.Max((int)GroupShardingSlotNumber.Value, MaxDegreeOfParallelism)
+                    : MaxDegreeOfParallelism;
+
+                return lanes * 2;
+            }
+
+            return 10;
+        }
+        set => _batchSize = value;
+    }
     
     /// <summary>
     /// Consumer name within the consumer group. Defaults to machine name + process ID

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -62,6 +62,7 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("Wolverine.MQTT")]
 [assembly: InternalsVisibleTo("Wolverine.Mqtt5")]
 [assembly: InternalsVisibleTo("Wolverine.Redis")]
+[assembly: InternalsVisibleTo("Wolverine.Redis.Tests")]
 [assembly: InternalsVisibleTo("Wolverine.SignalR")]
 [assembly: InternalsVisibleTo("Wolverine.Pubsub")]
 [assembly: InternalsVisibleTo("MetricsTests")]


### PR DESCRIPTION
Closes #4046.

Redis Streams is the second transport to accept `EndpointMode.NativeAck` (#3708), and per the #3715 triage it is the cheapest adopter — the one that proves the shape end to end without #4048 (lease renewal for queued envelopes) in the way.

## Why Redis qualifies

The mode needs two properties from a transport, and Redis has both.

**Settlement is per entry, and the delivery identity travels with the envelope.** `RedisStreamListener.CompleteAsync` acks with `XACK streamKey consumerGroup entryId`, where `entryId` comes off the envelope's own `RedisEnvelopeMapper.RedisEntryIdHeader` header rather than out of the read loop's stack frame. So an arbitrary worker thread can settle one delivery — and only that one — whenever its handler finishes, which is exactly what out-of-order completion from a partitioned execution block requires. There is no cumulative form to get wrong here: acking entry 5 says nothing about entries 1–4. That is the failure #3706 had to fix for RabbitMQ (`multiple: true`) and the reason Kafka was rejected outright.

I verified the "no cumulative effect" claim against a real server rather than from the docs: with three entries read into one consumer's PEL, `XACK` of the *last* one takes the pending count from 3 to 2 and leaves the earlier, still-unacked entries alone. The `only_the_completed_entry_is_settled_when_completion_is_out_of_order` test pins the same property end to end through Wolverine — the first entry in the stream is held in its handler while the two behind it complete and settle, and `XPENDING` shows exactly one entry left.

**Redelivery does not run on a lease clock.** The pending entries list plus `XAUTOCLAIM` *is* the redelivery mechanism. Nothing expires on a timer while an envelope sits queued in a lane, so unlike SQS visibility timeouts, ASB lock durations, Pub/Sub ack deadlines or JetStream `AckWait`, there is no deadline to renew for the (unbounded) lane queue time this mode introduces. #4048 is genuinely not a prerequisite here.

## What changed

1. **`protected override bool supportsNativeAck => true;`** on `RedisStreamEndpoint`, with the reasoning above written down where the next person will look for it, in the style of the `RabbitMqQueue` override.

2. **Mode-default tuning for `BatchSize`.** The stream read batch (the `count` on `XREADGROUP` / `XAUTOCLAIM`) is this transport's prefetch equivalent, so it now mirrors `RabbitMqQueue.PreFetchCount`'s NativeAck arm: it has to cover every lane that can be busy at once — the partition slot count when `GroupShardingSlotNumber` is set, otherwise `MaxDegreeOfParallelism` (whichever is larger, since GH-3899 exempted types run at endpoint parallelism), doubled so a lane is never idle waiting on the next poll. An explicit `BatchSize()` still wins, and every other mode keeps the old default of 10. The old default would have starved a default `MaxDegreeOfParallelism` on any decent box.

   One honest difference from RabbitMQ that is written into the code comment and the docs: this does **not** cap the unacked window. Redis has no unacked ceiling and the consumer loop polls again as soon as it has posted a batch, so what actually bounds the in-flight set is the bounded execution block — `ReceivedAsync` stops pulling entries once the block's channel is full. Back pressure is real, it just is not the read batch.

3. **Integration tests** mirroring `Wolverine.RabbitMQ.Tests/native_ack_mode.cs`, including the redelivery-after-a-dead-node case. Every test gets its own stream key, its own consumer group *and* its own tracking session keyed by a session id on the message — the RabbitMQ suite's shared static bag is what made late-arriving messages land in the next test's assertions.

4. **Docs**: a "Native Acks with Parallel Processing" section on the Redis transport page, including the two Redis-specific operational caveats below.

## What I verified

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors.
- Full CoreTests (`dotnet run -f net9.0 -c Release`) — 2537 passed, 2 skipped, 0 failed.
- The new Redis suite — 6/6, three times in a row, ~15s.
- The **full** Redis suite — 158/158, no regressions from the `BatchSize` change.

## Findings worth recording

**`DeleteOnAck` under out-of-order settlement (issue item 3): correct in principle, unusable on the Redis version this repo tests against.**

On the settlement question the answer is clean. `XACKDEL`/`XDEL` are per-entry operations on a radix tree keyed by entry id, so deleting a later entry cannot disturb an earlier one. Verified on Redis 8.10.1: with three entries pending, `StreamAcknowledgeAndDeleteAsync` of the *last* one takes pending 3 → 2 and stream length 3 → 2, leaving the two earlier unacked entries — and their PEL rows — intact. Out-of-order settlement is safe.

But `DeleteStreamEntryOnAck(true)` is dead on arrival on **Redis 7**, which is what `docker-compose.yml` runs *and* what `RedisContainerFixture` starts (`redis:7-alpine`), i.e. everything CI exercises. `XACKDEL` landed in Redis 8.2; on 7.4.9 the server answers `ERR unknown command 'XACKDEL'`. `RedisStreamListener.CompleteAsync` catches that and logs a warning, so the net effect is that **nothing is ever acknowledged** — the entry stays pending forever. That is not new and not specific to this mode (`DeferAsync` and `MoveToErrorsAsync` have the same swallow, and Inline/Buffered listeners are affected identically), but it gets worse under NativeAck: with auto-claim enabled, a never-acked entry is reclaimed and reprocessed indefinitely. I deliberately left it alone rather than smuggling a fix in here — a "fall back to `XACK` + `XDEL`" fix is not semantically equivalent for a stream with more than one consumer group, since `StreamTrimMode.Acknowledged` exists precisely to avoid deleting an entry another group still has pending. Worth its own issue.

**Auto-claim is the load-bearing part of "a dead node loses nothing" on this transport, and its `minIdle` is a de facto lease.** Two things the triage's "no lease clock" summary is worth qualifying with:

- Redis does not hand unacknowledged entries back when a connection drops the way RabbitMQ does. They stay in the dead consumer's PEL until *someone* runs `XAUTOCLAIM`, which means `EnableAutoClaim()` — off by default. The redelivery test therefore starts the replacement node with auto-claim on, and that is now documented. (Again, not introduced by this mode: an `Inline` Redis listener that dies mid-handler leaves the same orphan.)
- Once auto-claim *is* on, `AutoClaimMinIdle` behaves as a lease after all. This mode holds an entry for lane queue time plus handler time, so a `minIdle` shorter than worst-case lane residency lets a consumer re-claim an entry it is still working on and run it twice. Documented as "size it above your slowest lane, not your slowest handler". A tighter fix — having the listener skip entries this process still holds unsettled — is a plausible follow-up but is the same shape of problem as #4048, so it belongs with that work rather than here.

**A shared endpoint gotcha, found the hard way.** `opts.PublishMessage<T>().ToRedisStream(key).SendInline()` sets `Mode = Inline` on the *same* `Endpoint` object the listener configures, silently overwriting `ProcessInParallelWithNativeAcks()`. The first run of these tests failed with "PartitionProcessingByGroupId() was configured on an Inline endpoint" for exactly that reason. Not a Redis-specific behavior and not something this PR changes, but the test file says so out loud so the next person does not lose an hour to it.

**Issue item 4 is a no-op.** There is no per-transport release-gate test from the #3715 triage in the tree yet — `supportsNativeAck` appears only on `RabbitMqQueue`, in `Endpoint`, and in `CoreTests/Configuration/native_ack_mode_gate.cs`, none of which enumerate transports. Nothing to flip.

## Tests added

| Test | What it pins |
| --- | --- |
| `the_endpoint_really_is_in_native_ack_mode_with_a_native_ack_receiver` | The mode actually survives to runtime; no BackPressureAgent; the read batch covers the lanes |
| `batch_size_default_covers_every_lane_that_can_be_busy` | The mode default, partitioned and not, and that an explicit `BatchSize()` still wins |
| `messages_are_processed_end_to_end` | Ten messages handled, PEL drains to zero |
| `only_the_completed_entry_is_settled_when_completion_is_out_of_order` | Per-entry settlement — the earlier, still-running entry stays pending while later ones ack |
| `nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing` | The point of the mode: five entries still pending after the node dies mid-flight, all five claimed and processed by the replacement |
| `messages_sharing_a_group_id_never_execute_concurrently` | The hard guarantee: max intra-group concurrency 1 while overall concurrency is > 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
