### PR TITLE
GH-4060: warn when a Pulsar hot-tail listener carries requeue policy

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -111,6 +111,41 @@ A few things to know:
 - Reach for `TailFromLatest()` when you want **all** nodes to process each message; use a normal `Shared` /
   `KeyShared` subscription when you want each message processed **once** across the cluster.
 
+#### Handler failures on a hot-tail listener are dropped, not retried
+
+Losing a message because a node was down or had not attached its reader yet is inherent to choosing a
+non-durable cursor, and is the trade you accept when you call `TailFromLatest()`. Losing one because its
+**handler threw** is easier to be surprised by, so it is worth being explicit about what does and does not
+work here.
+
+A hot-tail listener commits no cursor, so there is nothing for the broker to redeliver from. Every
+requeue-shaped error policy therefore resolves to a no-op and the message is simply gone:
+
+| Error handling | On a hot-tail listener |
+| --- | --- |
+| `RetryTimes()`, `RetryWithCooldown()` | ✅ Works — the retry never leaves the process |
+| `ScheduleRetry()` | ✅ Works — rescheduled in memory, or in the durable inbox if one is configured |
+| `Requeue()`, `RequeueIndefinitely()`, `PauseThenRequeue()`, `MaximumAttempts()` | ❌ **Silently drops the message** |
+| Pulsar native dead letter topic (`DeadLetterQueueing()`) | ❌ Never reached — a native dead-letter move is a listener operation, and this listener is a `Reader` |
+| Wolverine's durable dead letter table | ✅ Works, if a message store is configured |
+
+Wolverine warns at bootstrap if a hot-tail listener is combined with any requeue-shaped policy, since none of
+it can run.
+
+In-process retries are the error handling to reach for on a hot-tail listener, and a configured message store
+is the only recovery route it can offer:
+
+```csharp
+opts.ListenToPulsarTopic("persistent://public/default/live-events").TailFromLatest();
+
+// Retried inside this process; nothing is handed back to the broker.
+opts.Policies.OnException<TransientFailureException>().RetryWithCooldown(
+    50.Milliseconds(), 100.Milliseconds(), 250.Milliseconds());
+```
+
+If these are messages you cannot afford to lose on a handler failure, use an ordinary `Shared` / `KeyShared`
+subscription instead — the cursor is what makes redelivery possible.
+
 ## Replaying a Topic <Badge type="tip" text="6.8" />
 
 When you need to **reprocess** a window of a topic's history — error recovery, rebuilding downstream state,

