### PR TITLE
GH-4079: let a continuation source decline so Pulsar stops swallowing every error policy

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -243,6 +243,30 @@ For delayed / backoff redelivery (growing the delay between attempts), use the P
 retry-letter topics instead — DotPulsar's client does not expose negative-acknowledgment backoff
 or ack-timeout settings.
 
+## Native Resiliency and Your Own Error Policies
+
+`UsePulsar()` registers a failure rule that hands a failed message to Pulsar's own retry-letter /
+dead-letter machinery. That rule is registered globally, ahead of anything you configure afterwards,
+so it is worth being precise about when it takes over:
+
+| Where the failure happened | What handles it |
+| --- | --- |
+| A Pulsar listener with `RetryLetterQueueing(...)`, `DeadLetterQueueing(...)` (native mode), or `UseNativeRedelivery()` | **Pulsar's native retry/DLQ.** Your `opts.Policies.OnException<T>()` rules do not run for that endpoint. |
+| A Pulsar listener with none of the above configured | Your own Wolverine error policies, exactly as on any other transport |
+| A hot-tail listener (`TailFromLatest()`) | Your own Wolverine error policies — see the caveat below |
+| Any other endpoint in the application: another transport, a local queue | Your own Wolverine error policies |
+
+In other words the native path only claims a failure it can actually act on; everything else falls
+through to the policies you configured. Chain-level rules (`chain.OnException<T>()`) always sort
+ahead of global rules, so those take precedence even on a natively-configured Pulsar endpoint.
+
+::: warning
+On a hot-tail listener your error policies do run, but requeue-shaped ones (`Requeue()`,
+`RequeueIndefinitely()`, `PauseThenRequeue()`, `MaximumAttempts()`) still cannot redeliver anything —
+a non-durable `Reader` commits no cursor, so there is nothing to requeue from. Reach for the
+in-process retries (`RetryTimes()`, `RetryWithCooldown()`, `ScheduleRetry()`) there instead.
+:::
+
 ## Tiered Retry-Letter Policy <Badge type="tip" text="6.8" />
 
 `RetryLetterQueueing(...)` configures Pulsar's native retry-letter topic per endpoint. For a

--- a/src/Testing/CoreTests/ErrorHandling/JitterIntegrationTests.cs
+++ b/src/Testing/CoreTests/ErrorHandling/JitterIntegrationTests.cs
@@ -109,6 +109,7 @@ public class JitterIntegrationTests
         var envelope = ObjectMother.Envelope();
         envelope.Attempts = 1;
         var continuation = slot.Build(new InvalidOperationException("boom"), envelope);
+        continuation.ShouldNotBeNull();
 
         var lifecycle = Substitute.For<IEnvelopeLifecycle>();
         lifecycle.Envelope.Returns(envelope);
@@ -158,6 +159,7 @@ public class JitterIntegrationTests
         var envelope = Wolverine.ComplianceTests.ObjectMother.Envelope();
         envelope.Attempts = 1;
         var continuation = slot.Build(ex, envelope);
+        continuation.ShouldNotBeNull();
 
         var lifecycle = NSubstitute.Substitute.For<IEnvelopeLifecycle>();
         lifecycle.Envelope.Returns(envelope);

