### PR TITLE
GH-4062: settle the original on an inline Azure Service Bus scheduled retry

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/scheduled_retry_settlement.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/scheduled_retry_settlement.cs
@@ -1,0 +1,88 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ErrorHandling;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// The existing native scheduling coverage only exercises CASCADED scheduling (context.ScheduleAsync),
+/// which sends a brand new message and leaves the incoming delivery to be completed normally. A scheduled
+/// RETRY of the incoming message goes through IListener.MoveToScheduledUntilAsync instead, which has to
+/// settle the ORIGINAL delivery in addition to sending the scheduled copy.
+/// </summary>
+public class scheduled_retry_settlement : IAsyncLifetime
+{
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync() => await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
+
+    [Fact]
+    public async Task inline_listener_settles_the_original_on_a_scheduled_retry()
+    {
+        AsbScheduledRetryHandler.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting()
+                    .AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToAzureServiceBusQueue("scheduled-retry-settle")
+                    // PT5S is the emulator's minimum lock duration. If the original delivery is never
+                    // settled, this is how long it takes Azure Service Bus to redeliver it -- keep it
+                    // short enough that the redelivery lands inside the test rather than after it.
+                    .ConfigureQueue(q => q.LockDuration = 5.Seconds())
+                    .ProcessInline();
+
+                opts.PublishMessage<AsbScheduledRetryMessage>()
+                    .ToAzureServiceBusQueue("scheduled-retry-settle");
+
+                opts.Policies.OnException<AsbScheduledRetryException>().ScheduleRetry(1.Seconds());
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.MessageBus().SendAsync(new AsbScheduledRetryMessage("only twice"));
+
+        // 1st attempt throws, the scheduled retry copy arrives about a second later and succeeds
+        await AsbScheduledRetryHandler.Succeeded.Task
+            .WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        // Now wait out the queue's lock duration. If MoveToScheduledUntilAsync left the original
+        // delivery unsettled, Azure Service Bus redelivers it here and the handler runs a third time.
+        await Task.Delay(12.Seconds(), TestContext.Current.CancellationToken);
+
+        AsbScheduledRetryHandler.Attempts.ShouldBe(2);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}
+
+public record AsbScheduledRetryMessage(string Name);
+
+public class AsbScheduledRetryException() : Exception("Fail the first attempt on purpose");
+
+public class AsbScheduledRetryHandler
+{
+    private static int _attempts;
+
+    public static TaskCompletionSource Succeeded { get; private set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static int Attempts => _attempts;
+
+    public static void Reset()
+    {
+        _attempts = 0;
+        Succeeded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Handle(AsbScheduledRetryMessage message)
+    {
+        if (Interlocked.Increment(ref _attempts) == 1)
+        {
+            throw new AsbScheduledRetryException();
+        }
+
+        Succeeded.TrySetResult();
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
@@ -45,7 +45,7 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
 
         _defer = new RetryBlock<AzureServiceBusEnvelope>(async (envelope, _) =>
         {
-            if (envelope is { } e)
+            if (envelope is { IsCompleted: false } e)
             {
                 await e.CompleteAsync(_cancellation.Token);
                 e.IsCompleted = true;
@@ -133,6 +133,18 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
     public async Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time)
     {
         envelope.ScheduledTime = time;
+
+        // GH-4062: settle the original before sending the scheduled copy, exactly like _defer above.
+        // This only re-sent the copy, so the original delivery stayed locked until Azure Service Bus
+        // expired the lock and redelivered it -- every ScheduleRetry() produced a duplicate on top of
+        // the scheduled copy. Latent until GH-4018 turned AutoCompleteMessages off, which had been
+        // covering the unsettled original when the processor callback returned.
+        if (envelope is AzureServiceBusEnvelope e)
+        {
+            await _defer.PostAsync(e);
+            return;
+        }
+
         await _requeue.SendAsync(envelope);
     }
 


### PR DESCRIPTION
Fixes #4062

## The bug

`InlineAzureServiceBusListener.MoveToScheduledUntilAsync` re-published the envelope as an Azure Service Bus scheduled message but **never settled the delivery it was retrying**:

```csharp
public async Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time)
{
    envelope.ScheduledTime = time;
    await _requeue.SendAsync(envelope);   // the original is never completed
}
```

The original stayed locked until Azure Service Bus expired the lock and redelivered it, so **every `ScheduleRetry(...)` against an inline listener ran the handler an extra time** on top of the scheduled copy.

This was latent until #4021 (GH-4018) forced `ServiceBusProcessorOptions.AutoCompleteMessages = false` in `BuildProcessorOptions`. Before that the SDK processor auto-completed anything left unsettled when the callback returned, which happened to cover this path.

`docs/guide/messaging/transports/azureservicebus/scheduled.md` documents this exact scenario ("scheduled retries, assuming that the listening endpoint was an **inline** Azure Service Bus listener"), so this restores the documented contract — no doc change needed.

## The fix

Route through the listener's existing `_defer` `RetryBlock`, which already settles before re-sending — the same shape `BatchedAzureServiceBusListener._defer` took for GH-3494 (AO8), whose comment describes this failure mode exactly. That block's guard is tightened from `is { } e` to `is { IsCompleted: false } e` now that two call paths share it, so a redundant `CompleteAsync` on an already-settled envelope can't throw and be retried.

`BatchedAzureServiceBusListener` is untouched.

## New coverage

The existing `using_native_scheduling.cs` only exercises **cascaded** scheduling (`context.ScheduleAsync`), which sends a brand new message and lets the incoming delivery complete normally — which is why a scheduled **retry** of the incoming message went uncovered.

`scheduled_retry_settlement.cs` adds that case: an inline listener with `LockDuration = 5s` (the emulator minimum, to keep the redelivery window inside the test), a handler that throws on its first invocation, and `opts.Policies.OnException<T>().ScheduleRetry(1.Seconds())`. Before the fix:

```
Shouldly.ShouldAssertException : AsbScheduledRetryHandler.Attempts
    should be
2
    but was
3
```

## Deliberately out of scope: the session listener

`InlineAzureServiceBusSessionListener.MoveToScheduledUntilAsync` has the identical defect, but **its `_defer` cannot settle at all** — `CompleteAsync` inside the session processor callback throws `SessionLockLost` every time, the `RetryBlock` burns its attempts, and the re-sent copy on the next line is never sent.

That reproduces on unmodified `main` through the plain `Requeue(3)` path, which this PR does not touch, so it predates this issue and is independent of it. Filed separately as #4068. Applying the same fix to the session listener would trade today's duplicate delivery for **no retry at all**, so the session half of #4062 is left blocked on #4068.

## Verification

- New test fails on `main` (`2 but was 3`), passes here.
- Full `Wolverine.AzureServiceBus.Tests`: 311/318. The 7 failures are pre-existing emulator flakiness, not regressions — a matched subset of the affected classes (`TopicAndSubscription{,WithCustomRule}SendingAndReceivingCompliance`, `using_native_scheduling`, `Bug_1933_multi_tenant_conventional_routing`) gives **13/52 red on unmodified `origin/main`** versus **2/52 on this branch**, and those 2 (`Bug_1933`) are red on `main` too.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
