### PR TITLE
GH-4048: NativeAck lease renewal for queued envelopes, with Amazon SQS as the first implementer

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -147,6 +147,36 @@ scope: a cumulative offset commit has no way to express a gap. Calling
 `ProcessInParallelWithNativeAcks()` on a transport that has not opted in throws at configuration time rather
 than degrading silently.
 
+### Brokers that put a clock on an unsettled delivery
+
+Some brokers expire an unsettled delivery on their own: Amazon SQS's visibility timeout, Azure Service Bus's
+lock duration, GCP Pub/Sub's ack deadline, NATS JetStream's `AckWait`. RabbitMQ and Redis Streams do not — an
+unacked delivery there lives until the channel closes.
+
+On a broker that does, Wolverine renews that lease for the whole time an envelope sits in an execution lane,
+not merely while its handler runs — the risk window opens the moment the envelope is *enqueued*. Renewal ticks
+at half the lease, sends nothing while the lanes are empty, and stops at a configurable ceiling (on SQS,
+`MaximumVisibilityExtension`, capped by the SQS limit of 12 hours). It is **not** opt-in for this mode:
+lane depth is unbounded by design, so an un-renewed endpoint would be a duplicate generator by construction.
+A NativeAck endpoint on such a broker whose listener cannot renew fails at startup rather than running.
+
+::: warning What happens when a lease is lost anyway
+If the broker refuses a renewal — or no renewal succeeds for a full lease duration — the broker owns that
+delivery again and is going to redeliver it. Wolverine's response depends on where the envelope had got to:
+
+* **Still queued, not yet executing.** The queued copy is **dropped: neither completed nor deferred.** That
+  looks harsh and is the only non-amplifying option. Every transport's defer path is *settle-then-republish*,
+  so deferring after the lease is gone would put a second copy on the queue on top of the redelivery already
+  coming. Dropping turns "handled twice" into "handled once, later".
+* **Already executing.** A running handler cannot be un-run. This one stays at-least-once — NativeAck's
+  documented contract — and Wolverine's only job is to not compound it, so its defer is suppressed too.
+
+Both are metered. `wolverine-leases-lost` is tagged `lease.loss.stage` = `not-started` (duplication prevented)
+or `executing` (duplication realized); `wolverine-leases-renewed` and `wolverine-lease-ceiling-reached` round
+out the picture. A rising `executing` count means lane depth has outgrown the configured lease — raise the
+lease, raise the slot count, or lower the prefetch.
+:::
+
 ## Buffered Endpoints
 
 ::: tip