--- a/src/Testing/CoreTests/ErrorHandling/declining_continuation_sources.cs
+++ b/src/Testing/CoreTests/ErrorHandling/declining_continuation_sources.cs
@@ -1,0 +1,144 @@
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.ErrorHandling;
+using Wolverine.ErrorHandling.Matches;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.ErrorHandling;
+
+/// <summary>
+/// An <see cref="IContinuationSource" /> declines an envelope by returning null, and a
+/// <see cref="FailureRule" /> whose sources all decline has to be skipped so the next rule gets a turn.
+/// Wolverine.Pulsar depends on this: UsePulsar() registers a global AlwaysMatches rule ahead of every
+/// user policy, and that rule may only claim failures Pulsar's native retry/DLQ can actually act on.
+/// </summary>
+public class declining_continuation_sources
+{
+    private readonly Envelope theEnvelope = ObjectMother.Envelope();
+
+    [Fact]
+    public void rule_is_not_handled_when_its_only_slot_declines()
+    {
+        var rule = new FailureRule(new TypeMatch<DivideByZeroException>());
+        rule.AddSlot(new DecliningSource());
+
+        rule.TryCreateContinuation(new DivideByZeroException(), theEnvelope, out var continuation)
+            .ShouldBeFalse();
+
+        continuation.ShouldBeOfType<NullContinuation>();
+    }
+
+    [Fact]
+    public void rule_is_not_handled_when_both_the_slot_and_the_infinite_source_decline()
+    {
+        var rule = new FailureRule(new TypeMatch<DivideByZeroException>());
+        rule.AddSlot(new DecliningSource());
+        rule.InfiniteSource = new DecliningSource();
+
+        rule.TryCreateContinuation(new DivideByZeroException(), theEnvelope, out _).ShouldBeFalse();
+
+        // ...and on an attempt past the last slot, where only the infinite source is consulted
+        theEnvelope.Attempts = 7;
+        rule.TryCreateContinuation(new DivideByZeroException(), theEnvelope, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_declining_slot_still_falls_through_to_the_infinite_source()
+    {
+        var rule = new FailureRule(new TypeMatch<DivideByZeroException>());
+        rule.AddSlot(new DecliningSource());
+        rule.InfiniteSource = RequeueContinuation.Instance;
+
+        rule.TryCreateContinuation(new DivideByZeroException(), theEnvelope, out var continuation)
+            .ShouldBeTrue();
+
+        continuation.ShouldBe(RequeueContinuation.Instance);
+    }
+
+    [Fact]
+    public void running_out_of_slots_is_still_a_dead_letter_and_not_a_decline()
+    {
+        var rule = new FailureRule(new TypeMatch<DivideByZeroException>());
+        rule.AddSlot(new DecliningSource());
+
+        // Past the one and only slot, so nothing was even asked -- that is exhaustion, not a decline
+        theEnvelope.Attempts = 2;
+
+        rule.TryCreateContinuation(new DivideByZeroException(), theEnvelope, out var continuation)
+            .ShouldBeTrue();
+
+        continuation.ShouldBeOfType<MoveToErrorQueue>();
+    }
+
+    [Fact]
+    public void slot_declines_when_every_one_of_its_sources_declines()
+    {
+        var slot = new FailureSlot(1, new DecliningSource());
+        slot.AddAdditionalSource(new DecliningSource());
+
+        slot.Build(new DivideByZeroException(), theEnvelope).ShouldBeNull();
+    }
+
+    [Fact]
+    public void slot_uses_the_surviving_source_when_only_some_decline()
+    {
+        var slot = new FailureSlot(1, new DecliningSource());
+        slot.AddAdditionalSource(RequeueContinuation.Instance);
+
+        slot.Build(new DivideByZeroException(), theEnvelope).ShouldBe(RequeueContinuation.Instance);
+    }
+
+    [Fact]
+    public void a_declining_rule_falls_through_to_the_next_rule_in_the_collection()
+    {
+        var handlers = new HandlerGraph();
+
+        // Stand-in for the rule UsePulsar() registers: matches everything, declines everything
+        var alwaysDeclines = new FailureRule(new TypeMatch<Exception>());
+        alwaysDeclines.AddSlot(new DecliningSource());
+        alwaysDeclines.InfiniteSource = new DecliningSource();
+        handlers.Failures.Add(alwaysDeclines);
+
+        handlers.OnException<DivideByZeroException>().RetryTimes(3);
+
+        handlers.Failures.DetermineExecutionContinuation(new DivideByZeroException(), theEnvelope)
+            .ShouldBeOfType<RetryInlineContinuation>();
+    }
+
+    [Fact]
+    public void a_declining_rule_with_nothing_behind_it_still_ends_in_the_error_queue()
+    {
+        var handlers = new HandlerGraph();
+
+        var alwaysDeclines = new FailureRule(new TypeMatch<Exception>());
+        alwaysDeclines.AddSlot(new DecliningSource());
+        handlers.Failures.Add(alwaysDeclines);
+
+        handlers.Failures.DetermineExecutionContinuation(new DivideByZeroException(), theEnvelope)
+            .ShouldBeOfType<MoveToErrorQueue>();
+    }
+
+    [Fact]
+    public void a_declining_rule_does_not_hide_a_later_inline_continuation()
+    {
+        var handlers = new HandlerGraph();
+
+        var alwaysDeclines = new FailureRule(new TypeMatch<Exception>());
+        alwaysDeclines.AddSlot(new DecliningSource());
+        handlers.Failures.Add(alwaysDeclines);
+
+        handlers.OnException<DivideByZeroException>().RetryTimes(3);
+
+        handlers.Failures.TryFindInlineContinuation(new DivideByZeroException(), theEnvelope)
+            .ShouldBeOfType<RetryInlineContinuation>();
+    }
+
+    private class DecliningSource : IContinuationSource
+    {
+        public string Description => "Declines everything";
+
+        public IContinuation? Build(Exception ex, Envelope envelope) => null;
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/global_failure_policies.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/global_failure_policies.cs
@@ -1,0 +1,212 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.ErrorHandling;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Pulsar.Tests;
+
+/// <summary>
+/// GH-4079. UsePulsar() registers a *global* AlwaysMatches failure rule, which sits ahead of every
+/// opts.Policies.OnException&lt;T&gt;() rule the user adds afterwards. The rule's continuation source
+/// declines (returns null) for anything that is not a PulsarListener, but FailureRule reported the rule
+/// as handled anyway, so the decline collapsed to MoveToErrorQueue instead of falling through to the
+/// user's rule. Blast radius is every endpoint in a Pulsar-enabled app, Pulsar or not.
+/// </summary>
+public class global_failure_policies
+{
+    [Fact]
+    public async Task global_retry_policy_applies_to_a_local_queue_in_a_pulsar_enabled_app()
+    {
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+
+            opts.Policies.OnException<AttemptCountingException>().RetryTimes(3);
+
+            opts.Services.AddSingleton(new AttemptCounter { SucceedOnAttempt = 3 });
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<CountedFailureHandler>();
+        });
+
+        await host.TrackActivity().Timeout(30.Seconds()).DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new CountedFailure());
+
+        host.Services.GetRequiredService<AttemptCounter>().Count.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// The control: the identical host with UsePulsar() removed.
+    /// </summary>
+    [Fact]
+    public async Task global_retry_policy_applies_to_a_local_queue_without_pulsar()
+    {
+        using var host = await WolverineHost.ForAsync(opts =>
+        {
+            opts.Policies.OnException<AttemptCountingException>().RetryTimes(3);
+
+            opts.Services.AddSingleton(new AttemptCounter { SucceedOnAttempt = 3 });
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<CountedFailureHandler>();
+        });
+
+        await host.TrackActivity().Timeout(30.Seconds()).DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new CountedFailure());
+
+        host.Services.GetRequiredService<AttemptCounter>().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task global_retry_policy_applies_to_a_hot_tail_pulsar_listener()
+    {
+        var topic = $"persistent://public/default/globalpolicy-{Guid.NewGuid():N}";
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+        });
+
+        using var listener = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.ListenToPulsarTopic(topic).ProcessInline().TailFromLatest();
+
+            opts.Policies.OnException<AttemptCountingException>().RetryTimes(3);
+
+            opts.Services.AddSingleton(new AttemptCounter { SucceedOnAttempt = 3 });
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<CountedFailureHandler>();
+        });
+
+        // TailFromLatest() only sees what is published after the reader attaches.
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+
+        await publisher.SendAsync(new CountedFailure());
+
+        var counter = listener.Services.GetRequiredService<AttemptCounter>();
+        await waitForAsync(() => counter.Count >= 3);
+
+        counter.Count.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// A plain Pulsar listener with no retry-letter topic, no dead letter topic and no native redelivery
+    /// gives PulsarNativeResiliencyContinuation nothing to do at all, so the failure used to be swallowed
+    /// whole -- no retry, no dead letter, no message.
+    /// </summary>
+    [Fact]
+    public async Task global_retry_policy_applies_to_a_pulsar_listener_with_no_native_resiliency()
+    {
+        var topic = $"persistent://public/default/globalpolicy-{Guid.NewGuid():N}";
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+        });
+
+        using var listener = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.ListenToPulsarTopic(topic).BufferedInMemory().WithSharedSubscriptionType();
+
+            opts.Policies.OnException<AttemptCountingException>().RetryTimes(3);
+
+            opts.Services.AddSingleton(new AttemptCounter { SucceedOnAttempt = 3 });
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<CountedFailureHandler>();
+        });
+
+        await publisher.SendAsync(new CountedFailure());
+
+        var counter = listener.Services.GetRequiredService<AttemptCounter>();
+        await waitForAsync(() => counter.Count >= 3);
+
+        counter.Count.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// The other side of the coin: where native resiliency *is* configured the Pulsar rule still claims the
+    /// failure ahead of the user's global policy, and the message goes to the native dead letter topic on
+    /// the first attempt rather than being retried in process.
+    /// </summary>
+    [Fact]
+    public async Task native_resiliency_still_wins_over_a_global_retry_policy()
+    {
+        var topic = $"persistent://public/default/globalpolicy-{Guid.NewGuid():N}";
+
+        using var publisher = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            opts.PublishAllMessages().ToPulsarTopic(topic).SendInline();
+        });
+
+        using var listener = await WolverineHost.ForAsync(opts =>
+        {
+            opts.UsePulsar(b => b.ServiceUrl(PulsarContainerFixture.ServiceUrl));
+            // The native resiliency DSL is staged -- nothing is applied to the endpoint until the
+            // retry-letter stage is terminated, so DisableRetryLetterQueueing() is what commits the DLQ.
+            opts.ListenToPulsarTopic(topic).BufferedInMemory().WithSharedSubscriptionType()
+                .DeadLetterQueueing(DeadLetterTopic.DefaultNative)
+                .DisableRetryLetterQueueing();
+
+            opts.Policies.OnException<AttemptCountingException>().RetryTimes(3);
+
+            opts.Services.AddSingleton(new AttemptCounter { SucceedOnAttempt = int.MaxValue });
+            opts.Discovery.DisableConventionalDiscovery().IncludeType<CountedFailureHandler>();
+        });
+
+        await publisher.SendAsync(new CountedFailure());
+
+        var counter = listener.Services.GetRequiredService<AttemptCounter>();
+        await waitForAsync(() => counter.Count >= 1);
+
+        // Give any retry that the global policy would have driven time to show up before asserting a
+        // negative -- an inline RetryTimes(3) would be finished long before this.
+        await Task.Delay(5.Seconds(), TestContext.Current.CancellationToken);
+
+        counter.Count.ShouldBe(1);
+    }
+
+    private static async Task waitForAsync(Func<bool> condition, int timeoutMs = 30000)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < cutoff)
+        {
+            if (condition()) return;
+            await Task.Delay(100);
+        }
+    }
+}
+
+public class CountedFailure;
+
+public class AttemptCountingException : Exception
+{
+    public AttemptCountingException(string message) : base(message)
+    {
+    }
+}
+
+public class AttemptCounter
+{
+    private int _count;
+
+    public int SucceedOnAttempt { get; init; } = int.MaxValue;
+
+    public int Count => _count;
+
+    public int Increment() => Interlocked.Increment(ref _count);
+}
+
+public class CountedFailureHandler
+{
+    public static void Handle(CountedFailure message, AttemptCounter counter)
+    {
+        var attempt = counter.Increment();
+        if (attempt < counter.SucceedOnAttempt)
+        {
+            throw new AttemptCountingException($"Simulated failure on attempt {attempt}");
+        }
+    }
+}