--- a/src/Testing/CoreTests/Configuration/hot_tail_requeue_policy_validation.cs
+++ b/src/Testing/CoreTests/Configuration/hot_tail_requeue_policy_validation.cs
@@ -1,0 +1,165 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Configuration;
+
+/// <summary>
+/// GH-4060. A listener whose cursor is ephemeral -- Pulsar's TailFromLatest() is the one transport feature that
+/// does this today -- has nowhere to redeliver a deferred message from, so its DeferAsync is necessarily a no-op.
+/// Requeue-shaped error handling configured against it does nothing at all, which nothing in the API says, so it
+/// is warned about at bootstrap.
+/// </summary>
+public class hot_tail_requeue_policy_validation
+{
+    private static Endpoint listenerThatCannotRedeliver() =>
+        new CursorlessEndpoint("stub://hot-tail".ToUri()) { IsListener = true };
+
+    private static Endpoint ordinaryListener() =>
+        new RedeliveringEndpoint("stub://ordinary".ToUri()) { IsListener = true };
+
+    [Fact]
+    public void warns_when_a_cursorless_listener_carries_requeue_policy()
+    {
+        var problem = ListenerConfigurationValidator
+            .Validate(listenerThatCannotRedeliver(), requeuePoliciesConfigured: true)
+            .Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+        problem.Message.ShouldContain("stub://hot-tail");
+        problem.Message.ShouldContain("Requeue()");
+        problem.Message.ShouldContain("TailFromLatest()");
+
+        // The whole point of the warning is telling people what DOES still work, not just what doesn't.
+        problem.Message.ShouldContain("RetryTimes()");
+        problem.Message.ShouldContain("dead letter table");
+    }
+
+    [Fact]
+    public void does_not_warn_when_no_requeue_policy_is_configured()
+    {
+        ListenerConfigurationValidator
+            .Validate(listenerThatCannotRedeliver(), requeuePoliciesConfigured: false)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void does_not_warn_for_a_listener_that_can_redeliver()
+    {
+        ListenerConfigurationValidator
+            .Validate(ordinaryListener(), requeuePoliciesConfigured: true)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_endpoint_is_not_listening()
+    {
+        var endpoint = new CursorlessEndpoint("stub://hot-tail".ToUri());
+        endpoint.IsListener.ShouldBeFalse();
+
+        ListenerConfigurationValidator.Validate(endpoint, requeuePoliciesConfigured: true).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The warning fires in every mode, not only Inline: a cursorless listener ignores requeue policies whether or
+    /// not Wolverine's local execution block sits in front of it.
+    /// </summary>
+    [Theory]
+    [InlineData(EndpointMode.Inline)]
+    [InlineData(EndpointMode.BufferedInMemory)]
+    public void warns_in_every_mode(EndpointMode mode)
+    {
+        var endpoint = listenerThatCannotRedeliver();
+        endpoint.Mode = mode;
+
+        ListenerConfigurationValidator.Validate(endpoint, requeuePoliciesConfigured: true)
+            .ShouldContain(x => x.Message.Contains("Requeue()"));
+    }
+
+    #region what counts as a requeue policy
+
+    [Fact]
+    public void an_empty_collection_has_no_requeue_policies()
+    {
+        new FailureRuleCollection().AnyRequeuePolicies().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void in_lane_retries_are_not_requeue_policies()
+    {
+        var rules = new PolicyHolder();
+        rules.OnException<DivideByZeroException>().RetryTimes(3);
+        rules.OnException<BadImageFormatException>().RetryWithCooldown(1.Milliseconds());
+        rules.OnException<TimeoutException>().ScheduleRetry(1.Seconds());
+
+        rules.Failures.AnyRequeuePolicies().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void requeue_counts()
+    {
+        var rules = new PolicyHolder();
+        rules.OnException<DivideByZeroException>().Requeue(3);
+
+        rules.Failures.AnyRequeuePolicies().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void pause_then_requeue_counts()
+    {
+        var rules = new PolicyHolder();
+        rules.OnException<DivideByZeroException>().PauseThenRequeue(50.Milliseconds());
+
+        rules.Failures.AnyRequeuePolicies().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void requeue_indefinitely_counts()
+    {
+        var rules = new PolicyHolder();
+        rules.OnException<DivideByZeroException>().RequeueIndefinitely();
+
+        rules.Failures.AnyRequeuePolicies().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void maximum_attempts_counts_because_it_synthesizes_a_requeue_ladder()
+    {
+        var rules = new FailureRuleCollection { MaximumAttempts = 3 };
+
+        rules.AnyRequeuePolicies().ShouldBeTrue();
+    }
+
+    #endregion
+
+    private class PolicyHolder : IWithFailurePolicies
+    {
+        public FailureRuleCollection Failures { get; } = new();
+    }
+
+    // Deliberately minimal stand-ins: this rule is about a property of the endpoint, and building a real Pulsar
+    // endpoint here would drag the Pulsar assembly into CoreTests. Wolverine.Pulsar.Tests covers the real one.
+    private class CursorlessEndpoint(Uri uri) : Endpoint(uri, EndpointRole.Application)
+    {
+        protected internal override bool supportsRedelivery => false;
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+            => throw new NotSupportedException();
+
+        protected override ISender CreateSender(IWolverineRuntime runtime) => throw new NotSupportedException();
+    }
+
+    private class RedeliveringEndpoint(Uri uri) : Endpoint(uri, EndpointRole.Application)
+    {
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+            => throw new NotSupportedException();
+
+        protected override ISender CreateSender(IWolverineRuntime runtime) => throw new NotSupportedException();
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_hot_tail_error_handling.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/pulsar_hot_tail_error_handling.cs
@@ -1,0 +1,349 @@
+using System.Buffers;
+using DotPulsar;
+using DotPulsar.Abstractions;
+using DotPulsar.Extensions;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// GH-4060. A hot-tail listener reads through a non-durable Pulsar <c>Reader</c> that commits no cursor, so
+/// <c>PulsarReaderListener.DeferAsync</c> is necessarily a no-op and nothing routed through it ever comes back.
+/// These tests pin down which error handling still functions there and which silently drops the message, because
+/// that distinction is the whole substance of the bootstrap warning and the docs.
+/// </summary>
+[Collection("pulsar")]
+public class pulsar_hot_tail_error_handling
+{
+    // ---- configuration (no broker) ----
+
+    private static PulsarEndpoint endpointFor(string name, bool hotTail) =>
+        new($"pulsar://persistent/public/default/{name}".ToUri(), new PulsarTransport())
+        {
+            IsHotTail = hotTail,
+            IsListener = true
+        };
+
+    [Fact]
+    public void a_hot_tail_endpoint_declares_that_it_cannot_redeliver()
+    {
+        endpointFor("hot", hotTail: true).supportsRedelivery.ShouldBeFalse();
+        endpointFor("ordinary", hotTail: false).supportsRedelivery.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void requeue_policy_on_a_hot_tail_listener_is_warned_about_at_bootstrap()
+    {
+        var problem = ListenerConfigurationValidator
+            .Validate(endpointFor("hot", hotTail: true), requeuePoliciesConfigured: true)
+            .Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Warning);
+        problem.Message.ShouldContain("TailFromLatest()");
+        problem.Message.ShouldContain("Requeue()");
+    }
+
+    [Fact]
+    public void an_ordinary_pulsar_listener_is_not_warned_about()
+    {
+        ListenerConfigurationValidator
+            .Validate(endpointFor("ordinary", hotTail: false), requeuePoliciesConfigured: true)
+            .ShouldBeEmpty();
+    }
+
+    // ---- end-to-end (Pulsar docker) ----
+
+    private static async Task<IHost> hotTailHostAsync(Action<WolverineOptions> configure)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+                opts.Services.AddSingleton<HotTailFailureSink>();
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<HotTailFailureHandler>();
+                configure(opts);
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        // MessageId.Latest: the reader only ever sees what is published after it attaches.
+        await Task.Delay(3.Seconds());
+
+        return host;
+    }
+
+    private static Task<IHost> publisherAsync(string topic) => Host.CreateDefaultBuilder()
+        .UseWolverine(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+            opts.Discovery.DisableConventionalDiscovery();
+        })
+        .StartAsync();
+
+    /// <summary>
+    /// The one form of error handling a hot-tail listener can actually run: a retry that never leaves the
+    /// process. Configured on the CHAIN rather than globally, because the Pulsar transport registers a global
+    /// AlwaysMatches failure rule at UsePulsar() time that currently pre-empts every global OnException rule --
+    /// see the note in the GH-4060 pull request. Chain rules sort ahead of it in CombineRules.
+    /// </summary>
+    [Fact]
+    public async Task in_lane_retries_still_run_on_a_hot_tail_listener()
+    {
+        var topic = $"persistent://public/default/hottail-retry-{Guid.NewGuid():N}";
+
+        using var publisher = await publisherAsync(topic);
+        using var listener = await hotTailHostAsync(opts =>
+        {
+            opts.ListenToPulsarTopic(topic).ProcessInline().TailFromLatest();
+            opts.HandlerGraph.ConfigureHandlerForMessage<HotTailFailingMessage>(chain =>
+                chain.OnException<HotTailBoom>().RetryTimes(3));
+        });
+
+        var sink = listener.Services.GetRequiredService<HotTailFailureSink>();
+        sink.FailuresBeforeSuccess = 2;
+
+        await publisher.MessageBus().SendAsync(new HotTailFailingMessage { Id = "retry-me" });
+
+        await waitForAsync(() => sink.Successes.Count == 1);
+
+        // Three attempts against the same delivery, all inside this process, ending in a success.
+        sink.Attempts.ShouldBe(3);
+        sink.Successes.ShouldBe(["retry-me"]);
+    }
+
+    /// <summary>
+    /// The hole itself. Requeue promises another delivery; the Reader has no cursor to produce one from, so the
+    /// handler runs exactly once and the message is gone.
+    /// </summary>
+    [Fact]
+    public async Task requeue_on_a_hot_tail_listener_never_redelivers()
+    {
+        var topic = $"persistent://public/default/hottail-requeue-{Guid.NewGuid():N}";
+
+        using var publisher = await publisherAsync(topic);
+        using var listener = await hotTailHostAsync(opts =>
+        {
+            opts.ListenToPulsarTopic(topic).ProcessInline().TailFromLatest();
+            opts.HandlerGraph.ConfigureHandlerForMessage<HotTailFailingMessage>(chain =>
+                chain.OnException<HotTailBoom>().Requeue(3));
+        });
+
+        var sink = listener.Services.GetRequiredService<HotTailFailureSink>();
+
+        // Would succeed on the second delivery, if there were one.
+        sink.FailuresBeforeSuccess = 1;
+
+        await publisher.MessageBus().SendAsync(new HotTailFailingMessage { Id = "requeue-me" });
+
+        await waitForAsync(() => sink.Attempts >= 1);
+        await Task.Delay(5.Seconds(), TestContext.Current.CancellationToken);
+
+        sink.Attempts.ShouldBe(1);
+        sink.Successes.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// A native dead-letter move is a listener operation and a hot-tail listener is a Reader, so Pulsar's
+    /// {topic}-DLQ never sees the failure.
+    /// </summary>
+    [Fact]
+    public async Task native_dead_letter_topic_never_receives_from_a_hot_tail_listener()
+    {
+        var topic = $"persistent://public/default/hottail-dlq-{Guid.NewGuid():N}";
+
+        await using var probe = await dlqProbeAsync(topic + "-DLQ");
+
+        using var publisher = await publisherAsync(topic);
+        using var listener = await hotTailHostAsync(opts =>
+            opts.ListenToPulsarTopic(topic)
+                .ProcessInline()
+                .TailFromLatest()
+                .DeadLetterQueueing(DeadLetterTopic.DefaultNative));
+
+        var sink = listener.Services.GetRequiredService<HotTailFailureSink>();
+        sink.FailuresBeforeSuccess = int.MaxValue;
+
+        await publisher.MessageBus().SendAsync(new HotTailFailingMessage { Id = "dlq-me" });
+
+        await waitForAsync(() => sink.Attempts >= 1);
+
+        (await probe.CountAsync(5.Seconds())).ShouldBe(0);
+    }
+
+    /// <summary>
+    /// Positive control for the test above: the same handler, the same failure and the same native dead letter
+    /// configuration on an ordinary durable-subscription listener DOES reach the dead letter topic. Without this,
+    /// a zero count above would only prove that the probe never worked.
+    /// </summary>
+    [Fact]
+    public async Task native_dead_letter_topic_does_receive_from_an_ordinary_listener()
+    {
+        var topic = $"persistent://public/default/normal-dlq-{Guid.NewGuid():N}";
+
+        await using var probe = await dlqProbeAsync(topic + "-DLQ");
+
+        using var publisher = await publisherAsync(topic);
+        using var listener = await hotTailHostAsync(opts =>
+            opts.ListenToPulsarTopic(topic)
+                .ProcessInline()
+                .WithSharedSubscriptionType()
+                .DeadLetterQueueing(DeadLetterTopic.DefaultNative)
+                .DisableRetryLetterQueueing());
+
+        var sink = listener.Services.GetRequiredService<HotTailFailureSink>();
+        sink.FailuresBeforeSuccess = int.MaxValue;
+
+        await publisher.MessageBus().SendAsync(new HotTailFailingMessage { Id = "dlq-me" });
+
+        (await probe.CountAsync(30.Seconds())).ShouldBeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// The one recovery route a hot-tail listener does offer: with a message store configured, the failure lands
+    /// in Wolverine's own dead letter table even though nothing native is reachable.
+    /// </summary>
+    [Fact]
+    public async Task the_durable_dead_letter_table_still_catches_a_hot_tail_failure()
+    {
+        var schema = "hottail_dlq_" + Guid.NewGuid().ToString("N")[..8];
+        var topic = $"persistent://public/default/hottail-durabledlq-{Guid.NewGuid():N}";
+
+        using var publisher = await publisherAsync(topic);
+        using var listener = await hotTailHostAsync(opts =>
+        {
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, schema);
+            opts.ListenToPulsarTopic(topic).ProcessInline().TailFromLatest();
+        });
+
+        var sink = listener.Services.GetRequiredService<HotTailFailureSink>();
+        sink.FailuresBeforeSuccess = int.MaxValue;
+
+        await publisher.MessageBus().SendAsync(new HotTailFailingMessage { Id = "durable-dlq" });
+
+        var count = 0L;
+        await waitForAsync(() =>
+        {
+            count = countDeadLetters(schema);
+            return count > 0;
+        });
+
+        count.ShouldBeGreaterThan(0);
+    }
+
+    private static long countDeadLetters(string schema)
+    {
+        using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select count(*) from {schema}.wolverine_dead_letters";
+        return (long)cmd.ExecuteScalar()!;
+    }
+
+    private static async Task<DlqProbe> dlqProbeAsync(string dlqTopic)
+    {
+        var client = PulsarClient.Builder().ServiceUrl(PulsarContainerFixture.ServiceUrl).Build();
+        var consumer = client.NewConsumer()
+            .Topic(dlqTopic)
+            .SubscriptionName("probe-" + Guid.NewGuid().ToString("N"))
+            .SubscriptionType(SubscriptionType.Shared)
+            .InitialPosition(SubscriptionInitialPosition.Earliest)
+            .Create();
+
+        // Force the subscription to exist before anything is published to the topic.
+        await consumer.OnStateChangeTo(ConsumerState.Active, TimeSpan.FromSeconds(30));
+
+        return new DlqProbe(client, consumer);
+    }
+
+    private sealed class DlqProbe(IPulsarClient client, IConsumer<ReadOnlySequence<byte>> consumer) : IAsyncDisposable
+    {
+        public async Task<int> CountAsync(TimeSpan window)
+        {
+            var count = 0;
+            using var cancellation = new CancellationTokenSource(window);
+
+            try
+            {
+                await foreach (var message in consumer.Messages(cancellation.Token))
+                {
+                    count++;
+                    await consumer.Acknowledge(message, CancellationToken.None);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            return count;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await consumer.DisposeAsync();
+            await client.DisposeAsync();
+        }
+    }
+
+    private static async Task waitForAsync(Func<bool> condition, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (condition()) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Condition was never met within {timeoutMs}ms");
+    }
+}
+
+public class HotTailFailingMessage
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class HotTailBoom() : Exception("Boom on a hot-tail listener");
+
+public class HotTailFailureSink
+{
+    private int _attempts;
+
+    public int FailuresBeforeSuccess { get; set; }
+
+    public int Attempts => _attempts;
+
+    public List<string> Successes { get; } = [];
+
+    public void Record(string id)
+    {
+        var attempt = Interlocked.Increment(ref _attempts);
+        if (attempt <= FailuresBeforeSuccess)
+        {
+            throw new HotTailBoom();
+        }
+
+        lock (Successes)
+        {
+            Successes.Add(id);
+        }
+    }
+}
+
+public class HotTailFailureHandler
+{
+    public static void Handle(HotTailFailingMessage message, HotTailFailureSink sink)
+    {
+        sink.Record(message.Id);
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarEndpoint.cs
@@ -84,6 +84,13 @@ public class PulsarEndpoint : Endpoint<IPulsarEnvelopeMapper, PulsarEnvelopeMapp
     internal bool IsHotTail { get; set; }
 
     /// <summary>
+    ///     GH-4060. A hot-tail listener commits no cursor at all, so <c>PulsarReaderListener.DeferAsync</c> has
+    ///     nothing to hand the message back to and is a deliberate no-op. Saying so here lets Wolverine warn at
+    ///     bootstrap when the application configured requeue-shaped error handling that cannot possibly run.
+    /// </summary>
+    protected internal override bool supportsRedelivery => !IsHotTail;
+
+    /// <summary>
     ///     When true, a requeue/defer of a single message uses Pulsar's native per-message
     ///     redelivery (<c>RedeliverUnacknowledgedMessages([messageId])</c>) — the message is left
     ///     unacknowledged and Pulsar redelivers that one message, preserving its redelivery count —

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarTransportExtensions.cs
@@ -354,6 +354,17 @@ public class PulsarListenerConfiguration : InteroperableListenerConfiguration<Pu
     /// cursor is throwaway and unacknowledged, so dead-letter / retry-letter queueing, native redelivery,
     /// and acknowledgment strategies do not apply. Pulsar analogue of the Kafka transport's
     /// <c>TailFromLatest()</c>.
+    ///
+    /// <para>
+    /// <b>Failures on a hot-tail listener are dropped, not retried (GH-4060).</b> With no cursor there is nothing
+    /// to redeliver from, so every requeue-shaped policy -- <c>Requeue()</c>, <c>RequeueIndefinitely()</c>,
+    /// <c>PauseThenRequeue()</c>, <c>MaximumAttempts()</c> -- resolves to a no-op and the message is simply gone.
+    /// Wolverine warns at bootstrap if you configure one. Error handling that stays inside the process still works
+    /// normally: <c>RetryTimes()</c>, <c>RetryWithCooldown()</c> and <c>ScheduleRetry()</c> all run. Pulsar's native
+    /// dead letter topic is <i>not</i> reachable from here either, because a native dead-letter move is a listener
+    /// operation and this listener is a <c>Reader</c>; a configured Wolverine message store does still capture the
+    /// failure in the durable dead letter table, and that is the only recovery route a hot-tail listener offers.
+    /// </para>
     /// </summary>
     /// <returns></returns>
     public PulsarListenerConfiguration TailFromLatest()

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -760,6 +760,22 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
     protected virtual bool supportsNativeAck => false;
 
     /// <summary>
+    /// GH-4060. Can a message handed back to this listener with <see cref="IChannelCallback.DeferAsync"/> ever be
+    /// delivered again? Default is <c>true</c>: nearly every listener sits on a broker cursor or a durable inbox
+    /// row, so "hand this back" genuinely means "try it again later".
+    ///
+    /// <para>
+    /// A listener answers <c>false</c> when its delivery has nowhere to come back from -- the motivating case is
+    /// Pulsar's <c>TailFromLatest()</c>, which reads through a non-durable <c>Reader</c> that commits no cursor at
+    /// all, so its <c>DeferAsync</c> is necessarily a no-op and a deferred message is simply gone. That is a
+    /// defensible consequence of choosing an ephemeral cursor, but it makes every requeue-shaped error policy inert,
+    /// which is not something the configuration says anywhere. <see cref="ListenerConfigurationValidator"/> reads
+    /// this to warn about the combination at bootstrap.
+    /// </para>
+    /// </summary>
+    protected internal virtual bool supportsRedelivery => true;
+
+    /// <summary>
     /// Check if this endpoint supports the specified mode
     /// </summary>
     public bool SupportsMode(EndpointMode mode)

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -35,9 +35,15 @@ internal static class ListenerConfigurationValidator
     /// Expects the endpoints to have already been compiled, so that endpoint policies and delayed
     /// configuration have had their say about the final mode.
     /// </summary>
-    internal static void AssertValid(IEnumerable<Endpoint> endpoints, ILogger? logger)
+    /// <param name="requeuePoliciesConfigured">
+    /// GH-4060. True when the application configured any error handling that hands a failed message back to its
+    /// listener for redelivery. Failure policies live on the handler graph rather than on an endpoint, so the
+    /// endpoint-scoped checks below cannot work this out for themselves and it is computed once by the caller.
+    /// </param>
+    internal static void AssertValid(IEnumerable<Endpoint> endpoints, ILogger? logger,
+        bool requeuePoliciesConfigured = false)
     {
-        var problems = endpoints.SelectMany(Validate).ToArray();
+        var problems = endpoints.SelectMany(x => Validate(x, requeuePoliciesConfigured)).ToArray();
 
         foreach (var problem in problems.Where(x => x.Severity == ListenerConfigurationSeverity.Warning))
         {
@@ -51,11 +57,27 @@ internal static class ListenerConfigurationValidator
         }
     }
 
-    internal static IEnumerable<ListenerConfigurationProblem> Validate(Endpoint endpoint)
+    internal static IEnumerable<ListenerConfigurationProblem> Validate(Endpoint endpoint,
+        bool requeuePoliciesConfigured = false)
     {
         if (!endpoint.IsListener && endpoint is not LocalQueue)
         {
             yield break;
+        }
+
+        // GH-4060. Deliberately ahead of the Inline-only gate below: a listener with no cursor to redeliver from
+        // ignores requeue policies in EVERY mode, not just Inline.
+        if (requeuePoliciesConfigured && !endpoint.supportsRedelivery)
+        {
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Warning,
+                $"Ignored listener configuration for {describe(endpoint)}: this listener reads through an ephemeral, " +
+                "non-durable cursor -- Pulsar's TailFromLatest() is the one transport feature that does this today -- so it " +
+                "has nothing to redeliver a message from. Requeue(), RequeueIndefinitely(), PauseThenRequeue() and " +
+                "MaximumAttempts() all resolve to DeferAsync(), which is necessarily a no-op here: a message that fails its " +
+                "handler is dropped rather than retried, and no error is raised. Error handling that never leaves the " +
+                "process still works -- RetryTimes(), RetryWithCooldown() and ScheduleRetry() all run normally -- and a " +
+                "configured message store still captures the failure in the durable dead letter table. Use those instead, " +
+                "or drop TailFromLatest() for an ordinary subscription if these messages are ones you cannot afford to lose.");
         }
 
         // GH-3710. The in-memory guard applies to every non-durable listening mode, so this check sits

--- a/src/Wolverine/ErrorHandling/FailureRule.cs
+++ b/src/Wolverine/ErrorHandling/FailureRule.cs
@@ -47,6 +47,17 @@ public class FailureRule : IEnumerable<FailureSlot>
         return false;
     }
 
+    /// <summary>
+    /// GH-4060. Does any attempt of this rule hand the message back to the listener for redelivery? Used by
+    /// <see cref="Wolverine.Configuration.ListenerConfigurationValidator"/> to spot requeue policies configured
+    /// against a listener that cannot redeliver anything.
+    /// </summary>
+    internal bool AnyRequeueContinuations()
+    {
+        return _slots.Any(slot => slot.Sources.Any(x => x is RequeueContinuation))
+               || InfiniteSource is RequeueContinuation;
+    }
+
     public FailureSlot AddSlot(IContinuationSource source)
     {
         var attempt = _slots.Count + 1;

--- a/src/Wolverine/ErrorHandling/FailureRuleCollection.cs
+++ b/src/Wolverine/ErrorHandling/FailureRuleCollection.cs
@@ -49,6 +49,16 @@ public class FailureRuleCollection : IEnumerable<FailureRule>
         }
     }
 
+    /// <summary>
+    /// GH-4060. Does anything in this collection route a failure back to the listener for redelivery? Both the
+    /// explicit Requeue()/RequeueIndefinitely()/PauseThenRequeue() rules and the requeue ladder that
+    /// <see cref="MaximumAttempts"/> synthesizes in <see cref="combine"/> count.
+    /// </summary>
+    internal bool AnyRequeuePolicies()
+    {
+        return MaximumAttempts.HasValue || _rules.Any(x => x.AnyRequeueContinuations());
+    }
+
     internal IContinuation DetermineExecutionContinuation(Exception e, Envelope envelope)
     {
         foreach (var rule in _rules)

--- a/src/Wolverine/ErrorHandling/FailureSlot.cs
+++ b/src/Wolverine/ErrorHandling/FailureSlot.cs
@@ -20,6 +20,12 @@ public class FailureSlot
 
     public int Attempt { get; }
 
+    /// <summary>
+    /// GH-4060. The continuation sources this slot will build from, so configuration validation can ask what a rule
+    /// would actually DO without having to manufacture an exception and an envelope to build it against.
+    /// </summary>
+    internal IReadOnlyList<IContinuationSource> Sources => _sources;
+
     public void AddAdditionalSource(IContinuationSource source)
     {
         _sources.Add(source);

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -632,7 +632,13 @@ public partial class WolverineRuntime
             endpoint.Compile(this);
         }
 
-        ListenerConfigurationValidator.AssertValid(listeners, Logger);
+        // GH-4060. Requeue policies are configured on the handler graph -- globally and per chain -- rather than on
+        // an endpoint, so the endpoint-scoped rules cannot see them. Handlers.Compile() has already run by this
+        // point, so both levels are settled and this is a straight read.
+        var requeuePoliciesConfigured = Handlers.Failures.AnyRequeuePolicies()
+                                        || Handlers.Chains.Any(x => x.Failures.AnyRequeuePolicies());
+
+        ListenerConfigurationValidator.AssertValid(listeners, Logger, requeuePoliciesConfigured);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #4060

## What this does

A Pulsar hot-tail listener (`TailFromLatest()`) reads through a non-durable `Reader` that commits no cursor, so `PulsarReaderListener.DeferAsync` is necessarily a no-op. Losing a message to a broker restart or a missed window is inherent to that choice and fine; losing one because **its handler failed** is a different thing, and nothing in the API said so.

Per the issue's options 1 and 2, this is deliberately conservative — no attempt to give hot-tail listeners real redelivery.

**Warn (option 1).** `Endpoint` gains a `supportsRedelivery` hook (default `true`); `PulsarEndpoint` answers `false` when `IsHotTail`. `ListenerConfigurationValidator` warns at bootstrap when such a listener is combined with any requeue-shaped policy — `Requeue()`, `RequeueIndefinitely()`, `PauseThenRequeue()`, `MaximumAttempts()`. Deliberately outside the Inline-only gate: this listener ignores requeue in **every** mode.

Failure policies live on the handler graph, not on an endpoint, so `WolverineRuntime` computes the flag once after `Handlers.Compile()` and passes it in (`FailureRuleCollection.AnyRequeuePolicies()`). This mirrors GH-3712's principle without duplicating #4057's fatal-only `validateModeConfiguration` hook — the two are independent and should merge cleanly.

**Document (option 2).** New "Handler failures on a hot-tail listener are dropped, not retried" section on the Pulsar page with a what-works/what-doesn't table, plus expanded `TailFromLatest()` xml-docs.

## Investigation results (options 3 and 4)

All verified against a live broker, not assumed.

| | Hot-tail listener |
| --- | --- |
| `RetryTimes()`, `RetryWithCooldown()`, `ScheduleRetry()` | ✅ **Work** — the retry never leaves the process |
| `Requeue()` and friends | ❌ Handler runs exactly once, message gone |
| Pulsar native dead letter topic | ❌ **Never reached** |
| Wolverine durable dead letter table | ✅ **Works** with a message store configured |

**Option 3 — in-lane retries work.** Proven: three attempts against the same delivery, ending in a success. This is the error handling to reach for on a hot-tail listener and the docs now say so.

**Option 4 — the native DLQ does *not* work.** A native dead-letter move is a listener operation (`ISupportDeadLetterQueue`), and `PulsarReaderListener` implements neither that nor `ISupportNativeScheduling`; `PulsarEndpoint.TryBuildDeadLetterSender` deliberately returns false (#3186), so `BufferedReceiver` reports no native DLQ either. `MoveToErrorQueue` falls back to `Storage.Inbox.MoveToDeadLetterStorageAsync` — a **silent no-op on `NullMessageStore`**. The test asserting zero DLQ messages ships with a positive control on an ordinary subscription, so the zero means something.

The durable dead letter table *does* catch it, verified with a real Postgres store. That is the only recovery route hot-tail can offer, and the docs say so.

## Separate bug found along the way — not fixed here

`UsePulsar()` registers a **global** `AlwaysMatches` failure rule (`PulsarNativeResiliencyPolicy`) ahead of anything the user configures later. `PulsarNativeContinuationSource.Build` returns `null` for a non-`PulsarListener` envelope, commented "let the next continuation source handle it" — but `FailureRule.TryCreateContinuation` returns `true` regardless, so the null falls through to `?? new MoveToErrorQueue(ex)` and the rule is terminal.

Consequence: on **any** Pulsar-enabled host, `opts.Policies.OnException<T>()` rules never run for an envelope whose listener is not a `PulsarListener`. Measured:

- Hot-tail listener + global `RetryTimes(3)` → 1 attempt, straight to the error queue.
- **A plain local queue in a Pulsar host** + global `RetryTimes(3)` → 1 attempt. Same host with `UsePulsar()` removed → 3 attempts.

Chain-level rules (`chain.OnException<T>()`) still work, because `CombineRules` sorts them ahead of the global ones — which is why the tests here configure retries on the chain. Worth its own issue; the fix has real blast radius for every Pulsar user and does not belong in a warn-and-document change.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 errors, 0 warnings
- Full CoreTests: **2591 total, 0 failed**
- Full `Wolverine.Pulsar.Tests`: **233 total, 0 failed**
- Red-baselined both ways: disabling the validator check fails 3 of the 12 new CoreTests (and only the warning-asserting ones); flipping `PulsarEndpoint.supportsRedelivery` to `true` fails both Pulsar-side warning tests.

Every new broker test gets its own topic and subscription; no shared static tracking state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
