### PR TITLE
GH-4047: EndpointMode.NativeAck for Pulsar, with cumulative acks refused

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -142,10 +142,15 @@ Three consequences follow from never acking at receipt, and all three are the po
 
 **Transport support is opt-in and default-closed.** A transport must settle each delivery individually *and*
 tolerate settling out of order, because the execution block completes messages in handler-completion order
-rather than delivery order. RabbitMQ queues qualify and are supported today. Kafka cannot and is out of
-scope: a cumulative offset commit has no way to express a gap. Calling
-`ProcessInParallelWithNativeAcks()` on a transport that has not opted in throws at configuration time rather
-than degrading silently.
+rather than delivery order. RabbitMQ queues and [Pulsar](/guide/messaging/transports/pulsar.html#native-ack-processing)
+topics qualify and are supported today. Kafka cannot and is out of scope: a cumulative offset commit has no
+way to express a gap. Calling `ProcessInParallelWithNativeAcks()` on a transport that has not opted in throws
+at configuration time rather than degrading silently.
+
+A transport may also refuse the mode for a *particular* endpoint whose own settings contradict it, again at
+bootstrap rather than at runtime. Pulsar is the example: its acknowledgment strategy is configurable, and
+`AcknowledgeCumulative()` reintroduces exactly the gap-less-commit problem that disqualifies Kafka, so that
+one combination is rejected by name.
 
 ## Buffered Endpoints
 

--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -345,6 +345,68 @@ listener can complete messages out of order, cumulative ack only ever advances t
 so no in-flight work is lost. Batched ack has no such ordering constraint and is safe for any
 subscription type.
 
+**Cumulative ack cannot be combined with `ProcessInParallelWithNativeAcks()`** — see the section
+below. That pair is refused at bootstrap.
+
+## Native Ack Processing <Badge type="tip" text="6.30" />
+
+Pulsar listeners support [`EndpointMode.NativeAck`](/guide/messaging/listeners.html#native-ack-endpoints):
+the delivery is held unacknowledged while the message flows through an in-memory, optionally
+group-partitioned execution block, and is settled natively from the completion continuation.
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/webhooks")
+    .ProcessInParallelWithNativeAcks()
+    .PartitionProcessingByGroupId(PartitionSlots.Five)
+    .MaximumParallelMessages(10);
+```
+
+Pulsar qualifies for the mode because a consumer settles each delivery by its own `MessageId` and the
+subscription cursor tracks individually acknowledged messages, so settling out of delivery order
+leaves earlier unacked deliveries exactly where they were.
+
+::: warning Cumulative acknowledgment is refused in this mode
+`AcknowledgeCumulative()` together with `ProcessInParallelWithNativeAcks()` throws at bootstrap with a
+message naming both settings. A cumulative ack confirms *everything up to a point in the
+subscription*, and this mode completes messages in handler-completion order rather than delivery
+order — so acknowledging a later message would silently settle earlier deliveries that are still in
+flight, turning the mode's no-loss guarantee into silent message loss. Use `AcknowledgeIndividually()`
+(the default) or `AcknowledgeInBatches()`.
+
+`TailFromLatest()` is refused for the related reason that a hot-tail listener reads through a
+non-durable Pulsar `Reader` with no subscription cursor: there is nothing to acknowledge and nothing
+is ever redelivered.
+:::
+
+### Receiver queue size
+
+The DotPulsar consumer's receiver queue (`MessagePrefetchCount`, default 1000) is Pulsar's nearest
+equivalent of RabbitMQ's prefetch window. A native-ack listener defaults it instead to **twice the
+number of lanes that can be busy at once** — the partition slot count when the endpoint is
+group-partitioned, `MaximumParallelMessages` otherwise. Override it explicitly if you need to:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/webhooks")
+    .ProcessInParallelWithNativeAcks()
+    .ReceiverQueueSize(64);
+```
+
+Note what this does and does not bound. Pulsar replenishes flow-control permits as the receive loop
+drains the client-side queue, *not* as messages are acknowledged, so the receiver queue is not an
+unacked-message ceiling the way RabbitMQ's prefetch is. What actually applies back pressure is the
+execution block's own bounded capacity throttling the receive loop. What the receiver queue bounds is
+the buffer of prefetched-but-unstarted deliveries — which under this mode is pure redelivery cost
+when a node dies, and DotPulsar's default of 1000 makes that cost far larger than it needs to be.
+
+### Failure handling
+
+Prefer `UseNativeRedelivery()` (or a retry-letter / dead-letter topic) on a native-ack listener. The
+default requeue path acknowledges the original message and re-publishes a copy, which opens a small
+window in which a crash between the two loses the message; native redelivery never acknowledges at
+all. Pulsar has no client-side negative-acknowledgment backoff, so a redelivered message returns
+immediately — use the retry-letter topics for a growing delay between attempts, or Wolverine's own
+in-lane `RetryWithCooldown` so the retry never leaves the process.
+
 ## Read Only Subscriptions <Badge type="tip" text="3.13" />
 
 As part of Wolverine's "Requeue" error handling action, the Pulsar transport tries to quietly create a matching sender

--- a/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
+++ b/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
@@ -28,6 +28,68 @@ public class native_ack_mode_gate
         protected override bool supportsNativeAck => true;
     }
 
+    /// <summary>
+    /// GH-4047. An endpoint type whose transport accepts the mode in general but not for every configuration --
+    /// Pulsar's cumulative acknowledgment being the real case.
+    /// </summary>
+    private class ConditionallyNativeAckCapableEndpoint : NativeAckCapableEndpoint
+    {
+        public ConditionallyNativeAckCapableEndpoint(string queueName, StubTransport transport)
+            : base(queueName, transport)
+        {
+        }
+
+        public bool SettlesCumulatively { get; set; }
+
+        protected internal override IEnumerable<string> validateModeConfiguration()
+        {
+            if (Mode == EndpointMode.NativeAck && SettlesCumulatively)
+            {
+                yield return "cumulative settlement cannot be combined with EndpointMode.NativeAck";
+            }
+        }
+    }
+
+    /// <summary>
+    /// The hook exists because the Mode setter cannot answer this question. Both settings are individually legal
+    /// and both are applied as delayed configuration, so whichever one the setter happened to see first would
+    /// decide whether the pair was caught. Validating after Compile() makes the final state decide instead.
+    /// </summary>
+    [Fact]
+    public void a_transport_can_refuse_native_ack_for_a_particular_configuration()
+    {
+        var endpoint = new ConditionallyNativeAckCapableEndpoint("six", new StubTransport())
+        {
+            IsListener = true
+        };
+
+        // The mode alone is fine -- this is not supportsNativeAck's question
+        endpoint.Mode = EndpointMode.NativeAck;
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+
+        endpoint.SettlesCumulatively = true;
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).ShouldHaveSingleItem();
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+        problem.Message.ShouldContain(nameof(EndpointMode.NativeAck));
+    }
+
+    [Fact]
+    public void the_transport_hook_is_consulted_outside_native_ack_too()
+    {
+        var endpoint = new ConditionallyNativeAckCapableEndpoint("seven", new StubTransport())
+        {
+            IsListener = true,
+            SettlesCumulatively = true
+        };
+
+        // BufferedInMemory: this endpoint type only objects to the pairing with NativeAck, so nothing fires --
+        // but the hook still ran, which is what keeps it usable for constraints that have nothing to do with
+        // Inline (the only mode the rest of this validator looks at).
+        endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
     [Fact]
     public void no_endpoint_type_accepts_native_ack_by_default()
     {

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_ack_mode.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_ack_mode.cs
@@ -1,0 +1,396 @@
+using System.Collections.Concurrent;
+using DotPulsar;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+#region messages and handler
+
+public record PulsarNativeAckWork(string Batch, int Number);
+
+/// <summary>
+/// Every piece of state here is keyed by a per-test batch id. These tests share one broker and one static
+/// class, and the RabbitMQ suite this mirrors had to learn the hard way that a single shared queue plus
+/// shared tracking lets one test's redelivered messages satisfy another test's assertion.
+/// </summary>
+public static class PulsarNativeAckTracking
+{
+    private static readonly ConcurrentDictionary<string, ConcurrentBag<int>> _handled = new();
+    private static readonly ConcurrentDictionary<string, ConcurrentBag<int>> _started = new();
+    private static readonly ConcurrentDictionary<string, byte> _parked = new();
+
+    /// <summary>
+    /// Cancelling this releases parked handlers into an exception rather than into a completion, so a delivery
+    /// that was in flight on the node that "died" can never record itself as handled afterwards. That matters:
+    /// if parked handlers were released normally, the redelivery assertion below would pass on the strength of
+    /// the dead node's own tasks finishing, with no redelivery involved at all.
+    /// </summary>
+    public static CancellationTokenSource Released { get; private set; } = new();
+
+    public static void Reset()
+    {
+        Released = new CancellationTokenSource();
+    }
+
+    public static void ParkHandlersFor(string batch)
+    {
+        _parked[batch] = 1;
+    }
+
+    public static void StopParking(string batch)
+    {
+        _parked.TryRemove(batch, out _);
+    }
+
+    public static bool IsParked(string batch)
+    {
+        return _parked.ContainsKey(batch);
+    }
+
+    public static ConcurrentBag<int> Handled(string batch)
+    {
+        return _handled.GetOrAdd(batch, _ => new ConcurrentBag<int>());
+    }
+
+    /// <summary>
+    /// Deliveries whose handler has actually STARTED. The receiver's QueueCount is no use for "has the broker
+    /// delivered these yet": the execution block dequeues all of them immediately and they park inside the
+    /// handler, so the queue reads zero the whole time.
+    /// </summary>
+    public static ConcurrentBag<int> Started(string batch)
+    {
+        return _started.GetOrAdd(batch, _ => new ConcurrentBag<int>());
+    }
+
+    public static IEnumerable<int> HandledInOrder(string batch)
+    {
+        return Handled(batch).Distinct().OrderBy(x => x);
+    }
+}
+
+public class PulsarNativeAckWorkHandler
+{
+    public async Task Handle(PulsarNativeAckWork message)
+    {
+        PulsarNativeAckTracking.Started(message.Batch).Add(message.Number);
+
+        if (PulsarNativeAckTracking.IsParked(message.Batch))
+        {
+            // Stands in for a node that dies mid-flight: the handler never terminates, so nothing is ever acked.
+            await Task.Delay(Timeout.InfiniteTimeSpan, PulsarNativeAckTracking.Released.Token);
+        }
+
+        PulsarNativeAckTracking.Handled(message.Batch).Add(message.Number);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// GH-4047. Pulsar's adoption of EndpointMode.NativeAck. Two things are under test: the guarantee the mode
+/// exists for (Buffered's throughput with Inline's no-loss behaviour), and the correctness trap that made this
+/// adoption more than a one-line opt-in -- Pulsar's ack strategy is configurable, and cumulative acking under
+/// this mode is silent message loss.
+/// </summary>
+[Collection("pulsar")]
+public class native_ack_mode : IAsyncLifetime
+{
+    public ValueTask InitializeAsync()
+    {
+        PulsarNativeAckTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await PulsarNativeAckTracking.Released.CancelAsync();
+    }
+
+    // A topic AND subscription per test, never a shared one.
+    private static string uniqueTopic(string prefix)
+    {
+        return $"persistent://public/default/{prefix}-{Guid.NewGuid():N}";
+    }
+
+    private static Task<IHost> startHostAsync(string topic, string subscription,
+        Action<PulsarListenerConfiguration>? configure = null)
+    {
+        return WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<PulsarNativeAckWorkHandler>();
+
+            var listener = opts.ListenToPulsarTopic(topic)
+                .Named("native-ack-listener")
+                .SubscriptionName(subscription)
+                // Earliest so a send that races subscription creation is still delivered -- otherwise the test
+                // would be measuring a startup race rather than the ack semantics.
+                .SubscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                // The redelivery test kills a node and starts another on the same subscription. Unsubscribing on
+                // close would delete the cursor along with every unacked delivery on it.
+                .UnsubscribeOnClose(false)
+                .ProcessInParallelWithNativeAcks();
+
+            configure?.Invoke(listener);
+
+            // Deliberately NOT SendInline(): the listener and the publisher resolve to the same PulsarEndpoint for
+            // this topic, and Mode is one property governing both directions -- so SendInline() would quietly
+            // reset the endpoint from NativeAck back to Inline and this whole class would test nothing.
+            opts.PublishMessage<PulsarNativeAckWork>().ToPulsarTopic(topic);
+        });
+    }
+
+    // ---- mode plumbing ----
+
+    [Fact]
+    public async Task the_endpoint_really_is_in_native_ack_mode()
+    {
+        var topic = uniqueTopic("nativeack-mode");
+        using var host = await startHostAsync(topic, "sub-" + Guid.NewGuid().ToString("N"));
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var endpoint = runtime.Endpoints.EndpointByName("native-ack-listener").ShouldNotBeNull();
+
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+
+        // The broker's delivery window is the back pressure for this mode, so no BackPressureAgent
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_pulsar_endpoint_opts_into_native_ack()
+    {
+        var endpoint = endpointFor();
+        endpoint.SupportsMode(EndpointMode.NativeAck).ShouldBeTrue();
+
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+    }
+
+    // ---- receiver queue size (the prefetch equivalent) ----
+
+    [Fact]
+    public void receiver_queue_size_is_left_to_dotpulsar_outside_native_ack()
+    {
+        var endpoint = endpointFor();
+
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+        endpoint.EffectiveReceiverQueueSize.ShouldBeNull();
+
+        endpoint.Mode = EndpointMode.Durable;
+        endpoint.EffectiveReceiverQueueSize.ShouldBeNull();
+    }
+
+    [Fact]
+    public void native_ack_sizes_the_receiver_queue_to_the_lanes_that_can_be_busy()
+    {
+        var endpoint = endpointFor();
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.MaxDegreeOfParallelism = 4;
+
+        endpoint.EffectiveReceiverQueueSize.ShouldBe(8u);
+
+        // Group partitioning is the other lane count, and the bigger of the two has to win -- a slot count
+        // above MaximumParallelMessages still means that many lanes can be occupied at once.
+        endpoint.GroupShardingSlotNumber = PartitionSlots.Nine;
+        endpoint.EffectiveReceiverQueueSize.ShouldBe(18u);
+
+        endpoint.GroupShardingSlotNumber = PartitionSlots.Three;
+        endpoint.EffectiveReceiverQueueSize.ShouldBe(8u);
+    }
+
+    [Fact]
+    public void an_explicit_receiver_queue_size_beats_the_mode_default()
+    {
+        var endpoint = endpointFor();
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.MaxDegreeOfParallelism = 8;
+        endpoint.ReceiverQueueSize = 500;
+
+        endpoint.EffectiveReceiverQueueSize.ShouldBe(500u);
+    }
+
+    // ---- the correctness trap ----
+
+    /// <summary>
+    /// THE test this issue exists for. A cumulative ack settles every message up to a point in the subscription,
+    /// and this mode completes messages in handler-completion order -- so the combination silently settles
+    /// in-flight deliveries. It must be impossible to configure it and have it merely misbehave.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void cumulative_acks_cannot_silently_coexist_with_native_ack(bool nativeAckFirst)
+    {
+        var endpoint = endpointFor();
+
+        // BOTH orderings, because these are applied as delayed configuration in the order the fluent calls were
+        // written. A guard in the Mode setter would only catch one of them, which is the whole reason this is
+        // validated after Compile().
+        if (nativeAckFirst)
+        {
+            endpoint.Mode = EndpointMode.NativeAck;
+            endpoint.AckStrategy = PulsarAckStrategy.Cumulative;
+        }
+        else
+        {
+            endpoint.AckStrategy = PulsarAckStrategy.Cumulative;
+            endpoint.Mode = EndpointMode.NativeAck;
+        }
+
+        var problems = ListenerConfigurationValidator.Validate(endpoint).ToArray();
+
+        var problem = problems.ShouldHaveSingleItem();
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+
+        // Names BOTH settings, so the message says what to change rather than only what is wrong
+        problem.Message.ShouldContain("AcknowledgeCumulative");
+        problem.Message.ShouldContain(nameof(EndpointMode.NativeAck));
+    }
+
+    [Fact]
+    public void individual_and_batched_acks_are_both_fine_with_native_ack()
+    {
+        foreach (var strategy in new[] { PulsarAckStrategy.Individual, PulsarAckStrategy.Batched })
+        {
+            var endpoint = endpointFor();
+            endpoint.Mode = EndpointMode.NativeAck;
+            endpoint.AckStrategy = strategy;
+
+            ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+        }
+    }
+
+    /// <summary>
+    /// The related refusal: a hot-tail listener reads through a non-durable Pulsar Reader with no cursor, so
+    /// nothing is ever acknowledged and nothing is ever redelivered. The mode's guarantee cannot be made there.
+    /// </summary>
+    [Fact]
+    public void hot_tail_listening_cannot_coexist_with_native_ack()
+    {
+        var endpoint = endpointFor();
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.IsHotTail = true;
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).ShouldHaveSingleItem();
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+        problem.Message.ShouldContain("TailFromLatest");
+    }
+
+    [Fact]
+    public async Task cumulative_acks_plus_native_ack_refuses_to_bootstrap()
+    {
+        var topic = uniqueTopic("nativeack-cumulative");
+
+        var ex = await Should.ThrowAsync<Exception>(async () =>
+        {
+            using var _ = await startHostAsync(topic, "sub-" + Guid.NewGuid().ToString("N"),
+                c => c.AcknowledgeCumulative());
+        });
+
+        ex.ToString().ShouldContain("AcknowledgeCumulative");
+        ex.ToString().ShouldContain(nameof(EndpointMode.NativeAck));
+    }
+
+    // ---- end to end ----
+
+    [Fact]
+    public async Task messages_are_processed_end_to_end()
+    {
+        var batch = Guid.NewGuid().ToString("N");
+        var topic = uniqueTopic("nativeack-e2e");
+
+        using var host = await startHostAsync(topic, "sub-" + Guid.NewGuid().ToString("N"));
+
+        for (var i = 0; i < 10; i++)
+        {
+            await host.SendAsync(new PulsarNativeAckWork(batch, i));
+        }
+
+        await waitForAsync(batch, 10);
+
+        PulsarNativeAckTracking.HandledInOrder(batch).ShouldBe(Enumerable.Range(0, 10));
+    }
+
+    /// <summary>
+    /// The whole point of the mode. Under BufferedInMemory these deliveries are acked the instant they arrive, so
+    /// a node that dies before the handlers finish loses every one of them. Under NativeAck nothing is acked until
+    /// the handler succeeds, so the broker hands them all back when the consumer drops.
+    /// </summary>
+    [Fact]
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    {
+        var batch = Guid.NewGuid().ToString("N");
+        var topic = uniqueTopic("nativeack-redelivery");
+        var subscription = "sub-" + Guid.NewGuid().ToString("N");
+
+        PulsarNativeAckTracking.ParkHandlersFor(batch);
+
+        // GH-4047 item 4. UseNativeRedelivery() makes a defer "leave it unacknowledged and ask Pulsar to
+        // redeliver it"; the default is ack-then-republish, which under shutdown would settle a delivery that
+        // is about to be re-sent by a process on its way out. Both survive here, but only one of them has no
+        // window at all -- and having no window is exactly what this mode is being asked to prove.
+        var firstHost = await startHostAsync(topic, subscription, c => c.UseNativeRedelivery());
+
+        for (var i = 0; i < 5; i++)
+        {
+            await firstHost.SendAsync(new PulsarNativeAckWork(batch, 100 + i));
+        }
+
+        // Every one of the five has to actually be in a parked handler before the node dies -- otherwise the test
+        // could be proving nothing more than that an undelivered message is still on the topic.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(60);
+        while (PulsarNativeAckTracking.Started(batch).Distinct().Count() < 5 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        PulsarNativeAckTracking.Started(batch).Distinct().OrderBy(x => x).ShouldBe(Enumerable.Range(100, 5));
+
+        // Not one of them acked, because not one handler has terminated
+        PulsarNativeAckTracking.HandledInOrder(batch).ShouldBeEmpty();
+
+        // The node goes away mid-flight. The parked handlers it leaves behind never terminate, so they can
+        // neither ack nor contribute to the count below -- every message that reaches the second host got
+        // there because Pulsar still owned it.
+        await firstHost.StopAsync(TestContext.Current.CancellationToken);
+        firstHost.Dispose();
+
+        PulsarNativeAckTracking.HandledInOrder(batch).ShouldBeEmpty();
+
+        // A fresh node on the same subscription picks up every redelivered message
+        PulsarNativeAckTracking.StopParking(batch);
+
+        using var secondHost = await startHostAsync(topic, subscription, c => c.UseNativeRedelivery());
+
+        await waitForAsync(batch, 5);
+
+        PulsarNativeAckTracking.HandledInOrder(batch).ShouldBe(Enumerable.Range(100, 5));
+    }
+
+    // ---- helpers ----
+
+    private static PulsarEndpoint endpointFor()
+    {
+        var endpoint = new PulsarTransport()[new Uri("pulsar://persistent/public/default/nativeack")];
+        endpoint.IsListener = true;
+        return endpoint;
+    }
+
+    private static async Task waitForAsync(string batch, int count)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(60);
+        while (PulsarNativeAckTracking.HandledInOrder(batch).Count() < count && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+    }
+
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -121,6 +121,53 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     public TimeSpan AckBatchInterval { get; internal set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
+    ///     GH-4047. How many messages the DotPulsar consumer prefetches into its client-side receiver queue
+    ///     (<c>MessagePrefetchCount</c>). Null uses DotPulsar's own default of 1000, except under
+    ///     <see cref="EndpointMode.NativeAck"/> -- see <see cref="EffectiveReceiverQueueSize"/>. Set through
+    ///     <c>ReceiverQueueSize()</c>.
+    /// </summary>
+    public uint? ReceiverQueueSize { get; internal set; }
+
+    /// <summary>
+    ///     The receiver queue size actually handed to the consumer builder, or null to leave DotPulsar's default
+    ///     of 1000 alone. An explicit <see cref="ReceiverQueueSize"/> always wins.
+    ///
+    ///     <para>
+    ///     Under <see cref="EndpointMode.NativeAck"/> the receiver queue is Pulsar's nearest equivalent of
+    ///     RabbitMQ's prefetch window (see <c>RabbitMqQueue.PreFetchCount</c>), and this mirrors that arm: it has
+    ///     to cover every lane that can be busy at once -- the partition slot count when the endpoint is
+    ///     group-partitioned, <see cref="Endpoint.MaxDegreeOfParallelism"/> otherwise -- doubled so a lane is never
+    ///     starved waiting on the next delivery. It is NOT an unacked-message ceiling the way RabbitMQ's prefetch
+    ///     is: Pulsar's flow-control permits are replenished as the receive loop drains the client queue, not as
+    ///     messages are acked, so what actually bounds the in-memory execution block is the block's own bounded
+    ///     capacity back-pressuring the receive loop. What this bounds is the buffer of prefetched-but-unstarted
+    ///     deliveries, which under this mode is pure redelivery cost when the node dies -- and DotPulsar's default
+    ///     of 1000 makes that cost roughly two orders of magnitude larger than it needs to be.
+    ///     </para>
+    /// </summary>
+    internal uint? EffectiveReceiverQueueSize
+    {
+        get
+        {
+            if (ReceiverQueueSize.HasValue)
+            {
+                return ReceiverQueueSize;
+            }
+
+            if (Mode != EndpointMode.NativeAck)
+            {
+                return null;
+            }
+
+            var lanes = GroupShardingSlotNumber.HasValue
+                ? Math.Max((int)GroupShardingSlotNumber.Value, MaxDegreeOfParallelism)
+                : MaxDegreeOfParallelism;
+
+            return (uint)Math.Max(lanes * 2, 1);
+        }
+    }
+
+    /// <summary>
     ///     Optional hook to customize the DotPulsar consumer for this listener (consumer name,
     ///     receive-queue size, priority level, properties, etc.) immediately before it is created.
     /// </summary>
@@ -198,6 +245,72 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
         EffectiveDeadLetterTopic is { Mode: DeadLetterTopicMode.Native }
             ? DeadLetterStorageMode.Native
             : DeadLetterStorageMode.Durable;
+
+    /// <summary>
+    /// GH-4047. Pulsar accepts <see cref="EndpointMode.NativeAck"/>. It qualifies on both counts the mode requires:
+    /// a Pulsar consumer settles each delivery by its own <c>MessageId</c> -- <c>Acknowledge(messageId)</c>, and
+    /// <c>RedeliverUnacknowledgedMessages([messageId])</c> for the negative case -- and the subscription cursor
+    /// tracks individually acked messages in a set rather than a single offset, so settling out of delivery order
+    /// leaves earlier unacked deliveries exactly where they were. That is what makes a completion-time ack from an
+    /// arbitrary execution-block lane safe here and impossible on Kafka.
+    ///
+    /// <para>
+    /// The qualification is conditional, and <see cref="validateModeConfiguration"/> enforces the condition:
+    /// <b>the endpoint must not be acking cumulatively</b>. <see cref="PulsarAckStrategy.Cumulative"/> settles every
+    /// message up to a point in the subscription with one ack, which under this mode -- where the execution block
+    /// completes in handler-completion order, not delivery order -- is the same silent-loss defect that disqualifies
+    /// Kafka and that GH-3706 fixed for RabbitMQ by making every ack <c>multiple: false</c>. Hot-tail listening is
+    /// rejected for the related reason that a Pulsar <c>Reader</c> has no cursor to settle against at all.
+    /// </para>
+    /// </summary>
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
+    /// GH-4047. The two ways a Pulsar endpoint can be configured into a state where native acks cannot deliver the
+    /// no-loss guarantee. Both are checked after Compile() rather than in the <see cref="Endpoint.Mode"/> setter,
+    /// because <c>AcknowledgeCumulative()</c> / <c>TailFromLatest()</c> and
+    /// <c>ProcessInParallelWithNativeAcks()</c> are applied as delayed configuration in whatever order the fluent
+    /// calls were written, and a check in the setter would only catch one of the two orderings.
+    /// </summary>
+    protected internal override IEnumerable<string> validateModeConfiguration()
+    {
+        if (Mode != EndpointMode.NativeAck)
+        {
+            yield break;
+        }
+
+        if (AckStrategy == PulsarAckStrategy.Cumulative)
+        {
+            yield return CumulativeAckIsIncompatibleWithNativeAck(this);
+        }
+
+        if (IsHotTail)
+        {
+            yield return
+                $"Invalid listener configuration for Pulsar topic {PulsarTopic()}: TailFromLatest() cannot be combined " +
+                $"with ProcessInParallelWithNativeAcks() (EndpointMode.{nameof(EndpointMode.NativeAck)}). Hot-tail " +
+                "listening consumes through a non-durable Pulsar Reader, which has no subscription cursor -- there is " +
+                "nothing to acknowledge, and nothing is ever redelivered, so the no-loss guarantee this mode exists " +
+                "for cannot be made. Drop TailFromLatest(), or use BufferedInMemory() with it.";
+        }
+    }
+
+    /// <summary>
+    /// The one message both the bootstrap validation and the <c>PulsarListener</c> guard use, so the two can never
+    /// drift into explaining the same refusal differently. Names BOTH settings, per GH-4047.
+    /// </summary>
+    internal static string CumulativeAckIsIncompatibleWithNativeAck(PulsarEndpoint endpoint)
+    {
+        return
+            $"Invalid listener configuration for Pulsar topic {endpoint.PulsarTopic()}: AcknowledgeCumulative() " +
+            $"(PulsarAckStrategy.{nameof(PulsarAckStrategy.Cumulative)}) cannot be combined with " +
+            $"ProcessInParallelWithNativeAcks() (EndpointMode.{nameof(EndpointMode.NativeAck)}). A cumulative " +
+            "acknowledgment settles every message up to a point in the subscription, and this mode completes " +
+            "messages in handler-completion order rather than delivery order -- so acking a later message would " +
+            "silently settle earlier deliveries that are still in flight, turning the mode's no-loss guarantee into " +
+            "silent message loss. Use AcknowledgeIndividually() (the default) or AcknowledgeInBatches(), or choose " +
+            "another endpoint mode.";
+    }
 
     public bool IsPersistent => Persistence.Equals(Persistent);
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -52,6 +52,16 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
         _cancellation = cancellation;
         _codec = endpoint.MessageCodec;
 
+        // GH-4047. Belt and braces with the bootstrap check in PulsarEndpoint.validateModeConfiguration(): that one
+        // runs over every *listening* endpoint at startup, this one covers any path that builds a listener without
+        // going through it. A cumulative ack under NativeAck is silent message loss, so it must be impossible to
+        // reach a running consumer in that state, not merely unlikely.
+        if (endpoint.Mode == EndpointMode.NativeAck && endpoint.AckStrategy == PulsarAckStrategy.Cumulative)
+        {
+            throw new InvalidOperationException(
+                PulsarEndpoint.CumulativeAckIsIncompatibleWithNativeAck(endpoint));
+        }
+
         if (endpoint.AckStrategy == PulsarAckStrategy.Cumulative &&
             endpoint.SubscriptionType is SubscriptionType.Shared or SubscriptionType.KeyShared)
         {
@@ -107,6 +117,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
         else
         {
             consumerBuilder = consumerBuilder.Topic(endpoint.PulsarTopic());
+        }
+
+        // GH-4047. Pulsar's client-side receiver queue is the prefetch analogue. Only set when the endpoint asks for
+        // one -- explicitly, or by being in NativeAck mode, whose default sizes the queue to the lanes that can be
+        // busy at once instead of DotPulsar's 1000. Applied BEFORE the user hook so ConfigureConsumer still wins.
+        if (endpoint.EffectiveReceiverQueueSize is { } prefetch)
+        {
+            consumerBuilder = consumerBuilder.MessagePrefetchCount(prefetch);
         }
 
         endpoint.ConfigureConsumer?.Invoke(consumerBuilder);
@@ -224,6 +242,13 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
             .SubscriptionType(endpoint.SubscriptionType)
             .InitialPosition(endpoint.SubscriptionInitialPosition)
             .Topic(topicRetry!.ToString());
+
+        // GH-4047. The retry-letter consumer holds unacked deliveries on exactly the same terms as the primary one,
+        // so it gets the same receiver queue sizing.
+        if (endpoint.EffectiveReceiverQueueSize is { } prefetch)
+        {
+            retryBuilder = retryBuilder.MessagePrefetchCount(prefetch);
+        }
 
         endpoint.ConfigureConsumer?.Invoke(retryBuilder);
 

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -494,6 +494,29 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     }
 
     /// <summary>
+    /// GH-4047. How many messages the DotPulsar consumer prefetches into its client-side receiver queue --
+    /// Pulsar's nearest equivalent of RabbitMQ's prefetch window. DotPulsar's own default is 1000.
+    ///
+    /// <para>
+    /// A <c>ProcessInParallelWithNativeAcks()</c> endpoint defaults this instead to twice the number of lanes that
+    /// can be busy at once (the partition slot count when group-partitioned, <c>MaximumParallelMessages</c>
+    /// otherwise), because under that mode every prefetched-but-unstarted delivery is redelivery cost if the node
+    /// dies. Set this explicitly to override the mode default in either direction.
+    /// </para>
+    /// </summary>
+    /// <param name="size">Number of messages to prefetch. Must be at least 1.</param>
+    public PulsarListenerConfiguration ReceiverQueueSize(int size)
+    {
+        if (size < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), "Must be at least 1");
+        }
+
+        add(e => e.ReceiverQueueSize = (uint)size);
+        return this;
+    }
+
+    /// <summary>
     /// Acknowledge each message individually as it completes (the default).
     /// </summary>
     /// <returns></returns>
@@ -509,6 +532,11 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     /// Failover subscriptions (a clear error is thrown at startup otherwise). Wolverine only advances
     /// the cumulative ack to the highest contiguous-completed message, so it never acks a message
     /// that is still being processed.
+    ///
+    /// <para>
+    /// Cannot be combined with <c>ProcessInParallelWithNativeAcks()</c>; that pair is refused at bootstrap. See
+    /// GH-4047.
+    /// </para>
     /// </summary>
     /// <returns></returns>
     public PulsarListenerConfiguration AcknowledgeCumulative()

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -732,6 +732,26 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     protected virtual bool supportsNativeAck => false;
 
     /// <summary>
+    /// GH-4047. Transport-specific configuration combinations that are only decidable once the FINAL state of the
+    /// endpoint has settled -- after endpoint policies and every delayed <c>ListenerConfiguration</c> lambda have run
+    /// in <see cref="Compile"/>. Return one message per problem; each is fatal and refuses the bootstrap.
+    ///
+    /// <para>
+    /// <see cref="supportsNativeAck"/> answers "can this transport ever do native acks", which the <see cref="Mode"/>
+    /// setter can ask the moment the mode is assigned. This hook answers the different question "can THIS endpoint,
+    /// configured the way it actually ended up, do them" -- which the Mode setter cannot ask, because the offending
+    /// setting may be applied after the mode. Pulsar is the motivating case: <c>AcknowledgeCumulative()</c> and
+    /// <c>ProcessInParallelWithNativeAcks()</c> are individually legal, and whichever of the two the Mode setter
+    /// happened to see first would decide whether the pair was caught. Validating after Compile makes the final
+    /// state, not the call order, decide.
+    /// </para>
+    /// </summary>
+    protected internal virtual IEnumerable<string> validateModeConfiguration()
+    {
+        yield break;
+    }
+
+    /// <summary>
     /// Check if this endpoint supports the specified mode
     /// </summary>
     public bool SupportsMode(EndpointMode mode)

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -58,6 +58,13 @@ internal static class ListenerConfigurationValidator
             yield break;
         }
 
+        // GH-4047. Transport-specific constraints first, and deliberately outside the Inline-only gate below: they
+        // are about combinations no core rule can see, and the Pulsar one they were added for is about NativeAck.
+        foreach (var message in endpoint.validateModeConfiguration())
+        {
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Fatal, message);
+        }
+
         if (endpoint.Mode != EndpointMode.Inline)
         {
             yield break;


### PR DESCRIPTION
Closes #4047.

## The decision: reject, don't force

The issue offered two ways out of the correctness trap. I took **(b) — reject the NativeAck +
cumulative-ack combination at configuration time**, with an error naming both settings.

Option (a) — forcing individual acks regardless of the configured strategy — is what #3706 did for
RabbitMQ, and it was right there because `multiple: true` was never a user-facing option; nobody had
asked for it. On Pulsar the strategy *is* an explicit, documented user choice (`AcknowledgeCumulative()`,
#3180). Silently discarding it would be the same class of defect #3712 exists to prevent, just pointed
the other way: the user reads their configuration, believes they have cumulative acks, and does not.
Refusing to start says exactly what is wrong and what to change.

It also matches what this transport already does: `PulsarListener` has thrown at startup for
cumulative-ack-on-a-Shared-subscription since #3180, for the same "this pairing cannot work" reason.

**Note on the existing cumulative handler.** `PulsarAckHandler`'s cumulative arm already tracks a
contiguous-completed watermark and would probably not lose messages under NativeAck. It is still
rejected, for two reasons. First, the safety depends on `Track()` having seen every in-flight id, and
the DLQ / retry-letter / requeue paths acknowledge on the consumer directly without going through the
handler — so those ids never leave `_inFlight` and the watermark pins permanently. Under this mode
those paths are the normal failure route, not an edge case. Second, cumulative ack buys nothing here:
its whole point is collapsing an ordered ack stream, and this mode's completions are not ordered.

## Where the check lives

`AcknowledgeCumulative()` and `ProcessInParallelWithNativeAcks()` are both applied as *delayed*
configuration, so a guard in the `Mode` setter would catch `.AcknowledgeCumulative().ProcessInParallelWithNativeAcks()`
and miss the reverse. The final state has to decide, not the call order.

So: a new `Endpoint.validateModeConfiguration()` hook (`protected internal virtual`, returns one string
per problem), consulted by `ListenerConfigurationValidator` — which already runs after `Compile()` for
exactly this reason. `PulsarListener`'s constructor keeps a belt-and-braces throw for any path that
builds a listener without going through bootstrap validation.

The hook is deliberately general; the other five adopter transports from the #3715 triage will each have
constraints of this shape.

## What else is here

- **`supportsNativeAck => true`** on `PulsarEndpoint`, with the XML doc spelling out both what qualifies
  Pulsar (per-`MessageId` settlement; a cursor that tracks individually acked messages, so settling out
  of order leaves earlier unacked deliveries alone) and what constraint the validation enforces.
- **`TailFromLatest()` is refused too.** A hot-tail listener reads through a non-durable `Reader` whose
  `CompleteAsync`/`DeferAsync` are no-ops and which has no cursor at all — nothing settles, nothing is
  ever redelivered. That is the mode's guarantee failing silently, so it gets the same treatment. This
  one was not in the issue.
- **Receiver queue size**, mirroring `RabbitMqQueue.PreFetchCount`'s NativeAck arm: `MessagePrefetchCount`
  now defaults under this mode to `max(slots, MaxDegreeOfParallelism) * 2` instead of DotPulsar's 1000.
  New `ReceiverQueueSize(n)` overrides it; every other mode is untouched.

## Item 4: `UseNativeRedelivery` and negative-ack backoff vs lane-based retry

Four findings, none blocking, all documented:

1. **There is no negative-ack backoff to interact with.** DotPulsar 5.1.2 exposes no
   `negativeAcknowledge` and no ack-timeout setting — only `RedeliverUnacknowledgedMessages`, which is
   immediate. So a `UseNativeRedelivery()` defer returns the message to the lane at full speed. Growing
   delays come from the retry-letter topics (#3182) or from Wolverine's own in-lane cooldown retries.
   Nothing about lanes changes this; it is the same as under Inline.
2. **A redelivered message re-enters its own lane, never a second one.** Redelivery goes back through
   the broker, into the receive loop, and is slotted by `SlotForProcessing(groupId)` exactly as the first
   delivery was. The intra-group concurrency guarantee holds; ordering is perturbed, which is the
   contract #3708 states.
3. **The default requeue path opens a small loss window that native redelivery does not.** With
   `UseNativeRedelivery` off (the default), `DeferAsync` acknowledges the original and re-publishes a
   copy; a crash between the ack and the send loses the message. This is the same shape as RabbitMQ's
   ack-then-republish that #3708 explicitly accepted, so I have not changed the default — but for this
   mode `UseNativeRedelivery()` is strictly better, and the docs now say so.
4. **A failure with no retry-letter topic, no DLQ, and `UseNativeRedelivery` off settles nothing at all.**
   `PulsarNativeResiliencyContinuation` is a deliberate no-op in that combination, so the delivery
   dangles unacked until the consumer closes. Not loss — Pulsar redelivers on reconnect — and identical
   to today's Inline behaviour, so it is reported rather than changed.

## Tests

`src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_ack_mode.cs`, 12 tests. Every test gets its own
topic *and* subscription, and all tracking state is keyed by a per-test batch id — the RabbitMQ suite's
note about cross-test contamination was earned.

- The acceptance test: cumulative + NativeAck produces a fatal problem, asserted in **both** fluent
  orderings, and the message names both settings. Plus the bootstrap-level version.
- `Individual` and `Batched` are asserted clean, so the rejection is specific rather than a blanket
  "no strategies".
- Hot-tail + NativeAck refused.
- Receiver-queue defaults: null outside the mode, lane-sized inside it, explicit value wins.
- End to end, and the redelivery-after-a-dead-node case.

Two things about the redelivery test worth calling out, because the obvious way to write it does not
actually test anything:

- Parked handlers park on a token that is **cancelled**, not completed. If they were released normally,
  the dead node's own tasks would finish and record their messages as handled — and the assertion would
  pass with no redelivery involved at all.
- It waits on a "handler entered" signal rather than the receiver's `QueueCount`. The execution block
  dequeues all five immediately and they park *inside* the handler, so the queue reads zero throughout;
  waiting on it just burns the timeout and then proves nothing about whether the broker had delivered.

Also updated `native_ack_mode_gate.cs` in CoreTests to cover the new core hook directly.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors.
- Full CoreTests: **2541 total, 0 failed** (2539 passed, 2 skipped).
- New Pulsar suite: 12/12, run twice; the redelivery test run 3 more times on its own.
- Full Pulsar suite: 237 total, 1 failed — `consumer_producer_hooks.per_endpoint_consumer_and_producer_hooks_are_invoked`,
  which passes on its own and is a 30s-wait timeout under a loaded broker. Its endpoint is `Inline`, so
  `EffectiveReceiverQueueSize` is null there and this change cannot reach it.
- RabbitMQ `native_ack_mode`: 3/3, confirming the core validator change did not disturb the reference adoption.

## One incidental gotcha

`SendInline()` on a topic that is also listened to resets the *shared* endpoint's `Mode` back to
`Inline`, silently undoing `ProcessInParallelWithNativeAcks()`. `Mode` is one property governing both
directions, so this is not Pulsar-specific and not new — but it cost a debugging round here and is
called out in a test comment. Might deserve its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