--- a/src/Transports/Pulsar/Wolverine.Pulsar/ErrorHandling/PulsarNativeContinuationSource.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/ErrorHandling/PulsarNativeContinuationSource.cs
@@ -7,17 +7,23 @@ public class PulsarNativeContinuationSource : IContinuationSource
 {
     public string Description => "Pulsar native retry/DLQ handling";
 
-#pragma warning disable CS8766 // Nullability of return type matches interface, null is valid for "not handled"
     public IContinuation? Build(Exception ex, Envelope envelope)
-#pragma warning restore CS8766
     {
-        // Only handle Pulsar envelopes/listeners
-        if (envelope.Listener is PulsarListener)
+        // GH-4079. Failure rules live on the handler graph rather than on an endpoint, so PulsarNativeResiliencyPolicy
+        // has no choice but to register this one *globally* -- ahead of every opts.Policies.OnException<T>()
+        // rule the user adds after UsePulsar(). That makes declining mandatory: this source may only claim a
+        // failure it can genuinely act on, and everything else has to fall through to the user's own rules.
+        //
+        // Two things disqualify a failure:
+        //   1. It did not arrive on a Pulsar listener at all -- any other transport, a local queue, or a
+        //      hot-tail PulsarReaderListener, which is not a PulsarListener and has no cursor to move.
+        //   2. It arrived on a Pulsar listener with no native resiliency configured, where
+        //      PulsarNativeResiliencyContinuation would do literally nothing and the message would vanish.
+        if (envelope.Listener is PulsarListener { HasNativeResiliency: true })
         {
             return new PulsarNativeResiliencyContinuation(ex);
         }
 
-        // Return null to let the next continuation source handle it
         return null;
     }
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar/PulsarListener.cs
@@ -463,6 +463,14 @@ internal class PulsarListener : IListener, ISupportDeadLetterQueue, ISupportNati
     /// </summary>
     internal bool UsesNativeRedelivery => _endpoint.UseNativeRedelivery;
 
+    /// <summary>
+    /// Is there any native Pulsar resiliency for this listener to hand a failure to? When there is not,
+    /// <see cref="ErrorHandling.PulsarNativeContinuationSource" /> declines the failure so that Wolverine's
+    /// own error policies get it instead of the message being silently dropped.
+    /// </summary>
+    internal bool HasNativeResiliency =>
+        NativeRetryLetterQueueEnabled || NativeDeadLetterQueueEnabled || UsesNativeRedelivery;
+
     public RetryLetterTopic? RetryLetterTopic => _endpoint.RetryLetterTopic;
 
     public async Task MoveToErrorsAsync(Envelope envelope, Exception exception)

--- a/src/Wolverine/ErrorHandling/FailureRule.cs
+++ b/src/Wolverine/ErrorHandling/FailureRule.cs
@@ -38,8 +38,32 @@ public class FailureRule : IEnumerable<FailureSlot>
             }
 
             var slot = _slots.FirstOrDefault(x => x.Attempt == env.Attempts);
