### PR TITLE
GH-3709: native-ack global partitioning cluster + failover tests and docs

### DIFF
--- a/docs/guide/messaging/partitioning.md
+++ b/docs/guide/messaging/partitioning.md
@@ -382,6 +382,10 @@ The example above uses the listener's default mode. Note what each mode costs yo
 The ordering guarantee is the same in every mode that supports it: messages sharing a group id never execute
 concurrently. Strict processing in original delivery order is *not* promised under failure or redelivery in any
 non-durable mode.
+
+Everything above is per *listener*. The cluster-wide equivalent -- one consumer per slot across every node,
+with the same database-free ack behaviour -- is
+[native ack global partitioning](#native-ack-global-partitioning).
 :::
 
 ## Exempting Message Types from Partitioned Processing <Badge type="tip" text="6.26" />
@@ -618,7 +622,8 @@ When you configure global partitioning, Wolverine:
 3. **Support for modular monoliths** -- You can configure multiple global partitioning topologies for the same message type in different modules. Each module can have its own set of sharded queues and routing rules, allowing independent sequential processing pipelines within a single application.
 
 ::: tip
-In single-node mode, global partitioning automatically shortcuts all messages to the companion local queues since the current node owns all listeners.
+In single-node mode, global partitioning automatically shortcuts all messages to the companion local queues since the current node owns all listeners. The shortcut is disabled under
+[`ProcessInParallelWithNativeAcks()`](#native-ack-global-partitioning), which has no companion local queues and where the broker delivery *is* the durability story -- every send goes through the broker even when this node owns the slot.
 :::
 
 ### Configuration
@@ -654,7 +659,7 @@ A couple of transport-specific notes:
 
 * **Kafka** -- all nodes listening to the sharded topics share a single Kafka consumer group named after the base name so that Kafka assigns each topic's partitions exclusively to one consumer at a time. Wolverine stamps that consumer group id onto the `GroupId` of incoming envelopes by default, which you can turn off per listener with `DisableConsumerGroupIdStamping()` when the consumer group name is not meaningful as envelope metadata (e.g. when combined with `PropagateGroupIdToPartitionKey()`).
 * **Azure Service Bus** -- the broker's native [session identifiers](/guide/messaging/transports/azureservicebus/session-identifiers) provide strictly ordered, per-session processing with a single queue and may be a simpler alternative if you are exclusively on Azure Service Bus. Global partitioning is the transport-agnostic option that behaves the same way across every broker in the table above.
-* **PostgreSQL / Sql Server** -- the database queues need no extra infrastructure at all; each shard is just another pair of tables in the database you already have. They are inherently durable, which suits global partitioning since the topology forces `EndpointMode.Durable` on every slot anyway. The Sql Server shard queues additionally opt into the [`seq`-clustered high-throughput table layout](/guide/durability/sqlserver#optimizing-queue-throughput) by default.
+* **PostgreSQL / Sql Server** -- the database queues need no extra infrastructure at all; each shard is just another pair of tables in the database you already have. They are inherently durable, which suits global partitioning since the topology defaults every slot to `EndpointMode.Durable`. The Sql Server shard queues additionally opt into the [`seq`-clustered high-throughput table layout](/guide/durability/sqlserver#optimizing-queue-throughput) by default.
 
 ### Example with RabbitMQ
 
@@ -687,6 +692,86 @@ using var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Samples.cs#L718-L744' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_global_partitioned_with_rabbit_mq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+### Native Ack Global Partitioning <Badge type="tip" text="6.30" />
+
+By default every slot in a global partitioned topology is `EndpointMode.Durable`, and the external listener
+is bridged into a companion local queue that does the actual partitioned execution. That is a database write
+per message on the way in (inbox insert) and another on the way out (mark handled), and the broker is
+acknowledged as soon as the inbox row lands -- long before the handler runs.
+
+`ProcessInParallelWithNativeAcks()` removes both the database and the bridge:
+
+```csharp
+opts.MessagePartitioning
+    .ByMessage<WebhookEvent>(x => x.EntityId)
+    .GlobalPartitioned(topology =>
+    {
+        topology.UseShardedRabbitQueues("webhooks", 5);
+        topology.Message<WebhookEvent>();
+
+        // Each slot listener settles its own broker deliveries and shards
+        // into sequential lanes by group id in memory. No companion local
+        // queues, no bridge, no inbox.
+        topology.ProcessInParallelWithNativeAcks();
+    });
+```
+
+Each slot listener now holds its broker delivery **unacknowledged** until the handler reaches a terminal, and
+shards incoming messages into sequential lanes by group id inside its own receiver. The transport has to opt
+in to `EndpointMode.NativeAck`; RabbitMQ does, and a transport that does not will fail fast at bootstrap
+naming the endpoint. See [Native Ack Endpoints](/guide/messaging/listeners#native-ack-endpoints).
+
+#### The guarantee
+
+**No two messages sharing a group id execute concurrently.** Within a node the sequential lane inside the
+slot's receiver enforces it; across the cluster the exclusive slot listener enforces it, because exactly one
+node consumes a given slot.
+
+Delivery is **at-least-once**, owned by the broker rather than by the inbox: anything received but not yet
+settled is redelivered if the node dies or the channel drops, so nothing is lost, and a handler may see a
+duplicate. Ordering is **per-slot best effort, not per-group guaranteed** -- redelivery or requeue may
+reorder. And the caveat from the durable topology still applies unchanged: the ordering unit is the **slot**,
+not the group, so two group ids that hash to the same slot serialize against each other.
+
+#### When to choose it over the durable default
+
+Reach for it when the traffic is a flood that the database cannot absorb -- webhook storms, telemetry,
+event fan-in -- and the handler's own work is what actually needs to be durable, not the transport hop.
+Concretely you are trading:
+
+| | Durable slots (default) | `ProcessInParallelWithNativeAcks()` |
+|---|---|---|
+| Database per message | inbox insert + mark handled | none |
+| Broker ack timing | at inbox insert, before the handler | at handler completion |
+| Loss on node death | none | none (redelivered) |
+| Duplicates | suppressed by inbox dedup | possible; handlers must tolerate them |
+| Outbox atomicity with handler side effects | yes | no |
+| Recovery of stranded messages | inbox recovery | broker redelivery |
+| Back pressure | in-process listener circuit | the broker's prefetch window |
+
+Because there is no inbox, there is also no inbox dedup and no outbox atomicity between a handler's database
+work and the messages it publishes. Handlers must be idempotent.
+
+#### Failover caveat
+
+Slot failover is the one place where the cluster-wide half of the guarantee is actually load bearing. When a
+slot moves nodes, the outgoing node stops **and drains** its listener -- it finishes the handlers already
+running and settles them -- before the leader is allowed to start the slot anywhere else. Only then does the
+incoming node begin pulling. That drain is what keeps a group from running in two places at once across a
+handoff, and it is why a redelivery after failover lands on the new owner rather than alongside the old one.
+
+The price is that a slot is briefly unconsumed during the handoff, and that in-flight messages the drain
+could not finish inside `DurabilitySettings.DrainTimeout` are redelivered rather than completed. Both are
+consistent with at-least-once; neither is consistent with "exactly once".
+
+::: warning Slot ownership still needs somewhere to coordinate
+The *messages* touch no database in this mode, but Wolverine's dynamic one-consumer-per-slot assignment is
+done by the node agent framework, which needs a message store to persist node records and agent assignments
+-- that is, `DurabilityMode.Balanced`. A host with no message store at all runs in `DurabilityMode.Solo`,
+where *every* node starts *every* listener, so a multi-node storage-free deployment has to assign slots to
+nodes itself (each node listening only to the slots it owns). Single-node deployments are unaffected.
+:::
 
 ### Excluding Message Types <Badge type="tip" text="6.25" />
 
@@ -735,6 +820,11 @@ Wolverine validates global partitioning configuration at startup. It will throw 
 - No message type matching policies are configured
 - No external transport topology is configured
 - The external and local topologies have different shard counts
+
+The last rule does not apply to a [native ack topology](#native-ack-global-partitioning), which deliberately
+has no companion local topology at all. Calling `LocalQueues()` and `ProcessInParallelWithNativeAcks()`
+together throws, as does `Mode(EndpointMode.NativeAck)` -- that would set the mode while leaving the bridge in
+place, and a local queue has no broker delivery to settle.
 
 ### Native Per-Transport Alternatives
 

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/latched_receiver_contract_3709.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/latched_receiver_contract_3709.cs
@@ -1,0 +1,56 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Shouldly;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-3709. <c>ListeningAgent.LatchReceiver()</c> used to be an if/else chain naming
+/// <c>DurableReceiver</c>, <c>BufferedReceiver</c> and <c>InlineReceiver</c> one at a time. When GH-3708
+/// added <see cref="NativeAckReceiver" /> the chain silently skipped it, and the consequence was not a
+/// compile error or an exception but a stop-and-drain that stopped waiting: an unlatched receiver's
+/// <c>DrainAsync</c> returns immediately, so the transport channel closed underneath running handlers, every
+/// unsettled delivery went back to the broker, and on an exclusive listener handoff the incoming node re-ran
+/// those messages concurrently with the outgoing one -- precisely the intra-group concurrency that
+/// partitioned processing exists to prevent.
+/// </summary>
+public class latched_receiver_contract_3709
+{
+    /// <summary>
+    /// A receiver that knows how to latch has to say so through <c>ILatchedReceiver</c>, because that is the
+    /// only thing <c>LatchReceiver()</c> looks at now. A <c>Latch()</c> method that no caller can see is the
+    /// exact shape of the original bug.
+    /// </summary>
+    [Fact]
+    public void every_receiver_that_can_latch_declares_ILatchedReceiver()
+    {
+        var offenders = typeof(IReceiver).Assembly
+            .GetTypes()
+            .Where(x => x is { IsClass: true, IsAbstract: false } && x.CanBeCastTo<IReceiver>())
+            .Where(x => x.GetMethod("Latch", Type.EmptyTypes) != null)
+            .Where(x => !x.CanBeCastTo<ILatchedReceiver>())
+            .Select(x => x.FullNameInCode())
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            "These receivers have a Latch() method that ListeningAgent.LatchReceiver() cannot see: "
+            + offenders.Join(", "));
+    }
+
+    /// <summary>
+    /// And the four that exist today are all wired up, so the guard above is asserting against a non-empty
+    /// population rather than passing vacuously.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(DurableReceiver))]
+    [InlineData(typeof(BufferedReceiver))]
+    [InlineData(typeof(InlineReceiver))]
+    [InlineData(typeof(NativeAckReceiver))]
+    public void the_known_receivers_are_latchable(Type receiverType)
+    {
+        receiverType.CanBeCastTo<ILatchedReceiver>().ShouldBeTrue();
+    }
+}

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_receiver.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_receiver.cs
@@ -25,8 +25,14 @@ public class NativeAckPingHandler
     /// <summary>Gate so a test can observe the receiver mid-flight without Task.Delay. </summary>
     public static TaskCompletionSource? Gate;
 
+    /// <summary>Signals that the handler has actually started, so a test can latch mid-flight rather than
+    /// racing the block.</summary>
+    public static TaskCompletionSource? Entered;
+
     public async Task Handle(NativeAckPing message)
     {
+        Entered?.TrySetResult();
+
         if (Gate != null)
         {
             await Gate.Task;
@@ -56,11 +62,13 @@ public class native_ack_receiver : IAsyncLifetime
         theRuntime = _host.Services.GetRequiredService<IWolverineRuntime>();
         NativeAckPingHandler.Handled.Clear();
         NativeAckPingHandler.Gate = null;
+        NativeAckPingHandler.Entered = null;
     }
 
     public async ValueTask DisposeAsync()
     {
         NativeAckPingHandler.Gate = null;
+        NativeAckPingHandler.Entered = null;
         await _host.StopAsync();
         _host.Dispose();
     }
@@ -135,6 +143,42 @@ public class native_ack_receiver : IAsyncLifetime
         listener.Deferred.Count.ShouldBe(1);
         listener.Completed.Count.ShouldBe(0);
         NativeAckPingHandler.Handled.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// GH-3709. The half of the drain contract that an exclusive listener handoff depends on: once the
+    /// receiver has been latched, <c>DrainAsync</c> must not report done while a handler is still running.
+    /// If it returns early the listener is disposed underneath live work, the still-unsettled deliveries go
+    /// back to the broker, and the node taking the listener over runs them concurrently with the node that
+    /// is still finishing them.
+    /// </summary>
+    [Fact]
+    public async Task draining_a_latched_receiver_waits_for_the_in_flight_handler()
+    {
+        var receiver = receiverFor();
+        var listener = new RecordingListener();
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        NativeAckPingHandler.Gate = gate;
+        NativeAckPingHandler.Entered = entered;
+
+        await receiver.ReceivedAsync(listener, pingEnvelope("in-flight"));
+        await entered.Task.WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        receiver.Latch();
+        var drain = receiver.DrainAsync().AsTask();
+
+        var raced = await Task.WhenAny(drain, Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken));
+        raced.ShouldNotBeSameAs(drain);
+
+        gate.SetResult();
+
+        await drain.WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        listener.Completed.Count.ShouldBe(1);
+        listener.Deferred.Count.ShouldBe(0);
+        NativeAckPingHandler.Handled.ShouldContain("in-flight");
     }
 
     /// <summary>

--- a/src/Testing/CoreTests/Runtime/pooled_outgoing_envelope_metrics_race_3709.cs
+++ b/src/Testing/CoreTests/Runtime/pooled_outgoing_envelope_metrics_race_3709.cs
@@ -1,0 +1,130 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Transports.Sending;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+/// <summary>
+/// GH-3709. <see cref="BufferedSendingAgent" /> hands out POOLED outgoing envelopes
+/// (<c>WolverineRuntime.AcquireOutgoingEnvelope</c>, wolverine#2955) and its <c>storeAndForwardAsync</c> does
+/// nothing but post the envelope to an in-memory block. The block's consumer then sends it, succeeds, and
+/// returns it to the pool -- <c>Envelope.Reset()</c>, which nulls <c>Destination</c> and <c>MessageType</c> --
+/// which means any read of that envelope after the post is a data race with a thread that is actively
+/// blanking it.
+/// </summary>
+/// <remarks>
+/// The read that existed was <c>_messageLogger.Sent(envelope)</c> at the end of
+/// <c>SendingAgent.StoreAndForwardAsync</c>, and the symptom was an intermittent
+/// <see cref="NullReferenceException" /> out of <c>Envelope.ToMetricsHeaders()</c>: <c>Destination</c> passed
+/// its own null guard and was null one line later at <c>Destination.ToString()</c>. It reproduced roughly one
+/// run in four in the GH-3709 RabbitMQ suites, because <see cref="Wolverine.Configuration.EndpointMode.NativeAck" />
+/// maps to <see cref="BufferedSendingAgent" />, but nothing about it is native-ack specific -- any
+/// BufferedInMemory endpoint under concurrent publishing could hit it.
+/// </remarks>
+public class pooled_outgoing_envelope_metrics_race_3709 : IAsyncLifetime
+{
+    private const int Messages = 2000;
+
+    private IHost _host = null!;
+    private WolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.DisableConventionalDiscovery())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    /// <summary>
+    /// The real <see cref="WolverineRuntime" /> message tracker is deliberately used rather than a
+    /// substitute: <c>Sent()</c> is what walks the envelope to build its metric tags, so it is the thing
+    /// that actually observes a half-blanked envelope.
+    /// </summary>
+    [Fact]
+    public async Task metrics_never_observe_a_recycled_envelope_under_concurrent_buffered_sends()
+    {
+        var endpoint = new StubEndpoint("pooled-metrics-3709", new StubTransport());
+        var sender = new ImmediateSender(endpoint.Uri);
+
+        var agent = new BufferedSendingAgent(NullLogger.Instance, theRuntime.MessageTracking, sender,
+            theRuntime.DurabilitySettings, endpoint, theRuntime, null);
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, Messages),
+            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+            async (i, _) =>
+            {
+                var envelope = theRuntime.AcquireOutgoingEnvelope(agent);
+
+                // Only a pooled envelope can be recycled out from under the caller, so a run where the pool
+                // gate declined would prove nothing.
+                envelope.FromPool.ShouldBeTrue();
+
+                envelope.Message = new PooledMetricsProbe(i);
+                envelope.Destination = endpoint.Uri;
+                envelope.Sender = agent;
+
+                await agent.StoreAndForwardAsync(envelope);
+            });
+
+        // Nothing to assert beyond "it did not throw" -- the failure mode is a NullReferenceException raised
+        // inside the send, which Parallel.ForEachAsync surfaces straight out of the await above. Confirm the
+        // sends really happened so a silently latched agent cannot pass this vacuously.
+        await sender.WaitForAtLeastAsync(Messages, 30.Seconds());
+
+        sender.Count.ShouldBeGreaterThanOrEqualTo(Messages);
+    }
+
+    public record PooledMetricsProbe(int Number);
+
+    /// <summary>
+    /// Sends synchronously and does nothing else, so the block's consumer gets back to
+    /// <c>sendWithExplicitHandlingAsync</c> -- and therefore to the pool release -- as fast as possible. That
+    /// is what makes the race wide enough to catch.
+    /// </summary>
+    private class ImmediateSender : ISender
+    {
+        private int _count;
+
+        public ImmediateSender(Uri destination)
+        {
+            Destination = destination;
+        }
+
+        public int Count => Volatile.Read(ref _count);
+
+        public bool SupportsNativeScheduledSend => false;
+        public Uri Destination { get; }
+
+        public Task<bool> PingAsync() => Task.FromResult(true);
+
+        public ValueTask SendAsync(Envelope envelope)
+        {
+            Interlocked.Increment(ref _count);
+            return ValueTask.CompletedTask;
+        }
+
+        public async Task WaitForAtLeastAsync(int count, TimeSpan timeout)
+        {
+            var deadline = DateTimeOffset.UtcNow.Add(timeout);
+            while (Count < count && DateTimeOffset.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+        }
+    }
+}

--- a/src/Testing/CoreTests/Runtime/pooled_outgoing_envelope_metrics_race_3709.cs
+++ b/src/Testing/CoreTests/Runtime/pooled_outgoing_envelope_metrics_race_3709.cs
@@ -2,8 +2,10 @@ using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Shouldly;
 using Wolverine;
+using Wolverine.Logging;
 using Wolverine.Runtime;
 using Wolverine.Transports.Sending;
 using Wolverine.Transports.Stub;
@@ -15,18 +17,21 @@ namespace CoreTests.Runtime;
 /// GH-3709. <see cref="BufferedSendingAgent" /> hands out POOLED outgoing envelopes
 /// (<c>WolverineRuntime.AcquireOutgoingEnvelope</c>, wolverine#2955) and its <c>storeAndForwardAsync</c> does
 /// nothing but post the envelope to an in-memory block. The block's consumer then sends it, succeeds, and
-/// returns it to the pool -- <c>Envelope.Reset()</c>, which nulls <c>Destination</c> and <c>MessageType</c> --
-/// which means any read of that envelope after the post is a data race with a thread that is actively
+/// returns it to the pool -- <c>Envelope.Reset()</c>, which nulls <c>Destination</c> and <c>MessageType</c>
+/// and clears <c>FromPool</c> -- so any read of that envelope after the post races a thread that is actively
 /// blanking it.
 /// </summary>
 /// <remarks>
-/// The read that existed was <c>_messageLogger.Sent(envelope)</c> at the end of
+/// <para>The read that existed was <c>_messageLogger.Sent(envelope)</c> at the end of
 /// <c>SendingAgent.StoreAndForwardAsync</c>, and the symptom was an intermittent
 /// <see cref="NullReferenceException" /> out of <c>Envelope.ToMetricsHeaders()</c>: <c>Destination</c> passed
-/// its own null guard and was null one line later at <c>Destination.ToString()</c>. It reproduced roughly one
-/// run in four in the GH-3709 RabbitMQ suites, because <see cref="Wolverine.Configuration.EndpointMode.NativeAck" />
-/// maps to <see cref="BufferedSendingAgent" />, but nothing about it is native-ack specific -- any
-/// BufferedInMemory endpoint under concurrent publishing could hit it.
+/// its own null guard and was null one line later at <c>Destination.ToString()</c>.</para>
+///
+/// <para>It was found through <see cref="Wolverine.Configuration.EndpointMode.NativeAck" />, which mapped to
+/// <see cref="BufferedSendingAgent" /> at the time. GH-4061 has since moved NativeAck onto
+/// <see cref="InlineSendingAgent" />, so that particular trigger is gone -- but nothing about the race was
+/// ever native-ack specific. The remaining exposure is any BufferedInMemory endpoint, which is what both
+/// tests below drive.</para>
 /// </remarks>
 public class pooled_outgoing_envelope_metrics_race_3709 : IAsyncLifetime
 {
@@ -50,36 +55,89 @@ public class pooled_outgoing_envelope_metrics_race_3709 : IAsyncLifetime
         _host.Dispose();
     }
 
+    private static StubEndpoint bufferedEndpoint() => new("pooled-metrics-3709", new StubTransport());
+
+    private BufferedSendingAgent agentFor(StubEndpoint endpoint, ISender sender, IMessageTracker tracker)
+    {
+        return new BufferedSendingAgent(NullLogger.Instance, tracker, sender, theRuntime.DurabilitySettings,
+            endpoint, theRuntime, null);
+    }
+
+    private Envelope pooledEnvelopeFor(BufferedSendingAgent agent, Uri destination, int number)
+    {
+        var envelope = theRuntime.AcquireOutgoingEnvelope(agent);
+
+        // Only a pooled envelope can be recycled out from under the caller, so a run where the pool gate
+        // declined would prove nothing.
+        envelope.FromPool.ShouldBeTrue();
+
+        envelope.Message = new PooledMetricsProbe(number);
+        envelope.Destination = destination;
+        envelope.Sender = agent;
+
+        return envelope;
+    }
+
     /// <summary>
-    /// The real <see cref="WolverineRuntime" /> message tracker is deliberately used rather than a
-    /// substitute: <c>Sent()</c> is what walks the envelope to build its metric tags, so it is the thing
-    /// that actually observes a half-blanked envelope.
+    /// The deterministic statement of the fix: for a pooled envelope the metrics read happens BEFORE the
+    /// envelope is handed to the sending block, so the recycle can never get there first.
+    /// </summary>
+    /// <remarks>
+    /// The gate is what makes this deterministic rather than a race the test hopes to lose. The stand-in
+    /// tracker spins inside <c>Sent()</c> until the envelope has been recycled -- <c>FromPool</c> is cleared
+    /// by <c>Envelope.Reset()</c>, so it is the recycle flag -- or a short deadline passes. With the fix
+    /// nothing has been posted yet when <c>Sent()</c> runs, so no recycle is possible, the spin times out and
+    /// the envelope is read intact. Without it, <c>Sent()</c> runs after the post and the spin waits for
+    /// exactly the recycle it is racing, so <c>Destination</c> is reliably null by the time it is read.
+    /// </remarks>
+    [Fact]
+    public async Task a_pooled_envelope_is_read_for_metrics_before_it_is_handed_to_the_sending_block()
+    {
+        var endpoint = bufferedEndpoint();
+        var tracker = Substitute.For<IMessageTracker>();
+
+        Uri? observedDestination = null;
+        var observedAtAll = false;
+
+        tracker.When(x => x.Sent(Arg.Any<Envelope>())).Do(call =>
+        {
+            var envelope = call.Arg<Envelope>();
+
+            var deadline = DateTimeOffset.UtcNow.Add(2.Seconds());
+            while (envelope.FromPool && DateTimeOffset.UtcNow < deadline)
+            {
+                Thread.Sleep(1);
+            }
+
+            observedDestination = envelope.Destination;
+            observedAtAll = true;
+        });
+
+        var agent = agentFor(endpoint, new ImmediateSender(endpoint.Uri), tracker);
+
+        await agent.StoreAndForwardAsync(pooledEnvelopeFor(agent, endpoint.Uri, 0));
+
+        observedAtAll.ShouldBeTrue("The message tracker was never called at all");
+        observedDestination.ShouldBe(endpoint.Uri,
+            "The metrics hook observed a recycled envelope -- the pooled read must happen before the handoff");
+    }
+
+    /// <summary>
+    /// The same invariant against the REAL <see cref="WolverineRuntime" /> message tracker under concurrency,
+    /// because <c>Sent()</c> is what actually walks the envelope to build its metric tags. This is the shape
+    /// the bug was originally caught in, so it stays -- but it is a probabilistic reproduction that depends on
+    /// machine load, which is why the deterministic gate above is the real guard.
     /// </summary>
     [Fact]
     public async Task metrics_never_observe_a_recycled_envelope_under_concurrent_buffered_sends()
     {
-        var endpoint = new StubEndpoint("pooled-metrics-3709", new StubTransport());
+        var endpoint = bufferedEndpoint();
         var sender = new ImmediateSender(endpoint.Uri);
-
-        var agent = new BufferedSendingAgent(NullLogger.Instance, theRuntime.MessageTracking, sender,
-            theRuntime.DurabilitySettings, endpoint, theRuntime, null);
+        var agent = agentFor(endpoint, sender, theRuntime.MessageTracking);
 
         await Parallel.ForEachAsync(Enumerable.Range(0, Messages),
             new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
-            async (i, _) =>
-            {
-                var envelope = theRuntime.AcquireOutgoingEnvelope(agent);
-
-                // Only a pooled envelope can be recycled out from under the caller, so a run where the pool
-                // gate declined would prove nothing.
-                envelope.FromPool.ShouldBeTrue();
-
-                envelope.Message = new PooledMetricsProbe(i);
-                envelope.Destination = endpoint.Uri;
-                envelope.Sender = agent;
-
-                await agent.StoreAndForwardAsync(envelope);
-            });
+            async (i, _) => await agent.StoreAndForwardAsync(pooledEnvelopeFor(agent, endpoint.Uri, i)));
 
         // Nothing to assert beyond "it did not throw" -- the failure mode is a NullReferenceException raised
         // inside the send, which Parallel.ForEachAsync surfaces straight out of the await above. Confirm the
@@ -93,8 +151,7 @@ public class pooled_outgoing_envelope_metrics_race_3709 : IAsyncLifetime
 
     /// <summary>
     /// Sends synchronously and does nothing else, so the block's consumer gets back to
-    /// <c>sendWithExplicitHandlingAsync</c> -- and therefore to the pool release -- as fast as possible. That
-    /// is what makes the race wide enough to catch.
+    /// <c>sendWithExplicitHandlingAsync</c> -- and therefore to the pool release -- as fast as possible.
     /// </summary>
     private class ImmediateSender : ISender
     {

--- a/src/Testing/Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs
@@ -1,0 +1,248 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Wolverine.ComplianceTests.Partitioning;
+
+/// <summary>
+/// GH-3709. The transport-agnostic harness for <c>ProcessInParallelWithNativeAcks()</c> on a global
+/// partitioned topology, in the same spirit as <see cref="ShardedProcessing" /> (GH-3467): a transport
+/// suite supplies only its own <c>UseSharded*()</c> call and the cluster shape, and everything else --
+/// the message type, the handler, the group ledger, the publishing burst, the assertions -- lives here.
+/// </summary>
+/// <remarks>
+/// <para><b>The guarantee under test, stated exactly:</b> no two messages sharing a group id execute
+/// concurrently. Within a node the sequential lane inside the slot's own receiver enforces it; across the
+/// cluster the exclusive slot listener enforces it, because exactly one node consumes a given slot.</para>
+///
+/// <para>Ordering is per-slot best effort, <b>not</b> per-group guaranteed: redelivery or requeue may
+/// reorder, and the ordering unit is the <b>slot</b>, not the group -- two groups hashing to the same slot
+/// serialize against each other. Nothing here asserts ordering.</para>
+///
+/// <para>Delivery is at-least-once and owned by the broker rather than by the inbox, so the completeness
+/// assertion is <see cref="AssertEveryLetterWasHandled" /> -- every published letter seen <i>at least</i>
+/// once. Duplicates are legal.</para>
+/// </remarks>
+public static class NativeAckPartitionedProcessing
+{
+    /// <summary>
+    /// The shared, cluster-wide ledger. Every host in a multi-node test runs in this same process, which is
+    /// exactly what makes a genuinely cluster-wide concurrency assertion possible.
+    /// </summary>
+    public static GroupConcurrencyLedger Ledger { get; } = new();
+
+    /// <summary>
+    /// How long each handler holds its group. This is the width of the window a concurrency violation has to
+    /// land in, so a test that wants to *catch* overlap needs it comfortably longer than the broker round trip.
+    /// </summary>
+    public static TimeSpan Dwell { get; set; } = 50.Milliseconds();
+
+    /// <summary>
+    /// Set up partitioning rules and handler discovery for <see cref="NativeAckLetter" />, then call the
+    /// transport's own <c>UseSharded*()</c> plus <c>ProcessInParallelWithNativeAcks()</c> inside
+    /// <paramref name="configureTopology" />.
+    /// </summary>
+    public static void UseNativeAckLetters(this WolverineOptions opts, string nodeName,
+        Action<Runtime.Partitioning.GlobalPartitionedMessageTopology> configureTopology)
+    {
+        opts.ServiceName = nodeName;
+
+        opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(NativeAckLetterHandler));
+        opts.Services.AddSingleton(new NativeAckNodeMarker(nodeName));
+
+        opts.MessagePartitioning.ByMessage<NativeAckLetter>(x => x.GroupId);
+
+        opts.MessagePartitioning.GlobalPartitioned(topology =>
+        {
+            configureTopology(topology);
+            topology.Message<NativeAckLetter>();
+        });
+    }
+
+    /// <summary>
+    /// Publish <paramref name="messagesPerGroup" /> letters for each of <paramref name="groupCount" /> group
+    /// ids, spreading the publishing across every host so no single node is the sole producer.
+    /// </summary>
+    /// <param name="busSources">
+    /// One factory per host, not one bus per host: an <see cref="IMessageBus" /> is scoped and is not built to
+    /// be shared across concurrent invocations, so each parallel publisher below resolves its own.
+    /// </param>
+    public static async Task<IReadOnlyList<(string GroupId, int Sequence)>> PumpOutLettersAsync(
+        IReadOnlyList<Func<IMessageBus>> busSources, int groupCount, int messagesPerGroup)
+    {
+        var published = new ConcurrentQueue<(string, int)>();
+
+        var groups = Enumerable.Range(0, groupCount).Select(_ => Guid.NewGuid().ToString()).ToArray();
+
+        await Parallel.ForEachAsync(groups, async (groupId, _) =>
+        {
+            var buses = busSources.Select(x => x()).ToArray();
+
+            for (var i = 0; i < messagesPerGroup; i++)
+            {
+                // Round robin the producer so the send path -- not just the receive path -- is exercised
+                // from more than one node.
+                var bus = buses[Math.Abs(groupId.GetHashCode() + i) % buses.Length];
+                await bus.PublishAsync(new NativeAckLetter(groupId, i));
+                published.Enqueue((groupId, i));
+            }
+        });
+
+        return published.ToArray();
+    }
+
+    /// <summary>
+    /// Poll until every published letter has been handled at least once, or the timeout expires. Returns
+    /// true if everything landed. Polling rather than a tracked session because the multi-node scenarios
+    /// deliberately stop a host mid-stream.
+    /// </summary>
+    public static async Task<bool> WaitForCompletionAsync(
+        IReadOnlyCollection<(string GroupId, int Sequence)> published, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (Ledger.OutstandingFrom(published).Count == 0)
+            {
+                return true;
+            }
+
+            await Task.Delay(100.Milliseconds());
+        }
+
+        return Ledger.OutstandingFrom(published).Count == 0;
+    }
+
+    /// <summary>
+    /// The heart of it: assert that no group id was ever executing in two places at once, anywhere in the
+    /// cluster. See <see cref="GroupConcurrencyLedger" /> for how overlap is detected.
+    /// </summary>
+    public static void AssertNoIntraGroupConcurrency()
+    {
+        Ledger.Handled.Count.ShouldBeGreaterThan(0, "Nothing was handled at all, so the invariant is untested");
+
+        Ledger.Violations.ShouldBeEmpty(
+            "Two messages sharing a group id executed concurrently: " + Ledger.Violations.Join(" | "));
+    }
+
+    /// <summary>
+    /// At-least-once completeness. Duplicates are expected and legal in this mode.
+    /// </summary>
+    public static void AssertEveryLetterWasHandled(IReadOnlyCollection<(string GroupId, int Sequence)> published)
+    {
+        var outstanding = Ledger.OutstandingFrom(published);
+
+        outstanding.ShouldBeEmpty(
+            $"{outstanding.Count} of {published.Count} published letters were never handled: "
+            + outstanding.Take(10).Select(x => $"{x.GroupId}#{x.Sequence}").Join(", "));
+    }
+
+    /// <summary>
+    /// Every slot in the topology must have actually executed something, otherwise a "no concurrency"
+    /// result would be trivially satisfied by everything landing on one slot.
+    /// </summary>
+    public static void AssertEverySlotWasUsed(int numberOfSlots)
+    {
+        var destinations = Ledger.Handled.Select(x => x.Destination).Distinct().ToArray();
+
+        destinations.Length.ShouldBe(numberOfSlots,
+            $"Expected all {numberOfSlots} slots to be used. Saw: {destinations.Select(x => x?.ToString() ?? "null").Join(", ")}");
+    }
+
+    /// <summary>
+    /// A group must never straddle two slots -- that is the routing half of the guarantee, and it is what
+    /// makes the single exclusive consumer per slot sufficient for the cluster-wide half.
+    /// </summary>
+    public static void AssertGroupsNeverStraddleSlots()
+    {
+        foreach (var group in Ledger.Handled.GroupBy(x => x.GroupId))
+        {
+            group.Select(x => x.Destination).Distinct().Count()
+                .ShouldBe(1, $"Group id {group.Key} was handled on more than one slot");
+        }
+    }
+}
+
+public record NativeAckLetter(string GroupId, int Sequence);
+
+/// <summary>
+/// Injected per host so the ledger can name which node executed a message. All hosts in a multi-node test
+/// share one process, so the node name has to come from configuration rather than from the environment.
+/// </summary>
+public class NativeAckNodeMarker(string nodeName)
+{
+    public string NodeName { get; } = nodeName;
+}
+
+public static class NativeAckLetterHandler
+{
+    public static Task Handle(NativeAckLetter letter, Envelope envelope, NativeAckNodeMarker node)
+    {
+        return NativeAckPartitionedProcessing.Ledger.ExecuteAsync(letter, envelope.Destination, node.NodeName,
+            NativeAckPartitionedProcessing.Dwell);
+    }
+}
+
+/// <summary>
+/// Detects overlapping execution of one group id across the whole cluster. A handler claims its group id on
+/// entry and releases it on exit; a claim that finds the group already held is recorded as a violation.
+/// </summary>
+/// <remarks>
+/// The release is a compare-and-remove on the claim token, not a blind remove, so a losing claimant can
+/// never evict the rightful holder's entry and cascade one real violation into a string of phantom ones.
+/// </remarks>
+public sealed class GroupConcurrencyLedger
+{
+    private readonly ConcurrentDictionary<string, string> _inFlight = new();
+    private readonly ConcurrentQueue<string> _violations = new();
+    private readonly ConcurrentQueue<HandledLetter> _handled = new();
+
+    public IReadOnlyList<string> Violations => _violations.ToArray();
+    public IReadOnlyList<HandledLetter> Handled => _handled.ToArray();
+
+    public void Clear()
+    {
+        _inFlight.Clear();
+        _violations.Clear();
+        _handled.Clear();
+    }
+
+    public async Task ExecuteAsync(NativeAckLetter letter, Uri? destination, string nodeName, TimeSpan dwell)
+    {
+        var claim = $"{nodeName}/{letter.Sequence}/{Guid.NewGuid():N}";
+
+        if (!_inFlight.TryAdd(letter.GroupId, claim))
+        {
+            _inFlight.TryGetValue(letter.GroupId, out var holder);
+            _violations.Enqueue(
+                $"group {letter.GroupId} was held by {holder ?? "(released)"} when {claim} began executing on {destination}");
+        }
+
+        try
+        {
+            if (dwell > TimeSpan.Zero)
+            {
+                await Task.Delay(dwell);
+            }
+
+            _handled.Enqueue(new HandledLetter(letter.GroupId, letter.Sequence, nodeName, destination));
+        }
+        finally
+        {
+            _inFlight.TryRemove(new KeyValuePair<string, string>(letter.GroupId, claim));
+        }
+    }
+
+    /// <summary>
+    /// The published letters that have not been handled even once yet.
+    /// </summary>
+    public IReadOnlyList<(string GroupId, int Sequence)> OutstandingFrom(
+        IReadOnlyCollection<(string GroupId, int Sequence)> published)
+    {
+        var seen = _handled.Select(x => (x.GroupId, x.Sequence)).ToHashSet();
+        return published.Where(x => !seen.Contains(x)).ToArray();
+    }
+
+    public record HandledLetter(string GroupId, int Sequence, string NodeName, Uri? Destination);
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_global_partitioning_cluster.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_global_partitioning_cluster.cs
@@ -1,0 +1,231 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests.Partitioning;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+/// <summary>
+/// GH-3709. <c>ProcessInParallelWithNativeAcks()</c> on a global partitioned topology, exercised end to end
+/// against a real broker on hosts with <b>no message store at all</b>.
+/// </summary>
+/// <remarks>
+/// <para><b>The guarantee:</b> no two messages sharing a group id execute concurrently. Within a node the
+/// sequential lane inside the slot's own receiver enforces it; across the cluster the exclusive slot listener
+/// enforces it, because exactly one node consumes a given slot. Ordering is per-slot best effort, <b>not</b>
+/// per-group guaranteed -- redelivery or requeue may reorder, and the ordering unit is the slot rather than
+/// the group, so two groups hashing to the same slot serialize against each other.</para>
+///
+/// <para><b>Why slot ownership is assigned statically here.</b> Wolverine's dynamic one-consumer-per-slot
+/// assignment is <c>ExclusiveListenerFamily</c>, which runs under <c>NodeAgentController</c> -- and
+/// <c>WolverineRuntime.startAgentsAsync</c> returns early when <c>Storage is NullMessageStore</c>, so a host
+/// with no message store never builds a node agent controller and never assigns an exclusive listener. On a
+/// storeless host the durability mode therefore has to be Solo, where <c>Endpoint.ShouldAutoStartAsListener</c>
+/// starts <i>every</i> listener on <i>every</i> node. Slot ownership in a storage-free cluster is consequently
+/// a deployment decision rather than something Wolverine negotiates, and this fixture makes it by stopping the
+/// unowned slot listeners on each node. The dynamic-assignment and failover half of the story needs a store
+/// for node coordination and lives in <see cref="native_ack_global_partitioning_failover" />.</para>
+/// </remarks>
+public class native_ack_global_partitioning_cluster : IAsyncLifetime
+{
+    private readonly List<IHost> _hosts = [];
+    private readonly List<(IHost Host, int[] Owned)> _ownership = [];
+
+    public ValueTask InitializeAsync()
+    {
+        NativeAckPartitionedProcessing.Ledger.Clear();
+        NativeAckPartitionedProcessing.Dwell = 50.Milliseconds();
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var host in _hosts.ToArray())
+        {
+            try
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+            catch (Exception)
+            {
+                // Nothing useful to do about a host that will not shut down cleanly during teardown
+            }
+        }
+
+        _hosts.Clear();
+        _ownership.Clear();
+        NativeAckPartitionedProcessing.Ledger.Clear();
+    }
+
+    /// <summary>
+    /// A host with no message store whatsoever -- no Marten, no Postgres, no inbox. <paramref name="ownedSlots" />
+    /// are the zero-based slot indexes this node consumes; every other slot is send-only here.
+    /// </summary>
+    /// <remarks>
+    /// Ownership is applied by stopping the unowned listeners <i>after</i> startup rather than by clearing
+    /// <c>IsListener</c> in configuration, for two reasons. It has to be after Compile: every
+    /// <c>ListenerConfiguration</c> carries a delayed <c>e.IsListener = true</c> that runs during
+    /// <c>Endpoint.Compile()</c>, after endpoint policies, so an <c>IsListener = false</c> set while
+    /// configuring is simply overwritten. And a stopped-and-drained listening agent is exactly the state
+    /// <c>ExclusiveListenerAgent</c> leaves behind on a node that is not assigned the slot -- so this
+    /// reproduces real slot ownership rather than approximating it.
+    /// </remarks>
+    private async Task<IHost> startStorelessHostAsync(string nodeName, string baseName, int slotCount,
+        params int[] ownedSlots)
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Storeless hosts have no cluster coordination available, so Solo is the only workable mode.
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseRabbitMq("host=localhost;port=5672").AutoProvision().AutoPurgeOnStartup();
+
+                opts.UseNativeAckLetters(nodeName,
+                    topology =>
+                    {
+                        topology.ProcessInParallelWithNativeAcks();
+                        topology.UseShardedRabbitQueues(baseName, slotCount);
+                    });
+            }).StartAsync();
+
+        _hosts.Add(host);
+        _ownership.Add((host, ownedSlots));
+
+        var runtime = host.GetRuntime();
+        for (var i = 0; i < slotCount; i++)
+        {
+            if (ownedSlots.Contains(i)) continue;
+
+            var endpoint = runtime.Endpoints.EndpointFor(slotUri(baseName, i))!;
+            await runtime.Endpoints.StopListenerAsync(endpoint, CancellationToken.None);
+        }
+
+        assertOwnsExactly(host, baseName, slotCount, ownedSlots);
+
+        return host;
+    }
+
+    private static Uri slotUri(string baseName, int slotIndex) => new($"rabbitmq://queue/{baseName}{slotIndex + 1}");
+
+    /// <summary>
+    /// One consumer per slot is the cluster-wide half of the guarantee, so it is asserted rather than assumed --
+    /// both right after ownership is applied and again at the end of the run.
+    /// </summary>
+    private void assertOwnershipStillHolds(string baseName, int slotCount)
+    {
+        foreach (var (host, owned) in _ownership)
+        {
+            assertOwnsExactly(host, baseName, slotCount, owned);
+        }
+    }
+
+    private static void assertOwnsExactly(IHost host, string baseName, int slotCount, int[] ownedSlots)
+    {
+        var runtime = host.GetRuntime();
+
+        for (var i = 0; i < slotCount; i++)
+        {
+            var status = runtime.Endpoints.FindListenerCircuit(slotUri(baseName, i))?.Status;
+            var expected = ownedSlots.Contains(i) ? ListeningStatus.Accepting : ListeningStatus.Stopped;
+
+            status.ShouldBe(expected,
+                $"{runtime.Options.ServiceName} had slot {baseName}{i + 1} in status {status}, expected {expected}");
+        }
+    }
+
+    private static void assertSlotsAreNativeAckWithNoCompanionQueue(IHost host, string baseName, int slotCount)
+    {
+        var runtime = host.GetRuntime();
+
+        for (var i = 1; i <= slotCount; i++)
+        {
+            var endpoint = runtime.Endpoints.EndpointFor(new Uri($"rabbitmq://queue/{baseName}{i}"))
+                .ShouldNotBeNull($"No endpoint was built for slot {baseName}{i}");
+
+            endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+            endpoint.ListenerScope.ShouldBe(ListenerScope.Exclusive);
+        }
+
+        // No companion local queues means no bridge and no durable receiver on the path.
+        runtime.Endpoints.ActiveSendingAgents()
+            .Select(x => x.Destination)
+            .Any(x => x.Scheme == "local" && x.Host.StartsWith($"global-{baseName}"))
+            .ShouldBeFalse("A native-ack topology must not create companion local queues");
+    }
+
+    /// <summary>
+    /// The cluster-wide statement of the guarantee: three storage-free nodes, six slots split between them,
+    /// and no group id ever executing in two places at once anywhere in the cluster.
+    /// </summary>
+    [Fact]
+    public async Task no_two_messages_of_a_group_execute_concurrently_across_a_storage_free_cluster()
+    {
+        const string baseName = "naclust";
+        const int slotCount = 6;
+
+        var node1 = await startStorelessHostAsync("NativeAckNode1", baseName, slotCount, 0, 1);
+        var node2 = await startStorelessHostAsync("NativeAckNode2", baseName, slotCount, 2, 3);
+        var node3 = await startStorelessHostAsync("NativeAckNode3", baseName, slotCount, 4, 5);
+
+        assertSlotsAreNativeAckWithNoCompanionQueue(node1, baseName, slotCount);
+
+        var published = await NativeAckPartitionedProcessing.PumpOutLettersAsync(
+            [node1.MessageBus, node2.MessageBus, node3.MessageBus], groupCount: 24, messagesPerGroup: 4);
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(published, 90.Seconds()))
+            .ShouldBeTrue("Not every published letter was handled inside the timeout");
+
+        // Nothing restarted a slot listener behind our back, so "exactly one consumer per slot" really did
+        // hold for the whole run rather than just at the start of it.
+        assertOwnershipStillHolds(baseName, slotCount);
+
+        NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency();
+        NativeAckPartitionedProcessing.AssertEveryLetterWasHandled(published);
+        NativeAckPartitionedProcessing.AssertGroupsNeverStraddleSlots();
+        NativeAckPartitionedProcessing.AssertEverySlotWasUsed(slotCount);
+
+        // Every node has to have done real work, otherwise "cluster-wide" is a claim about one node.
+        NativeAckPartitionedProcessing.Ledger.Handled.Select(x => x.NodeName).Distinct().OrderBy(x => x)
+            .ShouldBe(["NativeAckNode1", "NativeAckNode2", "NativeAckNode3"]);
+    }
+
+    /// <summary>
+    /// The local shortcut hands a message straight to the companion local queue when the publishing node
+    /// already owns the target slot. A native-ack topology has no companion queue, and the broker delivery
+    /// <i>is</i> the durability story, so the shortcut is disabled: every send goes through the broker even
+    /// when this very node is the exclusive consumer of the slot it hashes to.
+    /// </summary>
+    [Fact]
+    public async Task sends_go_through_the_broker_even_when_this_node_owns_every_slot()
+    {
+        const string baseName = "nashortcut";
+        const int slotCount = 3;
+
+        var host = await startStorelessHostAsync("NativeAckSoleNode", baseName, slotCount, 0, 1, 2);
+
+        var published = await NativeAckPartitionedProcessing.PumpOutLettersAsync(
+            [host.MessageBus], groupCount: 12, messagesPerGroup: 3);
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(published, 60.Seconds()))
+            .ShouldBeTrue("Not every published letter was handled inside the timeout");
+
+        var destinations = NativeAckPartitionedProcessing.Ledger.Handled
+            .Select(x => x.Destination).Distinct().ToArray();
+
+        destinations.ShouldAllBe(x => x!.Scheme == "rabbitmq");
+
+        // The durable topology's tell-tale is local://global-<base>N/ destinations. There must be none.
+        destinations.Any(x => x!.Scheme == "local")
+            .ShouldBeFalse("The local shortcut fired: " + destinations.Select(x => x!.ToString()).Join(", "));
+
+        NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency();
+        NativeAckPartitionedProcessing.AssertEveryLetterWasHandled(published);
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_global_partitioning_failover.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_global_partitioning_failover.cs
@@ -1,0 +1,392 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine.ComplianceTests.Partitioning;
+using Wolverine.Configuration;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+/// <summary>
+/// GH-3709. Slot failover is the one true cross-node concurrency hazard for a native-ack global partitioned
+/// topology: when a slot moves nodes, the new owner may start pulling while the old owner still has an
+/// in-flight handler for a group in that slot. <c>ExclusiveListenerAgent</c> is supposed to stop and
+/// <i>drain</i> the listener before releasing it. This suite verifies that claim under the new mode rather
+/// than assuming it.
+/// </summary>
+/// <remarks>
+/// <para><b>The guarantee:</b> no two messages sharing a group id execute concurrently -- within a node the
+/// sequential lane enforces it, across the cluster the exclusive slot listener does. Ordering is per-slot
+/// best effort, not per-group guaranteed; redelivery or requeue may reorder, and two groups hashing to the
+/// same slot serialize against each other.</para>
+///
+/// <para><b>Why there is a database here at all.</b> The slots themselves stay storage-free -- they are
+/// <see cref="EndpointMode.NativeAck" />, so no envelope touches an inbox and no message ever hits the
+/// database. Postgres is present only as the cluster's node/agent coordination store, because dynamic
+/// one-consumer-per-slot assignment runs through <c>NodeAgentController</c>, which
+/// <c>WolverineRuntime.startAgentsAsync</c> skips entirely when there is no message store. The genuinely
+/// store-free deployment shape -- static slot ownership per node -- is covered by
+/// <see cref="native_ack_global_partitioning_cluster" />.</para>
+/// </remarks>
+// Deliberately NOT in its own [Collection]. The assembly runs CollectionPerAssembly, so an explicit
+// collection attribute would put this class in a SEPARATE collection -- which xUnit then runs in PARALLEL
+// with the assembly collection, and native_ack_global_partitioning_cluster writes the same static
+// NativeAckPartitionedProcessing.Ledger. That combination produced exactly the cross-class contamination
+// you would expect.
+public class native_ack_global_partitioning_failover : IAsyncLifetime
+{
+    private const string SchemaName = "native_ack_gp_failover";
+    private const string BaseName = "nafail";
+    private const int SlotCount = 4;
+
+    private readonly List<IHost> _hosts = [];
+    private readonly ITestOutputHelper _output;
+
+    public native_ack_global_partitioning_failover(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        NativeAckPartitionedProcessing.Ledger.Clear();
+
+        // Wide enough that a handler is genuinely still in flight when its slot is handed off.
+        NativeAckPartitionedProcessing.Dwell = 250.Milliseconds();
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.CloseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _hosts.Reverse();
+        foreach (var host in _hosts.ToArray())
+        {
+            try
+            {
+                await shutdownHostAsync(host);
+            }
+            catch (Exception)
+            {
+                // Nothing useful to do about a host that will not shut down cleanly during teardown
+            }
+        }
+
+        _hosts.Clear();
+        NativeAckPartitionedProcessing.Ledger.Clear();
+        NativeAckPartitionedProcessing.Dwell = 50.Milliseconds();
+    }
+
+    private async Task<IHost> startHostAsync(string nodeName)
+    {
+        var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Balanced;
+            opts.Durability.HealthCheckPollingTime = 1.Seconds();
+            opts.Durability.NodeReassignmentPollingTime = 1.Seconds();
+            opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+            opts.Durability.StaleNodeTimeout = 3.Seconds();
+
+            opts.UseRabbitMq("host=localhost;port=5672").EnableWolverineControlQueues().AutoProvision();
+
+            // Node/agent coordination only -- see the class remarks. The slots never touch it.
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName);
+
+            opts.UseNativeAckLetters(nodeName, topology =>
+            {
+                topology.ProcessInParallelWithNativeAcks();
+                topology.UseShardedRabbitQueues(BaseName, SlotCount);
+            });
+
+            opts.Services.AddResourceSetupOnStartup();
+        }).StartAsync();
+
+        _hosts.Add(host);
+
+        return host;
+    }
+
+    private async Task shutdownHostAsync(IHost host)
+    {
+        host.GetRuntime().Agents.DisableHealthChecks();
+        await host.StopAsync();
+        host.Dispose();
+        _hosts.Remove(host);
+    }
+
+    private static Uri slotAgentUri(int slotNumber) =>
+        new($"{ExclusiveListenerFamily.SchemeName}://rabbitmq/{BaseName}{slotNumber}");
+
+    private IReadOnlyList<Uri> slotAgentsOn(IHost host)
+    {
+        var running = host.RunningAgents().ToHashSet();
+        return Enumerable.Range(1, SlotCount).Select(slotAgentUri).Where(running.Contains).ToArray();
+    }
+
+    /// <summary>
+    /// Every slot must be consumed by exactly one node -- never zero, never two.
+    /// </summary>
+    private bool everySlotOwnedExactlyOnce()
+    {
+        return Enumerable.Range(1, SlotCount)
+            .All(slot => _hosts.Count(h => slotAgentsOn(h).Contains(slotAgentUri(slot))) == 1);
+    }
+
+    private async Task waitForFullSlotOwnershipAsync(TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (everySlotOwnedExactlyOnce())
+            {
+                // Has to hold across a health-check cycle to count as settled rather than mid-flap.
+                await Task.Delay(1500.Milliseconds());
+                if (everySlotOwnedExactlyOnce()) return;
+            }
+
+            await Task.Delay(250.Milliseconds());
+        }
+
+        var report = _hosts.Select(h =>
+            $"{h.GetRuntime().Options.ServiceName}=[{slotAgentsOn(h).Select(x => x.ToString()).Join(", ")}]").Join("; ");
+
+        throw new TimeoutException($"The {SlotCount} slot listeners never settled one-per-node. Saw: {report}");
+    }
+
+    private void assertSlotsAreNativeAck(IHost host)
+    {
+        var runtime = host.GetRuntime();
+
+        for (var i = 1; i <= SlotCount; i++)
+        {
+            var endpoint = runtime.Endpoints.EndpointFor(new Uri($"rabbitmq://queue/{BaseName}{i}"))
+                .ShouldNotBeNull();
+
+            endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+            endpoint.ListenerScope.ShouldBe(ListenerScope.Exclusive);
+        }
+
+        _output.WriteLine($"{runtime.Options.ServiceName}: all {SlotCount} slots are NativeAck + Exclusive");
+    }
+
+    /// <summary>
+    /// Publish a steady stream of grouped letters until cancelled, so the cluster is genuinely mid-flight
+    /// when a node is taken away.
+    /// </summary>
+    private static Task<(Task Pump, ConcurrentQueue<(string GroupId, int Sequence)> Published)> startPumpAsync(
+        IMessageBus bus, int groupCount, CancellationToken token)
+    {
+        var published = new ConcurrentQueue<(string, int)>();
+        var groups = Enumerable.Range(0, groupCount).Select(_ => Guid.NewGuid().ToString()).ToArray();
+
+        var pump = Task.Run(async () =>
+        {
+            var sequence = 0;
+            while (!token.IsCancellationRequested)
+            {
+                foreach (var groupId in groups)
+                {
+                    if (token.IsCancellationRequested) return;
+
+                    await bus.PublishAsync(new NativeAckLetter(groupId, sequence));
+                    published.Enqueue((groupId, sequence));
+                }
+
+                sequence++;
+                await Task.Delay(100.Milliseconds(), CancellationToken.None);
+            }
+        }, CancellationToken.None);
+
+        return Task.FromResult((pump, published));
+    }
+
+    /// <summary>
+    /// The test the issue calls out as the one that matters: take the node owning a slot away mid-stream and
+    /// assert that the slot is reassigned, that processing continues, that no two messages sharing a group id
+    /// ever executed concurrently <i>across the handoff</i>, and that nothing was lost.
+    /// </summary>
+    [Fact]
+    public async Task no_intra_group_concurrency_when_a_slot_owner_leaves_mid_stream()
+    {
+        var leader = await startHostAsync("FailoverNode1");
+        await startHostAsync("FailoverNode2");
+        await startHostAsync("FailoverNode3");
+
+        (await leader.WaitUntilAssumesLeadershipAsync(30.Seconds()))
+            .ShouldBeTrue("The first host never assumed leadership");
+
+        assertSlotsAreNativeAck(leader);
+
+        await waitForFullSlotOwnershipAsync(60.Seconds());
+
+        using var cts = new CancellationTokenSource();
+        var (pump, published) = await startPumpAsync(leader.MessageBus(), groupCount: 16, cts.Token);
+
+        // Let real work get under way before pulling a node out from under it.
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+
+        // Take away a non-leader node that is actually consuming slots, so the reassignment is a genuine
+        // slot handoff rather than a leadership election.
+        var candidates = _hosts.Skip(1).Where(h => slotAgentsOn(h).Any()).ToArray();
+        candidates.ShouldNotBeEmpty("No non-leader node was consuming a slot, so there is no handoff to test");
+
+        var victim = candidates[0];
+        var orphanedSlots = slotAgentsOn(victim);
+        var victimName = victim.GetRuntime().Options.ServiceName;
+
+        _output.WriteLine($"Stopping {victimName}, which owns {orphanedSlots.Select(x => x.ToString()).Join(", ")}");
+        orphanedSlots.ShouldNotBeEmpty();
+
+        await shutdownHostAsync(victim);
+
+        await waitForFullSlotOwnershipAsync(90.Seconds());
+
+        foreach (var slot in orphanedSlots)
+        {
+            _hosts.Count(h => slotAgentsOn(h).Contains(slot))
+                .ShouldBe(1, $"Slot {slot} did not land on exactly one survivor");
+        }
+
+        // Processing has to keep going on the survivors, not merely resume owning the slots.
+        var handledBeforeSettling = NativeAckPartitionedProcessing.Ledger.Handled.Count;
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+        NativeAckPartitionedProcessing.Ledger.Handled.Count.ShouldBeGreaterThan(handledBeforeSettling,
+            "Nothing was processed after the slot handoff");
+
+        await cts.CancelAsync();
+        await pump;
+
+        var everything = published.ToArray();
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(everything, 120.Seconds()))
+            .ShouldBeTrue("Not every published letter was handled after the failover");
+
+        _output.WriteLine(
+            $"{everything.Length} published, {NativeAckPartitionedProcessing.Ledger.Handled.Count} handled "
+            + $"(duplicates are legal in this mode)");
+
+        // The claim under test: exclusive-listener handoff drains in-flight work before releasing the slot,
+        // so the new owner never overlaps the old owner on a shared group id.
+        NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency();
+
+        // At-least-once completeness -- the broker, not an inbox, is what makes this true.
+        NativeAckPartitionedProcessing.AssertEveryLetterWasHandled(everything);
+
+        // A group hashes to one slot and stays there; a handoff changes which node consumes that slot, never
+        // which slot the group belongs to.
+        NativeAckPartitionedProcessing.AssertGroupsNeverStraddleSlots();
+
+        // The handoff really did move work between nodes, otherwise nothing above was tested.
+        var nodes = NativeAckPartitionedProcessing.Ledger.Handled.Select(x => x.NodeName).Distinct().ToArray();
+        nodes.ShouldContain(victimName, "The node that was stopped never handled anything before it left");
+        nodes.Length.ShouldBeGreaterThan(1);
+
+        // And specifically: the orphaned slots kept being drained, on a survivor. A survivor can only ever
+        // handle one of those slots' messages after the handoff, because before it the victim owned them
+        // exclusively -- so this is the assertion that the reassigned slots did real work post-failover.
+        var orphanedQueues = orphanedSlots.Select(x => x.Segments.Last()).ToHashSet();
+        NativeAckPartitionedProcessing.Ledger.Handled
+            .Where(x => x.NodeName != victimName && orphanedQueues.Contains(x.Destination!.Segments.Last()))
+            .ShouldNotBeEmpty("No survivor ever processed a message from one of the reassigned slots");
+    }
+
+    /// <summary>
+    /// The sharper version of the same hazard: move a slot between two nodes that are <b>both still alive</b>,
+    /// mid-stream. Nothing here is helped along by a dying process -- the old owner keeps running, so the only
+    /// thing standing between the new owner's first pull and the old owner's in-flight handler is
+    /// <c>ExclusiveListenerAgent.StopAsync</c> draining the listener before it releases the slot.
+    /// </summary>
+    [Fact]
+    public async Task no_intra_group_concurrency_when_a_live_slot_handoff_moves_the_slot()
+    {
+        var leader = await startHostAsync("HandoffNode1");
+        await startHostAsync("HandoffNode2");
+        await startHostAsync("HandoffNode3");
+
+        (await leader.WaitUntilAssumesLeadershipAsync(30.Seconds()))
+            .ShouldBeTrue("The first host never assumed leadership");
+
+        await waitForFullSlotOwnershipAsync(60.Seconds());
+
+        using var cts = new CancellationTokenSource();
+        var (pump, published) = await startPumpAsync(leader.MessageBus(), groupCount: 16, cts.Token);
+
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+
+        var movedSlot = slotAgentUri(1);
+
+        var owners = _hosts.Where(h => slotAgentsOn(h).Contains(movedSlot)).ToArray();
+        owners.Length.ShouldBe(1,
+            $"{movedSlot} was owned by {owners.Length} nodes rather than exactly one when the handoff started");
+
+        var originalOwner = owners[0];
+        var target = _hosts.First(h => !ReferenceEquals(h, originalOwner));
+
+        var originalOwnerName = originalOwner.GetRuntime().Options.ServiceName;
+        var targetNumber = target.GetRuntime().DurabilitySettings.AssignedNodeNumber;
+
+        _output.WriteLine(
+            $"Moving {movedSlot} from {originalOwnerName} to {target.GetRuntime().Options.ServiceName} "
+            + $"(node {targetNumber}) while both are live");
+
+        var restrictions = new AgentRestrictions();
+        restrictions.PinAgent(movedSlot, targetNumber);
+        await leader.GetRuntime().Agents.ApplyRestrictionsAsync(restrictions, CancellationToken.None);
+
+        await waitForSlotOwnerAsync(movedSlot, target, 60.Seconds());
+        await waitForFullSlotOwnershipAsync(60.Seconds());
+
+        // Keep the stream running across the handoff so the new owner has real work waiting for it.
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+
+        await cts.CancelAsync();
+        await pump;
+
+        var everything = published.ToArray();
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(everything, 120.Seconds()))
+            .ShouldBeTrue("Not every published letter was handled after the live handoff");
+
+        _output.WriteLine(
+            $"{everything.Length} published, {NativeAckPartitionedProcessing.Ledger.Handled.Count} handled");
+
+        NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency();
+        NativeAckPartitionedProcessing.AssertEveryLetterWasHandled(everything);
+        NativeAckPartitionedProcessing.AssertGroupsNeverStraddleSlots();
+
+        // The moved slot has to have been worked by both nodes, or the handoff window was never entered.
+        var workersOnMovedSlot = NativeAckPartitionedProcessing.Ledger.Handled
+            .Where(x => x.Destination!.Segments.Last() == movedSlot.Segments.Last())
+            .Select(x => x.NodeName)
+            .Distinct()
+            .ToArray();
+
+        workersOnMovedSlot.ShouldContain(originalOwnerName);
+        workersOnMovedSlot.Length.ShouldBeGreaterThan(1,
+            $"Slot {movedSlot} was only ever processed by {workersOnMovedSlot.Join(", ")}, so no handoff happened");
+    }
+
+    private async Task waitForSlotOwnerAsync(Uri slotAgent, IHost expected, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (slotAgentsOn(expected).Contains(slotAgent)) return;
+            await Task.Delay(250.Milliseconds());
+        }
+
+        throw new TimeoutException(
+            $"{slotAgent} never moved to {expected.GetRuntime().Options.ServiceName}");
+    }
+}

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -13,7 +13,7 @@ using Wolverine.Transports.Sending;
 namespace Wolverine.Runtime.WorkerQueues;
 
 internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeScheduling, ISupportDeadLetterQueue,