--- a/docs/guide/messaging/transports/sqs/performance.md
+++ b/docs/guide/messaging/transports/sqs/performance.md
@@ -87,6 +87,14 @@ invisible for at most 12 hours from its receipt (the SQS limit; lower it with th
 6.x because it adds billable API calls under sustained slow handling and changes when a
 crashed node's in-flight messages reappear.
 
+- **NativeAck** endpoints hold the message longest of all — for lane queue time *plus* handler
+  time — and that queue time is unbounded by design. Renewal there is therefore **mandatory and
+  does not consult `ExtendVisibilityWhileHandling()`**: an opt-in default-false flag would mean
+  "off by default" for the one mode that cannot survive it being off. `MaximumVisibilityExtension`
+  is still the ceiling, and idle lanes still cost nothing. See
+  [Native Ack Endpoints](/guide/messaging/listeners#native-ack-endpoints) for what happens when a
+  visibility timeout is lost anyway.
+
 ## The send side: batch API, one batch in flight
 
 Wolverine sends with `SendMessageBatch` (10 messages per API call, the SQS maximum) through its

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/lease_renewal_4048.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/lease_renewal_4048.cs
@@ -1,0 +1,747 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+#region test message + handler
+
+public record LeasePing(string Name);
+
+public class LeasePingHandler
+{
+    public static readonly ConcurrentBag<string> Handled = new();
+
+    /// <summary>Gate so a test can hold a lane open without Task.Delay.</summary>
+    public static TaskCompletionSource? Gate;
+
+    /// <summary>Signalled the moment a handler actually starts, so a test never has to guess.</summary>
+    public static TaskCompletionSource? Entered;
+
+    public async Task Handle(LeasePing message)
+    {
+        Entered?.TrySetResult();
+
+        if (Gate != null)
+        {
+            await Gate.Task;
+        }
+
+        Handled.Add(message.Name);
+    }
+}
+
+#endregion
+
+/// <summary>
+///     GH-4048. A NativeAck delivery is held unsettled for lane queue time PLUS handler time, and on SQS / ASB /
+///     Pub/Sub / JetStream the broker runs a clock on it the whole time. These cover the tracker that keeps that
+///     clock alive and -- the part that actually matters -- what happens when it is lost anyway.
+/// </summary>
+public class lease_renewal_4048 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IWolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<LeasePingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = _host.Services.GetRequiredService<IWolverineRuntime>();
+        LeasePingHandler.Handled.Clear();
+        LeasePingHandler.Gate = null;
+        LeasePingHandler.Entered = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        LeasePingHandler.Gate = null;
+        LeasePingHandler.Entered = null;
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private LeasedStubEndpoint endpointFor(Action<Endpoint>? configure = null)
+    {
+        var endpoint = new LeasedStubEndpoint("leased", new StubTransport());
+        configure?.Invoke(endpoint);
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+        return endpoint;
+    }
+
+    private NativeAckReceiver receiverFor(Action<Endpoint>? configure = null, IHandlerPipeline? pipeline = null)
+    {
+        var endpoint = endpointFor(configure);
+
+        return new NativeAckReceiver(endpoint, theRuntime,
+            pipeline ?? new HandlerPipeline((WolverineRuntime)theRuntime, (WolverineRuntime)theRuntime, endpoint));
+    }
+
+    private static Envelope pingEnvelope(string name)
+    {
+        return new Envelope(new LeasePing(name)) { MessageType = typeof(LeasePing).ToMessageTypeName() };
+    }
+
+    private static LeaseRenewalTracker trackerFor(FakeLeaseListener listener)
+    {
+        // An hour-long interval so the loop never fires on its own -- every test drives TickAsync explicitly
+        return new LeaseRenewalTracker(listener, listener.Address, NullLogger.Instance, null,
+            CancellationToken.None, 1.Hours());
+    }
+
+    private static Envelope tracked(LeaseRenewalTracker tracker, FakeLeaseListener listener, string name,
+        DateTimeOffset? receivedAt = null)
+    {
+        var envelope = pingEnvelope(name);
+        envelope.Listener = listener;
+        envelope.ReceivedAt = receivedAt ?? DateTimeOffset.UtcNow;
+        tracker.Track(envelope);
+        return envelope;
+    }
+
+    #region scheduling
+
+    [Fact]
+    public async Task ticks_at_half_the_lease()
+    {
+        var listener = new FakeLeaseListener { LeaseDuration = 40.Seconds() };
+        await using var tracker = new LeaseRenewalTracker(listener, listener.Address, NullLogger.Instance, null,
+            CancellationToken.None);
+
+        tracker.Interval.ShouldBe(20.Seconds());
+    }
+
+    [Fact]
+    public async Task the_tick_interval_is_floored_at_one_second()
+    {
+        var listener = new FakeLeaseListener { LeaseDuration = 400.Milliseconds() };
+        await using var tracker = new LeaseRenewalTracker(listener, listener.Address, NullLogger.Instance, null,
+            CancellationToken.None);
+
+        tracker.Interval.ShouldBe(1.Seconds());
+    }
+
+    [Fact]
+    public async Task nothing_is_sent_while_nothing_is_in_flight()
+    {
+        var listener = new FakeLeaseListener();
+        await using var tracker = trackerFor(listener);
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        listener.Calls.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     A receiver can serve several listeners (ListenerCount > 1, per-tenant compound listeners), and a renewal
+    ///     -- exactly like a settle -- has to go to the listener the delivery actually arrived on.
+    /// </summary>
+    [Fact]
+    public async Task renewals_are_grouped_by_the_listener_that_delivered_the_envelope()
+    {
+        var a = new FakeLeaseListener { Address = new Uri("stub://a") };
+        var b = new FakeLeaseListener { Address = new Uri("stub://b") };
+        await using var tracker = trackerFor(a);
+
+        var one = tracked(tracker, a, "one");
+        var two = tracked(tracker, a, "two");
+        var three = tracked(tracker, b, "three");
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        a.Calls.Count.ShouldBe(1);
+        a.Calls.Single().Select(x => x.Id).OrderBy(x => x)
+            .ShouldBe(new[] { one.Id, two.Id }.OrderBy(x => x));
+
+        b.Calls.Count.ShouldBe(1);
+        b.Calls.Single().Single().Id.ShouldBe(three.Id);
+    }
+
+    [Fact]
+    public async Task no_renewal_calls_at_all_when_the_client_renews_for_us()
+    {
+        var listener = new FakeLeaseListener { RequiresExplicitRenewal = false };
+        await using var tracker = trackerFor(listener);
+
+        tracked(tracker, listener, "one");
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        // Pub/Sub's SubscriberClient shape: Wolverine enforces only the ceiling
+        listener.Calls.ShouldBeEmpty();
+        tracker.InFlightCount.ShouldBe(1);
+        tracker.LeasesLostBeforeStarting.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region the ceiling
+
+    [Fact]
+    public async Task stops_renewing_before_an_extension_would_cross_the_maximum()
+    {
+        var listener = new FakeLeaseListener
+        {
+            LeaseDuration = 30.Seconds(),
+            MaximumLeaseExtension = 60.Seconds()
+        };
+        await using var tracker = trackerFor(listener);
+
+        // 40s old: 40 + 30 > 60, so the next extension would carry it past the ceiling
+        tracked(tracker, listener, "old", DateTimeOffset.UtcNow.Subtract(40.Seconds()));
+        tracked(tracker, listener, "young", DateTimeOffset.UtcNow.Subtract(5.Seconds()));
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.CeilingsReached.ShouldBe(1);
+        tracker.InFlightCount.ShouldBe(1);
+        listener.Calls.Single().Single().Message.ShouldBeOfType<LeasePing>().Name.ShouldBe("young");
+    }
+
+    /// <summary>
+    ///     The ceiling is NOT a lost lease. The delivery may still finish inside the lease it already holds, so
+    ///     the envelope keeps running and is not dropped from the lane.
+    /// </summary>
+    [Fact]
+    public async Task reaching_the_ceiling_is_not_treated_as_a_lost_lease()
+    {
+        var listener = new FakeLeaseListener
+        {
+            LeaseDuration = 30.Seconds(),
+            MaximumLeaseExtension = 60.Seconds()
+        };
+        await using var tracker = trackerFor(listener);
+
+        var envelope = tracked(tracker, listener, "old", DateTimeOffset.UtcNow.Subtract(40.Seconds()));
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.LeasesLostBeforeStarting.ShouldBe(0);
+        tracker.LeasesLostWhileExecuting.ShouldBe(0);
+        tracker.WasLeaseLost(envelope).ShouldBeFalse();
+        tracker.TryBeginExecution(envelope).ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region loss classification
+
+    [Fact]
+    public async Task an_envelope_the_broker_refuses_to_renew_has_lost_its_lease()
+    {
+        var listener = new FakeLeaseListener();
+        await using var tracker = trackerFor(listener);
+
+        var refused = tracked(tracker, listener, "refused");
+        var kept = tracked(tracker, listener, "kept");
+        listener.RefuseWhen = e => e.Id == refused.Id;
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.WasLeaseLost(refused).ShouldBeTrue();
+        tracker.WasLeaseLost(kept).ShouldBeFalse();
+        tracker.LeasesLostBeforeStarting.ShouldBe(1);
+        tracker.LeasesRenewed.ShouldBe(1);
+        tracker.InFlightCount.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     A thrown renewal is transient -- network, throttle. Treating it as a lost lease would drop live work
+    ///     on a blip.
+    /// </summary>
+    [Fact]
+    public async Task a_thrown_renewal_is_retried_rather_than_treated_as_a_loss()
+    {
+        var listener = new FakeLeaseListener { LeaseDuration = 30.Seconds() };
+        await using var tracker = trackerFor(listener);
+
+        var envelope = tracked(tracker, listener, "one");
+        listener.Throw = true;
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.WasLeaseLost(envelope).ShouldBeFalse();
+        tracker.InFlightCount.ShouldBe(1);
+        tracker.LeasesLostBeforeStarting.ShouldBe(0);
+
+        listener.Throw = false;
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.LeasesRenewed.ShouldBe(1);
+        tracker.WasLeaseLost(envelope).ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     The second detector, and the only one available on a transport whose renewal call cannot report a
+    ///     per-message failure -- JetStream's AckProgressAsync is fire-and-forget without double-ack.
+    /// </summary>
+    [Fact]
+    public async Task loss_is_inferred_once_a_full_lease_passes_with_no_successful_renewal()
+    {
+        var listener = new FakeLeaseListener { LeaseDuration = 2.Seconds() };
+        await using var tracker = trackerFor(listener);
+
+        // Received far enough in the past that no renewal has ever succeeded inside a lease duration
+        var envelope = tracked(tracker, listener, "one", DateTimeOffset.UtcNow.Subtract(10.Seconds()));
+        listener.Throw = true;
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.WasLeaseLost(envelope).ShouldBeTrue();
+        tracker.LeasesLostBeforeStarting.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_successful_renewal_resets_the_inferred_loss_clock()
+    {
+        var listener = new FakeLeaseListener { LeaseDuration = 2.Seconds() };
+        await using var tracker = trackerFor(listener);
+
+        var envelope = tracked(tracker, listener, "one", DateTimeOffset.UtcNow.Subtract(10.Seconds()));
+
+        // Same stale envelope as the test above, but the renewal LANDS this time
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.WasLeaseLost(envelope).ShouldBeFalse();
+        tracker.LeasesRenewed.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_lease_lost_while_executing_is_metered_separately()
+    {
+        var listener = new FakeLeaseListener();
+        await using var tracker = trackerFor(listener);
+
+        var envelope = tracked(tracker, listener, "running");
+        tracker.TryBeginExecution(envelope).ShouldBeTrue();
+        listener.RefuseWhen = e => e.Id == envelope.Id;
+
+        await tracker.TickAsync(CancellationToken.None);
+
+        // Realized duplication, not prevented duplication -- the two counters mean different things
+        tracker.LeasesLostWhileExecuting.ShouldBe(1);
+        tracker.LeasesLostBeforeStarting.ShouldBe(0);
+        tracker.WasLeaseLost(envelope).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task untracking_clears_both_the_in_flight_and_the_lost_state()
+    {
+        var listener = new FakeLeaseListener();
+        await using var tracker = trackerFor(listener);
+
+        var envelope = tracked(tracker, listener, "one");
+        listener.RefuseWhen = e => e.Id == envelope.Id;
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.WasLeaseLost(envelope).ShouldBeTrue();
+
+        tracker.Untrack(envelope);
+
+        tracker.WasLeaseLost(envelope).ShouldBeFalse();
+        tracker.InFlightCount.ShouldBe(0);
+        tracker.LostCount.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region enforcement in the lane -- the assertions that matter
+
+    /// <summary>
+    ///     The single most important assertion in GH-4048. A lease-lost envelope that has not started executing is
+    ///     DROPPED: no Complete, and critically no Defer. Every transport's defer path is settle-then-republish,
+    ///     so deferring after the lease is gone publishes a second copy on top of the redelivery the broker is
+    ///     already performing.
+    /// </summary>
+    [Fact]
+    public async Task a_lease_lost_envelope_that_has_not_started_is_dropped_without_completing_or_deferring()
+    {
+        var receiver = receiverFor(e => e.MaxDegreeOfParallelism = 1);
+        var listener = new FakeLeaseListener();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        LeasePingHandler.Gate = gate;
+        LeasePingHandler.Entered = entered;
+
+        // "first" occupies the single lane; "second" is stuck behind it, which is exactly the state this issue
+        // exists for -- the risk window is lane queue time, not handler time.
+        var first = pingEnvelope("first");
+        var second = pingEnvelope("second");
+        await receiver.ReceivedAsync(listener, first);
+        await receiver.ReceivedAsync(listener, second);
+
+        receiver.Leases.ShouldNotBeNull();
+        var tracker = receiver.Leases!;
+        await entered.Task.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+        await waitUntil(() => tracker.InFlightCount == 2);
+
+        listener.RefuseWhen = e => e.Id == second.Id;
+        await tracker.TickAsync(CancellationToken.None);
+
+        tracker.WasLeaseLost(second).ShouldBeTrue();
+        tracker.LeasesLostBeforeStarting.ShouldBe(1);
+
+        gate.SetResult();
+        await waitUntil(() => listener.Completed.Count == 1);
+        await waitUntil(() => tracker.LostCount == 0 && tracker.InFlightCount == 0);
+
+        // "first" settled normally
+        LeasePingHandler.Handled.ShouldContain("first");
+        listener.Completed.Single().Id.ShouldBe(first.Id);
+
+        // "second" was never handled, never completed, and -- the whole point -- never deferred
+        LeasePingHandler.Handled.ShouldNotContain("second");
+        listener.Deferred.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     A running handler cannot be un-run, so this envelope stays at-least-once. What the design does do is
+    ///     stop compounding it: the receiver's own failure-path defer is suppressed, because deferring would
+    ///     republish on top of the redelivery the broker has already started.
+    /// </summary>
+    [Fact]
+    public async Task a_pipeline_failure_after_the_lease_is_lost_mid_execution_is_not_deferred()
+    {
+        var pipeline = new GatedThrowingPipeline();
+        var receiver = receiverFor(pipeline: pipeline);
+        var listener = new FakeLeaseListener();
+
+        var envelope = pingEnvelope("running");
+        await receiver.ReceivedAsync(listener, envelope);
+
+        receiver.Leases.ShouldNotBeNull();
+        var tracker = receiver.Leases!;
+
+        // The pipeline is on the stack, so this envelope is genuinely executing
+        await pipeline.Entered.Task.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        listener.RefuseWhen = e => e.Id == envelope.Id;
+        await tracker.TickAsync(CancellationToken.None);
+        tracker.LeasesLostWhileExecuting.ShouldBe(1);
+        tracker.LeasesLostBeforeStarting.ShouldBe(0);
+
+        pipeline.Gate.SetResult();
+        await waitUntil(() => tracker.InFlightCount == 0 && tracker.LostCount == 0);
+
+        listener.Deferred.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     The control for the test above: with the lease intact, the very same pipeline failure DOES defer. The
+    ///     pair is the test -- a green "no defer" alone would also pass if the receiver simply never deferred.
+    /// </summary>
+    [Fact]
+    public async Task a_pipeline_failure_with_an_intact_lease_still_defers()
+    {
+        var pipeline = new GatedThrowingPipeline();
+        var receiver = receiverFor(pipeline: pipeline);
+        var listener = new FakeLeaseListener();
+
+        await receiver.ReceivedAsync(listener, pingEnvelope("running"));
+        await pipeline.Entered.Task.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        pipeline.Gate.SetResult();
+        await waitUntil(() => listener.Deferred.Count == 1);
+
+        listener.Completed.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     The counterpart. A LATCHED receiver still holds the lease, so handing the delivery back is correct --
+    ///     the lost-lease branch sits right next to it and must not change this.
+    /// </summary>
+    [Fact]
+    public async Task a_latched_receiver_still_defers_because_the_lease_is_intact()
+    {
+        var receiver = receiverFor();
+        var listener = new FakeLeaseListener();
+
+        receiver.Latch();
+        await receiver.ReceivedAsync(listener, pingEnvelope("latched"));
+        await receiver.DrainAsync();
+
+        listener.Deferred.Count.ShouldBe(1);
+        listener.Completed.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task an_intact_lease_settles_normally_and_stops_being_tracked()
+    {
+        var receiver = receiverFor();
+        var listener = new FakeLeaseListener();
+
+        await receiver.ReceivedAsync(listener, pingEnvelope("fine"));
+
+        receiver.Leases.ShouldNotBeNull();
+        var tracker = receiver.Leases!;
+
+        await waitUntil(() => listener.Completed.Count == 1);
+        await waitUntil(() => tracker.InFlightCount == 0);
+
+        LeasePingHandler.Handled.ShouldContain("fine");
+        listener.Deferred.ShouldBeEmpty();
+        tracker.LostCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task no_tracker_is_built_for_a_listener_that_cannot_renew()
+    {
+        var receiver = receiverFor();
+        var listener = new PlainListener();
+
+        await receiver.ReceivedAsync(listener, pingEnvelope("plain"));
+        await waitUntil(() => listener.Completed.Count == 1);
+
+        // RabbitMQ / Redis Streams: an unsettled delivery never expires, so there is no clock and no loop
+        receiver.Leases.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region the startup contract
+
+    /// <summary>
+    ///     Without this check, opting a clocked transport into NativeAck and forgetting renewal produces a silent
+    ///     duplicate generator. With it, the mistake is a startup exception.
+    /// </summary>
+    [Fact]
+    public async Task a_native_ack_endpoint_on_a_clocked_transport_needs_a_lease_renewing_listener()
+    {
+        var endpoint = endpointFor(e => e.IsListener = true);
+        var agent = new ListeningAgent(endpoint, (WolverineRuntime)theRuntime);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await agent.StartAsync());
+
+        ex.Message.ShouldContain(nameof(ISupportLeaseRenewal));
+        ex.Message.ShouldContain(endpoint.Uri.ToString());
+
+        await agent.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task a_native_ack_endpoint_whose_listener_can_renew_starts_normally()
+    {
+        var endpoint = new LeaseRenewingStubEndpoint("renewing", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+
+        var agent = new ListeningAgent(endpoint, (WolverineRuntime)theRuntime);
+        await agent.StartAsync();
+
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+
+        await agent.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     The check is scoped to NativeAck. Inline settles inside the callback and Buffered/Durable settle at
+    ///     receipt, so none of them holds a delivery long enough to need a renewal -- requiring one there would
+    ///     break every existing SQS endpoint.
+    /// </summary>
+    [Fact]
+    public async Task the_contract_check_only_applies_to_native_ack()
+    {
+        var endpoint = new LeasedStubEndpoint("inline", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.Inline;
+        endpoint.Compile(theRuntime);
+
+        var agent = new ListeningAgent(endpoint, (WolverineRuntime)theRuntime);
+        await agent.StartAsync();
+
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+
+        await agent.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     And it is scoped to transports that actually expire an unsettled delivery. RabbitMQ has no clock, so a
+    ///     NativeAck Rabbit listener has nothing to renew.
+    /// </summary>
+    [Fact]
+    public async Task the_contract_check_does_not_apply_to_a_transport_with_no_clock()
+    {
+        var endpoint = new UnclockedStubEndpoint("unclocked", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+
+        var agent = new ListeningAgent(endpoint, (WolverineRuntime)theRuntime);
+        await agent.StartAsync();
+
+        agent.Status.ShouldBe(ListeningStatus.Accepting);
+
+        await agent.DisposeAsync();
+    }
+
+    #endregion
+
+    private static async Task waitUntil(Func<bool> condition)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (!condition() && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        condition().ShouldBeTrue();
+    }
+}
+
+/// <summary>GH-4048. A clocked transport that has opted into NativeAck, standing in for SQS.</summary>
+internal class LeasedStubEndpoint : StubEndpoint
+{
+    public LeasedStubEndpoint(string queueName, StubTransport transport) : base(queueName, transport)
+    {
+    }
+
+    protected override bool supportsNativeAck => true;
+
+    protected internal override bool holdsExpiringLease => true;
+}
+
+/// <summary>A clocked transport whose listener honours the contract.</summary>
+internal class LeaseRenewingStubEndpoint : LeasedStubEndpoint, ISupportLeaseRenewal
+{
+    public LeaseRenewingStubEndpoint(string queueName, StubTransport transport) : base(queueName, transport)
+    {
+    }
+
+    public TimeSpan LeaseDuration => 30.Seconds();
+    public TimeSpan MaximumLeaseExtension => 12.Hours();
+
+    public ValueTask<IReadOnlyList<Envelope>> RenewLeasesAsync(IReadOnlyList<Envelope> envelopes,
+        CancellationToken token)
+    {
+        return ValueTask.FromResult<IReadOnlyList<Envelope>>([]);
+    }
+}
+
+/// <summary>A NativeAck transport with no clock at all -- RabbitMQ, Redis Streams.</summary>
+internal class UnclockedStubEndpoint : StubEndpoint
+{
+    public UnclockedStubEndpoint(string queueName, StubTransport transport) : base(queueName, transport)
+    {
+    }
+
+    protected override bool supportsNativeAck => true;
+}
+
+/// <summary>A listener whose broker puts a clock on an unsettled delivery, with the clock under test control.</summary>
+internal class FakeLeaseListener : IListener, ISupportLeaseRenewal
+{
+    public ConcurrentBag<Envelope> Completed { get; } = new();
+    public ConcurrentBag<Envelope> Deferred { get; } = new();
+
+    /// <summary>Every batch this listener has been asked to renew, in the groups the tracker built.</summary>
+    public ConcurrentBag<IReadOnlyList<Envelope>> Calls { get; } = new();
+
+    /// <summary>Which envelopes the "broker" will refuse to renew.</summary>
+    public Func<Envelope, bool> RefuseWhen { get; set; } = _ => false;
+
+    /// <summary>Make the renewal call fail transiently.</summary>
+    public bool Throw { get; set; }
+
+    public TimeSpan LeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan MaximumLeaseExtension { get; set; } = TimeSpan.FromHours(12);
+    public bool RequiresExplicitRenewal { get; set; } = true;
+
+    public Uri Address { get; set; } = new("stub://leased");
+    public IHandlerPipeline? Pipeline => null;
+
+    public ValueTask<IReadOnlyList<Envelope>> RenewLeasesAsync(IReadOnlyList<Envelope> envelopes,
+        CancellationToken token)
+    {
+        Calls.Add(envelopes.ToArray());
+
+        if (Throw)
+        {
+            throw new TimeoutException("the broker is not answering");
+        }
+
+        IReadOnlyList<Envelope> refused = envelopes.Where(RefuseWhen).ToArray();
+        return ValueTask.FromResult(refused);
+    }
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        Completed.Add(envelope);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DeferAsync(Envelope envelope)
+    {
+        Deferred.Add(envelope);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask StopAsync() => ValueTask.CompletedTask;
+}
+
+/// <summary>A listener on a broker with no clock at all.</summary>
+internal class PlainListener : IListener
+{
+    public ConcurrentBag<Envelope> Completed { get; } = new();
+    public ConcurrentBag<Envelope> Deferred { get; } = new();
+
+    public Uri Address { get; } = new("stub://plain");
+    public IHandlerPipeline? Pipeline => null;
+
+    public ValueTask CompleteAsync(Envelope envelope)
+    {
+        Completed.Add(envelope);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DeferAsync(Envelope envelope)
+    {
+        Deferred.Add(envelope);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask StopAsync() => ValueTask.CompletedTask;
+}
+
+/// <summary>
+///     Holds the pipeline open on a gate and then throws OUT of InvokeAsync, which is the one failure the
+///     native-ack receiver handles itself (everything else is settled by the pipeline's own continuations).
+/// </summary>
+internal class GatedThrowingPipeline : IHandlerPipeline
+{
+    public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource Gate { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public async Task InvokeAsync(Envelope envelope, IChannelCallback channel)
+    {
+        Entered.TrySetResult();
+        await Gate.Task;
+        throw new DivideByZeroException("boom");
+    }
+
+    public Task InvokeAsync(Envelope envelope, IChannelCallback channel, Activity activity)
+    {
+        return InvokeAsync(envelope, channel);
+    }
+
+    public ValueTask<IContinuation> TryDeserializeEnvelope(Envelope envelope)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/lease_renewal_4048.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/lease_renewal_4048.cs
@@ -1,0 +1,249 @@
+using System.Collections.Concurrent;
+using Amazon.SQS.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration;
+using Wolverine.Transports;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+/// <summary>
+///     GH-4048, against LocalStack. <see cref="SqsListener" /> implements <see cref="ISupportLeaseRenewal" /> so that
+///     core's lease renewal tracker can keep a queued-but-unsettled delivery invisible for as long as it sits in a
+///     native-ack execution lane. These prove the SQS half of that contract does what it claims against a real
+///     broker: calling <c>RenewLeasesAsync</c> keeps a message invisible past its visibility timeout, and not
+///     calling it does not.
+/// </summary>
+/// <remarks>
+///     The pair is the test. A green "handled once" on its own would also pass on a machine fast enough to finish
+///     inside the visibility timeout, so the negative control -- the same run with no renewal, which must produce a
+///     redelivery -- is what actually pins the behaviour.
+/// </remarks>
+public class lease_renewal_4048
+{
+    // Short enough to keep the tests quick, long enough that LocalStack's second-granularity visibility clock is
+    // not the thing being measured
+    private const int VisibilityTimeoutSeconds = 3;
+
+    private static readonly TimeSpan ObservationWindow = 16.Seconds();
+
+    private static async Task<IHost> startHost(string queueName)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally().AutoProvision();
+
+                opts.ListenToSqsQueue(queueName, q =>
+                    {
+                        q.VisibilityTimeout = VisibilityTimeoutSeconds;
+                        q.WaitTimeSeconds = 1;
+                    })
+                    .ProcessInline()
+                    // The second listener is what picks up a redelivered copy while the first is still running
+                    .ListenerCount(2);
+
+                opts.PublishAllMessages().ToSqsQueue(queueName).SendInline();
+            }).StartAsync();
+    }
+
+    private static async Task<int> executionsAfterObservationWindow(IHost host, Guid id)
+    {
+        await host.MessageBus().SendAsync(new LeasedSqsMessage(id));
+        await Task.Delay(ObservationWindow, TestContext.Current.CancellationToken);
+
+        return LeasedSqsMessageTracker.ExecutionsOf(id);
+    }
+
+    [Fact]
+    public async Task renewing_the_lease_keeps_a_delivery_invisible_past_the_visibility_timeout()
+    {
+        LeasedSqsMessageTracker.Reset(renew: true);
+
+        var queueName = "lease-renew-on-" + Guid.NewGuid().ToString("N")[..8];
+        using var host = await startHost(queueName);
+        try
+        {
+            var executions = await executionsAfterObservationWindow(host, Guid.NewGuid());
+
+            executions.ShouldBe(1);
+            LeasedSqsMessageTracker.RenewalCalls.ShouldBeGreaterThan(0);
+
+            // Every renewal landed -- nothing came back in the "could not renew" subset
+            LeasedSqsMessageTracker.Refused.ShouldBeEmpty();
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    /// <summary>
+    ///     The negative control. Without renewal the message reappears at its visibility timeout while the first
+    ///     copy is still in flight, which is exactly the duplication an un-renewed native-ack lane would produce.
+    /// </summary>
+    [Fact]
+    public async Task without_renewal_the_delivery_is_redelivered_and_executed_again()
+    {
+        LeasedSqsMessageTracker.Reset(renew: false);
+
+        var queueName = "lease-renew-off-" + Guid.NewGuid().ToString("N")[..8];
+        using var host = await startHost(queueName);
+        try
+        {
+            var executions = await executionsAfterObservationWindow(host, Guid.NewGuid());
+
+            executions.ShouldBeGreaterThanOrEqualTo(2);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    /// <summary>
+    ///     A dead receipt handle is a LOST lease, not a transient failure, and the contract says it comes back in
+    ///     the result rather than as an exception. <c>ChangeMessageVisibilityBatch</c> reports per-entry failures
+    ///     inside an otherwise successful response, which is what makes that shape possible -- and what stops one
+    ///     dead handle from costing the rest of the batch its lease.
+    /// </summary>
+    [Fact]
+    public async Task an_unrenewable_delivery_comes_back_in_the_result_without_taking_the_batch_with_it()
+    {
+        LeasedSqsMessageTracker.Reset(renew: true);
+        LeasedSqsMessageTracker.ExtraEnvelope = new AmazonSqsEnvelope(new Message
+        {
+            MessageId = "not-a-real-message",
+            ReceiptHandle = "AQEBdefinitelyNotAValidReceiptHandle"
+        });
+
+        var queueName = "lease-refused-" + Guid.NewGuid().ToString("N")[..8];
+        using var host = await startHost(queueName);
+        try
+        {
+            var executions = await executionsAfterObservationWindow(host, Guid.NewGuid());
+
+            // The real message was still renewed, so it ran exactly once...
+            executions.ShouldBe(1);
+
+            // ...while the dead handle came back as un-renewable rather than throwing the whole batch away
+            LeasedSqsMessageTracker.Refused.ShouldContain(LeasedSqsMessageTracker.ExtraEnvelope!.Id);
+        }
+        finally
+        {
+            LeasedSqsMessageTracker.ExtraEnvelope = null;
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public void an_sqs_queue_declares_that_its_unsettled_deliveries_expire()
+    {
+        var transport = new AmazonSqsTransport();
+
+        // The endpoint-side half of the contract: ListeningAgent uses this to refuse to start a NativeAck
+        // endpoint whose listener cannot renew
+        transport.Queues["anything"].holdsExpiringLease.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     GH-4019's heartbeat stays Inline-only and keeps its opt-in flag. NativeAck renewal is driven from core
+    ///     through <see cref="ISupportLeaseRenewal" /> instead, because this heartbeat's Track/Untrack pair
+    ///     straddles <c>ReceivedAsync</c>, which under NativeAck returns as soon as the envelope is enqueued.
+    /// </summary>
+    [Fact]
+    public void the_inline_heartbeat_is_unchanged_by_native_ack_renewal()
+    {
+        var transport = new AmazonSqsTransport();
+
+        var inline = transport.Queues["inline"];
+        inline.Mode = EndpointMode.Inline;
+        inline.ExtendVisibilityWhileHandling = true;
+        SqsListener.ShouldExtendVisibility(inline).ShouldBeTrue();
+
+        inline.ExtendVisibilityWhileHandling = false;
+        SqsListener.ShouldExtendVisibility(inline).ShouldBeFalse();
+
+        var buffered = transport.Queues["buffered"];
+        buffered.ExtendVisibilityWhileHandling = true;
+        SqsListener.ShouldExtendVisibility(buffered).ShouldBeFalse();
+    }
+}
+
+public record LeasedSqsMessage(Guid Id);
+
+public static class LeasedSqsMessageTracker
+{
+    private static readonly ConcurrentDictionary<Guid, int> Executions = new();
+
+    /// <summary>How long the handler holds the delivery -- comfortably past several visibility timeouts.</summary>
+    public static readonly TimeSpan HandlerDuration = 9.Seconds();
+
+    public static volatile bool Renew;
+    public static int RenewalCalls;
+
+    /// <summary>An extra envelope carrying a dead receipt handle, mixed into the renewal batch.</summary>
+    public static Envelope? ExtraEnvelope;
+
+    public static ConcurrentBag<Guid> Refused { get; private set; } = new();
+
+    public static void Reset(bool renew)
+    {
+        Executions.Clear();
+        Refused = new ConcurrentBag<Guid>();
+        RenewalCalls = 0;
+        ExtraEnvelope = null;
+        Renew = renew;
+    }
+
+    public static void Record(Guid id)
+    {
+        Executions.AddOrUpdate(id, 1, (_, count) => count + 1);
+    }
+
+    public static int ExecutionsOf(Guid id)
+    {
+        return Executions.GetValueOrDefault(id);
+    }
+}
+
+public static class LeasedSqsMessageHandler
+{
+    /// <summary>
+    ///     Counted at the start, so a second delivery that begins while the first is still running shows up inside
+    ///     the observation window. The envelope is the live <c>AmazonSqsEnvelope</c> and its Listener is the
+    ///     <c>SqsListener</c> that delivered it -- exactly the pair core's tracker works with.
+    /// </summary>
+    public static async Task Handle(LeasedSqsMessage message, Envelope envelope, CancellationToken token)
+    {
+        LeasedSqsMessageTracker.Record(message.Id);
+
+        if (envelope.Listener is not ISupportLeaseRenewal renewal)
+        {
+            throw new InvalidOperationException(
+                $"{envelope.Listener?.GetType().Name} no longer implements {nameof(ISupportLeaseRenewal)}");
+        }
+
+        var deadline = DateTimeOffset.UtcNow.Add(LeasedSqsMessageTracker.HandlerDuration);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(1.Seconds(), token);
+
+            if (!LeasedSqsMessageTracker.Renew) continue;
+
+            IReadOnlyList<Envelope> batch = LeasedSqsMessageTracker.ExtraEnvelope is { } extra
+                ? new[] { envelope, extra }
+                : new[] { envelope };
+
+            var refused = await renewal.RenewLeasesAsync(batch, token);
+            Interlocked.Increment(ref LeasedSqsMessageTracker.RenewalCalls);
+
+            foreach (var lost in refused)
+            {
+                LeasedSqsMessageTracker.Refused.Add(lost.Id);
+            }
+        }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -217,14 +217,22 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     ///     finishes inside half the timeout. Ignored for Buffered and Durable endpoints, which delete the
     ///     message before the handler runs. Default false.
     /// </summary>
+    /// <remarks>
+    ///     GH-4048: <b>not consulted for <c>NativeAck</c></b>, where renewal is unconditional. A NativeAck lane
+    ///     holds the delivery for lane queue time plus handler time and queue time is unbounded by design, so an
+    ///     un-renewed NativeAck endpoint is a duplicate-delivery generator by construction rather than merely at
+    ///     risk under a slow handler -- an opt-in default-false flag would mean "off by default" for the one mode
+    ///     that cannot survive it. <see cref="MaximumVisibilityExtension" /> remains the ceiling for both modes.
+    /// </remarks>
     public bool ExtendVisibilityWhileHandling { get; set; }
 
     private TimeSpan _maximumVisibilityExtension = MaximumSqsVisibilityExtension;
 
     /// <summary>
-    ///     The longest a single message is kept invisible from its receipt by
-    ///     <see cref="ExtendVisibilityWhileHandling" /> before Wolverine stops extending it and lets SQS
-    ///     redeliver. Bounded above by the SQS limit of 12 hours. Default 12 hours.
+    ///     The longest a single message is kept invisible from its receipt -- by
+    ///     <see cref="ExtendVisibilityWhileHandling" /> under <c>Inline</c>, or unconditionally under
+    ///     <c>NativeAck</c> -- before Wolverine stops extending it and lets SQS redeliver. Bounded above by the
+    ///     SQS limit of 12 hours. Default 12 hours.
     /// </summary>
     public TimeSpan MaximumVisibilityExtension
     {
@@ -779,6 +787,14 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     {
         return true;
     }
+
+    /// <summary>
+    /// GH-4048. An unsettled SQS delivery is invisible only for <see cref="VisibilityTimeout" /> seconds, after
+    /// which SQS redelivers it -- so a NativeAck endpoint here has to renew that clock for as long as the
+    /// envelope sits in an execution lane. <see cref="SqsListener" /> supplies the renewal through
+    /// <see cref="ISupportLeaseRenewal" />.
+    /// </summary>
+    protected internal override bool holdsExpiringLease => true;
 
     internal void ConfigureRequest(ReceiveMessageRequest request)
     {

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -8,7 +8,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.AmazonSqs.Internal;
 
-internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveLoopHealth
+internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveLoopHealth, ISupportLeaseRenewal
 {
     private readonly RetryBlock<Envelope>? _deadLetterBlock;
     private readonly AmazonSqsQueue? _deadLetterQueue;
@@ -222,13 +222,83 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     }
 
     /// <summary>
-    /// GH-4019: the heartbeat only makes sense for an inline listener. Durable deletes the message right
-    /// after the inbox insert and Buffered deletes on receipt, so neither holds a message under the
-    /// visibility timeout while a handler runs.
+    /// GH-4019: this heartbeat covers an <em>inline</em> listener, which works through a received batch one
+    /// message at a time against a visibility timeout that was only set once, on the receive. Durable deletes
+    /// the message right after the inbox insert and Buffered deletes on receipt, so neither holds a message
+    /// under the visibility timeout while a handler runs.
     /// </summary>
+    /// <remarks>
+    /// GH-4048 corrected the half of the old comment that said no other mode holds a message under the
+    /// visibility timeout. <c>NativeAck</c> holds it for lane queue time <em>plus</em> handler time -- longer
+    /// than Inline ever does, and unbounded by design. That mode is renewed <b>unconditionally</b>, without
+    /// consulting <see cref="AmazonSqsQueue.ExtendVisibilityWhileHandling" />, but the renewal is driven from
+    /// core through <see cref="ISupportLeaseRenewal" /> rather than from this heartbeat: the heartbeat's
+    /// Track/Untrack pair straddles <c>IReceiver.ReceivedAsync</c>, which under NativeAck returns as soon as
+    /// the envelope is enqueued -- i.e. at the very moment the risk window opens. A second tick loop here would
+    /// therefore renew nothing. Both loops share <see cref="extendVisibilityAsync" />, which is the whole of
+    /// the SQS-side work either one does.
+    /// </remarks>
     internal static bool ShouldExtendVisibility(AmazonSqsQueue queue)
     {
         return queue.ExtendVisibilityWhileHandling && queue.Mode == EndpointMode.Inline;
+    }
+
+    public TimeSpan LeaseDuration => TimeSpan.FromSeconds(_queue.VisibilityTimeout);
+
+    public TimeSpan MaximumLeaseExtension => _queue.MaximumVisibilityExtension;
+
+    /// <summary>
+    /// GH-4048. Keep these queued-but-unsettled deliveries invisible. Deliberately does NOT consult
+    /// <see cref="AmazonSqsQueue.ExtendVisibilityWhileHandling" />: that flag is a cost trade for Inline, where
+    /// exposure is bounded by how long one receive of at most ten messages takes to run. Under NativeAck the
+    /// exposure is lane depth, which the mode's back-pressure model deliberately allows to grow, so renewal is
+    /// mandatory. The same reasoning made fragment reassembly unconditional in this listener.
+    /// </summary>
+    public async ValueTask<IReadOnlyList<Envelope>> RenewLeasesAsync(IReadOnlyList<Envelope> envelopes,
+        CancellationToken token)
+    {
+        // One envelope can be several SQS messages after GH-3926 fragment reassembly, and the whole set has to
+        // stay invisible together -- an incomplete set that reappears can never be reassembled.
+        var owners = new Dictionary<string, Envelope>();
+        var messages = new List<Message>(envelopes.Count);
+
+        foreach (var envelope in envelopes)
+        {
+            if (envelope is not AmazonSqsEnvelope sqs) continue;
+
+            foreach (var message in sqs.SqsMessages)
+            {
+                if (message.ReceiptHandle == null) continue;
+                if (owners.TryAdd(message.ReceiptHandle, envelope))
+                {
+                    messages.Add(message);
+                }
+            }
+        }
+
+        if (messages.Count == 0)
+        {
+            return [];
+        }
+
+        var dropped = await extendVisibilityAsync(messages.ToArray(), token);
+        if (dropped.Count == 0)
+        {
+            return [];
+        }
+
+        // Any fragment SQS would not extend loses the lease for the whole envelope.
+        var lost = new List<Envelope>();
+        foreach (var message in dropped)
+        {
+            if (message.ReceiptHandle == null) continue;
+            if (owners.TryGetValue(message.ReceiptHandle, out var envelope) && !lost.Contains(envelope))
+            {
+                lost.Add(envelope);
+            }
+        }
+
+        return lost;
     }
 
     /// <summary>

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsVisibilityHeartbeat.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsVisibilityHeartbeat.cs
@@ -14,12 +14,24 @@ namespace Wolverine.AmazonSqs.Internal;
 ///     copy's eventual delete carries a stale receipt handle that SQS accepts without deleting anything.
 /// </summary>
 /// <remarks>
-///     Only meaningful for <see cref="Wolverine.Configuration.EndpointMode.Inline" />. Durable endpoints
-///     delete the message right after the inbox insert and buffered endpoints delete on receipt, so
-///     neither holds a message under the visibility timeout while a handler runs. The SQS call itself
-///     is injected so the scheduling can be tested without a broker; the tick is a maximum age, not a
-///     debounce, and nothing is sent on a tick when nothing is in flight -- a listener whose batches
-///     finish inside half the visibility timeout never issues an extension at all.
+///     <para>
+///         Scoped to <see cref="Wolverine.Configuration.EndpointMode.Inline" />. Durable endpoints delete the
+///         message right after the inbox insert and buffered endpoints delete on receipt, so neither holds a
+///         message under the visibility timeout while a handler runs.
+///     </para>
+///     <para>
+///         GH-4048: <see cref="Wolverine.Configuration.EndpointMode.NativeAck" /> holds one for longer than any
+///         of them -- lane queue time plus handler time -- but it is not served from here. Its risk window opens
+///         when the envelope is <em>enqueued</em>, which is exactly when this class's Track/Untrack pair around
+///         <c>IReceiver.ReceivedAsync</c> would already have untracked it. Core's <c>LeaseRenewalTracker</c>,
+///         generalized from this class, owns that window through <c>ISupportLeaseRenewal</c>, and both loops
+///         issue the same <c>ChangeMessageVisibilityBatch</c> call.
+///     </para>
+///     <para>
+///         The SQS call itself is injected so the scheduling can be tested without a broker; the tick is a
+///         maximum age, not a debounce, and nothing is sent on a tick when nothing is in flight -- a listener
+///         whose batches finish inside half the visibility timeout never issues an extension at all.
+///     </para>
 /// </remarks>
 internal class SqsVisibilityHeartbeat : IAsyncDisposable
 {

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -21,6 +21,7 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("Wolverine.AzureServiceBus")]
 [assembly: InternalsVisibleTo("Wolverine.AmazonSqs")]
 [assembly: InternalsVisibleTo("Wolverine.AmazonSns")]
+[assembly: InternalsVisibleTo("Wolverine.AmazonSqs.Tests")]
 [assembly: InternalsVisibleTo("Wolverine.ConfluentKafka")]
 [assembly: InternalsVisibleTo("Wolverine.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("PersistenceTests")]

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -732,6 +732,21 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     protected virtual bool supportsNativeAck => false;
 
     /// <summary>
+    /// GH-4048. Does this endpoint's broker put a clock on an <em>unsettled</em> delivery? True for SQS (visibility
+    /// timeout), Azure Service Bus (lock duration), Pub/Sub (ack deadline) and JetStream (AckWait); false for
+    /// RabbitMQ and Redis Streams, where an unacked delivery lives until the channel closes and there is nothing
+    /// to renew.
+    /// </summary>
+    /// <remarks>
+    /// This is the endpoint-side half of the lease contract. Under <see cref="EndpointMode.NativeAck"/> a delivery
+    /// is held unsettled for lane queue time <em>plus</em> handler time, so an endpoint that answers true here must
+    /// build a listener implementing <see cref="Transports.ISupportLeaseRenewal"/>. <c>ListeningAgent</c> enforces
+    /// that at startup, deliberately: without the check, opting into NativeAck and forgetting renewal produces a
+    /// silent duplicate generator instead of an error.
+    /// </remarks>
+    protected internal virtual bool holdsExpiringLease => false;
+
+    /// <summary>
     /// Check if this endpoint supports the specified mode
     /// </summary>
     public bool SupportsMode(EndpointMode mode)

--- a/src/Wolverine/MetricsConstants.cs
+++ b/src/Wolverine/MetricsConstants.cs
@@ -22,6 +22,16 @@ public class MetricsConstants
     public const string DatabaseConnectionCount = "wolverine-database-connection-count";
     public const string DatabaseConnectionBudget = "wolverine-database-connection-budget";
 
+    // GH-4048. Broker lease renewal for envelopes queued but not yet settled under EndpointMode.NativeAck.
+    // "lost" is split by LeaseLossStageKey because the two halves mean different things: "not-started" is
+    // duplication that was PREVENTED (the queued copy is dropped without being completed or deferred),
+    // "executing" is duplication that was REALIZED and can only be reported. A rising "executing" count is
+    // the operator's signal that lane depth has outgrown the configured lease.
+    public const string LeasesRenewed = "wolverine-leases-renewed";
+    public const string LeasesLost = "wolverine-leases-lost";
+    public const string LeaseCeilingReached = "wolverine-lease-ceiling-reached";
+    public const string LeaseLossStageKey = "lease.loss.stage";
+
     public const string MessageTypeKey = "message.type";
     public const string MessageDestinationKey = "message.destination";
     public const string TenantIdKey = "tenant.id";

--- a/src/Wolverine/Runtime/WorkerQueues/LeaseRenewalTracker.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/LeaseRenewalTracker.cs
@@ -1,0 +1,393 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using Wolverine.Transports;
+
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+///     GH-4048. Keeps the broker's clock alive on every delivery that <see cref="NativeAckReceiver" /> has enqueued
+///     but not yet settled, and decides what happens when that clock is lost anyway.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is a generalization of <c>SqsVisibilityHeartbeat</c>, which solved the same problem for a single
+///         transport and a single mode. NativeAck makes the problem universal: the delivery is held unsettled for
+///         lane queue time <em>plus</em> handler time, and lane queue time is unbounded by design.
+///     </para>
+///     <para>
+///         The tick is a maximum age rather than a debounce, and nothing is sent on a tick when nothing is in
+///         flight -- an endpoint whose lanes stay shallow never issues a single renewal call. Renewals are grouped
+///         by <see cref="Envelope.Listener" /> because a receiver can serve several listeners
+///         (<c>ListenerCount &gt; 1</c>, per-tenant compound listeners) and, exactly as with settlement, a renewal
+///         has to go to the listener the delivery actually arrived on.
+///     </para>
+/// </remarks>
+internal class LeaseRenewalTracker : IAsyncDisposable
+{
+    private readonly ConcurrentDictionary<Guid, Tracked> _inFlight = new();
+
+    // Envelopes whose lease has been lost, still sitting in an execution lane. An entry is consumed by
+    // NativeAckReceiver -- dropped outright if it had not started, or (if it had) left in place so the receiver
+    // knows to suppress its defer -- and removed by Untrack. Bounded by the same broker prefetch window as
+    // _inFlight, and swept by age so an entry whose envelope never reaches the block cannot linger.
+    private readonly ConcurrentDictionary<Guid, DateTimeOffset> _lost = new();
+
+    private readonly TimeSpan _leaseDuration;
+    private readonly TimeSpan _maximumExtension;
+    private readonly bool _requiresExplicitRenewal;
+    private readonly TimeSpan _interval;
+    private readonly ILogger _logger;
+    private readonly Uri _uri;
+    private readonly CancellationTokenSource _cancellation;
+    private readonly Task _loop;
+
+    private readonly Counter<int>? _renewedCounter;
+    private readonly Counter<int>? _lostCounter;
+    private readonly Counter<int>? _ceilingCounter;
+    private readonly KeyValuePair<string, object?> _endpointTag;
+
+    /// <param name="template">
+    ///     The first lease-renewing listener seen on this endpoint. Every listener built for one endpoint reads the
+    ///     same configuration, so the durations are taken once from here; the renewal call itself always goes to
+    ///     the listener that delivered the envelope.
+    /// </param>
+    /// <param name="uri">Endpoint Uri, for logging and metric tags</param>
+    /// <param name="logger"></param>
+    /// <param name="meter">Runtime meter. Null in tests that only care about the scheduling</param>
+    /// <param name="cancellation">Runtime shutdown</param>
+    /// <param name="interval">Tick interval. Defaults to half the lease duration, never under one second</param>
+    public LeaseRenewalTracker(ISupportLeaseRenewal template, Uri uri, ILogger logger, Meter? meter,
+        CancellationToken cancellation, TimeSpan? interval = null)
+    {
+        _leaseDuration = template.LeaseDuration;
+        _maximumExtension = template.MaximumLeaseExtension;
+        _requiresExplicitRenewal = template.RequiresExplicitRenewal;
+        _uri = uri;
+        _logger = logger;
+
+        var half = TimeSpan.FromTicks(_leaseDuration.Ticks / 2);
+        _interval = interval ?? (half < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : half);
+
+        _endpointTag = new KeyValuePair<string, object?>(MetricsConstants.MessageDestinationKey, uri.ToString());
+
+        if (meter != null)
+        {
+            _renewedCounter = meter.CreateCounter<int>(MetricsConstants.LeasesRenewed, MetricsConstants.Messages,
+                "Number of broker leases renewed while an envelope waited in a native-ack execution lane");
+            _lostCounter = meter.CreateCounter<int>(MetricsConstants.LeasesLost, MetricsConstants.Messages,
+                "Number of broker leases lost on an unsettled envelope, tagged by whether it had started executing");
+            _ceilingCounter = meter.CreateCounter<int>(MetricsConstants.LeaseCeilingReached, MetricsConstants.Messages,
+                "Number of envelopes that hit the maximum lease extension and stopped being renewed");
+        }
+
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        _loop = Task.Run(runAsync);
+    }
+
+    public TimeSpan Interval => _interval;
+
+    /// <summary>Number of envelopes whose lease is currently being kept alive</summary>
+    public int InFlightCount => _inFlight.Count;
+
+    /// <summary>Number of lease-lost envelopes still sitting in a lane waiting to be dropped</summary>
+    public int LostCount => _lost.Count;
+
+    // Local counters alongside the OTel instruments so tests -- and a debugger -- can read the same numbers
+    // without standing up a MeterListener.
+    public int LeasesRenewed { get; private set; }
+    public int LeasesLostBeforeStarting { get; private set; }
+    public int LeasesLostWhileExecuting { get; private set; }
+    public int CeilingsReached { get; private set; }
+
+    /// <summary>
+    ///     Start keeping this envelope's delivery alive. No-op unless it arrived on a lease-renewing listener.
+    /// </summary>
+    public void Track(Envelope envelope)
+    {
+        if (envelope.Listener is not ISupportLeaseRenewal renewal) return;
+
+        var receivedAt = envelope.ReceivedAt ?? DateTimeOffset.UtcNow;
+        _inFlight.TryAdd(envelope.Id, new Tracked(envelope, renewal, receivedAt));
+    }
+
+    /// <summary>
+    ///     The gate in front of <c>Pipeline.InvokeAsync</c>. Returns false when this envelope's lease is already
+    ///     gone and it must be dropped -- neither completed nor deferred. Returns true otherwise, and atomically
+    ///     marks the envelope as executing so a lease lost from here on is classified as realized duplication
+    ///     rather than prevented duplication.
+    /// </summary>
+    public bool TryBeginExecution(Envelope envelope)
+    {
+        if (_lost.ContainsKey(envelope.Id)) return false;
+
+        if (_inFlight.TryGetValue(envelope.Id, out var tracked))
+        {
+            lock (tracked.Gate)
+            {
+                // The tick can mark this lost between the _lost probe above and this lock; the same lock is
+                // what makes "lost or started" a single decision rather than a race.
+                if (tracked.IsLost) return false;
+                tracked.HasStarted = true;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Has this envelope's lease been lost? True for the whole time it is still in the lane, so a caller
+    ///     that has already started executing can suppress its defer -- deferring after the lease is gone
+    ///     republishes a second copy on top of the broker's redelivery.
+    /// </summary>
+    public bool WasLeaseLost(Envelope envelope)
+    {
+        return _lost.ContainsKey(envelope.Id);
+    }
+
+    /// <summary>
+    ///     This envelope has reached a terminal (or is being abandoned); stop renewing it.
+    /// </summary>
+    public void Untrack(Envelope envelope)
+    {
+        _inFlight.TryRemove(envelope.Id, out _);
+        _lost.TryRemove(envelope.Id, out _);
+    }
+
+    private async Task runAsync()
+    {
+        var token = _cancellation.Token;
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_interval, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (_inFlight.IsEmpty && _lost.IsEmpty) continue;
+
+            try
+            {
+                await TickAsync(token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Error renewing the broker leases of in-flight envelopes at {Uri}", _uri);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     One pass: retire anything past the ceiling, renew the rest, mark refusals lost, then infer loss for
+    ///     anything that has gone a full lease duration without a successful renewal. Exposed for tests.
+    /// </summary>
+    internal async Task TickAsync(CancellationToken token)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        sweepLostSet(now);
+
+        var due = new List<Tracked>();
+        foreach (var pair in _inFlight)
+        {
+            var tracked = pair.Value;
+
+            // Every renewal pushes the delivery out by a full lease, so stop before one would carry it past
+            // the maximum. Deliberately not a lost lease: the delivery may still finish inside what it holds.
+            if (now - tracked.ReceivedAt + _leaseDuration > _maximumExtension)
+            {
+                if (_inFlight.TryRemove(pair.Key, out _))
+                {
+                    CeilingsReached++;
+                    _ceilingCounter?.Add(1, _endpointTag);
+                    _logger.LogWarning(
+                        "Envelope {EnvelopeId} at {Uri} has been unsettled for {Elapsed} and will not have its broker lease renewed past the maximum of {Maximum}; the broker may redeliver it while it is still queued or being handled",
+                        tracked.Envelope.Id, _uri, now - tracked.ReceivedAt, _maximumExtension);
+                }
+
+                continue;
+            }
+
+            due.Add(tracked);
+        }
+
+        if (_requiresExplicitRenewal && due.Count > 0)
+        {
+            foreach (var group in due.GroupBy(x => x.Listener))
+            {
+                await renewGroupAsync(group.Key, group.ToArray(), token).ConfigureAwait(false);
+            }
+        }
+
+        // The second detector, and the only one available on a transport whose renewal call cannot report a
+        // per-message failure. Skipped when the transport renews for us -- there are no renewals to age.
+        if (_requiresExplicitRenewal)
+        {
+            inferLoss(DateTimeOffset.UtcNow);
+        }
+    }
+
+    private async Task renewGroupAsync(ISupportLeaseRenewal listener, Tracked[] group, CancellationToken token)
+    {
+        var envelopes = group.Select(x => x.Envelope).ToArray();
+
+        IReadOnlyList<Envelope> refused;
+        try
+        {
+            refused = await listener.RenewLeasesAsync(envelopes, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            // Transient by contract. Keep tracking and try again on the next tick -- a renewal that never
+            // lands is caught by the inferred detector below rather than by guessing here.
+            _logger.LogWarning(e, "Error renewing the broker leases of {Count} envelopes at {Uri}", group.Length, _uri);
+            return;
+        }
+
+        var refusedIds = refused.Count == 0 ? null : refused.Select(x => x.Id).ToHashSet();
+        var renewedAt = DateTimeOffset.UtcNow;
+
+        foreach (var tracked in group)
+        {
+            if (refusedIds != null && refusedIds.Contains(tracked.Envelope.Id))
+            {
+                markLost(tracked, renewedAt, "the broker refused to renew it");
+                continue;
+            }
+
+            lock (tracked.Gate)
+            {
+                tracked.LastRenewedAt = renewedAt;
+            }
+
+            LeasesRenewed++;
+            _renewedCounter?.Add(1, _endpointTag);
+        }
+    }
+
+    private void inferLoss(DateTimeOffset now)
+    {
+        foreach (var pair in _inFlight)
+        {
+            var tracked = pair.Value;
+            DateTimeOffset last;
+            lock (tracked.Gate)
+            {
+                last = tracked.LastRenewedAt;
+            }
+
+            if (now - last > _leaseDuration)
+            {
+                markLost(tracked, now, $"no renewal has succeeded for {now - last}");
+            }
+        }
+    }
+
+    private void markLost(Tracked tracked, DateTimeOffset now, string reason)
+    {
+        bool hadStarted;
+        lock (tracked.Gate)
+        {
+            if (tracked.IsLost) return;
+            tracked.IsLost = true;
+            hadStarted = tracked.HasStarted;
+        }
+
+        _inFlight.TryRemove(tracked.Envelope.Id, out _);
+        _lost.TryAdd(tracked.Envelope.Id, now);
+
+        if (hadStarted)
+        {
+            // Nothing to be done: a running handler cannot be un-run, and the broker is redelivering. Meter it
+            // so an operator sees realized duplication instead of inferring it.
+            LeasesLostWhileExecuting++;
+            _lostCounter?.Add(1, _endpointTag, ExecutingTag);
+            _logger.LogWarning(
+                "Lost the broker lease on envelope {EnvelopeId} at {Uri} after {Elapsed} while it was already executing ({Reason}). The broker owns this delivery again, so it may be handled more than once",
+                tracked.Envelope.Id, _uri, now - tracked.ReceivedAt, reason);
+        }
+        else
+        {
+            // The fixable case: NativeAckReceiver.executeAsync will drop it rather than run a second copy.
+            LeasesLostBeforeStarting++;
+            _lostCounter?.Add(1, _endpointTag, NotStartedTag);
+            _logger.LogWarning(
+                "Lost the broker lease on envelope {EnvelopeId} at {Uri} after {Elapsed} before it started executing ({Reason}). It will be dropped from the execution lane without being completed or deferred so that the broker's redelivery is the only remaining copy",
+                tracked.Envelope.Id, _uri, now - tracked.ReceivedAt, reason);
+        }
+    }
+
+    private void sweepLostSet(DateTimeOffset now)
+    {
+        if (_lost.IsEmpty) return;
+
+        foreach (var pair in _lost)
+        {
+            // Past the ceiling the envelope can no longer be in the lane for any reason this tracker cares
+            // about -- either it was dropped or its lane was drained with the receiver.
+            if (now - pair.Value > _maximumExtension)
+            {
+                _lost.TryRemove(pair.Key, out _);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellation.CancelAsync().ConfigureAwait(false);
+        try
+        {
+            // The loop exits on the next tick at the latest; bound the wait so disposing a receiver can never
+            // hang on it
+            await _loop.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Cancelled or timed out -- either way the loop is done with as far as we care
+        }
+
+        _inFlight.Clear();
+        _lost.Clear();
+        _cancellation.Dispose();
+    }
+
+    private static readonly KeyValuePair<string, object?> NotStartedTag =
+        new(MetricsConstants.LeaseLossStageKey, "not-started");
+
+    private static readonly KeyValuePair<string, object?> ExecutingTag =
+        new(MetricsConstants.LeaseLossStageKey, "executing");
+
+    private sealed class Tracked
+    {
+        public Tracked(Envelope envelope, ISupportLeaseRenewal listener, DateTimeOffset receivedAt)
+        {
+            Envelope = envelope;
+            Listener = listener;
+            ReceivedAt = receivedAt;
+            LastRenewedAt = receivedAt;
+        }
+
+        public Envelope Envelope { get; }
+        public ISupportLeaseRenewal Listener { get; }
+        public DateTimeOffset ReceivedAt { get; }
+
+        /// <summary>Guards the LastRenewedAt / HasStarted / IsLost transitions as one decision</summary>
+        public object Gate { get; } = new();
+
+        public DateTimeOffset LastRenewedAt { get; set; }
+        public bool HasStarted { get; set; }
+        public bool IsLost { get; set; }
+    }
+}

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
@@ -44,12 +45,20 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
     private readonly DurabilitySettings _settings;
     private bool _latched;
 
+    // GH-4048. Lazily built on the first delivery that arrives on a lease-renewing listener -- the listener does
+    // not exist yet at construction time, because ListeningAgent builds the receiver first and hands it to the
+    // listener. Null forever on a transport whose unsettled deliveries never expire (RabbitMQ, Redis Streams).
+    private readonly object _leaseGate = new();
+    private readonly Meter? _meter;
+    private LeaseRenewalTracker? _leases;
+
     public NativeAckReceiver(Endpoint endpoint, IWolverineRuntime runtime, IHandlerPipeline pipeline)
     {
         _endpoint = endpoint;
         Uri = endpoint.Uri;
         _logger = runtime.LoggerFactory.CreateLogger<NativeAckReceiver>();
         _settings = runtime.DurabilitySettings;
+        _meter = runtime.Meter;
         Pipeline = pipeline;
 
         // Guard against a listener-less envelope reaching either retry block -- env.Listener is null for the
@@ -98,11 +107,25 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
     /// <summary>CritterWatch#942 -- set when the receiving block faults terminally (jasperfx#506).</summary>
     public bool HasFaulted { get; private set; }
 
+    /// <summary>
+    /// GH-4048. The lease renewal tracker, if this endpoint's listener has one. Null until the first delivery
+    /// arrives on a lease-renewing listener, and forever on a transport whose deliveries do not expire.
+    /// </summary>
+    internal LeaseRenewalTracker? Leases => _leases;
+
     public void Dispose()
     {
         _receivingBlock.Complete();
         _completeBlock.Dispose();
         _deferBlock.Dispose();
+
+        // Fire and forget: the tracker's loop exits on its own cancellation and bounds its own wait, and
+        // IReceiver.Dispose is synchronous.
+        var leases = Interlocked.Exchange(ref _leases, null);
+        if (leases != null)
+        {
+            _ = leases.DisposeAsync().AsTask();
+        }
     }
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope[] messages)
@@ -145,11 +168,31 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
 
         var activity = _endpoint.TelemetryEnabled ? WolverineTracing.StartReceiving(envelope) : null;
 
+        // GH-4048. The risk window opens HERE, not when a handler starts: from this point the delivery is held
+        // unsettled for lane queue time plus handler time, and on a clocked transport that clock is already
+        // running. Untracked in executeAsync's finally.
+        leasesFor(listener)?.Track(envelope);
+
         // NOTE the absence of a _completeBlock.PostAsync here. That single line is what separates this mode
         // from BufferedInMemory: the delivery stays unacknowledged until the pipeline settles it.
         await _receivingBlock.PostAsync(envelope).ConfigureAwait(false);
 
         activity?.Stop();
+    }
+
+    private LeaseRenewalTracker? leasesFor(IListener listener)
+    {
+        var existing = _leases;
+        if (existing != null) return existing;
+
+        if (listener is not ISupportLeaseRenewal renewal) return null;
+
+        lock (_leaseGate)
+        {
+            // Every listener built for one endpoint reads the same configuration, so the durations only need
+            // to be read once; the renewal call still goes to whichever listener delivered the envelope.
+            return _leases ??= new LeaseRenewalTracker(renewal, Uri, _logger, _meter, _settings.Cancellation);
+        }
     }
 
     internal async Task executeAsync(Envelope envelope, CancellationToken _)
@@ -159,6 +202,22 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
             // Latched before this one started: hand it straight back to the broker instead of holding an
             // unacked delivery that nothing is going to process.
             await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
+            return;
+        }
+
+        // GH-4048. Sits deliberately NEXT TO the latched branch above and behaves in the opposite way. Latched
+        // still holds the lease, so handing the delivery back is correct. A lost lease does not: the broker owns
+        // it again and is redelivering it. Every transport's defer path is settle-then-republish -- SQS's requeue
+        // block deletes and re-sends, ASB's completes and re-sends, Pub/Sub's republishes -- so deferring here
+        // would put a SECOND copy on the queue on top of the redelivery. Completing is no better: a settle with a
+        // dead handle is either silently ignored (SQS) or a permanent failure inside a RetryBlock (ASB).
+        // Dropping is the only non-amplifying option, and it turns "handled twice" into "handled once, later".
+        if (_leases is { } leases && !leases.TryBeginExecution(envelope))
+        {
+            leases.Untrack(envelope);
+            _logger.LogDebug(
+                "Dropping envelope {EnvelopeId} from the native-ack lane at {Uri} without settling it; its broker lease was lost before it started executing",
+                envelope.Id, Uri);
             return;
         }
 
@@ -184,16 +243,35 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
                 // rung, and a faulted block never recovers. Swallow: the message fails, the listener survives.
             }
 
-            // The pipeline did not settle it, so the broker still owns it. Nack rather than leaving the
-            // delivery dangling until the connection drops.
-            try
+            // GH-4048. Suppressed when the lease was lost mid-execution. The broker is already redelivering
+            // this one, and every defer path settles-then-republishes, so a nack here would add a second copy
+            // on top of it. This envelope stays at-least-once -- a running handler cannot be un-run -- but the
+            // duplication is not compounded, and the tracker has already metered it as lost-while-executing.
+            if (_leases?.WasLeaseLost(envelope) == true)
             {
-                await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
+                _logger.LogDebug(
+                    "Not deferring envelope {EnvelopeId} at {Uri} after a failed pipeline invocation; its broker lease was lost while it was executing, so the broker already owns the delivery",
+                    envelope.Id, Uri);
             }
-            catch (Exception ex)
+            else
             {
-                _logger.LogError(ex, "Error trying to defer envelope {EnvelopeId} back to the broker", envelope.Id);
+                // The pipeline did not settle it, so the broker still owns it. Nack rather than leaving the
+                // delivery dangling until the connection drops.
+                try
+                {
+                    await _deferBlock.PostAsync(envelope).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error trying to defer envelope {EnvelopeId} back to the broker", envelope.Id);
+                }
             }
+        }
+        finally
+        {
+            // The risk window closes here: whatever the terminal was, this envelope is no longer waiting in a
+            // lane on a lease Wolverine has to keep alive.
+            _leases?.Untrack(envelope);
         }
     }
 
@@ -235,6 +313,14 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
         // prefetch window -- not loss. Quantifying that duplicate count under a rolling deploy is GH-3713.
         await _completeBlock.DrainAsync().ConfigureAwait(false);
         await _deferBlock.DrainAsync().ConfigureAwait(false);
+
+        // GH-4048. Nothing left to keep alive: whatever this drain could not process is unacked, so the broker
+        // gets it back on its own clock.
+        var leases = Interlocked.Exchange(ref _leases, null);
+        if (leases != null)
+        {
+            await leases.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private void onBlockError(Envelope? envelope, Exception ex)

--- a/src/Wolverine/Transports/IChannelCallback.cs
+++ b/src/Wolverine/Transports/IChannelCallback.cs
@@ -88,3 +88,51 @@ public interface IChannelCallback
         return Task.FromResult(false);
     }
 }
+
+/// <summary>
+/// GH-4048. Marks a listener whose broker puts a clock on an <em>unsettled</em> delivery -- SQS's visibility
+/// timeout, Azure Service Bus's lock duration, Pub/Sub's ack deadline, JetStream's AckWait -- so that
+/// <see cref="Wolverine.Configuration.EndpointMode.NativeAck" /> can keep that clock alive for as long as the
+/// envelope sits in an execution lane, rather than only while a handler runs.
+/// </summary>
+/// <remarks>
+/// The tick timing, the ceiling, the loss classification and the enforcement all live in core, in
+/// <c>LeaseRenewalTracker</c>. A transport contributes only the broker call plus the two durations that
+/// describe its clock. The matching endpoint-side declaration is <c>Endpoint.holdsExpiringLease</c>, and
+/// a NativeAck endpoint that declares an expiring lease without a listener implementing this interface
+/// fails at startup rather than silently generating duplicates.
+/// </remarks>
+public interface ISupportLeaseRenewal
+{
+    /// <summary>
+    ///     How long the broker's clock runs on one unsettled delivery. Each successful renewal re-arms it
+    ///     for this long, and the tracker ticks at half of it.
+    /// </summary>
+    TimeSpan LeaseDuration { get; }
+
+    /// <summary>
+    ///     Longest a single delivery may be kept alive, measured from its receipt. Broker-capped -- SQS, for
+    ///     instance, will not keep a message invisible for more than 12 hours. Reaching this stops renewal;
+    ///     it is deliberately NOT treated as a lost lease, because the delivery may still finish inside the
+    ///     lease it already holds.
+    /// </summary>
+    TimeSpan MaximumLeaseExtension { get; }
+
+    /// <summary>
+    ///     False when the transport's own client already renews for the whole time a delivery is unsettled
+    ///     (Pub/Sub's SubscriberClient does). Wolverine then issues no renewal calls at all and enforces only
+    ///     the ceiling.
+    /// </summary>
+    bool RequiresExplicitRenewal => true;
+
+    /// <summary>
+    ///     Re-arm the broker's clock on these deliveries. Returns the envelopes the broker would <b>not</b>
+    ///     renew -- their lease is gone and the broker owns them again.
+    /// </summary>
+    /// <remarks>
+    ///     Throwing is a <em>transient</em> failure (network, throttle) and is explicitly NOT a lost lease;
+    ///     the tracker keeps those envelopes and retries on the next tick. Report a lost lease only by
+    ///     returning the envelope in the result.
+    /// </remarks>
+    ValueTask<IReadOnlyList<Envelope>> RenewLeasesAsync(IReadOnlyList<Envelope> envelopes, CancellationToken token);
+}

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -445,12 +445,66 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             Listener = await Endpoint.BuildListenerAsync(_runtime, _receiver);
         }
 
+        assertLeaseRenewalContract(Listener);
+
         Status = ListeningStatus.Accepting;
         _runtime.Tracker.Publish(new ListenerState(Uri, Endpoint.EndpointName, Status));
 
         _logger.LogInformation("Started message listening at {Uri}", Uri);
 
         startInboxRecoveryIfNecessary();
+    }
+
+    /// <summary>
+    /// GH-4048. A NativeAck endpoint on a transport that puts a clock on an unsettled delivery MUST build a
+    /// lease-renewing listener. Without one, the delivery expires while the envelope is still sitting in an
+    /// execution lane and the broker redelivers it -- so the endpoint is a silent duplicate generator by
+    /// construction, not merely at risk under load. Failing at startup is the same treatment GH-3712 gave
+    /// silently-ignored listener settings.
+    /// </summary>
+    private void assertLeaseRenewalContract(IListener? listener)
+    {
+        if (Endpoint.Mode != EndpointMode.NativeAck) return;
+        if (!Endpoint.holdsExpiringLease) return;
+        if (listener == null) return;
+
+        foreach (var inner in flatten(listener))
+        {
+            if (inner is ISupportLeaseRenewal) continue;
+
+            throw new InvalidOperationException(
+                $"The listener for endpoint {Uri} ({inner.GetType().FullName}) is using EndpointMode.NativeAck on a transport whose unsettled deliveries expire, but it does not implement {nameof(ISupportLeaseRenewal)}. " +
+                "Under NativeAck a delivery stays unsettled for lane queue time plus handler time, so the broker's lease has to be renewed for the whole time the envelope is queued. " +
+                $"Implement {nameof(ISupportLeaseRenewal)} on the listener, or override Endpoint.holdsExpiringLease to false if this transport really does not expire an unsettled delivery.");
+        }
+    }
+
+    private static IEnumerable<IListener> flatten(IListener listener)
+    {
+        switch (listener)
+        {
+            case ParallelListener parallel:
+                foreach (var inner in parallel.InnerListeners)
+                foreach (var leaf in flatten(inner))
+                {
+                    yield return leaf;
+                }
+
+                break;
+
+            case CompoundListener compound:
+                foreach (var inner in compound.Inner)
+                foreach (var leaf in flatten(inner))
+                {
+                    yield return leaf;
+                }
+
+                break;
+
+            default:
+                yield return listener;
+                break;
+        }
     }
 
     /// <summary>

--- a/src/Wolverine/Transports/ParallelListener.cs
+++ b/src/Wolverine/Transports/ParallelListener.cs
@@ -14,6 +14,12 @@ public class ParallelListener : IListener, IDisposable
         _listeners.AddRange(listeners);
     }
 
+    /// <summary>
+    /// GH-4048. The listeners this one fans out to. Needed by ListeningAgent's lease-renewal contract check,
+    /// which has to look at the objects that actually own a broker delivery.
+    /// </summary>
+    internal IReadOnlyList<IListener> InnerListeners => _listeners;
+
     public void Dispose()
     {
         foreach (var listener in _listeners.OfType<IDisposable>()) listener.SafeDispose();


### PR DESCRIPTION
Closes #4048

Implements the design agreed on the issue: the core lease-renewal mechanism, plus Amazon SQS as the first implementer of the transport-side contract.

## Why

Under `EndpointMode.NativeAck` a broker delivery is held unsettled for **lane queue time plus handler time**, and lane queue time is unbounded by design — a deep lane is the feature. On SQS, ASB, Pub/Sub and JetStream the broker is running a clock on that delivery the whole time, so an un-renewed NativeAck endpoint on any of them is a duplicate-delivery generator by construction, not merely at risk under a slow handler.

The codebase already stated the soon-to-be-false assumption out loud, in `SqsListener.ShouldExtendVisibility`: *"neither holds a message under the visibility timeout while a handler runs."* That comment is corrected here.

## Core

- **`ISupportLeaseRenewal`** (`src/Wolverine/Transports/IChannelCallback.cs`) — a listener declares its clock (`LeaseDuration`, `MaximumLeaseExtension`, `RequiresExplicitRenewal`) and contributes one call, `RenewLeasesAsync`, which returns the subset it could **not** renew. Throwing is transient by contract and explicitly *not* a lost lease.
- **`LeaseRenewalTracker`** (new, `src/Wolverine/Runtime/WorkerQueues/`) — a straight generalization of `SqsVisibilityHeartbeat`. Ticks at half the lease floored at one second, sends nothing while the lanes are idle, groups renewals by the listener each envelope actually arrived on (`ListenerCount > 1`, per-tenant compound listeners), stops at the ceiling by untracking rather than forcing a settle, and infers loss when a full lease passes with no successful renewal — the only detector available to a transport whose renewal call cannot report per-message failure.
- **`NativeAckReceiver`** tracks on enqueue and untracks when `Pipeline.InvokeAsync` returns — the same `Track` / `finally Untrack` shape `SqsListener` already used for Inline.
- **`Endpoint.holdsExpiringLease`** plus a `ListeningAgent` startup throw when a NativeAck endpoint on a clocked transport builds a listener that cannot renew. Same treatment GH-3712 gave silently-ignored listener settings.

## Failure semantics — the part worth reading twice

- A lease-lost envelope that has **not** started executing is **dropped: no Complete, and critically no Defer.** Every transport's defer path is settle-then-republish — `SqsListener`'s requeue block does `if (!env.WasDeleted) await CompleteAsync(...)` then `sendOrDiscardAsync` — so deferring after the lease is gone adds a *second* copy on top of the redelivery the broker is already performing. Dropping is the only non-amplifying option, and it turns "handled twice" into "handled once, later". The lost-lease branch sits deliberately next to the existing `_latched` branch and behaves in the opposite way, because a latched receiver still *holds* the lease.
- An envelope already executing stays at-least-once — a running handler cannot be un-run. Its failure-path defer is suppressed for the same reason, and the event is metered so the number is visible rather than inferred.

## Metering

`wolverine-leases-renewed`, `wolverine-leases-lost` (tagged `lease.loss.stage` = `not-started` vs `executing` — prevented duplication vs realized duplication), `wolverine-lease-ceiling-reached`.

## Amazon SQS

- `SqsListener` implements `ISupportLeaseRenewal` over the existing `extendVisibilityAsync`. Its per-entry `ChangeMessageVisibilityBatch` failure handling already produces exactly the "could not renew" subset the contract wants; one envelope can be several SQS messages after GH-3926 fragment reassembly, and any refused fragment loses the lease for the whole envelope.
- **Unconditional for NativeAck.** `ExtendVisibilityWhileHandling` is not consulted for that mode — an opt-in default-false flag means "off by default" for the one mode that cannot survive it. Inline behaviour and its opt-in flag are unchanged.
- `AmazonSqsQueue.holdsExpiringLease => true`; the three stale comments (`ShouldExtendVisibility`, `SqsVisibilityHeartbeat`'s remarks, `ExtendVisibilityWhileHandling`'s XML doc) are corrected.

**Note on `ShouldExtendVisibility`:** the design sketch had it return `true` for NativeAck. It stays Inline-only here, deliberately and with the reasoning in the code: that heartbeat's `Track`/`Untrack` pair straddles `IReceiver.ReceivedAsync`, which under NativeAck returns the instant the envelope is *enqueued* — i.e. exactly when the risk window opens — so a second tick loop there would renew nothing while duplicating the loop §1 rejected Option A for. The mandate is honoured where it matters: `RenewLeasesAsync` never consults the flag. Both loops share `extendVisibilityAsync`.

## Out of scope

`supportsNativeAck => true` on `AmazonSqsQueue` stays with **#4050**, which owns the FIFO verdict, the `MaxNumberOfMessages` prefetch tuning and the release-gate flip. ASB (#4051), Pub/Sub (#4052) and JetStream (#4053) are untouched.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings.
- Full CoreTests: 2571 passed, 0 failed.
- Full `Wolverine.AmazonSqs.Tests` against LocalStack: 314 passed, 0 failed.
- `Wolverine.RabbitMQ.Tests.native_ack_mode`: 3 passed (RabbitMQ has no clock, so the startup guard must not fire — and does not).

**Red-baselined**, every one individually: dropping the enforcement branch, the defer suppression, the startup guard, the ceiling check, the transient-throw policy, the inferred detector, the per-listener grouping, the not-started/executing split, and SQS's `RenewLeasesAsync` each fail exactly the test that claims to cover it and nothing else. The SQS suite carries its own negative control — the same run with renewal off must produce a redelivery — because a green positive alone would also pass on a machine fast enough to finish inside the visibility timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