-            
-            continuation = slot?.Build(ex, env) ?? InfiniteSource?.Build(ex, env) ?? new MoveToErrorQueue(ex);
+
+            if (slot?.Build(ex, env) is { } fromSlot)
+            {
+                continuation = fromSlot;
+                return true;
+            }
+
+            if (InfiniteSource?.Build(ex, env) is { } fromInfiniteSource)
+            {
+                continuation = fromInfiniteSource;
+                return true;
+            }
+
+            // GH-4079. Every source this rule could offer for this attempt *declined* the envelope, which is not
+            // the same thing as the rule running out of attempts. Report the rule as unhandled so that
+            // FailureRuleCollection moves on to the next rule -- otherwise a globally registered rule
+            // that only speaks for one transport would swallow every user-configured policy behind it.
+            // See IContinuationSource.Build.
+            if (slot != null || InfiniteSource != null)
+            {
+                continuation = NullContinuation.Instance;
+                return false;
+            }
+
+            // No slot for this attempt and no infinite source: this rule's attempts are exhausted.
+            continuation = new MoveToErrorQueue(ex);
             return true;
         }
 

--- a/src/Wolverine/ErrorHandling/FailureSlot.cs
+++ b/src/Wolverine/ErrorHandling/FailureSlot.cs
@@ -43,20 +43,32 @@ public class FailureSlot
         return applied;
     }
 