-    IFaultTrackingReceiver
+    IFaultTrackingReceiver, ILatchedReceiver
 {
     private readonly RetryBlock<Envelope> _completeBlock;
 

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -13,7 +13,7 @@ using Wolverine.Transports.Sending;
 namespace Wolverine.Runtime.WorkerQueues;
 
 public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeScheduling, ISupportDeadLetterQueue,
-    IAsyncDisposable, IFaultTrackingReceiver
+    IAsyncDisposable, IFaultTrackingReceiver, ILatchedReceiver
 {
     private readonly RetryBlock<Envelope> _completeBlock;
 

--- a/src/Wolverine/Runtime/WorkerQueues/ILatchedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/ILatchedReceiver.cs
@@ -1,0 +1,24 @@
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+/// A receiver that can be latched -- told to stop executing anything further -- ahead of
+/// <see cref="Wolverine.Transports.IReceiver.DrainAsync" />.
+/// </summary>
+/// <remarks>
+/// <para>GH-3709. This exists so <c>ListeningAgent.LatchReceiver()</c> is a single type test rather than an
+/// if/else chain naming each receiver implementation. The chain had already silently missed
+/// <see cref="NativeAckReceiver" /> when GH-3708 added it, and the failure was invisible rather than loud:
+/// an unlatched receiver's <c>DrainAsync</c> returns immediately instead of waiting for in-flight handlers,
+/// so a stop-and-drain closed the transport channel underneath still-running work. Every unsettled delivery
+/// was then requeued and redelivered <i>while the original was still executing</i> -- which on an exclusive
+/// listener handoff means the new owner runs a message concurrently with the old owner, breaking the
+/// no-two-messages-of-a-group-at-once guarantee that partitioned processing exists to provide.</para>
+/// </remarks>
+internal interface ILatchedReceiver
+{
+    /// <summary>
+    /// Stop executing further messages. Does not wait for in-flight work -- that is <c>DrainAsync</c>'s job,
+    /// and it only waits when the receiver has been latched first.
+    /// </summary>
+    void Latch();
+}

--- a/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
@@ -7,7 +7,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.Runtime.WorkerQueues;
 
-internal class InlineReceiver : IReceiver
+internal class InlineReceiver : IReceiver, ILatchedReceiver
 {
     private readonly ILogger _logger;
     private readonly Endpoint _endpoint;

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -34,7 +34,7 @@ namespace Wolverine.Runtime.WorkerQueues;
 /// this mode exists to provide.
 /// </para>
 /// </summary>
-internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver
+internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedReceiver
 {
     private readonly RetryBlock<Envelope> _completeBlock;
     private readonly RetryBlock<Envelope> _deferBlock;

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -247,18 +247,16 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     /// </summary>
     public void LatchReceiver()
     {
+        // GH-3709. Deliberately a single ILatchedReceiver test rather than an if/else chain naming each
+        // receiver type. As a chain this silently missed NativeAckReceiver when GH-3708 added it, and an
+        // unlatched receiver's DrainAsync returns immediately instead of waiting for in-flight handlers --
+        // so a stop-and-drain closed the transport channel underneath running work, the unsettled deliveries
+        // were requeued, and on an exclusive listener handoff the new owner re-ran them concurrently with
+        // the old owner. That is exactly the intra-group concurrency the partitioned modes forbid.
         var actual = _receiver is ReceiverWithRules rwr ? rwr.Inner : _receiver;
-        if (actual is DurableReceiver dr)
+        if (actual is ILatchedReceiver latched)
         {
-            dr.Latch();
-        }
-        else if (actual is BufferedReceiver br)
-        {
-            br.Latch();
-        }
-        else if (actual is InlineReceiver ir)
-        {
-            ir.Latch();
+            latched.Latch();
         }
     }
 

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -167,10 +167,11 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
         // send it, succeed, and return it to the pool -- Envelope.Reset(), which nulls Destination and
         // MessageType -- before this frame resumes. Reading it afterwards for metrics is therefore a data
         // race, and it surfaced as an intermittent NullReferenceException out of Envelope.ToMetricsHeaders()
-        // (Destination non-null at its own guard, null one line later) under concurrent publishing to any
-        // BufferedInMemory endpoint. EndpointMode.NativeAck maps to BufferedSendingAgent, which is what made
-        // it easy to hit. Non-pooled envelopes -- every durable send, and anything published inside a
-        // tracking session -- keep the original ordering, so a store that throws still reports no send.
+        // (Destination non-null at its own guard, null one line later) under concurrent publishing. It was
+        // found through EndpointMode.NativeAck, which mapped to BufferedSendingAgent at the time; GH-4061 has
+        // since moved NativeAck onto the inline agent, so the remaining exposure is any BufferedInMemory
+        // endpoint. Non-pooled envelopes -- every durable send, and anything published inside a tracking
+        // session -- keep the original ordering, so a store that throws still reports no send.
         var pooled = envelope.FromPool;
         if (pooled) _messageLogger.Sent(envelope);
 

--- a/src/Wolverine/Transports/Sending/SendingAgent.cs
+++ b/src/Wolverine/Transports/Sending/SendingAgent.cs
@@ -149,19 +149,35 @@ public abstract class SendingAgent : ISendingAgent, ISenderCallback, ISenderCirc
     public async ValueTask EnqueueOutgoingAsync(Envelope envelope)
     {
         setDefaults(envelope);
+
+        var pooled = envelope.FromPool;
+        if (pooled) _messageLogger.Sent(envelope);
+
         await _sending.PostAsync(envelope);
+
         _lastMessageSentAt = DateTimeOffset.UtcNow;
-        _messageLogger.Sent(envelope);
+        if (!pooled) _messageLogger.Sent(envelope);
     }
 
     public async ValueTask StoreAndForwardAsync(Envelope envelope)
     {
         setDefaults(envelope);
 
+        // GH-3709. Handing a POOLED envelope to the sending block publishes it to another thread that may
+        // send it, succeed, and return it to the pool -- Envelope.Reset(), which nulls Destination and
+        // MessageType -- before this frame resumes. Reading it afterwards for metrics is therefore a data
+        // race, and it surfaced as an intermittent NullReferenceException out of Envelope.ToMetricsHeaders()
+        // (Destination non-null at its own guard, null one line later) under concurrent publishing to any
+        // BufferedInMemory endpoint. EndpointMode.NativeAck maps to BufferedSendingAgent, which is what made
+        // it easy to hit. Non-pooled envelopes -- every durable send, and anything published inside a
+        // tracking session -- keep the original ordering, so a store that throws still reports no send.
+        var pooled = envelope.FromPool;
+        if (pooled) _messageLogger.Sent(envelope);
+
         await storeAndForwardAsync(envelope);
 
         _lastMessageSentAt = DateTimeOffset.UtcNow;
-        _messageLogger.Sent(envelope);
+        if (!pooled) _messageLogger.Sent(envelope);
     }
 
     public bool SupportsNativeScheduledSend => _sender.SupportsNativeScheduledSend;


### PR DESCRIPTION
Closes #3709.

Finishes the issue behind the opt-in that landed in #4041 (items 1, 2, 3, 6). Merged with `origin/main` at `2ea4266b6`, so #4055, #4056, #4061 and #4043 are all in — no conflicts.

Scope: **item 5, the tests, the docs**. Two product bugs the new tests exposed are fixed here as well, both with red-baselined regression coverage.

---

## ⚠️ Limitation discovered: acceptance criterion "storage-free host works end to end" cannot be met as written for a *cluster*

This is the most important thing in the PR and it contradicts one of #3709's acceptance criteria, so it needs a decision rather than an inference from a docs warning.

**A truly storage-free multi-node cluster cannot use Wolverine's dynamic one-consumer-per-slot assignment.** The chain:

1. Cluster-wide slot exclusivity is `ExclusiveListenerFamily`, which runs under `NodeAgentController`.
2. `WolverineRuntime.startAgentsAsync` returns **early** when `Storage is NullMessageStore` — a storeless host never builds a `NodeAgentController` at all, so no exclusive listener agent is ever created or assigned.
3. A storeless host therefore has to run `DurabilityMode.Solo` (under `Balanced`, `Endpoint.ShouldAutoStartAsListener` returns true only for `CompetingConsumers`, so the exclusive slots would never start listening at all).
4. Under `Solo`, `ShouldAutoStartAsListener` returns true unconditionally — **every node starts every listener**. Three storeless nodes means three competing consumers on every slot, and the guarantee is gone.

Empirically confirmed: the first run of the multi-node test, before slot ownership was applied, logged 3 listeners started on each of the 6 slot queues and the ledger reported **37 intra-group concurrency violations**.

So the honest statement is:

* **Single-node storage-free: works end to end.** Fully covered here.
* **Multi-node storage-free: works end to end, but slot ownership is a deployment decision, not something Wolverine negotiates.** Each node must be configured to consume only the slots it owns.
* **Multi-node with dynamic assignment and failover: needs a message store for node/agent coordination** (`DurabilityMode.Balanced`). The *messages* still never touch it — the slots stay `EndpointMode.NativeAck`, so there is no inbox insert, no mark-handled, and no per-message database work. It is a node-registry, not a message store, in this mode.

I did **not** try to close this gap — storeless cluster coordination is a much larger piece of work than #3709. The tests are split accordingly (see below), and the docs carry a `::: warning` saying the same thing. If the acceptance criterion is meant to cover the clustered case, it needs its own issue.

---

## Item 5 — verified free, nothing added

The issue asks to skip inbox recovery and the `EnqueueDirectlyAsync` bridge branch for native-ack slots. **Both are already no-ops, so this PR deliberately adds no guards for either.**

* `ListeningAgent.startInboxRecoveryIfNecessary` opens with `if (Endpoint.Mode != EndpointMode.Durable) return;`. A native-ack slot is `EndpointMode.NativeAck`, so the loop is never built. (A second guard, `_runtime.Storage is NullMessageStore`, covers the storage-free case independently.)
* The `EnqueueDirectlyAsync` bridge branch is `_receiver is GlobalPartitionedReceiverBridge`. The bridge is only ever constructed when `Endpoint.GlobalPartitionLocalQueueUri != null`, and a native-ack topology never stamps that property — leaving it null *is* the opt-out, exactly as the re-verification comment on the issue predicted. Native-ack slots land in the `NativeAckReceiver` branch added by GH-4011 instead.

## The guarantee, stated exactly

Used verbatim in the docs and in the test names:

> **No two messages sharing a group id execute concurrently.** Within a node the sequential lane inside the slot's receiver enforces it; across the cluster the exclusive slot listener enforces it, because exactly one node consumes a given slot.

Ordering is **per-slot best effort, not per-group guaranteed** — redelivery or requeue may reorder. And the existing caveat is restated unchanged: the ordering unit is the **slot**, not the group, so two group ids that hash to the same slot serialize against each other.

## Tests

New transport-agnostic harness in the `ShardedProcessing.cs` (GH-3467) style: `Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs`. A transport supplies only its own `UseSharded*()` call plus the cluster shape; the message type, handler, cluster-wide group ledger, publishing burst and assertions live in the harness. The ledger detects overlap by claim-and-release on the group id, with a compare-and-remove on the claim token so a losing claimant cannot evict the rightful holder and cascade phantom violations.

**`native_ack_global_partitioning_cluster`** (RabbitMQ, storage-free)

* `no_two_messages_of_a_group_execute_concurrently_across_a_storage_free_cluster` — 3 hosts with **no message store at all**, 6 slots split 2/2/2, 24 groups × 4 messages. Asserts no intra-group concurrency cluster-wide, at-least-once completeness, groups never straddle slots, every slot used, every node did work, and that slot ownership still held at the *end* of the run rather than only at the start.
* `sends_go_through_the_broker_even_when_this_node_owns_every_slot` — the routing test. Every executed envelope's `Destination` is `rabbitmq://queue/...`; there is no `local://global-*` destination anywhere, so the local shortcut really is disabled.

Ownership is applied by stopping the unowned slot listeners after startup — which is precisely the state `ExclusiveListenerAgent` leaves behind on a node not assigned a slot. Clearing `IsListener` in configuration does not work: every `ListenerConfiguration` carries a delayed `e.IsListener = true` that runs during `Endpoint.Compile()`, *after* endpoint policies.

**`native_ack_global_partitioning_failover`** (RabbitMQ + Postgres as the node registry only)

* `no_intra_group_concurrency_when_a_slot_owner_leaves_mid_stream` — the test the issue names. ~1,230 messages streaming, a non-leader slot owner stopped mid-stream; asserts reassignment lands each orphaned slot on exactly one survivor, processing continues after the handoff, a survivor actually drained the reassigned slots, no intra-group concurrency across the handoff, and at-least-once completeness.
* `no_intra_group_concurrency_when_a_live_slot_handoff_moves_the_slot` — the sharper form: pin a slot to a different node while **both are alive**, so nothing is helped along by a dying process and the only thing between the new owner's first pull and the old owner's in-flight handler is the drain.

## Product bug 1 — `LatchReceiver()` never latched a `NativeAckReceiver`

**Found by the live-handoff test, which failed before the fix.** `ListeningAgent.LatchReceiver()` was an if/else chain naming `DurableReceiver`, `BufferedReceiver` and `InlineReceiver`. GH-3708 added `NativeAckReceiver` and the chain silently skipped it — no compile error, no exception. The consequence: `NativeAckReceiver.DrainAsync` decides whether to wait on `_latched`, so an unlatched receiver returned immediately instead of waiting for in-flight handlers. `StopAndDrainCoreAsync` then disposed the listener underneath running work, the still-unsettled deliveries were requeued, and on an exclusive listener handoff the incoming node re-ran them **concurrently with the outgoing node** — exactly the intra-group concurrency the mode exists to prevent.

**#3709 asserted "exclusive-listener handoff drains in-flight work before releasing" as fact. It was false under this mode until this fix.**

Fix: an `ILatchedReceiver` interface implemented by all four receivers, and `LatchReceiver()` becomes a single type test, so the next receiver type cannot silently drop out.

Red baseline: `no_intra_group_concurrency_when_a_live_slot_handoff_moves_the_slot` failed with 4 violations on the moved slot before the fix — each pairing the same `(group, sequence)` on the old and new owner — and passes after. Duplicate count on that test went from 1252-handled-for-1216-published to 1232/1232.

Regression coverage: `latched_receiver_contract_3709` (reflection guard: any `IReceiver` with a `Latch()` method must declare `ILatchedReceiver`, plus a `[Theory]` over the four known receivers so the guard is not vacuous) and `native_ack_receiver.draining_a_latched_receiver_waits_for_the_in_flight_handler`. Verified the guard fails when `ILatchedReceiver` is removed from `NativeAckReceiver`.

## Product bug 2 — pooled outgoing envelope recycled out from under the metrics read

**Pre-existing, not introduced by #3709.** Reproduced as an intermittent `NullReferenceException` in `Envelope.ToMetricsHeaders()` — `Destination` non-null at its own guard, null one line later at `Destination.ToString()` — roughly 1 run in 4 of the new cluster suite.

Mechanism: `BufferedSendingAgent` is in the poolable set for `WolverineRuntime.AcquireOutgoingEnvelope` (wolverine#2955), but its `storeAndForwardAsync` only *posts* the envelope to an in-memory block. The block's consumer then sends it, succeeds, and returns it to the pool — `Envelope.Reset()`, which nulls `Destination` and `MessageType` — while the producing frame is still inside `SendingAgent.StoreAndForwardAsync` reading that same envelope for `_messageLogger.Sent()`.

**Attribution, corrected for #4061.** I found this through `EndpointMode.NativeAck`, which mapped to `BufferedSendingAgent` at the time. **#4061 has since remapped NativeAck onto `InlineSendingAgent`, so that trigger is gone.** The race is unchanged and was never native-ack specific: the remaining exposure is **any `BufferedInMemory` endpoint under concurrent publishing**, and that is how both tests now drive it. Comments and test docs have been re-framed accordingly.

Fix: in `SendingAgent.StoreAndForwardAsync` and `EnqueueOutgoingAsync`, do the metrics read **before** the handoff when the envelope is pooled. Non-pooled envelopes — every durable send, and anything published inside a tracking session — keep the original ordering, so a store that throws still reports no send. `InlineSendingAgent` was already correct: it awaits the real send and calls `_messageLogger.Sent` before `tryReturnToPool`.

I deliberately did **not** take the other candidate fix, removing `BufferedSendingAgent` from `IsPoolableOutgoingAgent`. It works, but `shared_memory_envelope_pooling_3015` (GH-3015) explicitly asserts that a `BufferedSendingAgent` hands out a pooled envelope, so that set is intentional and load bearing.

### The stress test stopped reproducing after the merge, so the red baseline is now deterministic

The original guard was a 2,000-message concurrency stress test through the real `WolverineRuntime` tracker. On the pre-merge tree it failed in 113ms with the fix reverted; **after merging main it passed 8/8 with the fix reverted** — the product files on that path are byte-identical, so this is machine load, not a behaviour change (the earlier failing runs were on a box busy with RabbitMQ suites).

A probabilistic red baseline is not a red baseline, so `a_pooled_envelope_is_read_for_metrics_before_it_is_handed_to_the_sending_block` was added. It gates the metrics hook on the recycle flag rather than racing it: `Envelope.Reset()` clears `FromPool`, so a stand-in tracker spins inside `Sent()` until the envelope has been recycled or a 2s deadline passes. With the fix nothing has been posted when `Sent()` runs, so no recycle is possible, the spin times out and the envelope reads intact. Without the fix `Sent()` runs after the post and the spin waits for exactly the recycle it is racing, so `Destination` is reliably null.

**Verified on the merged tree: 5/5 deterministic failures with the fix reverted, 2/2 pass with it.** The stress test stays as a real-tracker smoke check, now documented as probabilistic rather than as the guard.

## Docs

New `### Native Ack Global Partitioning` section in `docs/guide/messaging/partitioning.md`, placed after the RabbitMQ example and cross-linked both ways with the existing "Partitioned processing without the database" tip so the per-listener and cluster-wide stories read as one. Covers the config sample, the guarantee statement, a durable-vs-native-ack trade table, when to choose it (flood tolerance, no DB load, at-least-once plus best-effort order), the failover caveat, and a `::: warning` for the storage-free clustering limitation above. Also amends two now-stale lines: the single-node local-shortcut tip, and the Postgres/SQL Server note that said the topology "forces `EndpointMode.Durable`".

## Verification (all re-run after the merge)

* `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors.
* Full `CoreTests` (Release, net9.0) — **2587 tests, 0 failed**.
* New RabbitMQ suites, Release, 3 consecutive clean runs of both classes together. (Before the merge: cluster class 8 consecutive clean runs, failover class 3.)
* RabbitMQ regression subset around the touched code — `native_ack_mode`, `global_partitioned_sharded_processing`, `exclusive_listeners`, `multi_node_exclusive_listener_failover`, `durable_compliance` — 31 tests, 0 failed.

### Red baselines

Every assertion that claims to prove an invariant was verified to fail when the invariant is broken:

1. **Cluster-wide exclusivity removed** — with all 3 storage-free nodes listening to all 6 slots (competing consumers), the concurrency ledger reported **37 violations**.
2. **Handoff drain broken** — the live-handoff test reported 4 violations before the `ILatchedReceiver` fix.
3. **`ILatchedReceiver` removed from `NativeAckReceiver`** — both guard tests fail, naming the offender.
4. **Pooled-metrics fix reverted** — the deterministic ordering test fails 5/5 on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
