### PR TITLE
Fix live regression: NativeAck endpoints get an unregistered BatchedSender

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSns/Internal/AmazonSnsTopic.cs
@@ -212,7 +212,7 @@ public class AmazonSnsTopic : Endpoint, IBrokerQueue
             return tenantedSender;
         }
 
-        if (Mode == EndpointMode.Inline)
+        if (SendsInline)
         {
             return new InlineSnsSender(runtime, this);
         }

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -704,7 +704,7 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
             return tenantedSender;
         }
 
-        if (Mode == EndpointMode.Inline)
+        if (SendsInline)
         {
             return new InlineSqsSender(runtime, this);
         }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Sending.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Sending.cs
@@ -31,7 +31,7 @@ public partial class AzureServiceBusTransport
     {
         var sender = BusClient.CreateSender(topic.TopicName);
 
-        if (topic.Mode == EndpointMode.Inline)
+        if (topic.SendsInline)
         {
             var inlineSender = new InlineAzureServiceBusSender(topic, mapper, sender,
                 runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusSender>(), runtime.Cancellation);
@@ -120,7 +120,7 @@ public partial class AzureServiceBusTransport
     {
         var sender = BusClient.CreateSender(queue.QueueName);
 
-        if (queue.Mode == EndpointMode.Inline)
+        if (queue.SendsInline)
         {
             var inlineSender = new InlineAzureServiceBusSender(queue, mapper, sender,
                 runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusSender>(), runtime.Cancellation);

--- a/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/KafkaTopic.cs
@@ -331,7 +331,7 @@ public class KafkaTopic : Endpoint<IKafkaEnvelopeMapper, KafkaEnvelopeMapper>, I
             return tenantedSender;
         }
 
-        return Mode == EndpointMode.Inline
+        return SendsInline
             ? new InlineKafkaSender(this)
             : new BatchedSender(this, new KafkaSenderProtocol(this), runtime.Cancellation,
                 runtime.LoggerFactory.CreateLogger<KafkaSenderProtocol>());

--- a/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
+++ b/src/Transports/MQTT/Wolverine.MQTT/MqttTopic.cs
@@ -131,7 +131,7 @@ public class MqttTopic : Endpoint, ISender, ITopicEndpoint
 
         // Inline keeps the historical immediate/fire-and-forget path (this itself, via SendAsync
         // below) so explicit inline usage is unaffected.
-        if (Mode == EndpointMode.Inline)
+        if (SendsInline)
         {
             return this;
         }

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamEndpoint.cs
@@ -341,7 +341,7 @@ public class RedisStreamEndpoint : Endpoint<IRedisEnvelopeMapper, RedisEnvelopeM
             return tenantedSender;
         }
 
-        return Mode == EndpointMode.Inline
+        return SendsInline
             ? new InlineRedisStreamSender(_transport, this, runtime)
             : new BatchedSender(this, new RedisSenderProtocol(_transport, this), runtime.Cancellation,
                 runtime.LoggerFactory.CreateLogger<RedisSenderProtocol>());

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -283,6 +283,26 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     internal bool ModeIgnoresParallelism => Mode == EndpointMode.Inline;
 
     /// <summary>
+    /// GH-4061. Does this endpoint send synchronously, awaiting the transport, rather than through a batching
+    /// sender?
+    ///
+    /// <para>
+    /// Transports use this to choose between their inline sender and a <c>BatchedSender</c>. It is one property
+    /// because getting it wrong is silent and total: a <c>BatchedSender</c> only functions once the sending agent
+    /// has registered a callback on it, and <c>InlineSendingAgent</c> is NOT an <c>ISenderCallback</c>, so the
+    /// registration in <c>EndpointCollection.CreateSendingAgent</c> is skipped for it. A transport that asks
+    /// <c>Mode == EndpointMode.Inline</c> directly therefore hands a NativeAck endpoint an unregistered
+    /// <c>BatchedSender</c> whose every send throws "This sender has not been registered."
+    /// </para>
+    ///
+    /// <para>
+    /// Ask this rather than comparing against <see cref="EndpointMode.Inline"/>, so that a future mode which also
+    /// sends inline does not require finding all nine call sites again.
+    /// </para>
+    /// </summary>
+    public bool SendsInline => Mode is EndpointMode.Inline or EndpointMode.NativeAck;
+
+    /// <summary>
     /// GH-3712. Render <see cref="MaxDegreeOfParallelism"/> for diagnostics, saying "n/a" rather than
     /// printing a dead number for a mode that never reads it.
     /// </summary>


### PR DESCRIPTION
**Live regression on `main`, introduced by #4061 (mine).** Sending anything to a NativeAck endpoint on Redis fails outright:

```
System.InvalidOperationException: This sender has not been registered.
```

## Mechanism

1. #4061 remapped `EndpointMode.NativeAck` from `BufferedSendingAgent` to `InlineSendingAgent`, to close the global-partitioned interceptor's loss window.
2. `InlineSendingAgent` is `ISendingAgent, IDisposable` — **not** an `ISenderCallback`. So the registration in `EndpointCollection.CreateSendingAgent` is skipped:
   ```csharp
   if (sender is ISenderRequiresCallback senderRequiringCallback && agent is ISenderCallback callbackAgent)
   {
       senderRequiringCallback.RegisterCallback(callbackAgent);
   }
   ```
3. Every transport that uses `BatchedSender` selects it by asking `Mode == EndpointMode.Inline`. NativeAck is not Inline, so those transports still build one.
4. `BatchedSender` throws whenever `_callback` is null — on send, on ping, and on the failure path.

**Redis adopted NativeAck in #4056, so this is broken on `main` right now.**

## Why no PR's CI caught it

RabbitMQ and Pulsar use their own senders rather than `BatchedSender`, and they are the only transports with NativeAck integration tests. Redis has such tests, from #4056 — but #4061 branched from `main` *before* #4056 merged, so #4061's CI ran against a tree that did not contain them.

Both PRs were green. The combination is red. This is the classic stale-base gap, and it is worth knowing that nothing in the current workflow would have caught it: neither branch was wrong on its own.

## The fix

One property rather than nine copies of a boolean:

```csharp
public bool SendsInline => Mode is EndpointMode.Inline or EndpointMode.NativeAck;
```

Applied to the sender gates in SNS, SQS, Azure Service Bus (topic and queue), Kafka, MQTT and Redis.

It is centralised deliberately. The failure mode is silent and total — an endpoint that looks configured and cannot send a single message — and the per-transport form invites exactly this bug again the next time a mode is added. The xml-docs on `SendsInline` state the coupling to `ISenderCallback` explicitly, so the next person changing a sending-agent mapping can see why the property exists.

**GCP Pub/Sub is deliberately untouched.** It has not adopted NativeAck (`supportsNativeAck` is false), so it cannot reach this today, and that file is being actively edited under #4065/#4066. Its gate should move to `SendsInline` when #4052 adopts the mode.

## Verification

- **Red-baselined**: with the Redis gate reverted to `Mode == EndpointMode.Inline`, three of six `Wolverine.Redis.Tests.native_ack_mode` tests fail with the exact `"This sender has not been registered."` exception. With `SendsInline`, 6/6 pass.
- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors
- CoreTests — 2581 total, 0 failed, 2 skipped
- `Wolverine.Redis.Tests.native_ack_mode` — 6/6

## Credit

Found by the agent working #4049 while investigating what looked like emulator contention. A 10-second assertion failure is not a timeout, so it traced the cause instead of writing it off — which is the only reason this was caught before release rather than by a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)