-    public IContinuation Build(Exception ex, Envelope envelope)
+    /// <summary>
+    /// Build the continuation for this attempt, or null if every source in this slot declined the
+    /// envelope. See <see cref="IContinuationSource.Build" /> for what declining means.
+    /// </summary>
+    public IContinuation? Build(Exception ex, Envelope envelope)
     {
         if (_sources.Count == 1)
         {
             return _sources[0].Build(ex, envelope);
         }
 
-        var continuations = new IContinuation[_sources.Count];
-        for (var i = 0; i < _sources.Count; i++)
+        var continuations = new List<IContinuation>(_sources.Count);
+        foreach (var source in _sources)
         {
-            continuations[i] = _sources[i].Build(ex, envelope);
+            if (source.Build(ex, envelope) is { } continuation)
+            {
+                continuations.Add(continuation);
+            }
         }
 
-        return new CompositeContinuation(continuations);
+        return continuations.Count switch
+        {
+            0 => null,
+            1 => continuations[0],
+            _ => new CompositeContinuation(continuations.ToArray())
+        };
     }
 
     public string Describe()

--- a/src/Wolverine/ErrorHandling/IContinuationSource.cs
+++ b/src/Wolverine/ErrorHandling/IContinuationSource.cs
@@ -13,10 +13,15 @@ public interface IContinuationSource
     string Description { get; }
 
     /// <summary>
