### PR TITLE
GH-3709: send inline from NativeAck endpoints to close the interceptor loss window

### DIFF
--- a/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
+++ b/src/Testing/CoreTests/Configuration/native_ack_mode_gate.cs
@@ -5,6 +5,8 @@ using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Partitioning;
 using Wolverine.Transports.Local;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
 using Wolverine.Transports.Stub;
 using Wolverine.Transports.Tcp;
 using Xunit;
@@ -142,5 +144,90 @@ public class native_ack_mode_gate
         // Partitioned processing plus real parallelism is the POINT of this mode, so the GH-3712 checks -- which
         // reject exactly that combination on an Inline endpoint -- must not fire here.
         ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+}
+
+/// <summary>
+/// GH-3709. A NativeAck endpoint sends through the INLINE sending agent, not the buffered one. Not a stylistic
+/// choice: GlobalPartitionedInterceptor re-publishes a message and then acks the SOURCE delivery, and a buffered
+/// agent returns before the envelope reaches the transport -- so the source was being settled while the only copy
+/// lived in this process's memory.
+///
+/// These deliberately do NOT use StubEndpoint. StubEndpoint is its own ISendingAgent (it assigns Agent = this in
+/// its constructor), so it bypasses EndpointCollection.buildSendingAgent entirely -- a test written against it
+/// passes identically with the buffered mapping and proves nothing.
+/// </summary>
+public class native_ack_sends_inline
+{
+    [Fact]
+    public void a_native_ack_endpoint_gets_the_inline_sending_agent()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(_ => { }).Build();
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = new NativeAckSendingEndpoint(new Uri("nativeacksend://one"));
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.StartSending(runtime, null).ShouldBeOfType<InlineSendingAgent>();
+    }
+
+    [Fact]
+    public void a_buffered_endpoint_still_gets_the_buffered_agent()
+    {
+        using var host = Host.CreateDefaultBuilder().UseWolverine(_ => { }).Build();
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = new NativeAckSendingEndpoint(new Uri("nativeacksend://two"));
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+
+        endpoint.StartSending(runtime, null).ShouldBeOfType<BufferedSendingAgent>();
+    }
+
+    // NOTE: there is deliberately no "the send reached the transport before the call returned" test here.
+    // It was written, and it passes under BOTH mappings, so it proves nothing: Block<T>.PostAsync runs the
+    // handler inline when the block is idle, which is exactly the case a single-envelope unit test creates.
+    // The loss window this change closes is load-dependent -- it opens when the block already has queued work
+    // or the send is retrying -- so it cannot be reproduced by posting one envelope to an idle agent. The
+    // agent-type assertions above are what actually distinguish the two mappings; both were verified to fail
+    // when the NativeAck arm is reverted to BufferedSendingAgent.
+}
+
+public record NativeAckSendPing(string Name);
+
+/// <summary>A real Endpoint (not a stub agent) so sending actually flows through buildSendingAgent.</summary>
+internal class NativeAckSendingEndpoint : Endpoint
+{
+    public RecordingSender Sender { get; }
+
+    public NativeAckSendingEndpoint(Uri uri) : base(uri, EndpointRole.Application)
+    {
+        Sender = new RecordingSender(uri);
+    }
+
+    protected override bool supportsNativeAck => true;
+
+    protected override ISender CreateSender(IWolverineRuntime runtime) => Sender;
+
+    public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+internal class RecordingSender : ISender
+{
+    public List<Envelope> Sent { get; } = new();
+
+    public RecordingSender(Uri destination) => Destination = destination;
+
+    public bool SupportsNativeScheduledSend => false;
+    public Uri Destination { get; }
+
+    public Task<bool> PingAsync() => Task.FromResult(true);
+
+    public ValueTask SendAsync(Envelope envelope)
+    {
+        Sent.Add(envelope);
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -467,14 +467,27 @@ public class EndpointCollection : IEndpointCollection
                     _runtime.DurabilitySettings, _runtime, sendingPolicies);
 
             case EndpointMode.NativeAck:
-                // GH-3708. Mode is a single property governing BOTH directions, so an endpoint that listens with
-                // native acks and is also used for replies or sending arrives here. NativeAck describes how incoming
-                // deliveries are settled and says nothing about sending; on the outgoing side it means exactly what
-                // BufferedInMemory means -- no outbox. Without this arm such an endpoint hit the throw below, which
-                // carried no message at all.
-                return new BufferedSendingAgent(_runtime.LoggerFactory.CreateLogger<BufferedSendingAgent>(),
-                    _runtime.MessageTrackingFor(endpoint), sender, _runtime.DurabilitySettings,
-                    endpoint, _runtime, sendingPolicies);
+                // GH-3708 / GH-3709. Mode is a single property governing BOTH directions, so an endpoint that listens
+                // with native acks and is also used for replies or sending arrives here.
+                //
+                // This deliberately maps to the INLINE sending agent rather than the buffered one, reversing the
+                // original GH-3708 choice. NativeAck is a listening optimization -- nobody selects it for its sending
+                // characteristics -- so the outgoing side should be the safe option rather than the fast one.
+                //
+                // The concrete failure that forced this: GlobalPartitionedInterceptor.TryReRouteAsync re-publishes a
+                // message and then acks the SOURCE delivery. BufferedSendingAgent.storeAndForwardAsync posts to an
+                // in-memory Block and returns before the envelope reaches the transport, so the source was being
+                // settled while the only copy lived in this process's memory -- a crash in between lost the message
+                // outright, with no redelivery because the source was already acked. Under the durable topology that
+                // hop was safe because the re-publish hit the outbox first. InlineSendingAgent posts to a RetryBlock
+                // that runs the send rather than queueing it, so the ack follows the send.
+                //
+                // Note this narrows the window rather than eliminating it: Wolverine publishes with RabbitMQ
+                // publisher confirms disabled by default, so an inline send awaits the frame being written, not the
+                // broker acknowledging it. Enabling confirms on these endpoints is the remaining step.
+                return new InlineSendingAgent(_runtime.LoggerFactory.CreateLogger<InlineSendingAgent>(), sender,
+                    endpoint, _runtime.MessageTrackingFor(endpoint),
+                    _runtime.DurabilitySettings, _runtime, sendingPolicies);
         }
 
         throw new InvalidOperationException(


### PR DESCRIPTION
Addresses item 4 of #3709 — see [the analysis comment](https://github.com/JasperFx/wolverine/issues/3709#issuecomment-5389227077). Does not close the issue; the multi-node and failover tests remain.

## The bug

`GlobalPartitionedInterceptor.TryReRouteAsync` re-publishes a message and then acknowledges the **source** delivery:

```csharp
await bus.PublishAsync(envelope.Message!, options);
await listener.CompleteAsync(envelope);
```

#4040 mapped `EndpointMode.NativeAck` to `BufferedSendingAgent`, reasoning that the mode means "no outbox" — which is what `BufferedInMemory` means. That is correct for ordinary sends and wrong for this particular sequence. `BufferedSendingAgent.storeAndForwardAsync` posts to an in-memory `Block`, so the source delivery could be settled while the only copy of the message was sitting in this process's memory. Crash in between and it is gone, with no redelivery available because the source was already acked.

Under the durable topology this hop was safe for the reason #3709 item 4 predicted: the re-publish landed in the durable outbox before the source ack. #4041 made native-ack global partitioning reachable, which made this live on `main`.

## The fix

`NativeAck` now maps to `InlineSendingAgent`, which posts to a `RetryBlock` that runs the send rather than queueing it.

The reasoning for doing it at the mode level rather than special-casing the interceptor: **`NativeAck` is a listening optimization.** Nobody selects it for its sending characteristics, so the outgoing side should take the safe option rather than the fast one. A narrower special-case (`Mode == NativeAck && UsedInShardedTopology`) was considered and rejected as more machinery for no benefit.

## Two limits, stated rather than glossed

**This narrows the window rather than closing it.** Wolverine publishes with RabbitMQ publisher confirms disabled by default, so an inline send awaits the frame being written, not the broker acknowledging it. Enabling confirms for these endpoints is the remaining step and is not in this PR.

**The window was never deterministic.** `Block<T>.PostAsync` runs its handler inline when the block is idle, so the buffered agent happened to deliver synchronously for a single envelope. The gap opens only when the block already has queued work or a send is retrying — making this a load-dependent bug that works fine in tests and loses messages in production. My original write-up on #3709 implied it was deterministic; it is not, and that makes it harder to catch, not easier.

## On the tests

There is deliberately **no** behavioral "the send reached the transport before the call returned" test. One was written. It passes identically under both mappings, for the reason above, and was deleted rather than kept as decoration — a test that cannot fail is worse than no test, because it reads like coverage.

What is here is the agent-type assertions, plus one guarding that `BufferedInMemory` still gets the buffered agent so the change is not over-applied. Both were **red-baselined**: with the `NativeAck` arm reverted to `BufferedSendingAgent`, `a_native_ack_endpoint_gets_the_inline_sending_agent` fails and the buffered one still passes.

Note the tests use a purpose-built `Endpoint` rather than `StubEndpoint`. `StubEndpoint` assigns `Agent = this` in its constructor and is its own `ISendingAgent`, so it bypasses `buildSendingAgent` entirely — the first version of these tests used it and passed under both mappings for that reason too.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors
- CoreTests — 2552 total, 0 failed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)