### PR TITLE
GH-4058: refuse to start when DeleteStreamEntryOnAck meets a pre-8.2 Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,11 @@ services:
       - "9101:9101"
 
   redis-server:
-    image: "redis:7-alpine"
+    # Kept in step with RedisContainerFixture, which is what the Redis tests actually run against
+    # (Testcontainers). Pinned rather than floating on "redis:8-alpine": XACKDEL, which
+    # DeleteStreamEntryOnAck(true) requires, only exists from 8.2 on, so a tag that could resolve
+    # to 8.0 or 8.1 would quietly take the GH-4058 coverage back out.
+    image: "redis:8.2.9-alpine"
     command: redis-server
     ports:
       - "6379:6379"

--- a/docs/guide/messaging/transports/redis.md
+++ b/docs/guide/messaging/transports/redis.md
@@ -419,6 +419,33 @@ that can be busy at once — the partition slot count when `PartitionProcessingB
 prefetch, it does not cap how many entries can be unacknowledged: the bounded execution block is what applies back
 pressure, and the consumer loop stops reading once that block is full.
 
+## Deleting Stream Entries on Ack
+
+By default Wolverine settles a handled entry with `XACK`, which clears it from the consumer group's pending entries
+list but leaves it in the stream. `DeleteStreamEntryOnAck(true)` additionally removes the entry, so a stream consumed
+by a single group does not grow without bound:
+
+```csharp
+opts.UseRedisTransport(connectionString)
+    .DeleteStreamEntryOnAck(true);
+```
+
+::: warning Requires Redis 8.2 or later
+This setting settles with `XACKDEL`, which was added in Redis 8.2. Against an older server every acknowledgement is
+rejected, so **nothing is ever acknowledged** — entries accumulate in the pending entries list forever, and with
+`EnableAutoClaim()` on they are re-claimed and reprocessed indefinitely. Wolverine therefore refuses to start a
+listener when this setting meets a server that does not implement the command, and the exception tells you to either
+upgrade the server or turn the setting off.
+
+Wolverine deliberately does **not** fall back to `XACK` followed by `XDEL`. The two are not equivalent: `XDEL` removes
+the entry for *every* consumer group on the stream rather than only the one acknowledging it, which would silently
+destroy messages other groups have not read yet. That difference is why `XACKDEL` exists.
+
+Note that the capability is detected by asking the server what commands it implements rather than by comparing version
+numbers, so Redis-compatible servers that carry their own versioning — Valkey, DragonflyDB, and the managed cloud
+offerings — are judged on what they actually support.
+:::
+
 ## Scheduled Messaging <Badge type="tip" text="5.10" />
 
 The Redis transport supports native Redis message scheduling for delayed or scheduled delivery. There's no configuration

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisContainerFixture.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisContainerFixture.cs
@@ -8,6 +8,12 @@ public static class RedisContainerFixture
 {
     private static RedisContainer? _container;
 
+    /// <summary>
+    ///     The image the suite runs against. Must stay at or above Redis 8.2 -- see the note at the container
+    ///     build below, and GH-4058.
+    /// </summary>
+    public const string RedisImage = "redis:8.2.9-alpine";
+
     public static string ConnectionString { get; private set; } = "localhost:6379";
 
     [ModuleInitializer]
@@ -28,8 +34,12 @@ public static class RedisContainerFixture
         // stdout, and a [ModuleInitializer] runs BEFORE Main -- so before xUnit has redirected
         // Console.Out. The banner lands in the raw protocol channel and the whole assembly dies
         // with "Test process did not return valid JSON", running no tests at all.
+        // GH-4058: this was "redis:7-alpine", on which XACKDEL does not exist, so every run of the suite
+        // exercised a DeleteStreamEntryOnAck(true) code path that could not possibly work and said so only
+        // in a per-message warning. Pinned rather than floating on "redis:8-alpine" because XACKDEL landed
+        // in 8.2 -- a tag resolving to 8.0 or 8.1 would put the blind spot straight back.
         _container = new RedisBuilder()
-            .WithImage("redis:7-alpine")
+            .WithImage(RedisImage)
             .WithLogger(NullLogger.Instance)
             .Build();
 

--- a/src/Transports/Redis/Wolverine.Redis.Tests/RedisMultiBrokerHelpers.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/RedisMultiBrokerHelpers.cs
@@ -60,7 +60,8 @@ public sealed class SecondRedisServerFixture : IAsyncLifetime
     {
         try
         {
-            _container = new RedisBuilder().WithImage("redis:7-alpine").Build();
+            // Same image as the primary fixture, so a multi-broker test never straddles two server versions
+            _container = new RedisBuilder().WithImage(RedisContainerFixture.RedisImage).Build();
             await _container.StartAsync();
             ConnectionString = _container.GetConnectionString();
         }

--- a/src/Transports/Redis/Wolverine.Redis.Tests/delete_stream_entry_on_ack_4058.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/delete_stream_entry_on_ack_4058.cs
@@ -1,0 +1,275 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+using Wolverine.Redis.Internal;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.Redis.Tests;
+
+#region message and handler
+
+public record DeleteOnAckMessage(Guid SessionId, int Number);
+
+public static class DeleteOnAckTracking
+{
+    public static ConcurrentDictionary<Guid, ConcurrentBag<int>> Handled { get; } = new();
+
+    public static ConcurrentBag<int> For(Guid sessionId) => Handled.GetOrAdd(sessionId, _ => new ConcurrentBag<int>());
+}
+
+public class DeleteOnAckHandler
+{
+    public void Handle(DeleteOnAckMessage message) => DeleteOnAckTracking.For(message.SessionId).Add(message.Number);
+}
+
+#endregion
+
+/// <summary>
+///     GH-4058. <c>DeleteStreamEntryOnAck(true)</c> settles with <c>XACKDEL</c>, which requires Redis 8.2.
+///     Against anything older every ack threw, the listener swallowed it as a warning, and nothing was ever
+///     acknowledged -- entries piled up in the consumer group's pending list forever.
+/// </summary>
+public class delete_stream_entry_on_ack_4058
+{
+    /// <summary>
+    ///     The regression test proper. Before the fix this passed the "everything was handled" check and then
+    ///     failed here, with all five entries still pending, because every XACKDEL was rejected and swallowed.
+    ///     It only goes green on a server that actually implements the command, which is what the image bump
+    ///     in docker-compose.yml and RedisContainerFixture is for.
+    /// </summary>
+    [Fact]
+    public async Task entries_are_acknowledged_and_deleted_when_delete_on_ack_is_on()
+    {
+        var sessionId = Guid.NewGuid();
+        var streamKey = $"delete-on-ack-4058-{Guid.NewGuid():N}";
+        const string group = "delete-on-ack-group";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString)
+                    .AutoProvision()
+                    .DeleteStreamEntryOnAck(true);
+
+                opts.PublishMessage<DeleteOnAckMessage>().ToRedisStream(streamKey).SendInline();
+                opts.ListenToRedisStream(streamKey, group).StartFromBeginning();
+
+                opts.Discovery.IncludeType(typeof(DeleteOnAckHandler));
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var bus = host.MessageBus();
+            for (var i = 0; i < 5; i++)
+            {
+                await bus.SendAsync(new DeleteOnAckMessage(sessionId, i));
+            }
+
+            await waitUntilAsync(() => DeleteOnAckTracking.For(sessionId).Count == 5);
+
+            DeleteOnAckTracking.For(sessionId).Count.ShouldBe(5);
+
+            var database = databaseFor(host);
+
+            // The actual assertion: the entries were settled for THIS consumer group and removed from the
+            // stream. This is what silently never happened on a pre-8.2 server.
+            await waitUntilAsync(async () => await pendingCountAsync(database, streamKey, group) == 0);
+
+            (await pendingCountAsync(database, streamKey, group)).ShouldBe(0);
+            (await database.StreamLengthAsync(streamKey)).ShouldBe(0);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    /// <summary>
+    ///     The XACK path was never broken -- pinning it here so the fix cannot regress the default.
+    /// </summary>
+    [Fact]
+    public async Task entries_are_acknowledged_but_retained_when_delete_on_ack_is_off()
+    {
+        var sessionId = Guid.NewGuid();
+        var streamKey = $"ack-only-4058-{Guid.NewGuid():N}";
+        const string group = "ack-only-group";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRedisTransport(RedisContainerFixture.ConnectionString).AutoProvision();
+
+                opts.PublishMessage<DeleteOnAckMessage>().ToRedisStream(streamKey).SendInline();
+                opts.ListenToRedisStream(streamKey, group).StartFromBeginning();
+
+                opts.Discovery.IncludeType(typeof(DeleteOnAckHandler));
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var bus = host.MessageBus();
+            for (var i = 0; i < 5; i++)
+            {
+                await bus.SendAsync(new DeleteOnAckMessage(sessionId, i));
+            }
+
+            await waitUntilAsync(() => DeleteOnAckTracking.For(sessionId).Count == 5);
+
+            var database = databaseFor(host);
+
+            await waitUntilAsync(async () => await pendingCountAsync(database, streamKey, group) == 0);
+
+            (await pendingCountAsync(database, streamKey, group)).ShouldBe(0);
+
+            // XACK settles the entry without removing it, so the stream itself is untouched
+            (await database.StreamLengthAsync(streamKey)).ShouldBe(5);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    private static IDatabase databaseFor(IHost host)
+    {
+        var transport = host.Services.GetRequiredService<IWolverineRuntime>()
+            .Options.Transports.GetOrCreate<RedisTransport>();
+
+        return transport.GetDatabase();
+    }
+
+    private static async Task<long> pendingCountAsync(IDatabase database, string streamKey, string group)
+    {
+        var groups = await database.StreamGroupInfoAsync(streamKey);
+        return groups.FirstOrDefault(x => x.Name == group).PendingMessageCount;
+    }
+
+    /// <summary>
+    ///     Deliberately returns rather than throwing on timeout, so the assertion that follows each call is the
+    ///     thing that reports the failure -- "pending should be 0 but was 5" says far more about GH-4058 than a
+    ///     bare timeout would.
+    /// </summary>
+    private static async Task waitUntilAsync(Func<Task<bool>> condition)
+    {
+        var expiry = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (DateTimeOffset.UtcNow < expiry)
+        {
+            if (await condition()) return;
+            await Task.Delay(100);
+        }
+    }
+
+    private static Task waitUntilAsync(Func<bool> condition)
+    {
+        return waitUntilAsync(() => Task.FromResult(condition()));
+    }
+}
+
+/// <summary>
+///     GH-4058. These deliberately run against a Redis 7 container of their own, so the guard against a server
+///     that cannot honor <c>DeleteStreamEntryOnAck(true)</c> stays exercised even though the rest of the suite
+///     has moved to an 8.2 image.
+/// </summary>
+public class delete_stream_entry_on_ack_on_an_old_server_4058 : IAsyncLifetime
+{
+    private RedisContainer _container = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _container = new RedisBuilder()
+            .WithImage("redis:7-alpine")
+            .WithLogger(NullLogger.Instance)
+            .Build();
+
+        await _container.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     The capability probe itself: Redis 7 does not know XACKDEL, the fixture's server does.
+    /// </summary>
+    [Fact]
+    public async Task the_capability_probe_tells_the_two_servers_apart()
+    {
+        await using var old = await ConnectionMultiplexer.ConnectAsync(_container.GetConnectionString());
+        (await RedisStreamCapabilities.SupportsXackDelAsync(old.GetDatabase())).ShouldBe(false);
+
+        await using var current =
+            await ConnectionMultiplexer.ConnectAsync(RedisContainerFixture.ConnectionString);
+        (await RedisStreamCapabilities.SupportsXackDelAsync(current.GetDatabase())).ShouldBe(true);
+    }
+
+    /// <summary>
+    ///     Before the fix this host started perfectly happily and then silently acknowledged nothing.
+    /// </summary>
+    [Fact]
+    public async Task refuses_to_start_a_listener_the_server_cannot_acknowledge()
+    {
+        var streamKey = $"old-server-4058-{Guid.NewGuid():N}";
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.UseRedisTransport(_container.GetConnectionString())
+                        .AutoProvision()
+                        .DeleteStreamEntryOnAck(true);
+
+                    opts.ListenToRedisStream(streamKey, "old-server-group").StartFromBeginning();
+                    opts.Discovery.IncludeType(typeof(DeleteOnAckHandler));
+                }).StartAsync(TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain("XACKDEL");
+        ex.Message.ShouldContain("DeleteStreamEntryOnAck");
+        ex.Message.ShouldContain("8.2");
+    }
+
+    /// <summary>
+    ///     The same old server is perfectly usable with the default XACK path -- the guard must not punish a
+    ///     configuration that works.
+    /// </summary>
+    [Fact]
+    public async Task starts_and_acknowledges_normally_on_the_same_server_without_delete_on_ack()
+    {
+        var sessionId = Guid.NewGuid();
+        var streamKey = $"old-server-ok-4058-{Guid.NewGuid():N}";
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseRedisTransport(_container.GetConnectionString()).AutoProvision();
+
+                opts.PublishMessage<DeleteOnAckMessage>().ToRedisStream(streamKey).SendInline();
+                opts.ListenToRedisStream(streamKey, "old-server-ok-group").StartFromBeginning();
+                opts.Discovery.IncludeType(typeof(DeleteOnAckHandler));
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            await host.MessageBus().SendAsync(new DeleteOnAckMessage(sessionId, 1));
+
+            var expiry = DateTimeOffset.UtcNow.AddSeconds(15);
+            while (DateTimeOffset.UtcNow < expiry && DeleteOnAckTracking.For(sessionId).Count < 1)
+            {
+                await Task.Delay(100, TestContext.Current.CancellationToken);
+            }
+
+            DeleteOnAckTracking.For(sessionId).Count.ShouldBe(1);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamCapabilities.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamCapabilities.cs
@@ -1,0 +1,65 @@
+using StackExchange.Redis;
+
+namespace Wolverine.Redis.Internal;
+
+/// <summary>
+///     GH-4058. Server-side capability checks for the Redis stream transport.
+/// </summary>
+/// <remarks>
+///     These ask the server what it actually implements rather than comparing <c>INFO server</c> version
+///     numbers. Wolverine runs against plenty of things that speak the Redis protocol but do not carry
+///     Redis's own version line -- Valkey, DragonflyDB, Memurai, and the managed AWS/Azure/GCP flavors all
+///     report their own numbering -- so a <c>Version &gt;= 8.2</c> comparison would both reject servers that
+///     do support the command and admit servers that do not.
+/// </remarks>
+internal static class RedisStreamCapabilities
+{
+    /// <summary>
+    ///     The command behind <c>IDatabaseAsync.StreamAcknowledgeAndDeleteAsync</c>, which is how
+    ///     <c>DeleteStreamEntryOnAck(true)</c> settles an entry. Added in Redis 8.2.
+    /// </summary>
+    internal const string XackDel = "XACKDEL";
+
+    /// <summary>
+    ///     Ask the server whether it implements <c>XACKDEL</c> via <c>COMMAND INFO</c>. A server that does not
+    ///     know the command answers with a one-element array holding a nil, which is how this tells the two
+    ///     apart.
+    /// </summary>
+    /// <returns>
+    ///     <c>true</c> or <c>false</c> when the server gave a usable answer, and <c>null</c> when the probe
+    ///     itself could not be run -- some managed offerings rename or ACL-restrict <c>COMMAND</c>, and an
+    ///     inconclusive probe is not grounds for refusing to start.
+    /// </returns>
+    internal static async Task<bool?> SupportsXackDelAsync(IDatabaseAsync db)
+    {
+        try
+        {
+            var result = await db.ExecuteAsync("COMMAND", "INFO", XackDel);
+
+            if (result.IsNull || result.Resp2Type != ResultType.Array || result.Length == 0)
+            {
+                return null;
+            }
+
+            return !result[0].IsNull;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     True when Redis rejected a command outright as unknown -- i.e. the server is too old for the command
+    ///     Wolverine just issued, which no amount of retrying will fix.
+    /// </summary>
+    internal static bool IsUnknownCommandFailure(Exception ex)
+    {
+        return ex is RedisServerException &&
+               ex.Message.Contains("unknown command", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -72,7 +72,69 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     public DateTimeOffset? LastReceiveLoopActivityAt => _loop?.LastReceiveLoopActivityAt;
 
     internal bool DeleteOnAck => _transport.DeleteStreamEntryOnAck;
-    
+
+    /// <summary>
+    ///     GH-4058. <c>DeleteStreamEntryOnAck(true)</c> settles with <c>XACKDEL</c>, which arrived in Redis 8.2.
+    ///     An older server answers <c>ERR unknown command 'XACKDEL'</c> to every single ack, so the entries pile
+    ///     up in the consumer group's pending list forever: under auto-claim they are redelivered and reprocessed
+    ///     without end, and without it they leak. There is no honest fallback -- <c>XACK</c> plus <c>XDEL</c> is
+    ///     not the same operation, because <c>XDEL</c> drops the entry for every consumer group on the stream
+    ///     rather than only this one, which is precisely why <c>XACKDEL</c> exists. So refuse to start instead.
+    /// </summary>
+    private async Task assertDeleteOnAckIsSupportedAsync()
+    {
+        if (!DeleteOnAck) return;
+
+        var supported = await RedisStreamCapabilities.SupportsXackDelAsync(getDatabase());
+
+        if (supported == false)
+        {
+            throw new InvalidOperationException(
+                $"The Redis transport is configured with DeleteStreamEntryOnAck(true), but the Redis server behind stream '{_endpoint.StreamKey}' (db {_endpoint.DatabaseId}) does not support the {RedisStreamCapabilities.XackDel} command that setting requires. {RedisStreamCapabilities.XackDel} was added in Redis 8.2; on an older server every acknowledgement fails and no message on this listener is ever settled. Upgrade the server to Redis 8.2 or later, or call DeleteStreamEntryOnAck(false) to acknowledge with XACK and leave the entries in the stream. Wolverine deliberately does not fall back to XACK plus XDEL, because XDEL removes the entry for every consumer group on the stream rather than only this one.");
+        }
+
+        if (supported == null)
+        {
+            _logger.LogWarning(
+                "Unable to confirm that the Redis server behind stream {StreamKey} (db {DatabaseId}) supports the {Command} command required by DeleteStreamEntryOnAck(true). Starting anyway, but acknowledgements will fail at runtime if the server is older than Redis 8.2.",
+                _endpoint.StreamKey, _endpoint.DatabaseId, RedisStreamCapabilities.XackDel);
+        }
+    }
+
+    /// <summary>
+    ///     The one place that settles a stream entry for this consumer group, so the <c>DeleteOnAck</c> choice
+    ///     cannot drift between the complete, requeue, and dead-letter paths.
+    /// </summary>
+    private Task acknowledgeAsync(IDatabase db, string entryId)
+    {
+        return DeleteOnAck
+            ? db.StreamAcknowledgeAndDeleteAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!,
+                StreamTrimMode.Acknowledged, entryId)
+            : db.StreamAcknowledgeAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, entryId);
+    }
+
+    /// <summary>
+    ///     GH-4058. A one-off ack failure is a warning -- the entry stays pending and gets redelivered. Redis
+    ///     rejecting the command as unknown is not: it means nothing on this listener is being acknowledged, and
+    ///     nothing ever will be, so it is logged at Error with the fix in the message.
+    /// </summary>
+    private void logAckFailure(Exception ex, Envelope envelope, string context)
+    {
+        if (RedisStreamCapabilities.IsUnknownCommandFailure(ex))
+        {
+            _logger.LogError(ex,
+                "Redis rejected the acknowledgement command for stream {StreamKey} (db {DatabaseId}) as unknown while {Context} envelope {EnvelopeId}. No message on this listener is being acknowledged, and entries will accumulate in the pending list of consumer group {ConsumerGroup} indefinitely. DeleteStreamEntryOnAck(true) requires {Command}, which needs Redis 8.2 or later; upgrade the server or call DeleteStreamEntryOnAck(false).",
+                _endpoint.StreamKey, _endpoint.DatabaseId, context, envelope.Id, _endpoint.ConsumerGroup,
+                RedisStreamCapabilities.XackDel);
+        }
+        else
+        {
+            _logger.LogWarning(ex,
+                "Error ACKing Redis stream message on {StreamKey} while {Context} envelope {EnvelopeId}",
+                _endpoint.StreamKey, context, envelope.Id);
+        }
+    }
+
     // ISupportDeadLetterQueue implementation
     public bool NativeDeadLetterQueueEnabled => _endpoint.NativeDeadLetterQueueEnabled;
     
@@ -116,14 +178,11 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
             {
                 try
                 {
-                    if (DeleteOnAck)
-                        await database.StreamAcknowledgeAndDeleteAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, StreamTrimMode.Acknowledged, idString!);
-                    else
-                        await database.StreamAcknowledgeAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, idString!);
+                    await acknowledgeAsync(database, idString!);
                 }
                 catch (Exception ackEx)
                 {
-                    _logger.LogWarning(ackEx, "Error ACKing message {EnvelopeId} after moving to dead letter queue", envelope.Id);
+                    logAckFailure(ackEx, envelope, "acknowledging after a move to the dead letter queue");
                 }
             }
         }
@@ -138,6 +197,11 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
     // ISupportNativeScheduling implementation
     public async ValueTask InitializeAsync()
     {
+        // GH-4058: reject a DeleteStreamEntryOnAck(true) that this server cannot honor before we provision
+        // anything. Left unchecked it is a total, silent failure -- every settle throws and nothing is ever
+        // acknowledged -- so it is not something to discover one warning at a time in production.
+        await assertDeleteOnAckIsSupportedAsync();
+
         // Only create resources at listener init time if AutoProvision is enabled. Provision the consumer
         // group over THIS listener's connection so a tenant listener creates its group on the tenant's own
         // server (broker-per-tenant), not the shared one. GH-3309.
@@ -231,16 +295,12 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
                 return;
             }
 
-            var db = getDatabase();
-            if (DeleteOnAck)
-                await db.StreamAcknowledgeAndDeleteAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, StreamTrimMode.Acknowledged, idString!);
-            else
-                await db.StreamAcknowledgeAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, idString!);
+            await acknowledgeAsync(getDatabase(), idString!);
             _logger.LogDebug("Acknowledged Redis stream message {StreamId} on {StreamKey}", idString, _endpoint.StreamKey);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error ACKing Redis stream message for envelope {EnvelopeId}", envelope.Id);
+            logAckFailure(ex, envelope, "completing");
         }
     }
 
@@ -274,14 +334,11 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
             {
                 try
                 {
-                    if(DeleteOnAck)
-                        await db.StreamAcknowledgeAndDeleteAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, StreamTrimMode.Acknowledged, idString!);
-                    else
-                        await db.StreamAcknowledgeAsync(_endpoint.StreamKey, _endpoint.ConsumerGroup!, idString!);
+                    await acknowledgeAsync(db, idString!);
                 }
                 catch (Exception ackEx)
                 {
-                    _logger.LogWarning(ackEx, "Error ACKing Redis stream message before requeue for envelope {EnvelopeId}", envelope.Id);
+                    logAckFailure(ackEx, envelope, "acknowledging before a requeue");
                 }
             }
 


### PR DESCRIPTION
Closes #4058.

`DeleteStreamEntryOnAck(true)` settles a handled entry with `XACKDEL`, which was added in **Redis 8.2**. Against an older server Redis answers `ERR unknown command 'XACKDEL'`, `RedisStreamListener.CompleteAsync` swallowed it as a per-message `Warning`, and the entry stayed in the consumer group's pending list forever. So on Redis < 8.2 with this setting, **nothing was ever acknowledged**, in any endpoint mode — and the only symptom was a warning per message.

## Which option, and why

The issue offered three. This is **(1) as the detection mechanism, (2) as the policy, and (3) as defence in depth** — they are not really alternatives.

**Capability probing turned out to be clean and cheap, so it is worth doing — but not as a route to a fallback.** The probe is a single `COMMAND INFO XACKDEL` at listener start, issued only when `DeleteStreamEntryOnAck(true)` is set. A server that does not know the command answers with a one-element array holding a nil, which distinguishes the two cases exactly. Verified against `redis:7.4.9` and `redis:8.2.9`.

Worth noting *why* the probe beats reading `INFO server`'s version, which was the obvious first instinct: Wolverine runs against plenty of things that speak the Redis protocol but carry their own version numbering — Valkey, DragonflyDB, Memurai, the managed AWS/Azure/GCP offerings. A `Version >= 8.2` comparison would both reject servers that do support the command and admit servers that do not. Asking the server what it implements is the honest question.

**But a probe only helps if there is something useful to do with a `false`, and there isn't.** The candidate degraded paths are all worse than failing:

- **`XACK` + `XDEL`** — rejected, as the issue anticipated. `XDEL` removes the entry for *every* consumer group on the stream, not just the acknowledging one, so on a multi-group stream this silently destroys messages other groups have not read yet. That difference is precisely why `XACKDEL` exists. (I also considered gating that fallback on "the stream currently has exactly one consumer group" — but that is a check against live, mutable server state; a group created a second later would start losing messages with no signal at all. Too clever, and it fails silently in the direction that costs data.)
- **Silently downgrade to plain `XACK`** — acks work, but the stream now grows without bound, which is the exact thing the user turned the setting on to prevent. Trading one silent failure for a different silent failure.

So the probe's `false` becomes a startup exception, naming the setting, the command, the version, and both ways out. A configuration that cannot work should not start.

And **(3) regardless**: an unknown-command failure at settle time is no longer a `Warning`. It now logs at `Error` saying that nothing is being acknowledged and entries will accumulate indefinitely. Ordinary one-off ack failures — where the entry simply stays pending and gets redelivered — stay at `Warning`, because that genuinely is a warning. With the startup guard in place this path is nearly unreachable, but it still covers a server downgraded under a running app, and a broker-per-tenant connection pointed at a different server.

If the probe itself cannot run — some managed offerings rename or ACL-restrict `COMMAND` — it returns "unknown" rather than "unsupported", and the listener starts with a warning. An inconclusive probe is not grounds for refusing to boot, and the runtime `Error` above is the backstop.

## Behaviour change

An app on Redis < 8.2 with `DeleteStreamEntryOnAck(true)` will now **fail to start** where it previously started and quietly acknowledged nothing. That is the intent: such an app is already 100% broken, just invisibly. The escape hatch needs no new API — `DeleteStreamEntryOnAck(false)` is the documented, working configuration.

## Image bump

`docker-compose.yml` and `RedisContainerFixture` both ran `redis:7-alpine`, so every CI run exercised a code path that was dead on the server it ran against. Both now run `redis:8.2.9-alpine`, as does the secondary broker in `RedisMultiBrokerHelpers`, so a multi-broker test never straddles two server versions.

Pinned rather than floating on `redis:8-alpine` deliberately: `XACKDEL` landed in 8.2, so a tag that could resolve to 8.0 or 8.1 would quietly take this coverage back out.

The new `delete_stream_entry_on_ack_on_an_old_server_4058` fixture keeps a `redis:7-alpine` container of its own, so the guard against an unsupported server stays genuinely exercised even though the rest of the suite has moved up.

## Tests, and their red baseline

Every test below was run against `redis:7-alpine` with the guard commented out, to confirm it fails for the right reason before the fix:

| Test | Red baseline (redis:7, no fix) |
|---|---|
| `entries_are_acknowledged_and_deleted_when_delete_on_ack_is_on` | **FAILED** — pending count 5, with `ERR unknown command 'XACKDEL'` logged 5 times |
| `refuses_to_start_a_listener_the_server_cannot_acknowledge` | **FAILED** — host started happily, no exception thrown |
| `the_capability_probe_tells_the_two_servers_apart` | **FAILED** — both servers probed as unsupported |
| `entries_are_acknowledged_but_retained_when_delete_on_ack_is_off` | passed (the `XACK` path was never broken — pinned so the fix cannot regress the default) |
| `starts_and_acknowledges_normally_on_the_same_server_without_delete_on_ack` | passed (the guard must not punish a configuration that works) |

All five pass against `redis:8.2.9-alpine` with the fix.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings.
- **CoreTests**: 2581 total, **0 failed**, 2 skipped.
- **Full Redis suite** on `redis:8.2.9-alpine`: 163 total, **4 failed** — all four in `native_ack_mode`, all timeouts.

Those four are **pre-existing on `main` and unrelated to this change**, and I checked rather than assuming. `native_ack_mode` never sets `DeleteStreamEntryOnAck`, so the new guard is inert for it and the rest of the listener change is a pure refactor. Isolating it:

| Code | Server | `native_ack_mode` |
|---|---|---|
| This branch | redis:8.2.9 | 4 failed |
| This branch | redis:7-alpine | 4 failed |
| **Clean `origin/main`** | **redis:7-alpine** | **4 failed** |

Same four tests, same timeouts, on unmodified `main` against the old image — so neither the fix nor the image bump is implicated. Flagging them here rather than folding them into this PR; they look like they belong to the recent NativeAck wave.

## Also

Consolidated the three duplicated ack call sites (complete, requeue, dead-letter) into one `acknowledgeAsync`, so the `DeleteOnAck` choice cannot drift between them — the dead-letter path in particular was easy to miss.

Documented the setting in `docs/guide/messaging/transports/redis.md`, including the 8.2 requirement and why there is no `XACK`+`XDEL` fallback.