-    ///     Build a continuation for a runtime exception and message envelope
+    ///     Build a continuation for a runtime exception and message envelope. Return <c>null</c> to
+    ///     <em>decline</em> this envelope, meaning "this source has nothing to say about this failure."
+    ///     A <see cref="FailureRule" /> whose sources all decline is skipped entirely, and the next rule in
+    ///     the collection is consulted. This matters for rules a transport registers globally — a rule that
+    ///     can only act on its own transport's envelopes must decline everything else, or it would pre-empt
+    ///     every user-configured policy in the application.
     /// </summary>
     /// <param name="ex"></param>
     /// <param name="envelope"></param>
-    /// <returns></returns>
-    IContinuation Build(Exception ex, Envelope envelope);
+    /// <returns>The continuation to execute, or <c>null</c> to decline this envelope</returns>
+    IContinuation? Build(Exception ex, Envelope envelope);
 }


### PR DESCRIPTION
Closes #4079

## The bug

`UsePulsar()` registers a **global** `AlwaysMatches` failure rule (`PulsarNativeResiliencyPolicy`), so
it lands in `HandlerGraph.Failures` ahead of every `opts.Policies.OnException<T>()` rule the user adds
afterwards. `PulsarNativeContinuationSource.Build` returns `null` for a non-`PulsarListener` envelope,
commented "Return null to let the next continuation source handle it" — but `FailureRule.TryCreateContinuation`
returned `true` regardless, so the null resolved through `?? new MoveToErrorQueue(ex)` and the rule was
terminal.

