### PR TITLE
GH-4065/GH-4066: bound Pub/Sub listener shutdown and surface ack extension exhaustion

### DIFF
--- a/docs/guide/messaging/transports/gcp-pubsub/listening.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/listening.md
@@ -42,3 +42,85 @@ var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L64-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_listen_to_pubsub_topic' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Long running handlers and the ack extension budget
+
+While Wolverine is processing a Pub/Sub message, the Pub/Sub client keeps the message's ack deadline alive
+for it by repeatedly extending that deadline in the background. It will only do so for a bounded total
+amount of time, controlled by `MaxTotalAckExtension`.
+
+Wolverine sets that budget explicitly to **one hour**:
+
+```cs
+opts.ListenToPubsubTopic("incoming")
+    .ConfigureListener(client =>
+    {
+        // The default. Raise it if you knowingly run handlers longer than an hour;
+        // lower it if you would rather a wedged message be redelivered sooner.
+        client.MaxTotalAckExtension = TimeSpan.FromHours(1);
+    });
+```
+
+::: danger
+When the budget is exhausted the Pub/Sub client simply **stops extending** the deadline. It does *not*
+cancel your handler and it does *not* raise anything into it. The service then redelivers the message, so a
+**second execution of that message begins while the first one is still running**.
+
+This is more dangerous than ordinary at-least-once redelivery. Wolverine's delivery contract already means
+your handlers must tolerate seeing a message twice — but here the two executions **overlap**. Anything that
+assumes a message is not running concurrently with itself will be violated rather than merely retried:
+optimistic concurrency checks, event stream appends, sagas, and the intra-group ordering guarantee of
+`PartitionProcessingByGroupId`.
+:::
+
+Because the two failure modes are so lopsided — too low silently corrupts data, too high only delays the
+redelivery of a genuinely stuck message and holds a flow control slot meanwhile — the default deliberately
+errs generous. One hour is sixty times Wolverine's default `DefaultExecutionTimeout`, leaving ample room
+for a slow handler and its inline retries.
+
+Wolverine cannot prevent the overlap, but it will no longer let it happen silently. When a message outlives
+the budget, the listener logs a warning naming the message id and how long it has been running:
+
+```
+pubsub://your-project-id/incoming: Google Cloud Platform Pub/Sub message 1480 has been processing for
+00:01:02.9102363, which exceeds the MaxTotalAckExtension budget of 00:01:00. ...
+```
+
+Treat that warning as a correctness alarm, not a performance note. Either shorten the handler or raise
+`MaxTotalAckExtension` to cover it.
+
+::: tip
+A handler that has *already* outlived the budget is not cancelled — it keeps running alongside its own
+duplicate. Cancelling it instead is under consideration; see
+[#4066](https://github.com/JasperFx/wolverine/issues/4066).
+:::
+
+## Concurrency and flow control
+
+`MaxOutstandingMessages` bounds how many messages a listener may have in flight at once, and
+`MaxOutstandingByteCount` does the same by payload size:
+
+```cs
+opts.ListenToPubsubTopic("incoming")
+    .ConfigureListener(client =>
+    {
+        client.MaxOutstandingMessages = 1000;              // default
+        client.MaxOutstandingByteCount = 100 * 1024 * 1024; // default
+    });
+```
+
+::: warning
+`MaxOutstandingMessages` is a bound on the **whole** listener. `ListenerCount` does **not** multiply it.
+
+Google's own API remarks say that a `SubscriberClient` builds several inner clients and that "each will
+observe the flow control settings independently", which reads as though the effective ceiling were
+`ListenerCount × MaxOutstandingMessages`. Measured against the real client library, that is not what
+happens — the client builds a single shared flow controller. Sizing a listener from the documented reading
+will over-provision by a factor of `ListenerCount`. See
+[#4067](https://github.com/JasperFx/wolverine/issues/4067).
+:::
+
+If the subscription was created with message ordering enabled, Pub/Sub additionally serializes delivery per
+ordering key — Wolverine maps `Envelope.GroupId` onto that key. Effective concurrency then becomes the
+*lesser* of `MaxOutstandingMessages` and the number of distinct group ids currently in flight, so an
+endpoint with only a handful of hot group ids will run at that group count no matter how it is sized.

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ack_extension_warning_end_to_end_4066.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ack_extension_warning_end_to_end_4066.cs
@@ -1,0 +1,166 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+/// <summary>
+/// GH-4066, end to end. Proves the ack extension watchdog is actually wired into a live listener: an
+/// EndpointMode.Inline endpoint holds the subscriber callback for the whole handler, so a handler that outlives
+/// MaxTotalAckExtension must produce a Warning rather than passing in silence.
+///
+/// What this DOES verify: the crossing is detected and logged while the handler is still running.
+/// What this does NOT verify: that the emulator then delivers the concurrent duplicate. See the notes on the PR.
+/// </summary>
+public class ack_extension_warning_end_to_end_4066 : IAsyncLifetime
+{
+    private bool _skip;
+
+    public async ValueTask InitializeAsync()
+    {
+        _skip = !await TestingExtensions.IsEmulatorAvailable();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task warns_when_an_inline_handler_outlives_the_ack_extension_budget()
+    {
+        if (_skip) return;
+
+        var recorder = new RecordingLoggerProvider();
+
+        SlowPubsubHandler.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureLogging(x => x.AddProvider(recorder))
+            .UseWolverine(opts =>
+            {
+                opts.UsePubsubTesting().AutoProvision().AutoPurgeOnStartup();
+
+                opts.PublishMessage<SlowPubsubMessage>().ToPubsubTopic("ackext4066");
+
+                opts.ListenToPubsubTopic("ackext4066")
+                    .ProcessInline()
+                    // Deliberately tiny so the crossing happens in seconds instead of the one hour default
+                    .ConfigureListener(c => c.MaxTotalAckExtension = 2.Seconds());
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        try
+        {
+            await host.MessageBus().SendAsync(new SlowPubsubMessage());
+
+            // The handler must actually be running, otherwise there is nothing to warn about
+            await SlowPubsubHandler.Started.Task.WaitAsync(60.Seconds(), TestContext.Current.CancellationToken);
+
+            var expiration = DateTimeOffset.UtcNow.AddSeconds(60);
+            while (!recorder.Warnings.Any(x => x.Contains("MaxTotalAckExtension"))
+                   && DateTimeOffset.UtcNow < expiration)
+            {
+                await Task.Delay(200, TestContext.Current.CancellationToken);
+            }
+
+            var warning = recorder.Warnings.FirstOrDefault(x => x.Contains("MaxTotalAckExtension"));
+            warning.ShouldNotBeNull();
+            warning.ShouldContain("CONCURRENT");
+        }
+        finally
+        {
+            // Let the handler go before the host tears down
+            SlowPubsubHandler.Release.TrySetResult();
+        }
+    }
+}
+
+public record SlowPubsubMessage;
+
+public static class SlowPubsubHandler
+{
+    public static TaskCompletionSource Started { get; private set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public static TaskCompletionSource Release { get; private set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static void Reset()
+    {
+        Started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static async Task Handle(SlowPubsubMessage message)
+    {
+        Started.TrySetResult();
+
+        // Held well past the two second budget configured above, but released by the test rather than a
+        // fixed sleep so the suite does not pay for it twice
+        await Release.Task.WaitAsync(2.Minutes());
+    }
+}
+
+internal class RecordingLoggerProvider : ILoggerProvider
+{
+    private readonly List<string> _warnings = [];
+
+    public IReadOnlyList<string> Warnings
+    {
+        get
+        {
+            lock (_warnings)
+            {
+                return _warnings.ToArray();
+            }
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new Recorder(this);
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private void record(string message)
+    {
+        lock (_warnings)
+        {
+            _warnings.Add(message);
+        }
+    }
+
+    private class Recorder : ILogger
+    {
+        private readonly RecordingLoggerProvider _parent;
+
+        public Recorder(RecordingLoggerProvider parent)
+        {
+            _parent = parent;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel >= LogLevel.Warning;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel < LogLevel.Warning)
+            {
+                return;
+            }
+
+            _parent.record(formatter(state, exception));
+        }
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ack_extension_watchdog_4066.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ack_extension_watchdog_4066.cs
@@ -1,0 +1,192 @@
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine.Pubsub.Internal;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+// GH-4066. Exhausting MaxTotalAckExtension makes Pub/Sub redeliver a message into a SECOND, concurrent
+// callback while the first is still running -- with no cancellation, no exception, and (before this) no log
+// line of any kind. These cover the detection of that crossing.
+public class ack_extension_watchdog_4066
+{
+    private static readonly Uri TheUri = new("pubsub://wolverine/ackext");
+
+    [Fact]
+    public async Task warns_when_a_delivery_outlives_the_ack_extension_budget()
+    {
+        var logger = new RecordingLogger();
+        await using var watchdog = new AckExtensionWatchdog(TheUri, TimeSpan.FromMilliseconds(50), logger);
+
+        watchdog.Track("message-1");
+
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        watchdog.CheckForExpiredDeliveries();
+
+        var warning = logger.Warnings.ShouldHaveSingleItem();
+        warning.ShouldContain("message-1");
+        warning.ShouldContain("MaxTotalAckExtension");
+    }
+
+    [Fact]
+    public async Task only_warns_once_for_the_same_delivery()
+    {
+        var logger = new RecordingLogger();
+        await using var watchdog = new AckExtensionWatchdog(TheUri, TimeSpan.FromMilliseconds(50), logger);
+
+        watchdog.Track("message-1");
+
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        watchdog.CheckForExpiredDeliveries();
+        watchdog.CheckForExpiredDeliveries();
+        watchdog.CheckForExpiredDeliveries();
+
+        logger.Warnings.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task does_not_warn_for_a_delivery_that_is_still_inside_the_budget()
+    {
+        var logger = new RecordingLogger();
+        await using var watchdog = new AckExtensionWatchdog(TheUri, TimeSpan.FromMinutes(30), logger);
+
+        watchdog.Track("message-1");
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        watchdog.CheckForExpiredDeliveries();
+
+        logger.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task does_not_warn_for_a_delivery_that_was_released_in_time()
+    {
+        var logger = new RecordingLogger();
+        await using var watchdog = new AckExtensionWatchdog(TheUri, TimeSpan.FromMilliseconds(50), logger);
+
+        var ticket = watchdog.Track("message-1");
+        watchdog.Release(ticket);
+
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        watchdog.CheckForExpiredDeliveries();
+
+        logger.Warnings.ShouldBeEmpty();
+        watchdog.InFlightCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task the_background_timer_warns_without_anyone_calling_the_scan()
+    {
+        var logger = new RecordingLogger();
+
+        // Budget/10 == 100ms, which clamps up to the 1s minimum scan interval
+        await using var watchdog = new AckExtensionWatchdog(TheUri, TimeSpan.FromSeconds(1), logger);
+
+        watchdog.Track("message-1");
+
+        var expiration = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (logger.Warnings.Count == 0 && DateTimeOffset.UtcNow < expiration)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        logger.Warnings.ShouldHaveSingleItem().ShouldContain("message-1");
+    }
+
+    [Fact]
+    public void scan_interval_is_clamped_at_both_ends()
+    {
+        var logger = new RecordingLogger();
+
+        // A one hour budget would otherwise scan every six minutes
+        new AckExtensionWatchdog(TheUri, TimeSpan.FromHours(1), logger).ScanInterval
+            .ShouldBe(AckExtensionWatchdog.MaximumScanInterval);
+
+        // A very short budget would otherwise spin
+        new AckExtensionWatchdog(TheUri, TimeSpan.FromMilliseconds(10), logger).ScanInterval
+            .ShouldBe(AckExtensionWatchdog.MinimumScanInterval);
+
+        // In between, a tenth of the budget
+        new AckExtensionWatchdog(TheUri, TimeSpan.FromSeconds(100), logger).ScanInterval
+            .ShouldBe(TimeSpan.FromSeconds(10));
+    }
+}
+
+internal class RecordingLogger : ILogger
+{
+    private readonly List<string> _warnings = [];
+
+    public IReadOnlyList<string> Warnings
+    {
+        get
+        {
+            lock (_warnings)
+            {
+                return _warnings.ToArray();
+            }
+        }
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel < LogLevel.Warning)
+        {
+            return;
+        }
+
+        lock (_warnings)
+        {
+            _warnings.Add(formatter(state, exception));
+        }
+    }
+}
+
+// GH-4066 / GH-4067. The watchdog reads MaxTotalAckExtension straight off PubsubClientOptions, so it would
+// still warn even if the value never reached the SubscriberClient. These guard the plumbing that makes the
+// warning mean something -- and that the flow control bound is carried on EVERY listener, not just the
+// batched one.
+public class subscriber_settings_plumbing
+{
+    [Fact]
+    public void carries_the_configured_ack_extension_budget_and_flow_control()
+    {
+        var options = new PubsubClientOptions
+        {
+            MaxTotalAckExtension = TimeSpan.FromMinutes(7),
+            MaxOutstandingMessages = 42,
+            MaxOutstandingByteCount = 4242
+        };
+
+        var settings = PubsubListener.BuildSubscriberSettings(options);
+
+        settings.MaxTotalAckExtension.ShouldBe(TimeSpan.FromMinutes(7));
+        settings.FlowControlSettings!.MaxOutstandingElementCount.ShouldBe(42);
+        settings.FlowControlSettings.MaxOutstandingByteCount.ShouldBe(4242);
+    }
+
+    [Fact]
+    public void the_default_ack_extension_budget_is_one_hour_and_is_chosen_deliberately()
+    {
+        // Documented in PubsubClientOptions.MaxTotalAckExtension: too low silently corrupts data via
+        // concurrent duplicate execution, too high only delays redelivery of a wedged message. Erring
+        // generous is the deliberate call, and it is set explicitly rather than inherited from the SDK.
+        new PubsubClientOptions().MaxTotalAckExtension.ShouldBe(TimeSpan.FromHours(1));
+        PubsubListener.BuildSubscriberSettings(new PubsubClientOptions())
+            .MaxTotalAckExtension.ShouldBe(TimeSpan.FromHours(1));
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/listener_shutdown_4065.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/listener_shutdown_4065.cs
@@ -1,0 +1,157 @@
+using System.Diagnostics;
+using Google.Api.Gax;
+using Google.Cloud.PubSub.V1;
+using Google.Protobuf;
+using Grpc.Core;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.Pubsub.Internal;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+/// <summary>
+/// GH-4065. SubscriberClient.StopAsync() waits on in-flight message callbacks, and Wolverine's callback awaits
+/// IReceiver.ReceivedAsync -- which on an EndpointMode.Inline endpoint runs the whole handler pipeline. The
+/// listener used to stop with CancellationToken.None, so a single slow handler wedged listener teardown with
+/// nothing bounding the wait at all.
+///
+/// These run against the real Google.Cloud.PubSub.V1 SubscriberClient (pointed at the emulator) with a callback
+/// that never returns, which is the exact shape of the hang. Skip-guarded when the emulator is unavailable.
+/// </summary>
+public class listener_shutdown_4065 : IAsyncLifetime
+{
+    private static readonly Uri TheUri = new("pubsub://wolverine/shutdown");
+
+    private bool _skip;
+
+    public async ValueTask InitializeAsync()
+    {
+        _skip = !await TestingExtensions.IsEmulatorAvailable();
+        Environment.SetEnvironmentVariable("PUBSUB_EMULATOR_HOST", TestingExtensions.EmulatorHost);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task stops_within_the_drain_budget_even_when_a_callback_never_returns()
+    {
+        if (_skip) return;
+
+        // Never completed -- this callback models a handler that outlives shutdown and ignores cancellation
+        var held = new TaskCompletionSource<SubscriberClient.Reply>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var subscription = await provisionAsync();
+        var subscriber = await new SubscriberClientBuilder
+        {
+            SubscriptionName = subscription,
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        }.BuildAsync(TestContext.Current.CancellationToken);
+
+        _ = subscriber.StartAsync((_, _) =>
+        {
+            callbackEntered.TrySetResult();
+            return held.Task;
+        });
+
+        await publishAsync(subscription);
+
+        // Only meaningful if the callback is genuinely in flight when we stop
+        await callbackEntered.Task.WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        var drainTimeout = 2.Seconds();
+        var stopwatch = Stopwatch.StartNew();
+
+        // WaitAsync so a regression FAILS the test instead of hanging the suite forever
+        await PubsubListener
+            .StopAndDisposeSubscriberAsync(subscriber, drainTimeout, NullLogger.Instance, TheUri)
+            .WaitAsync(60.Seconds(), TestContext.Current.CancellationToken);
+
+        stopwatch.Stop();
+
+        // The bound is drainTimeout for the stop plus drainTimeout/2 for the disposal. Assert generously --
+        // the point is that it RETURNS, not the exact number of milliseconds.
+        stopwatch.Elapsed.ShouldBeLessThan(20.Seconds());
+
+        held.TrySetResult(SubscriberClient.Reply.Nack);
+    }
+
+    [Fact]
+    public async Task returns_promptly_when_there_is_nothing_in_flight()
+    {
+        if (_skip) return;
+
+        var subscription = await provisionAsync();
+        var subscriber = await new SubscriberClientBuilder
+        {
+            SubscriptionName = subscription,
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        }.BuildAsync(TestContext.Current.CancellationToken);
+
+        _ = subscriber.StartAsync((_, _) => Task.FromResult(SubscriberClient.Reply.Ack));
+
+        var stopwatch = Stopwatch.StartNew();
+
+        await PubsubListener
+            .StopAndDisposeSubscriberAsync(subscriber, 30.Seconds(), NullLogger.Instance, TheUri)
+            .WaitAsync(60.Seconds(), TestContext.Current.CancellationToken);
+
+        stopwatch.Stop();
+
+        // An idle subscriber must not sit out the drain budget
+        stopwatch.Elapsed.ShouldBeLessThan(15.Seconds());
+    }
+
+    private static async Task<SubscriptionName> provisionAsync()
+    {
+        var id = $"shutdown-{Guid.NewGuid():N}";
+
+        var publisher = await new PublisherServiceApiClientBuilder
+        {
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+        var subscriber = await new SubscriberServiceApiClientBuilder
+        {
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+
+        var topicName = new TopicName("wolverine", id);
+        var subscriptionName = new SubscriptionName("wolverine", id);
+
+        try
+        {
+            await publisher.CreateTopicAsync(topicName);
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.AlreadyExists)
+        {
+        }
+
+        try
+        {
+            await subscriber.CreateSubscriptionAsync(subscriptionName, topicName, pushConfig: null,
+                ackDeadlineSeconds: 60);
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.AlreadyExists)
+        {
+        }
+
+        return subscriptionName;
+    }
+
+    private static async Task publishAsync(SubscriptionName subscription)
+    {
+        var publisher = await new PublisherServiceApiClientBuilder
+        {
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+
+        await publisher.PublishAsync(new TopicName(subscription.ProjectId, subscription.SubscriptionId), [
+            new PubsubMessage { Data = ByteString.CopyFromUtf8("hold me") }
+        ]);
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/AckExtensionWatchdog.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/AckExtensionWatchdog.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Pubsub.Internal;
+
+/// <summary>
+/// GH-4066. Watches how long each Google Cloud Platform Pub/Sub delivery has been held inside its subscriber
+/// callback and warns when one outlives <see cref="PubsubClientOptions.MaxTotalAckExtension" />.
+/// <para>
+/// This matters because of how the Pub/Sub client behaves at that boundary: it stops extending the ack deadline
+/// and then does nothing else. The running callback is not cancelled, receives no exception, and is told nothing.
+/// The service simply redelivers the message once the last extended deadline lapses, so a <em>second</em>
+/// execution starts while the first is still running. Wolverine's at-least-once contract covers a message
+/// arriving twice, but not a message overlapping itself — that breaks optimistic concurrency, event stream
+/// appends, sagas, and the intra-group ordering guarantee. Before this watchdog the first sign of any of it was
+/// downstream corruption.
+/// </para>
+/// <para>
+/// One shared periodic scan per listener rather than a timer per message: tracking is two dictionary operations
+/// on the receive hot path, which matters because <c>BufferedInMemory</c> and <c>Durable</c> endpoints run this
+/// path at full broker throughput while never getting anywhere near the budget.
+/// </para>
+/// </summary>
+internal sealed class AckExtensionWatchdog : IAsyncDisposable
+{
+    /// <summary>
+    /// Clamps the scan interval. The warning fires on the first scan after the budget elapses, so the interval is
+    /// also the worst-case reporting lag.
+    /// </summary>
+    internal static readonly TimeSpan MinimumScanInterval = TimeSpan.FromSeconds(1);
+
+    internal static readonly TimeSpan MaximumScanInterval = TimeSpan.FromSeconds(30);
+
+    private readonly TimeSpan _budget;
+    private readonly ConcurrentDictionary<long, Delivery> _inFlight = new();
+    private readonly ILogger _logger;
+    private readonly Timer _timer;
+    private readonly Uri _uri;
+
+    private long _ticket;
+
+    public AckExtensionWatchdog(Uri uri, TimeSpan budget, ILogger logger)
+    {
+        _uri = uri;
+        _budget = budget;
+        _logger = logger;
+
+        ScanInterval = determineScanInterval(budget);
+        _timer = new Timer(_ => scan(), null, ScanInterval, ScanInterval);
+    }
+
+    internal TimeSpan ScanInterval { get; }
+
+    /// <summary>
+    /// Exposed for testing -- the number of deliveries currently being watched.
+    /// </summary>
+    internal int InFlightCount => _inFlight.Count;
+
+    public async ValueTask DisposeAsync()
+    {
+        // Timer.DisposeAsync() completes once any in-flight scan callback has finished
+        await _timer.DisposeAsync();
+        _inFlight.Clear();
+    }
+
+    /// <summary>
+    /// Begin watching a delivery. The returned ticket must be handed back to <see cref="Release" /> when the
+    /// subscriber callback returns.
+    /// </summary>
+    public long Track(string? messageId)
+    {
+        var ticket = Interlocked.Increment(ref _ticket);
+        _inFlight[ticket] = new Delivery(messageId, Stopwatch.GetTimestamp());
+
+        return ticket;
+    }
+
+    public void Release(long ticket)
+    {
+        _inFlight.TryRemove(ticket, out _);
+    }
+
+    /// <summary>
+    /// Warn about every tracked delivery that has now outlived the ack extension budget. Each delivery is only
+    /// reported once. Internal so tests can drive it deterministically instead of waiting on the timer.
+    /// </summary>
+    internal void CheckForExpiredDeliveries()
+    {
+        var now = Stopwatch.GetTimestamp();
+
+        foreach (var pair in _inFlight)
+        {
+            var delivery = pair.Value;
+            if (delivery.Warned)
+            {
+                continue;
+            }
+
+            var elapsed = Stopwatch.GetElapsedTime(delivery.StartedAt, now);
+            if (elapsed < _budget)
+            {
+                continue;
+            }
+
+            // Losing the race just means somebody else already warned about this delivery
+            if (!delivery.TryMarkWarned())
+            {
+                continue;
+            }
+
+            _logger.LogWarning(
+                "{Uri}: Google Cloud Platform Pub/Sub message {MessageId} has been processing for {Elapsed}, which exceeds the MaxTotalAckExtension budget of {Budget}. Wolverine's Pub/Sub client has stopped extending this message's ack deadline, so Pub/Sub will redeliver it and a SECOND, CONCURRENT execution of the same message will begin while this one is still running. Handlers that are not safe to run concurrently with themselves -- optimistic concurrency, event stream appends, sagas, group-ordered processing -- can be corrupted by this. Either shorten the handler or raise MaxTotalAckExtension via ConfigureListener(x => x.MaxTotalAckExtension = ...).",
+                _uri,
+                delivery.MessageId ?? "(unknown)",
+                elapsed,
+                _budget);
+        }
+    }
+
+    /// <summary>
+    /// Scan often enough that the warning lands close to the crossing, without spinning for an endpoint whose
+    /// budget is measured in hours.
+    /// </summary>
+    private static TimeSpan determineScanInterval(TimeSpan budget)
+    {
+        var interval = TimeSpan.FromTicks(budget.Ticks / 10);
+
+        if (interval < MinimumScanInterval)
+        {
+            return MinimumScanInterval;
+        }
+
+        return interval > MaximumScanInterval ? MaximumScanInterval : interval;
+    }
+
+    /// <summary>
+    /// Scans may overlap if one runs long; <see cref="CheckForExpiredDeliveries" /> is idempotent, so that is
+    /// harmless. Nothing in here may be allowed to throw onto the timer's thread pool thread.
+    /// </summary>
+    private void scan()
+    {
+        try
+        {
+            CheckForExpiredDeliveries();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "{Uri}: Error in the Pub/Sub ack extension watchdog.", _uri);
+        }
+    }
+
+    private sealed class Delivery
+    {
+        private int _warned;
+
+        public Delivery(string? messageId, long startedAt)
+        {
+            MessageId = messageId;
+            StartedAt = startedAt;
+        }
+
+        public string? MessageId { get; }
+        public long StartedAt { get; }
+        public bool Warned => Volatile.Read(ref _warned) == 1;
+
+        public bool TryMarkWarned()
+        {
+            return Interlocked.CompareExchange(ref _warned, 1, 0) == 0;
+        }
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/BatchedPubsubListener.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/BatchedPubsubListener.cs
@@ -18,38 +18,11 @@ public class BatchedPubsubListener : PubsubListener
 
     public override async Task StartAsync()
     {
-        await listenForMessagesAsync(async () =>
+        await listenForMessagesAsync(() => listenWithSubscriberAsync(new SubscriberClientBuilder
         {
-            var subscriptionName = ListeningSubscriptionName;
-            var subscriberBuilder = new SubscriberClientBuilder
-            {
-                SubscriptionName = subscriptionName,
-                EmulatorDetection = _clients.EmulatorDetection,
-                Settings = new()
-                {
-                    // https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PubSub.V1/latest/Google.Cloud.PubSub.V1.SubscriberClient.Settings#Google_Cloud_PubSub_V1_SubscriberClient_Settings_FlowControlSettings
-                    // Remarks: Flow control uses these settings for two purposes: fetching messages to process, and processing them.
-                    // In terms of fetching messages, a single SubscriberClient creates multiple instances of SubscriberServiceApiClient, and each will observe the flow control settings independently
-                    FlowControlSettings = new(_endpoint.Client.MaxOutstandingMessages, _endpoint.Client.MaxOutstandingByteCount),
-                }
-            };
-            if (_clients.ConfigureSubscriberClientBuilder != null)
-                await _clients.ConfigureSubscriberClientBuilder(subscriberBuilder);
-            await using SubscriberClient subscriber = await subscriberBuilder.BuildAsync();
-            var ctRegistration = _cancellation.Token.Register(() => subscriber.StopAsync(CancellationToken.None));
-            try
-            {
-                await subscriber.StartAsync(async (PubsubMessage message, CancellationToken cancel) =>
-                    {
-                        var success = await handleMessageAsync(message);
-                        return success ? SubscriberClient.Reply.Ack : SubscriberClient.Reply.Nack;
-                    });
-            }
-            finally
-            {
-                ctRegistration.Unregister();
-                await subscriber.StopAsync(CancellationToken.None);
-            }
-        });
+            SubscriptionName = ListeningSubscriptionName,
+            EmulatorDetection = _clients.EmulatorDetection,
+            Settings = buildSubscriberSettings()
+        }));
     }
 }

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/InlinePubsubListener.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/InlinePubsubListener.cs
@@ -19,31 +19,16 @@ public class InlinePubsubListener : PubsubListener
 
     public override async Task StartAsync()
     {
-        await listenForMessagesAsync(async () =>
+        // This listener used to pass no Settings at all, so it silently ran on the SDK defaults and ignored
+        // whatever the user had configured through ConfigureListener(). The defaults happen to match
+        // PubsubClientOptions' own defaults, so setting them explicitly is not a behavioural change -- but it
+        // does mean MaxOutstandingMessages and, for GH-4066, MaxTotalAckExtension are now honoured on the very
+        // endpoint mode where the subscriber callback is held for the entire handler pipeline.
+        await listenForMessagesAsync(() => listenWithSubscriberAsync(new SubscriberClientBuilder
         {
-            var subscriptionName = ListeningSubscriptionName;
-            var subscriberBuilder = new SubscriberClientBuilder
-            {
-                SubscriptionName = subscriptionName,
-                EmulatorDetection = _clients.EmulatorDetection,
-            };
-            if (_clients.ConfigureSubscriberClientBuilder != null)
-                await _clients.ConfigureSubscriberClientBuilder(subscriberBuilder);
-            await using SubscriberClient subscriber = await subscriberBuilder.BuildAsync();
-            var ctRegistration = _cancellation.Token.Register(() => subscriber.StopAsync(CancellationToken.None));
-            try
-            {
-                await subscriber.StartAsync(async (PubsubMessage message, CancellationToken cancel) =>
-                {
-                    var success = await handleMessageAsync(message);
-                    return success ? SubscriberClient.Reply.Ack : SubscriberClient.Reply.Nack;
-                });
-            }
-            finally
-            {
-                ctRegistration.Unregister();
-                await subscriber.StopAsync(CancellationToken.None);
-            }
-        });
+            SubscriptionName = ListeningSubscriptionName,
+            EmulatorDetection = _clients.EmulatorDetection,
+            Settings = buildSubscriberSettings()
+        }));
     }
 }

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubListener.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubListener.cs
@@ -1,3 +1,4 @@
+using Google.Api.Gax;
 using Google.Cloud.PubSub.V1;
 using Google.Protobuf.Collections;
 using Grpc.Core;
@@ -37,6 +38,12 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
     protected readonly PubsubClientSet _clients;
     private readonly IPubsubEnvelopeMapper _mapper;
 
+    /// <summary>
+    /// GH-4066. Warns when a delivery is held longer than the ack extension budget, at which point Pub/Sub
+    /// begins redelivering it into a second, concurrent execution.
+    /// </summary>
+    private readonly AckExtensionWatchdog _ackExtensionWatchdog;
+
     public PubsubListener(
         PubsubEndpoint endpoint,
         PubsubTransport transport,
@@ -58,6 +65,7 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
         _runtime = runtime;
         _clients = clients;
         _logger = runtime.LoggerFactory.CreateLogger<PubsubListener>();
+        _ackExtensionWatchdog = new AckExtensionWatchdog(_endpoint.Uri, _endpoint.Client.MaxTotalAckExtension, _logger);
 
         if (_endpoint.DeadLetterName.IsNotEmpty())
         {
@@ -121,6 +129,7 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
         _task.SafeDispose();
         _requeue.SafeDispose();
         _deadLetter.SafeDispose();
+        await _ackExtensionWatchdog.DisposeAsync();
     }
 
     public bool NativeDeadLetterQueueEnabled { get; }
@@ -205,9 +214,171 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
         }
     }
 
+    /// <summary>
+    /// The <see cref="SubscriberClient.Settings" /> every listener runs on. Both the flow control bound and the
+    /// ack deadline extension budget are set explicitly here rather than left to the SDK defaults, so that
+    /// <see cref="PubsubClientOptions" /> is honoured on every endpoint mode. See
+    /// <see cref="PubsubClientOptions.MaxTotalAckExtension" /> for why that budget is a deliberate choice.
+    /// </summary>
+    protected SubscriberClient.Settings buildSubscriberSettings()
+    {
+        return BuildSubscriberSettings(_endpoint.Client);
+    }
+
+    internal static SubscriberClient.Settings BuildSubscriberSettings(PubsubClientOptions options)
+    {
+        return new SubscriberClient.Settings
+        {
+            // GH-4067. MaxOutstandingMessages is a bound on the WHOLE SubscriberClient, and ClientCount does
+            // NOT multiply it.
+            //
+            // This previously carried the "Remarks" paragraph from Google's own docs, which says a single
+            // SubscriberClient creates multiple SubscriberServiceApiClient instances "and each will observe the
+            // flow control settings independently". Measured against the real client library (3.24.0), that is
+            // not what happens. Observed peak concurrently in-flight vs. MaxOutstandingElementCount was exactly
+            // 1 -> 1, 3 -> 3, 8 -> 8 and 1000 -> 1000; with ClientCount = 4 and a limit of 3 the peak was 3,
+            // not 12. Structurally the SDK builds one Flow inside StartAsync() and passes it to every
+            // SingleChannel, and SubscriberClientImpl holds no per-client Flow -- one Flow, shared.
+            //
+            // Sizing a listener off the old comment would over-provision by a factor of ClientCount, so treat
+            // MaxOutstandingMessages as the total in-flight ceiling for the endpoint.
+            FlowControlSettings =
+                new FlowControlSettings(options.MaxOutstandingMessages, options.MaxOutstandingByteCount),
+            MaxTotalAckExtension = options.MaxTotalAckExtension
+        };
+    }
+
+    /// <summary>
+    /// Run one streaming pull session: build the subscriber, pump messages until the listener is cancelled or the
+    /// session faults, then shut the subscriber down within a bounded budget.
+    /// </summary>
+    protected async Task listenWithSubscriberAsync(SubscriberClientBuilder subscriberBuilder)
+    {
+        if (_clients.ConfigureSubscriberClientBuilder != null)
+        {
+            await _clients.ConfigureSubscriberClientBuilder(subscriberBuilder);
+        }
+
+        var subscriber = await subscriberBuilder.BuildAsync();
+
+        // GH-4065: the cancellation registration used to fire off StopAsync() and drop the returned task on the
+        // floor, so nothing ever observed its completion or its exceptions. Route both the registration and the
+        // finally block through the same memoized task instead: cancellation still starts the shutdown promptly,
+        // and the finally block awaits that very same shutdown rather than racing a second one.
+        var gate = new object();
+        Task? shutdown = null;
+
+        Task shutDownOnceAsync()
+        {
+            lock (gate)
+            {
+                return shutdown ??= stopAndDisposeSubscriberAsync(subscriber);
+            }
+        }
+
+        var ctRegistration = _cancellation.Token.Register(() => _ = shutDownOnceAsync());
+
+        try
+        {
+            await subscriber.StartAsync(async (PubsubMessage message, CancellationToken cancel) =>
+            {
+                var success = await handleMessageAsync(message);
+                return success ? SubscriberClient.Reply.Ack : SubscriberClient.Reply.Nack;
+            });
+        }
+        finally
+        {
+            ctRegistration.Unregister();
+            await shutDownOnceAsync();
+        }
+    }
+
+    private Task stopAndDisposeSubscriberAsync(SubscriberClient subscriber)
+    {
+        return StopAndDisposeSubscriberAsync(subscriber, _runtime.DurabilitySettings.DrainTimeout, _logger,
+            _endpoint.Uri);
+    }
+
+    /// <summary>
+    /// GH-4065. Shut a <see cref="SubscriberClient" /> down inside a bounded budget.
+    /// <para>
+    /// <c>SubscriberClient.StopAsync</c> waits on in-flight message callbacks, and our callback awaits
+    /// <c>IReceiver.ReceivedAsync</c> -- which on an <c>EndpointMode.Inline</c> endpoint runs the whole handler
+    /// pipeline. Passing <c>CancellationToken.None</c>, as this used to, therefore means a single slow handler
+    /// wedges listener teardown with nothing at all bounding the wait.
+    /// </para>
+    /// <para>
+    /// The budget is <see cref="DurabilitySettings.DrainTimeout" />, which is what
+    /// <c>BufferedReceiver.DrainAsync</c> and <c>InlineReceiver.DrainAsync</c> already use for exactly this
+    /// decision. Two nested deadlines are needed because <c>StopAsync(TimeSpan)</c> is only a <em>soft</em>
+    /// stop: at its timeout it cancels each callback's <see cref="CancellationToken" /> and then keeps waiting
+    /// for those callbacks to return, so a callback that never observes cancellation would still hang forever.
+    /// Half the budget is spent letting callbacks finish on their own; the outer wait over the full budget is
+    /// the hard stop that guarantees this method returns. Disposal re-enters the same wait inside the SDK and
+    /// so gets a bound of its own.
+    /// </para>
+    /// <para>
+    /// Anything still unacked when we give up is simply redelivered by Pub/Sub. Preferring "stop within the
+    /// drain budget and let the rest be redelivered" over "wait forever" is the same trade every other
+    /// Wolverine transport makes.
+    /// </para>
+    /// </summary>
+    internal static async Task StopAndDisposeSubscriberAsync(SubscriberClient subscriber, TimeSpan drainTimeout,
+        ILogger logger, Uri uri)
+    {
+        var softStop = TimeSpan.FromTicks(Math.Max(drainTimeout.Ticks / 2, 0));
+
+        try
+        {
+            await subscriber.StopAsync(softStop).WaitAsync(drainTimeout);
+        }
+        catch (OperationCanceledException)
+        {
+            // The soft stop elapsed, the SDK cancelled the in-flight callbacks, and they unwound. Normal.
+            logger.LogInformation(
+                "{Uri}: Google Cloud Platform Pub/Sub listener did not finish its in-flight messages within the drain timeout of {DrainTimeout}; unacknowledged messages will be redelivered.",
+                uri, drainTimeout);
+        }
+        catch (TimeoutException)
+        {
+            logger.LogWarning(
+                "{Uri}: Google Cloud Platform Pub/Sub listener could not be stopped within the drain timeout of {DrainTimeout} because at least one message callback never returned. Abandoning the wait; unacknowledged messages will be redelivered.",
+                uri, drainTimeout);
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "{Uri}: Error while stopping the Google Cloud Platform Pub/Sub subscriber.", uri);
+        }
+
+        try
+        {
+            await subscriber.DisposeAsync().AsTask().WaitAsync(softStop);
+        }
+        catch (Exception e)
+        {
+            logger.LogDebug(e, "{Uri}: Error while disposing the Google Cloud Platform Pub/Sub subscriber.", uri);
+        }
+    }
+
     protected async Task<bool> handleMessageAsync(PubsubMessage message)
     {
+        // GH-4066. The subscriber callback is held for as long as this takes, and on an EndpointMode.Inline
+        // endpoint that is the entire handler pipeline. Outliving the ack extension budget means Pub/Sub starts
+        // redelivering into a concurrent second execution, silently, so watch the clock on every delivery.
+        var ticket = _ackExtensionWatchdog.Track(message.MessageId);
 
+        try
+        {
+            return await processMessageAsync(message);
+        }
+        finally
+        {
+            _ackExtensionWatchdog.Release(ticket);
+        }
+    }
+
+    private async Task<bool> processMessageAsync(PubsubMessage message)
+    {
         if (message.Attributes.Keys.Contains("batched"))
         {
             var batched = EnvelopeSerializer.ReadMany(message.Data.ToByteArray());

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubOptions.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubOptions.cs
@@ -49,6 +49,37 @@ public class PubsubClientOptions
 {
     public long MaxOutstandingByteCount = 100 * 1024 * 1024;
     public long MaxOutstandingMessages = 1000;
+
+    /// <summary>
+    ///     GH-4066. The total budget the Pub/Sub client may spend extending a message's ack deadline while
+    ///     Wolverine is still processing it. Wolverine sets this explicitly on every listener rather than
+    ///     letting it fall through to the SDK default.
+    ///     <para>
+    ///     Once this budget is exhausted the client simply <em>stops</em> extending. It does not cancel the
+    ///     running callback and it does not raise anything into it — the service just redelivers, so a second
+    ///     execution of the same message begins while the first is still in flight. That is materially worse
+    ///     than ordinary at-least-once redelivery, because the two executions <em>overlap</em>: optimistic
+    ///     concurrency, event stream appends, sagas and group-ordered processing all assume a message is not
+    ///     running concurrently with itself.
+    ///     </para>
+    ///     <para>
+    ///     The two failure modes are wildly asymmetric. Setting this too low silently corrupts data; setting
+    ///     it too high only means a genuinely wedged message waits longer before it is redelivered, and holds
+    ///     a flow-control slot in the meantime. So the deliberate choice is to be generous: one hour, which is
+    ///     sixty times <see cref="WolverineOptions.DefaultExecutionTimeout" /> and therefore leaves ample room
+    ///     for a slow handler plus its inline retries. This happens to equal
+    ///     <c>SubscriberClient.DefaultMaxTotalAckExtension</c>, so it is not a behavioural change — the point
+    ///     is that it is now a value Wolverine chose, is documented, is configurable, and is monitored:
+    ///     crossing it is logged at Warning rather than passing in silence.
+    ///     </para>
+    ///     <para>
+    ///     Lower this if you would rather a stuck message be redelivered promptly and your handlers are
+    ///     genuinely idempotent under concurrent execution. Raise it if you knowingly run handlers longer
+    ///     than an hour.
+    ///     </para>
+    /// </summary>
+    public TimeSpan MaxTotalAckExtension = TimeSpan.FromHours(1);
+
     public PubsubRetryPolicy RetryPolicy = new();
 }
 


### PR DESCRIPTION
Closes #4065
Closes #4066

Two GCP Pub/Sub listener lifecycle bugs found during the #4052 spike, plus the comment correction from #4067.

## #4065 — bounded listener shutdown

`BatchedPubsubListener` and `InlinePubsubListener` both stopped their subscriber with
`subscriber.StopAsync(CancellationToken.None)`, in two places each. `SubscriberClient.StopAsync` waits on
in-flight message callbacks, and Wolverine's callback awaits `IReceiver.ReceivedAsync` — which on an
`EndpointMode.Inline` endpoint runs the whole handler pipeline. With no token there was nothing bounding
that wait at all.

Shutdown is now bounded by `DurabilitySettings.DrainTimeout`, the same budget `BufferedReceiver.DrainAsync`
and `InlineReceiver.DrainAsync` already use for this exact decision. Two nested deadlines are needed:
`StopAsync(TimeSpan)` is only a *soft* stop — at its timeout it cancels each callback's token and then keeps
waiting for the callbacks to return, so a callback that never observes cancellation would still hang. Half
the budget lets callbacks finish on their own; an outer wait over the full budget is the hard stop.
Disposal re-enters the same wait inside the SDK, so it gets a bound of its own. Anything left unacked is
simply redelivered.

The fire-and-forget `StopAsync` in the cancellation registration is gone: both the registration and the
`finally` now route through one memoized shutdown task, so the task is actually observed and the two paths
cannot race a double stop.

**Blast radius today, stated precisely.** This does not currently wedge `IHost.StopAsync`.
`ListeningAgent.StopAndDrainCoreAsync` awaits `receiver.DrainAsync()`, which is already `DrainTimeout`-bounded,
and `PubsubListener.DisposeAsync` only calls `_task.SafeDispose()`, which does not await. So the present-day
symptom is the listener's background loop never completing and the `SubscriberClient` never being disposed —
a leaked streaming-pull session and its gRPC channels on every listener stop or `DEADLINE_EXCEEDED` restart —
rather than a hung host shutdown. Under `EndpointMode.NativeAck` (#3708, Pub/Sub in #4052), where every
in-flight message holds a callback by design, this becomes the normal shutdown path.

## #4066 — silent concurrent duplicate on ack extension exhaustion

When `MaxTotalAckExtension` runs out the client stops extending the ack deadline and does nothing else: the
running callback is not cancelled, gets no exception, and is told nothing. Pub/Sub redelivers, so a second
execution of the message starts **while the first is still running**. Wolverine's at-least-once contract
covers a message arriving twice; it does not cover a message overlapping itself, which is what breaks
optimistic concurrency, event stream appends, sagas, and `PartitionProcessingByGroupId`'s intra-group
guarantee.

Scoped exactly as the issue asks:

1. **A deliberate, configurable budget.** New `PubsubClientOptions.MaxTotalAckExtension`, set explicitly on
   every listener via `ConfigureListener`. The reasoning is in a doc comment on the field.

   The value is **one hour, and deliberately unchanged from what the SDK default happened to be**. That is
   the point rather than a dodge: the two failure modes are wildly asymmetric — too low silently corrupts
   data, too high only delays redelivery of a wedged message and holds a flow-control slot meanwhile — so
   the right choice errs generous, and one hour is 60x `WolverineOptions.DefaultExecutionTimeout`. Picking a
   *different* number would have been a silent behaviour change for anyone running long inline handlers. What
   changes is that the value is now chosen by Wolverine, documented, configurable, and monitored.

2. **The crossing is logged at Warning**, naming the message id and how long it has been running, once per
   delivery. Implemented as one shared periodic scan per listener (`AckExtensionWatchdog`) rather than a
   timer per message, because `BufferedInMemory`/`Durable` endpoints run this path at full broker throughput
   while never approaching the budget; tracking costs two dictionary operations.

3. **Documented** on the Pub/Sub listening page.

**Explicitly out of scope**, as instructed: a handler that has already outlived the budget is *not* cancelled.
It keeps running alongside its own duplicate. I think that is worth doing as a follow-up — the callback
already receives a `CancellationToken` from the SDK that Wolverine currently ignores entirely, so there is a
natural seam — but it changes handler cancellation semantics across every Pub/Sub mode and deserves its own
design call. Noted in the docs with a pointer back to #4066.

## #4067 — flow control comment correction (comment + docs only)

The `FlowControlSettings` initializer carried Google's own API remarks, which say a `SubscriberClient` builds
several inner clients that "each will observe the flow control settings independently". Measured against the
real client library during the #4052 spike, that is not what happens: observed peak in-flight matched
`MaxOutstandingElementCount` exactly (1→1, 3→3, 8→8, 1000→1000), and with `ClientCount = 4` and a limit of 3
the peak was 3, not 12. Anyone sizing a listener from the old comment would over-provision by a factor of
`ClientCount`.

Replaced with what was actually observed, and documented as a warning on the listening page along with the
ordering-key interaction (effective concurrency collapses to the number of distinct in-flight group ids).

Per the instruction on that issue I did **not** re-verify this against the emulator — the measurement came
from the real client library, and emulator fidelity on flow control is exactly the sort of thing that
diverges. No flow-control values and no `ClientCount` behaviour were changed; the rest of #4067 stays open.

## Incidental behaviour change worth flagging

`InlinePubsubListener` previously passed **no** `SubscriberClient.Settings` at all, so it silently ran on SDK
defaults and ignored whatever the user configured through `ConfigureListener`. Both listeners now build
settings identically. The defaults are byte-for-byte what the SDK was already using (1000 / 100 MB / 1 hour),
so this is not a functional change out of the box — but `MaxOutstandingMessages` and `MaxTotalAckExtension`
are now honoured on the inline path, which is precisely the path #4066 says is reachable today.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean.
- Full CoreTests (`dotnet run -f net9.0 -c Release`) — 2577 passed, 0 failed, 2 skipped.
- Full `Wolverine.Pubsub.Tests` against the emulator — green.

**Red baselines.** Every test that claims to prove a fix was checked by breaking the fix and confirming
failure:

| Break | Result |
|---|---|
| `StopAndDisposeSubscriberAsync` reverted to `StopAsync(CancellationToken.None)` | `stops_within_the_drain_budget_even_when_a_callback_never_returns` hangs for the full 60s guard and fails with `TimeoutException`. With the fix it returns in **3.2s**. |
| `CheckForExpiredDeliveries` made a no-op | 4 tests fail, including the end-to-end. |
| Watchdog unwired from `handleMessageAsync` | *Only* the end-to-end fails — confirming it covers the wiring, not just the watchdog. |
| `MaxTotalAckExtension` dropped from the subscriber settings | Both `subscriber_settings_plumbing` tests fail. |

The shutdown test drives a **real** `Google.Cloud.PubSub.V1.SubscriberClient` (pointed at the emulator) with
a callback that never returns — the exact shape of the hang, not a stand-in.

### What the emulator could and could not show

**Verified against the emulator:**
- Bounded shutdown with a real client and a genuinely held callback, including the pre-fix hang.
- The Warning firing end-to-end from a real `ProcessInline` handler: 2.91s elapsed against a 2s budget.

**Not verified, and not claimed:**
- **The concurrent duplicate delivery itself.** I did not add a test asserting that the second callback
  starts. Such a test would be asserting behaviour this PR deliberately does not fix, so it would be a
  characterization test of a known bug rather than a regression guard. The #4052 spike did measure it on this
  same emulator — redelivery on a ~17s cadence with an 8s budget and a 10s ack deadline, original callback
  still running, no cancellation and no exception — which is the evidence the issue rests on.
- **Real-service behaviour for long holds.** The spike's longest observed hold was 5 minutes. A one-hour
  budget is untested anywhere, and the interaction with `DeadLetterPolicy.MaxDeliveryAttempts` (redelivery
  driven by an exhausted budget will increment delivery attempts against a message that is still being
  processed successfully) needs a live project, not the emulator.
- **The flow-control globality claim** — deliberately not re-tested here, per above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