Global error policies were therefore dead on **every** endpoint in a Pulsar-enabled application, not
just Pulsar ones.

Measured against a live broker with a global `OnException<T>().RetryTimes(3)`, counting handler invocations:

| Setup | Before | After |
| --- | --- | --- |
| A plain **local queue** in a `UsePulsar()` host | **1** | 3 |
| The identical host with `UsePulsar()` removed | 3 | 3 |
| Hot-tail listener (`TailFromLatest()`) | **1** | 3 |
| Pulsar listener with **no** native retry/DLQ configured | **1**, message silently dropped | 3 |
| Pulsar listener with native DLQ configured | 1 | 1 — the native path is *supposed* to win here |

## The fix

**Core — declining is now real, which is what the Pulsar code already believed.**
`IContinuationSource.Build` returns `IContinuation?`; `null` means "this source declines this envelope."
`FailureRule.TryCreateContinuation` returns `false` when every source it could offer for the attempt
declined, so `FailureRuleCollection` moves on to the next rule. `FailureSlot.Build` drops declining
sources instead of stuffing nulls into a `CompositeContinuation`.

Running **out of slots** is deliberately untouched — that is exhaustion, still a handled
`MoveToErrorQueue`, not a decline. The only behavior that changes is a source that explicitly returns
null, and `PulsarNativeContinuationSource` is the only one in the codebase that does (it needed a
`#pragma warning disable CS8766` to do it; that pragma is gone now).

**Pulsar — the native rule only claims a failure it can act on.** The listener must be a
`PulsarListener` **and** have native retry-letter, native dead-letter, or native redelivery in effect
(`PulsarListener.HasNativeResiliency`). That also closes a second hole on the other branch of the same
`if`: a `PulsarListener` with none of those configured produced a `PulsarNativeResiliencyContinuation`
that fell through every branch and did *literally nothing* — no retry, no dead letter, message gone —
while still pre-empting the user's policy. Row 4 of the table above.

### Why not scope the rule's exception match instead

`IExceptionMatch.Matches` only sees the `Exception`, so an envelope-aware match needs a core API
addition too — and it would not fix row 4, where the source returns non-null and the *continuation* is
the no-op. The decline protocol fixes both with one mechanism, and the `IContinuationSource` plugin
point is where the envelope already is.

## Interaction with GH-4060 / #4074

Complementary, and #4074's bootstrap warning is untouched and still wanted. On a hot-tail listener a
requeue policy now genuinely starts running, and will then hit `PulsarReaderListener.DeferAsync`, which
is a no-op — which is exactly what #4074 warns about at bootstrap. The two changes touch disjoint files
and should merge cleanly.

## Docs

New "Native Resiliency and Your Own Error Policies" section on the Pulsar page: a table of which
failures the native path claims and which fall through to your own policies, the chain-vs-global
ordering, and the hot-tail requeue caveat.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 errors, 0 warnings
- Full CoreTests: **2590 total, 0 failed**
- Full `Wolverine.Pulsar.Tests`: **242 total, 0 failed** (against a live 4.2.4 broker)
- PolicyTests 10/0, CircuitBreakingTests 24/0 — the other suites that lean on the failure-rule machinery

Red-baselined in both halves rather than assumed:

- Restoring the old `FailureRule`/`FailureSlot` bodies (keeping the nullable signatures so it compiles)
  fails **5 of the 9** new CoreTests; the 4 that still pass are the preservation cases — exhaustion still
  dead-letters, a declining slot still falls through to the `InfiniteSource`.
- Reverting just the `HasNativeResiliency` predicate to the old `is PulsarListener` fails **exactly** the
  no-native-config test and nothing else.
- The two Pulsar cases from the issue were measured red first: 1 attempt each, with the no-`UsePulsar()`
  control at 3 in the same run.

`native_resiliency_still_wins_over_a_global_retry_policy` is a guard in the other direction: it passes
before and after, so the native path keeps its precedence where it is actually configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
