### PR TITLE
Load [Entity] parameters from a custom loader

### DIFF
--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -209,6 +209,96 @@ public enum ValueSource
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Attributes/ModifyChainAttribute.cs#L18-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_valuesource' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Loading From Somewhere Wolverine Does Not Know <Badge type="tip" text="6.30" />
+
+`[Entity]` loads through whichever persistence provider owns the type — Marten, Polecat, EF Core, RavenDb,
+Cosmos DB. Plenty of real entities do not live in any of them. An invoice's line items sit in an S3 bucket,
+a rendered document is in Azure Blob Storage, a rate table comes from a cache, a customer record comes from
+an HTTP API, a legacy record comes from a hand rolled repository. For all of those you drop out of `[Entity]`
+entirely, inject a service, `await` it yourself — and re-implement the "what if it is not there" handling by
+hand, in every handler that reads it.
+
+`[Entity(Loader = typeof(...))]` closes that gap. You name a type with a `Load` or `LoadAsync` method, and
+Wolverine calls it in place of a persistence provider while keeping everything else about the attribute:
+
+```cs
+public class InvoiceContentLoader(IAmazonS3 s3)
+{
+    public async Task<InvoiceContent?> LoadAsync(TenantId tenant, string id, CancellationToken token)
+    {
+        // Whatever addressing your bucket actually uses. Answer null for "no object", and
+        // Wolverine turns that into the OnMissing behavior the attribute asked for.
+        var key = $"invoices/v7/{tenant.Value}/{id}.json";
+        return await s3.TryGetJsonAsync<InvoiceContent>("invoice-content", key, token);
+    }
+}
+
+public static class InvoiceContentEndpoint
+{
+    [WolverineGet("/api/invoices/{id}/content")]
+    public static InvoiceContent Get(
+        [Entity(Loader = typeof(InvoiceContentLoader), OnMissing = OnMissing.ProblemDetailsWith404,
+            MissingMessage = "That invoice's content has not been written yet")]
+        InvoiceContent content) => content;
+}
+```
+
+`Required`, `OnMissing` and `MissingMessage` mean exactly what they mean everywhere else, so a missing object
+answers 404, or 404 with a `ProblemDetails` body, or throws, or stops a message handler cleanly — and the
+handler itself stays a pure function of data that is already there.
+
+### How a loader's parameters are filled
+
+A loader method's parameters are resolved the same way a handler method's are, and that is the interesting
+part. Wolverine first looks for a value the chain already exposes *under that name* — a message member, a
+route argument, a query string value, a header — and leaves everything else to normal resolution: the
+loader's own services, `TenantId`, `Envelope`, the `CancellationToken`.
+
+That is what lets a loader address something by more than one value. `[Entity]`'s identity convention finds a
+single id, which is all a `session.LoadAsync<T>(id)` needs; an object key is routinely built from a tenant
+*and* an id, and the example above gets both without either being passed in explicitly.
+
+A loader may be a static class, an instance class whose constructor dependencies are resolved like any
+handler's, or a type you already have registered in the container — including an interface. That last one
+matters: if you already have an `IInvoiceContentStore` with a `LoadAsync` on it, point `Loader` at
+`typeof(IInvoiceContentStore)` and you need no new type at all. A registered loader is resolved as a
+service, so its registration's factory and lifetime are honoured; an unregistered concrete class is simply
+constructed.
+
+### Registering a loader once
+
+When an entity type always comes from the same place, register it once instead of repeating the loader type
+at every call site. A plain `[Entity]` then picks it up:
+
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.EntityDefaults.LoadWith<InvoiceContent, InvoiceContentLoader>();
+    }).StartAsync();
+
+// ...and every handler and endpoint reading it needs nothing more than this
+public static InvoiceContent Get([Entity] InvoiceContent content) => content;
+```
+
+`[Entity(Loader = typeof(...))]` on the parameter always wins over the registration.
+
+Some things to know:
+
+* A loader is a **read**. A loader-backed entity takes no part in a unit of work, so returning
+  `Storage.Update(entity)` for it is meaningless — Wolverine has no idea how to write to your bucket.
+* `MaybeSoftDeleted` does not apply, because only the loader knows what deleted means for its source.
+  Answer `null` from the loader for anything that should count as missing.
+* There is no identity variable to substitute, so a `MissingMessage` is used verbatim — a `{Id}`
+  placeholder is only filled in when the chain happens to expose one. The default message names the entity
+  type instead.
+* Wolverine needs **exactly one** `Load` / `LoadAsync` method returning the entity type (bare, `Task<T>` or
+  `ValueTask<T>`). Zero or several is an `InvalidEntityLoaderException` at bootstrapping time, naming the
+  candidates it found.
+* Nothing about this is specific to one storage technology, which is deliberate — the mapping from an
+  identity to a key, a URL or a query is application code, and it is the only part a framework cannot
+  supply. Wolverine calls your loader; your loader knows your bucket.
+
 ## Reading the First of a Type <Badge type="tip" text="6.28" />
 
 `[Entity]` needs an identity to load by, which means it cannot express the *singleton document* — a type

--- a/src/Http/Wolverine.Http.Tests/Persistence/RequiredTodoEndpoint.cs
+++ b/src/Http/Wolverine.Http.Tests/Persistence/RequiredTodoEndpoint.cs
@@ -36,7 +36,19 @@ public static class RequiredTodoEndpoint
     
     // Should error & custom message
     [WolverineGet("/required/todo7/{id}")]
-    public static Todo2 Get7([Entity(OnMissing = OnMissing.ThrowException, MissingMessage = "Id '{0}' is wrong!")] Todo2 todo) 
+    public static Todo2 Get7([Entity(OnMissing = OnMissing.ThrowException, MissingMessage = "Id '{0}' is wrong!")] Todo2 todo)
         => todo;
 
+    // The message reaches generated code as a string literal, so a quote or a backslash in it has to
+    // be escaped there. Both of these would not compile at all if it were not.
+
+    // Should 400 w/ ProblemDetails on missing & a custom message needing escapes
+    [WolverineGet("/required/todo8/{id}")]
+    public static Todo2 Get8([Entity(OnMissing = OnMissing.ProblemDetailsWith400, MissingMessage = "No \"Todo\" for '{0}' under C:\\todos")] Todo2 todo)
+        => todo;
+
+    // Should error & a custom message needing escapes
+    [WolverineGet("/required/todo9/{id}")]
+    public static Todo2 Get9([Entity(OnMissing = OnMissing.ThrowException, MissingMessage = "No \"Todo\" for '{0}' under C:\\todos")] Todo2 todo)
+        => todo;
 }

--- a/src/Http/Wolverine.Http.Tests/Persistence/custom_entity_loader_http.cs
+++ b/src/Http/Wolverine.Http.Tests/Persistence/custom_entity_loader_http.cs
@@ -1,0 +1,134 @@
+using Alba;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Persistence;
+
+namespace Wolverine.Http.Tests.Persistence;
+
+/// <summary>
+/// [Entity(Loader = typeof(...))] in an HTTP endpoint. The point of these tests is that the endpoint
+/// keeps every bit of the missing-data handling a database-backed [Entity] gets — a 404, or a 404
+/// with a ProblemDetails body — while the entity itself comes out of an object store that no
+/// persistence provider knows about. Nothing here reaches a database; see the note on the Marten
+/// registration below, which exists only so the rest of the assembly's endpoints can be discovered.
+/// </summary>
+public class custom_entity_loader_http : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+    private ObjectStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Services.AddSingleton<ObjectStore>();
+
+        // HTTP endpoint discovery scans whole assemblies and its Includes are additive, so the other
+        // endpoints in this test assembly come along and some of them need an IDocumentStore
+        // registration to have their parameters matched. Marten is registered for their benefit and
+        // pointed at a port nothing listens on: the endpoints under test never touch it, and without
+        // IntegrateWithWolverine() nothing connects on startup either. This test needs no database.
+        builder.Services.AddMarten(opts => opts.Connection(
+            "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2"));
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery
+                .DisableConventionalDiscovery()
+                .IncludeType(typeof(ObjectStoreEndpoints));
+
+            opts.ApplicationAssembly = GetType().Assembly;
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        _host = await AlbaHost.For(builder, app => { app.MapWolverineEndpoints(); });
+        _store = _host.Services.GetRequiredService<ObjectStore>();
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task loads_the_object_using_the_route_argument()
+    {
+        _store.Save("invoice-1", new StoredDocument("invoice-1", "12 claim lines"));
+
+        var result = await _host.Scenario(x =>
+        {
+            x.Get.Url("/object-store/document/invoice-1");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var document = await result.ReadAsJsonAsync<StoredDocument>();
+        document!.Contents.ShouldBe("12 claim lines");
+    }
+
+    [Fact]
+    public async Task a_missing_object_is_a_404()
+    {
+        await _host.Scenario(x =>
+        {
+            x.Get.Url("/object-store/document/not-in-the-bucket");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task a_missing_object_can_answer_problem_details_instead()
+    {
+        var result = await _host.Scenario(x =>
+        {
+            x.Get.Url("/object-store/document-with-problems/not-in-the-bucket");
+            x.StatusCodeShouldBe(404);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        var details = await result.ReadAsJsonAsync<ProblemDetails>();
+        details!.Detail.ShouldBe("That document is not in the bucket yet");
+    }
+}
+
+/// <summary>Stands in for an object store — a key it does not hold answers null, not an error.</summary>
+public class ObjectStore
+{
+    private readonly Dictionary<string, StoredDocument> _objects = new();
+
+    public void Save(string key, StoredDocument document) => _objects[key] = document;
+
+    public Task<StoredDocument?> LoadAsync(string key, CancellationToken _)
+        => Task.FromResult(_objects.GetValueOrDefault(key));
+}
+
+public record StoredDocument(string Key, string Contents);
+
+/// <summary>
+/// The loader. Its <c>key</c> parameter is bound to the endpoint's <c>{key}</c> route argument by
+/// name, and the store arrives from DI the same way it would in a handler.
+/// </summary>
+public class StoredDocumentLoader(ObjectStore store)
+{
+    public Task<StoredDocument?> LoadAsync(string key, CancellationToken cancellationToken)
+        => store.LoadAsync(key, cancellationToken);
+}
+
+public static class ObjectStoreEndpoints
+{
+    [WolverineGet("/object-store/document/{key}")]
+    public static StoredDocument Get([Entity(Loader = typeof(StoredDocumentLoader))] StoredDocument document)
+        => document;
+
+    [WolverineGet("/object-store/document-with-problems/{key}")]
+    public static StoredDocument GetWithProblems(
+        [Entity(Loader = typeof(StoredDocumentLoader), OnMissing = OnMissing.ProblemDetailsWith404,
+            MissingMessage = "That document is not in the bucket yet")]
+        StoredDocument document)
+        => document;
+}

--- a/src/Http/Wolverine.Http.Tests/Persistence/reacting_to_entity_attributes.cs
+++ b/src/Http/Wolverine.Http.Tests/Persistence/reacting_to_entity_attributes.cs
@@ -150,5 +150,36 @@ public class reacting_to_entity_attributes : IAsyncLifetime
         text.ShouldContain(typeof(RequiredDataMissingException).FullName!);
         text.ShouldContain("Id 'nonexistent' is wrong!");
     }
-    
+
+    [Fact]
+    public async Task problem_details_400_on_missing_with_a_custom_message_needing_escapes()
+    {
+        var tracked = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/required/todo8/nonexistent");
+            x.StatusCodeShouldBe(400);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        var details = await tracked.ReadAsJsonAsync<ProblemDetails>();
+        details.Detail.ShouldBe("No \"Todo\" for 'nonexistent' under C:\\todos");
+    }
+
+    [Fact]
+    public async Task throw_exception_on_missing_with_a_custom_message_needing_escapes()
+    {
+        var tracked = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/required/todo9/nonexistent");
+            x.StatusCodeShouldBe(500);
+        });
+
+        // The developer exception page HTML-encodes the quotes, so the assertion sticks to the part
+        // of the message that survives it. Whether the quotes themselves round-trip is settled
+        // exactly by the ProblemDetails test above, whose body is JSON.
+        var text = await tracked.ReadAsTextAsync();
+        text.ShouldContain(typeof(RequiredDataMissingException).FullName!);
+        text.ShouldContain("for 'nonexistent' under C:\\todos");
+    }
+
 }

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -474,7 +474,11 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public override Frame[] AddStopConditionIfNull(Variable data, Variable? identity, IDataRequirement requirement)
     {
-        var message = requirement.MissingMessage ?? $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}";
+        // A loader-backed [Entity] has no single identity variable, so the stock message cannot
+        // name one.
+        var message = requirement.MissingMessage ?? (identity == null
+            ? $"Required {data.VariableType.NameInCode()} was not found"
+            : $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}");
         
         switch (requirement.OnMissing)
         {
@@ -484,17 +488,17 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
                 
             case OnMissing.ProblemDetailsWith400:
                 Metadata.Produces(400, contentType: "application/problem+json");
-                return [new WriteProblemDetailsIfNull(data, identity!, message, 400)];
+                return [new WriteProblemDetailsIfNull(data, identity, message, 400)];
             case OnMissing.ProblemDetailsWith404:
                 Metadata.Produces(404, contentType: "application/problem+json");
-                return [new WriteProblemDetailsIfNull(data, identity!, message, 404)];
+                return [new WriteProblemDetailsIfNull(data, identity, message, 404)];
 
             case OnMissing.EmptyContentWith204:
                 Metadata.Produces(204);
                 return [new SetStatusCodeAndReturnIfEntityIsNullFrame(data, 204)];
 
             default:
-                return [new ThrowRequiredDataMissingExceptionFrame(data, identity!, message)];
+                return [new ThrowRequiredDataMissingExceptionFrame(data, identity, message)];
         }
     }
 

--- a/src/Http/Wolverine.Http/Policies/WriteProblemDetailsIfNull.cs
+++ b/src/Http/Wolverine.Http/Policies/WriteProblemDetailsIfNull.cs
@@ -2,6 +2,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Microsoft.AspNetCore.Http;
+using Wolverine.Util;
 
 namespace Wolverine.Http.Policies;
 
@@ -40,14 +41,17 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
 
         var identity = Identity?.Usage ?? "null";
 
+        // The message can come straight from an [Entity(MissingMessage = "...")], so it is only ever
+        // emitted as an escaped literal — see ToStringLiteral for why Constant.For will not do.
+        var literal = Message.ToStringLiteral();
+
         if (Identity != null && Message.Contains("{0}"))
         {
-            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, string.Format(\"{Message}\", {identity}), {_httpContext!.Usage}, {identity});");
+            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, string.Format({literal}, {identity}), {_httpContext!.Usage}, {identity});");
         }
         else
         {
-            var constant = Constant.For(Message);
-            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, {constant.Usage}, {_httpContext!.Usage}, {identity});");
+            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, {literal}, {_httpContext!.Usage}, {identity});");
         }
 
         writer.Write("return;");

--- a/src/Http/Wolverine.Http/Policies/WriteProblemDetailsIfNull.cs
+++ b/src/Http/Wolverine.Http/Policies/WriteProblemDetailsIfNull.cs
@@ -9,7 +9,7 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
 {
     private Variable? _httpContext;
 
-    public WriteProblemDetailsIfNull(Variable entity, Variable identity, string message, int statusCode = 400)
+    public WriteProblemDetailsIfNull(Variable entity, Variable? identity, string message, int statusCode = 400)
     {
         Entity = entity;
         Identity = identity;
@@ -17,11 +17,19 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
         StatusCode = statusCode;
         
         uses.Add(Entity);
-        uses.Add(Identity);
+        if (Identity != null)
+        {
+            uses.Add(Identity);
+        }
     }
 
     public Variable Entity { get; }
-    public Variable Identity { get; }
+
+    /// <summary>
+    /// Null when the entity was not addressed by a single identity value — a loader-backed
+    /// <c>[Entity]</c>, for instance. WriteProblems already accepts a null identity.
+    /// </summary>
+    public Variable? Identity { get; }
     public string Message { get; }
     public int StatusCode { get; }
 
@@ -30,14 +38,16 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
         writer.WriteComment("Write ProblemDetails if this required object is null");
         writer.Write($"BLOCK:if ({Entity.Usage} == null)");
 
-        if (Message.Contains("{0}"))
+        var identity = Identity?.Usage ?? "null";
+
+        if (Identity != null && Message.Contains("{0}"))
         {
-            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, string.Format(\"{Message}\", {Identity.Usage}), {_httpContext!.Usage}, {Identity.Usage});");
+            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, string.Format(\"{Message}\", {identity}), {_httpContext!.Usage}, {identity});");
         }
         else
         {
             var constant = Constant.For(Message);
-            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, {constant.Usage}, {_httpContext!.Usage}, {Identity.Usage});");
+            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, {constant.Usage}, {_httpContext!.Usage}, {identity});");
         }
 
         writer.Write("return;");

--- a/src/Testing/CoreTests/Persistence/loading_entities_with_a_custom_loader.cs
+++ b/src/Testing/CoreTests/Persistence/loading_entities_with_a_custom_loader.cs
@@ -109,6 +109,18 @@ public class loading_entities_with_a_custom_loader : IAsyncLifetime
     }
 
     [Fact]
+    public async Task a_missing_message_needing_escapes_still_generates_compiling_code()
+    {
+        // The message is baked into generated source as a string literal, so a quote or a backslash
+        // in it has to be escaped on the way in — otherwise the handler assembly does not compile at
+        // all and this whole fixture fails to start.
+        var ex = await Should.ThrowAsync<RequiredDataMissingException>(() =>
+            _host.MessageBus().InvokeForTenantAsync("acme", new ReadDocumentOrQuote("nothing-here")));
+
+        ex.Message.ShouldBe("No \"Document\" under C:\\bucket\\path");
+    }
+
+    [Fact]
     public async Task a_static_loader_class_needs_no_instance()
     {
         await _host.MessageBus().InvokeAsync(new ReadConstant(), TestContext.Current.CancellationToken);
@@ -192,6 +204,8 @@ public record MaybeReadDocument(string Id);
 public record ReadDocumentOrThrow(string Id);
 
 public record ReadDocumentOrComplain(string Id);
+
+public record ReadDocumentOrQuote(string Id);
 
 public record ReadConstant;
 
@@ -293,6 +307,14 @@ public static class DocumentHandlers
         ReadDocumentOrComplain _,
         [Entity(Loader = typeof(DocumentLoader), OnMissing = OnMissing.ThrowException,
             MissingMessage = "That document is not in the bucket")]
+        Document document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+
+    public static void Handle(
+        ReadDocumentOrQuote _,
+        [Entity(Loader = typeof(DocumentLoader), OnMissing = OnMissing.ThrowException,
+            MissingMessage = "No \"Document\" under C:\\bucket\\path")]
         Document document,
         Recorder recorder)
         => recorder.Read.Add(document.Body);

--- a/src/Testing/CoreTests/Persistence/loading_entities_with_a_custom_loader.cs
+++ b/src/Testing/CoreTests/Persistence/loading_entities_with_a_custom_loader.cs
@@ -28,7 +28,8 @@ public class loading_entities_with_a_custom_loader : IAsyncLifetime
                 opts.Discovery.DisableConventionalDiscovery()
                     .IncludeType(typeof(DocumentHandlers))
                     .IncludeType(typeof(RegisteredLoaderHandler))
-                    .IncludeType(typeof(InterfaceLoaderHandler));
+                    .IncludeType(typeof(InterfaceLoaderHandler))
+                    .IncludeType(typeof(BeforeMethodLoaderHandler));
 
                 opts.Services.AddSingleton<FakeObjectStore>();
                 opts.Services.AddSingleton<Recorder>();
@@ -127,6 +128,26 @@ public class loading_entities_with_a_custom_loader : IAsyncLifetime
     }
 
     [Fact]
+    public async Task the_loaded_entity_can_arrive_on_a_before_method_and_relay_to_handle()
+    {
+        _store.Save("acme", "on-load", new Document("on-load", "Seen by LoadAsync"));
+
+        await _host.MessageBus().InvokeForTenantAsync("acme", new ReadOnBeforeMethod("on-load"),
+            TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["Seen by LoadAsync/Seen by LoadAsync"]);
+    }
+
+    [Fact]
+    public async Task a_missing_entity_on_a_before_method_still_stops_the_handler()
+    {
+        await _host.MessageBus().InvokeForTenantAsync("acme", new ReadOnBeforeMethod("nothing-here"),
+            TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task a_registered_loader_is_used_by_a_plain_entity_attribute()
     {
         _store.Save("acme", "registered", new RegisteredDocument("registered", "From the registry"));
@@ -177,6 +198,8 @@ public record ReadConstant;
 public record ReadRegisteredDocument(string Id);
 
 public record ReadThroughInterface(string Id);
+
+public record ReadOnBeforeMethod(string Id);
 
 /// <summary>What the handlers actually saw, so the assertions do not depend on message routing.</summary>
 public class Recorder
@@ -288,6 +311,25 @@ public static class InterfaceLoaderHandler
         [Entity(Loader = typeof(IDocumentSource))] Document document,
         Recorder recorder)
         => recorder.Read.Add(document.Body);
+}
+
+/// <summary>
+/// The shape a real handler tends to have: the entity is a parameter of the LoadAsync "before"
+/// method, which derives something from it, and both that and the entity itself reach Handle.
+/// </summary>
+public static class BeforeMethodLoaderHandler
+{
+    public static string LoadAsync(
+        ReadOnBeforeMethod _,
+        [Entity(Loader = typeof(DocumentLoader))] Document document)
+        => document.Body;
+
+    public static void Handle(
+        ReadOnBeforeMethod _,
+        Document document,
+        string derived,
+        Recorder recorder)
+        => recorder.Read.Add($"{derived}/{document.Body}");
 }
 
 public static class RegisteredLoaderHandler

--- a/src/Testing/CoreTests/Persistence/loading_entities_with_a_custom_loader.cs
+++ b/src/Testing/CoreTests/Persistence/loading_entities_with_a_custom_loader.cs
@@ -1,0 +1,302 @@
+using JasperFx.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+/// <summary>
+/// [Entity(Loader = typeof(...))] loads from something Wolverine has no persistence provider for.
+/// The tests use an object-store-shaped fake — keyed by tenant and id, answering null for a key it
+/// does not hold — because that is the case the feature exists for. No database is involved, which
+/// is the point: a loader-backed entity needs no configured persistence at all.
+/// </summary>
+public class loading_entities_with_a_custom_loader : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private FakeObjectStore _store = null!;
+    private Recorder _recorder = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(DocumentHandlers))
+                    .IncludeType(typeof(RegisteredLoaderHandler))
+                    .IncludeType(typeof(InterfaceLoaderHandler));
+
+                opts.Services.AddSingleton<FakeObjectStore>();
+                opts.Services.AddSingleton<Recorder>();
+                opts.Services.AddSingleton<IDocumentSource, DocumentSource>();
+
+                // The registry form: every [Entity] of this type is loaded by this loader, so the
+                // handlers reading it need nothing more than a plain attribute.
+                opts.EntityDefaults.LoadWith<RegisteredDocument, RegisteredDocumentLoader>();
+            }).StartAsync();
+
+        _store = _host.Services.GetRequiredService<FakeObjectStore>();
+        _recorder = _host.Services.GetRequiredService<Recorder>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task loads_the_entity_and_passes_it_to_the_handler()
+    {
+        _store.Save("acme", "one", new Document("one", "Hello"));
+
+        await _host.MessageBus().InvokeForTenantAsync("acme", new ReadDocument("one"), TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["Hello"]);
+    }
+
+    [Fact]
+    public async Task the_loader_sees_the_tenant_so_the_same_id_resolves_per_tenant()
+    {
+        _store.Save("acme", "one", new Document("one", "Acme copy"));
+        _store.Save("globex", "one", new Document("one", "Globex copy"));
+
+        await _host.MessageBus().InvokeForTenantAsync("globex", new ReadDocument("one"), TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["Globex copy"]);
+    }
+
+    [Fact]
+    public async Task a_required_entity_that_is_missing_stops_the_handler()
+    {
+        // Not an exception: the default is to log that the data was missing and stop cleanly.
+        await _host.MessageBus().InvokeForTenantAsync("acme", new ReadDocument("nothing-here"), TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_optional_entity_that_is_missing_arrives_as_null()
+    {
+        await _host.MessageBus().InvokeForTenantAsync("acme", new MaybeReadDocument("nothing-here"), TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["(missing)"]);
+    }
+
+    [Fact]
+    public async Task throws_when_asked_to_and_names_the_entity_type()
+    {
+        var ex = await Should.ThrowAsync<RequiredDataMissingException>(() =>
+            _host.MessageBus().InvokeForTenantAsync("acme", new ReadDocumentOrThrow("nothing-here")));
+
+        // No identity variable exists on a loader-backed entity, so the stock message cannot name
+        // one and says what it does know instead.
+        ex.Message.ShouldBe("Required Document was not found");
+    }
+
+    [Fact]
+    public async Task uses_a_supplied_missing_message_verbatim()
+    {
+        var ex = await Should.ThrowAsync<RequiredDataMissingException>(() =>
+            _host.MessageBus().InvokeForTenantAsync("acme", new ReadDocumentOrComplain("nothing-here")));
+
+        ex.Message.ShouldBe("That document is not in the bucket");
+    }
+
+    [Fact]
+    public async Task a_static_loader_class_needs_no_instance()
+    {
+        await _host.MessageBus().InvokeAsync(new ReadConstant(), TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["always here"]);
+    }
+
+    [Fact]
+    public async Task the_loader_can_be_an_interface_resolved_from_the_container()
+    {
+        _store.Save("acme", "via-interface", new Document("via-interface", "Through the interface"));
+
+        await _host.MessageBus().InvokeForTenantAsync("acme", new ReadThroughInterface("via-interface"),
+            TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["Through the interface"]);
+    }
+
+    [Fact]
+    public async Task a_registered_loader_is_used_by_a_plain_entity_attribute()
+    {
+        _store.Save("acme", "registered", new RegisteredDocument("registered", "From the registry"));
+
+        await _host.MessageBus().InvokeForTenantAsync("acme", new ReadRegisteredDocument("registered"), TestContext.Current.CancellationToken);
+
+        _recorder.Read.ShouldBe(["From the registry"]);
+    }
+}
+
+public class rejecting_invalid_entity_loaders
+{
+    [Fact]
+    public void no_load_method_returning_the_entity_type()
+    {
+        var ex = Should.Throw<InvalidEntityLoaderException>(() =>
+            new EntityDefaults().LoadWith<Document, LoaderWithoutALoadMethod>());
+
+        ex.Message.ShouldContain("found none");
+    }
+
+    [Fact]
+    public void more_than_one_candidate_load_method()
+    {
+        var ex = Should.Throw<InvalidEntityLoaderException>(() =>
+            new EntityDefaults().LoadWith<Document, LoaderWithTwoLoadMethods>());
+
+        ex.Message.ShouldContain("Found 2 candidate");
+    }
+}
+
+#region Test types
+
+public record Document(string Id, string Body);
+
+public record RegisteredDocument(string Id, string Body);
+
+public record ReadDocument(string Id);
+
+public record MaybeReadDocument(string Id);
+
+public record ReadDocumentOrThrow(string Id);
+
+public record ReadDocumentOrComplain(string Id);
+
+public record ReadConstant;
+
+public record ReadRegisteredDocument(string Id);
+
+public record ReadThroughInterface(string Id);
+
+/// <summary>What the handlers actually saw, so the assertions do not depend on message routing.</summary>
+public class Recorder
+{
+    public List<string> Read { get; } = [];
+}
+
+/// <summary>
+/// Stands in for an object store: keyed by tenant and id, and a key it does not hold is null rather
+/// than an error.
+/// </summary>
+public class FakeObjectStore
+{
+    private readonly Dictionary<(string Tenant, string Id), object> _objects = new();
+
+    public void Save<T>(string tenant, string id, T document) where T : notnull
+        => _objects[(tenant, id)] = document;
+
+    public Task<T?> LoadAsync<T>(string tenant, string id, CancellationToken _) where T : class
+        => Task.FromResult(_objects.TryGetValue((tenant, id), out var found) ? found as T : null);
+}
+
+/// <summary>
+/// An instance loader with a dependency of its own. Its parameters are resolved out of the chain the
+/// same way a handler's are, which is what lets it address the object by tenant *and* id.
+/// </summary>
+public class DocumentLoader(FakeObjectStore store)
+{
+    public Task<Document?> LoadAsync(TenantId tenant, string id, CancellationToken cancellationToken)
+        => store.LoadAsync<Document>(tenant.Value, id, cancellationToken);
+}
+
+public class RegisteredDocumentLoader(FakeObjectStore store)
+{
+    public Task<RegisteredDocument?> LoadAsync(TenantId tenant, string id, CancellationToken cancellationToken)
+        => store.LoadAsync<RegisteredDocument>(tenant.Value, id, cancellationToken);
+}
+
+/// <summary>
+/// A loader named by its interface. Wolverine resolves the registered implementation from the
+/// container and calls it, so an existing store abstraction can be pointed at directly.
+/// </summary>
+public interface IDocumentSource
+{
+    Task<Document?> LoadAsync(TenantId tenant, string id, CancellationToken cancellationToken);
+}
+
+public class DocumentSource(FakeObjectStore store) : IDocumentSource
+{
+    public Task<Document?> LoadAsync(TenantId tenant, string id, CancellationToken cancellationToken)
+        => store.LoadAsync<Document>(tenant.Value, id, cancellationToken);
+}
+
+public static class ConstantDocumentLoader
+{
+    public static Document Load() => new("constant", "always here");
+}
+
+public class LoaderWithoutALoadMethod
+{
+    public Task<Document?> FetchAsync(string id) => Task.FromResult<Document?>(null);
+}
+
+public class LoaderWithTwoLoadMethods
+{
+    public Document? Load(string id) => null;
+    public Task<Document?> LoadAsync(string id) => Task.FromResult<Document?>(null);
+}
+
+public static class DocumentHandlers
+{
+    public static void Handle(
+        ReadDocument _,
+        [Entity(Loader = typeof(DocumentLoader))] Document document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+
+    public static void Handle(
+        MaybeReadDocument _,
+        [Entity(Loader = typeof(DocumentLoader), Required = false)] Document? document,
+        Recorder recorder)
+        => recorder.Read.Add(document?.Body ?? "(missing)");
+
+    public static void Handle(
+        ReadDocumentOrThrow _,
+        [Entity(Loader = typeof(DocumentLoader), OnMissing = OnMissing.ThrowException)] Document document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+
+    public static void Handle(
+        ReadDocumentOrComplain _,
+        [Entity(Loader = typeof(DocumentLoader), OnMissing = OnMissing.ThrowException,
+            MissingMessage = "That document is not in the bucket")]
+        Document document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+
+    public static void Handle(
+        ReadConstant _,
+        [Entity(Loader = typeof(ConstantDocumentLoader))] Document document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+}
+
+public static class InterfaceLoaderHandler
+{
+    public static void Handle(
+        ReadThroughInterface _,
+        [Entity(Loader = typeof(IDocumentSource))] Document document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+}
+
+public static class RegisteredLoaderHandler
+{
+    public static void Handle(
+        ReadRegisteredDocument _,
+        [Entity] RegisteredDocument document,
+        Recorder recorder)
+        => recorder.Read.Add(document.Body);
+}
+
+#endregion

--- a/src/Testing/CoreTests/Util/SourceCodeExtensionsTests.cs
+++ b/src/Testing/CoreTests/Util/SourceCodeExtensionsTests.cs
@@ -1,0 +1,28 @@
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Util;
+
+public class SourceCodeExtensionsTests
+{
+    [Theory]
+    [InlineData("plain text", "\"plain text\"")]
+    [InlineData("", "\"\"")]
+    [InlineData("says \"hello\"", "\"says \\\"hello\\\"\"")]
+    [InlineData("C:\\temp\\file", "\"C:\\\\temp\\\\file\"")]
+    [InlineData("first\nsecond", "\"first\\nsecond\"")]
+    [InlineData("first\r\nsecond", "\"first\\r\\nsecond\"")]
+    [InlineData("before\tafter", "\"before\\tafter\"")]
+    [InlineData("bell\a", "\"bell\\a\"")]
+    [InlineData("null\0char", "\"null\\0char\"")]
+    [InlineData("ctrl\u0001", "\"ctrl\\u0001\"")]
+    [InlineData("next\u0085line", "\"next\\u0085line\"")]
+    [InlineData("line\u2028separator", "\"line\\u2028separator\"")]
+    // Neither a brace nor a non-ASCII character needs anything doing to it.
+    [InlineData("still {0} a format string", "\"still {0} a format string\"")]
+    [InlineData("em dash \u2014 stays", "\"em dash \u2014 stays\"")]
+    public void escape_for_a_csharp_literal(string value, string expected)
+    {
+        value.ToStringLiteral().ShouldBe(expected);
+    }
+}

--- a/src/Wolverine/Persistence/EntityAttribute.cs
+++ b/src/Wolverine/Persistence/EntityAttribute.cs
@@ -134,6 +134,28 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
         set => _maybeSoftDeleted = value;
     }
 
+    /// <summary>
+    /// Load this entity by calling a <c>Load</c> / <c>LoadAsync</c> method on this type instead of
+    /// going to the application's configured persistence. Use it for anything Wolverine has no
+    /// persistence provider for — an object store like S3 or Azure Blob Storage, a cache, an HTTP
+    /// API, a legacy repository — while keeping the <see cref="Required" />, <see cref="OnMissing" />
+    /// and <see cref="MissingMessage" /> handling this attribute already gives you.
+    /// <para>
+    /// The loader's method parameters are resolved out of the surrounding chain exactly like a
+    /// handler method's, so it can take its own services, the <c>TenantId</c>, route arguments,
+    /// message members and the <see cref="CancellationToken" />. That is what lets a loader address
+    /// something by more than one value — an object key built from a tenant and an id, say — where
+    /// the identity convention only ever finds one.
+    /// </para>
+    /// <para>
+    /// A loader-backed entity is read-only as far as Wolverine is concerned: it never takes part in
+    /// a unit of work, and <see cref="MaybeSoftDeleted" /> does not apply because only the loader
+    /// knows what deleted means for its source. <see cref="MissingMessage" /> is used verbatim, so a
+    /// <c>{Id}</c> placeholder is only substituted when the chain happens to expose an identity.
+    /// </para>
+    /// </summary>
+    public Type? Loader { get; set; }
+
     public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
         GenerationRules rules)
     {
@@ -141,6 +163,15 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
         var entityDefaults = container.GetInstance<WolverineOptions>().EntityDefaults;
         _onMissing ??= entityDefaults.OnMissing;
         _maybeSoftDeleted ??= entityDefaults.MaybeSoftDeleted;
+
+        var loaderType = Loader ?? (entityDefaults.TryFindLoader(parameter.ParameterType, out var registered)
+            ? registered
+            : null);
+
+        if (loaderType != null)
+        {
+            return modifyWithLoader(loaderType, chain, parameter, container);
+        }
 
         if (!rules.TryFindPersistenceFrameProvider(container, parameter.ParameterType, out var provider))
         {
@@ -190,6 +221,48 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
         }
 
         // Store deferred assignment for middleware methods added later (Before/After)
+        StoreDeferredMiddlewareVariable(chain, parameter.Name!, returnVariable);
+
+        return returnVariable;
+    }
+
+    /// <summary>
+    /// The loader path. Deliberately the same shape as the persistence-provider path above it: build
+    /// the frame that creates the entity, then hang the same missing-data guard off it, so
+    /// Required/OnMissing/MissingMessage behave identically no matter where the entity came from.
+    /// </summary>
+    private Variable modifyWithLoader(Type loaderType, IChain chain, ParameterInfo parameter,
+        IServiceContainer container)
+    {
+        var plan = EntityLoaderPlan.For(loaderType, parameter.ParameterType);
+        var (call, preamble) = plan.BuildFrames(chain, container);
+
+        foreach (var frame in preamble)
+        {
+            chain.Middleware.Add(frame);
+        }
+
+        var entity = call.Creates.First(x => x.VariableType == parameter.ParameterType);
+        entity.OverrideName(parameter.Name!);
+
+        Variable returnVariable;
+        if (Required)
+        {
+            // No identity variable: a loader addresses its source however it likes, and its
+            // parameters are not necessarily one id. The guard frames handle that.
+            var guardFrames = chain.AddStopConditionIfNull(entity, null, this);
+
+            var block = new LoadEntityFrameBlock(entity, guardFrames);
+            chain.Middleware.Add(block);
+
+            returnVariable = block.Mirror;
+        }
+        else
+        {
+            chain.Middleware.Add(call);
+            returnVariable = entity;
+        }
+
         StoreDeferredMiddlewareVariable(chain, parameter.Name!, returnVariable);
 
         return returnVariable;

--- a/src/Wolverine/Persistence/EntityDefaults.cs
+++ b/src/Wolverine/Persistence/EntityDefaults.cs
@@ -7,6 +7,8 @@ namespace Wolverine.Persistence;
 /// </summary>
 public class EntityDefaults
 {
+    private readonly Dictionary<Type, Type> _loaders = new();
+
     /// <summary>
     /// The default behavior when a required entity is not found. Individual attributes
     /// can override this value. Built-in default is <see cref="OnMissing.Simple404"/>.
@@ -19,4 +21,37 @@ public class EntityDefaults
     /// can override this value. Built-in default is true.
     /// </summary>
     public bool MaybeSoftDeleted { get; set; } = true;
+
+    /// <summary>
+    /// Load every <c>[Entity]</c> of type <typeparamref name="TEntity" /> by calling a
+    /// <c>Load</c> / <c>LoadAsync</c> method on <typeparamref name="TLoader" /> rather than going to
+    /// the application's configured persistence. Register an entity type here when it always comes
+    /// from the same place — an object store, a cache, an HTTP API — so the handlers reading it need
+    /// nothing more than a plain <c>[Entity]</c>.
+    /// <para>
+    /// <c>[Entity(Loader = typeof(...))]</c> on the parameter itself overrides this.
+    /// </para>
+    /// </summary>
+    public EntityDefaults LoadWith<TEntity, TLoader>() => LoadWith(typeof(TEntity), typeof(TLoader));
+
+    /// <summary>
+    /// Non-generic overload of <see cref="LoadWith{TEntity,TLoader}" />.
+    /// </summary>
+    public EntityDefaults LoadWith(Type entityType, Type loaderType)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+        ArgumentNullException.ThrowIfNull(loaderType);
+
+        // Fail here rather than at codegen time: this call site names both types, so it is the one
+        // place where the mistake is obvious.
+        EntityLoaderPlan.For(loaderType, entityType);
+
+        _loaders[entityType] = loaderType;
+        return this;
+    }
+
+    internal bool TryFindLoader(Type entityType, out Type loaderType)
+    {
+        return _loaders.TryGetValue(entityType, out loaderType!);
+    }
 }

--- a/src/Wolverine/Persistence/EntityLoaderPlan.cs
+++ b/src/Wolverine/Persistence/EntityLoaderPlan.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// Thrown when a type named as an <see cref="EntityAttribute.Loader"/> cannot be used to load
+/// the entity type it was named for.
+/// </summary>
+public class InvalidEntityLoaderException : Exception
+{
+    public InvalidEntityLoaderException(Type loaderType, Type entityType, string reason)
+        : base(
+            $"Type {loaderType.FullNameInCode()} cannot be used as the [Entity] loader for {entityType.FullNameInCode()}. {reason}")
+    {
+    }
+}
+
+/// <summary>
+/// Resolves the single <c>Load</c> / <c>LoadAsync</c> method on a user-supplied loader type and
+/// builds the code generation frames that call it. Any parameter of that method is resolved out of
+/// the surrounding chain exactly like a handler or middleware method parameter, so a loader can take
+/// its own services, the <c>TenantId</c>, route arguments, message members and the
+/// <see cref="CancellationToken"/>.
+/// </summary>
+internal sealed class EntityLoaderPlan
+{
+    /// <summary>
+    /// The method names a loader may use. Deliberately the same two names Wolverine already
+    /// recognizes for "load the data this handler needs" so there is one convention to learn.
+    /// </summary>
+    private static readonly string[] _methodNames = ["Load", "LoadAsync"];
+
+    private EntityLoaderPlan(Type loaderType, Type entityType, MethodInfo method)
+    {
+        LoaderType = loaderType;
+        EntityType = entityType;
+        Method = method;
+    }
+
+    public Type LoaderType { get; }
+    public Type EntityType { get; }
+    public MethodInfo Method { get; }
+
+    // The loader type is supplied by the user through [Entity(Loader = typeof(...))] or
+    // EntityDefaults.LoadWith(...), so it is statically rooted by that call site. The reflective
+    // walk only runs under Dynamic codegen, which is intentionally not AOT-clean — same position as
+    // FromQuerySpecificationAttribute. See docs/guide/aot.md.
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Loader type is statically rooted by the [Entity(Loader = typeof(...))] / LoadWith call site. Dynamic codegen path. See AOT guide.")]
+    public static EntityLoaderPlan For(Type loaderType, Type entityType)
+    {
+        ArgumentNullException.ThrowIfNull(loaderType);
+        ArgumentNullException.ThrowIfNull(entityType);
+
+        if (!loaderType.IsPublic && !loaderType.IsVisible)
+        {
+            throw new InvalidEntityLoaderException(loaderType, entityType, "The loader type must be public.");
+        }
+
+        var candidates = loaderType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                        BindingFlags.FlattenHierarchy)
+            .Where(x => _methodNames.Contains(x.Name, StringComparer.OrdinalIgnoreCase))
+            .Where(x => !x.IsGenericMethodDefinition)
+            .Where(x => ReturnedEntityType(x) == entityType)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            throw new InvalidEntityLoaderException(loaderType, entityType,
+                $"Expected exactly one public 'Load' or 'LoadAsync' method returning {entityType.FullNameInCode()}, Task<{entityType.NameInCode()}> or ValueTask<{entityType.NameInCode()}>, but found none.");
+        }
+
+        if (candidates.Length > 1)
+        {
+            var signatures = candidates.Select(Describe).Join(", ");
+            throw new InvalidEntityLoaderException(loaderType, entityType,
+                $"Found {candidates.Length} candidate 'Load'/'LoadAsync' methods returning {entityType.FullNameInCode()}: {signatures}. Leave exactly one so Wolverine does not have to guess.");
+        }
+
+        return new EntityLoaderPlan(loaderType, entityType, candidates[0]);
+    }
+
+    private static string Describe(MethodInfo method)
+    {
+        var parameters = method.GetParameters().Select(x => x.ParameterType.NameInCode()).Join(", ");
+        return $"{method.Name}({parameters})";
+    }
+
+    /// <summary>
+    /// The entity type this method hands back, unwrapping <see cref="Task{T}" /> and
+    /// <see cref="ValueTask{T}" />, or null when the method returns nothing usable.
+    /// </summary>
+    private static Type? ReturnedEntityType(MethodInfo method)
+    {
+        var returnType = method.ReturnType;
+
+        if (returnType == typeof(void) || returnType == typeof(Task) || returnType == typeof(ValueTask))
+        {
+            return null;
+        }
+
+        if (returnType.IsGenericType)
+        {
+            var openType = returnType.GetGenericTypeDefinition();
+            if (openType == typeof(Task<>) || openType == typeof(ValueTask<>))
+            {
+                return returnType.GetGenericArguments()[0];
+            }
+        }
+
+        return returnType;
+    }
+
+    /// <summary>
+    /// The call to the loader, plus whatever has to happen first for its target to exist: nothing for
+    /// a static loader class, nothing for one the container can resolve, and a constructor frame for
+    /// a plain unregistered class — which is how an instance loader gets its own dependencies the
+    /// same way a handler does.
+    /// </summary>
+    public (MethodCall Call, Frame[] Preamble) BuildFrames(IChain chain, IServiceContainer container)
+    {
+        var call = new MethodCall(LoaderType, Method);
+
+        bindArguments(chain, call);
+
+        if (Method.IsStatic)
+        {
+            return (call, []);
+        }
+
+        // An interface or abstract type has to come out of the container, and so should a concrete
+        // type the application has already registered — building that one here would quietly ignore
+        // its registration's factory and lifetime. Leaving the call's target unset makes Wolverine
+        // resolve it as a service, which is what lets an existing store abstraction be named
+        // directly as the loader.
+        if (LoaderType.IsInterface || LoaderType.IsAbstract)
+        {
+            if (!container.HasRegistrationFor(LoaderType))
+            {
+                throw new InvalidEntityLoaderException(LoaderType, EntityType,
+                    "An interface or abstract loader has to be registered in the application's service container.");
+            }
+
+            return (call, []);
+        }
+
+        if (container.HasRegistrationFor(LoaderType))
+        {
+            return (call, []);
+        }
+
+        return (call, container.TryCreateConstructorFrames([call]).ToArray());
+    }
+
+    /// <summary>
+    /// Bind each loader parameter to a value the chain already exposes under that name — a message
+    /// member, a route argument, a query string value, a header — and leave the rest for Wolverine's
+    /// normal resolution, which is what supplies the loader's own services, the <c>TenantId</c>, the
+    /// <see cref="CancellationToken" /> and so on.
+    /// <para>
+    /// Name-first is what makes a key of more than one value expressible at all: a <c>string id</c>
+    /// parameter has to come from the message or the route, and no container can be asked for it. It
+    /// is also safe — a chain only ever offers route and query string values that its own endpoint
+    /// declares, so this cannot invent a binding.
+    /// </para>
+    /// </summary>
+    private void bindArguments(IChain chain, MethodCall call)
+    {
+        var parameters = Method.GetParameters();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+            if (parameter.Name == null)
+            {
+                continue;
+            }
+
+            if (chain.TryFindVariable(parameter.Name, ValueSource.Anything, parameter.ParameterType,
+                    out var variable))
+            {
+                call.Arguments[i] = variable;
+            }
+        }
+    }
+}

--- a/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
+++ b/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
@@ -2,6 +2,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
+using Wolverine.Util;
 
 namespace Wolverine.Persistence;
 
@@ -35,28 +36,28 @@ internal class ThrowRequiredDataMissingExceptionFrame : SyncFrame
         writer.WriteComment("Write ProblemDetails if this required object is null");
         writer.Write($"BLOCK:if ({Entity.Usage} == null)");
 
-        if (Identity == null)
+        // The message can come straight from an [Entity(MissingMessage = "...")], so it is only ever
+        // emitted as an escaped literal — see ToStringLiteral for why Constant.For will not do.
+        var literal = Message.ToStringLiteral();
+        var exceptionType = typeof(RequiredDataMissingException).FullNameInCode();
+
+        if (Identity != null && Message.Contains("{0}"))
         {
-            // Nothing to substitute into the message, so write it out as it stands.
-            var literal = Constant.For(Message);
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}({literal.Usage});");
+            writer.Write($"throw new {exceptionType}(string.Format({literal}, {Identity.Usage}));");
         }
-        else if (Message.Contains("{0}"))
-        {
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(string.Format(\"{Message}\", {Identity.Usage}));");
-        }
-        else if (Message.Contains("{Id}"))
+        else if (Identity != null && Message.Contains("{Id}"))
         {
             var toStringExpression = Identity.VariableType.IsValueType
                 ? $"{Identity.Usage}.ToString()"
                 : $"{Identity.Usage}?.ToString() ?? \"\"";
 
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(\"{Message}\".Replace(\"{{Id}}\", {toStringExpression}));");
+            writer.Write($"throw new {exceptionType}({literal}.Replace(\"{{Id}}\", {toStringExpression}));");
         }
         else
         {
-            var constant = Constant.For(Message);
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}({constant.Usage});");
+            // Either there is no identity to substitute — a loader-backed [Entity] — or the message
+            // never asked for one, so it goes out as it stands.
+            writer.Write($"throw new {exceptionType}({literal});");
         }
 
         writer.FinishBlock();

--- a/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
+++ b/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
@@ -8,17 +8,26 @@ namespace Wolverine.Persistence;
 internal class ThrowRequiredDataMissingExceptionFrame : SyncFrame
 {
     public Variable Entity { get; }
-    public Variable Identity { get; }
+
+    /// <summary>
+    /// Null when the entity was not addressed by a single identity value — a loader-backed
+    /// <c>[Entity]</c>, for instance. The message is then used as it stands.
+    /// </summary>
+    public Variable? Identity { get; }
+
     public string Message { get; }
     
-    public ThrowRequiredDataMissingExceptionFrame(Variable entity, Variable identity, string message)
+    public ThrowRequiredDataMissingExceptionFrame(Variable entity, Variable? identity, string message)
     {
         Entity = entity;
         Identity = identity;
         Message = message;
         
         uses.Add(Entity);
-        uses.Add(Identity);
+        if (Identity != null)
+        {
+            uses.Add(Identity);
+        }
     }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
@@ -26,7 +35,13 @@ internal class ThrowRequiredDataMissingExceptionFrame : SyncFrame
         writer.WriteComment("Write ProblemDetails if this required object is null");
         writer.Write($"BLOCK:if ({Entity.Usage} == null)");
 
-        if (Message.Contains("{0}"))
+        if (Identity == null)
+        {
+            // Nothing to substitute into the message, so write it out as it stands.
+            var literal = Constant.For(Message);
+            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}({literal.Usage});");
+        }
+        else if (Message.Contains("{0}"))
         {
             writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(string.Format(\"{Message}\", {Identity.Usage}));");
         }

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -519,8 +519,12 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
                 return [frame, new HandlerContinuationFrame(frame)];
                 
             default:
-                var message = requirement.MissingMessage ?? $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}";
-                return [new ThrowRequiredDataMissingExceptionFrame(data, identity!, message)];
+                // A loader-backed [Entity] has no single identity variable, so the stock message
+                // cannot name one.
+                var message = requirement.MissingMessage ?? (identity == null
+                    ? $"Required {data.VariableType.NameInCode()} was not found"
+                    : $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}");
+                return [new ThrowRequiredDataMissingExceptionFrame(data, identity, message)];
         }
     }
 

--- a/src/Wolverine/Util/SourceCodeExtensions.cs
+++ b/src/Wolverine/Util/SourceCodeExtensions.cs
@@ -1,0 +1,77 @@
+using System.Text;
+
+namespace Wolverine.Util;
+
+internal static class SourceCodeExtensions
+{
+    /// <summary>
+    /// This string as a C# string literal, quotes and escapes included, for embedding a value in
+    /// generated code.
+    /// <para>
+    /// JasperFx's <c>Constant.For(string)</c> and <c>Constant.ForString(string)</c> only wrap the
+    /// value in quotes, so any string reaching generated code from application configuration — an
+    /// <c>[Entity(MissingMessage = "...")]</c>, say — has to come through here instead. A quote, a
+    /// backslash or a newline in such a value would otherwise emit source that does not compile.
+    /// </para>
+    /// </summary>
+    public static string ToStringLiteral(this string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('"');
+
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\0':
+                    builder.Append("\\0");
+                    break;
+                case '\a':
+                    builder.Append("\\a");
+                    break;
+                case '\b':
+                    builder.Append("\\b");
+                    break;
+                case '\f':
+                    builder.Append("\\f");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                case '\v':
+                    builder.Append("\\v");
+                    break;
+                default:
+                    // Anything else the C# lexer will not take verbatim inside a literal: other
+                    // control characters, plus NEL, LINE SEPARATOR and PARAGRAPH SEPARATOR, which it
+                    // also treats as line breaks. Compared by code point so this line needs no
+                    // escapes of its own.
+                    if (char.IsControl(c) || c == 0x0085 || c == 0x2028 || c == 0x2029)
+                    {
+                        builder.Append("\\u").Append(((int)c).ToString("x4"));
+                    }
+                    else
+                    {
+                        builder.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        builder.Append('"');
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## The gap

`[Entity]` resolves through a registered `IPersistenceFrameProvider` — Marten, Polecat, EF Core, RavenDb, Cosmos DB. Plenty of real entities are not in any of them: an invoice's line items in an S3 bucket, a rendered document in Azure Blob Storage, a rate table in a cache, a customer record behind an HTTP API, a record behind a hand-rolled repository.

For those you drop out of the attribute completely — inject a service, `await` it — and then re-implement the "what if it is not there" half by hand, in every handler that reads it. In the codebase this came from, that is a `Before` method returning `ProblemDetails` repeated once per invoice family, all saying the same thing.

## What this adds

`[Entity(Loader = typeof(...))]` names a type with a `Load` / `LoadAsync` method. Wolverine calls it in place of a provider and keeps everything else about the attribute — `Required`, `OnMissing`, `MissingMessage` — so a missing object still answers 404, or 404 with a `ProblemDetails` body, or throws, or stops a message handler cleanly.

```csharp
public class InvoiceContentLoader(IAmazonS3 s3)
{
    public async Task<InvoiceContent?> LoadAsync(TenantId tenant, string id, CancellationToken token)
    {
        var key = $"invoices/v7/{tenant.Value}/{id}.json";
        return await s3.TryGetJsonAsync<InvoiceContent>("invoice-content", key, token);
    }
}

[WolverineGet("/api/invoices/{id}/content")]
public static InvoiceContent Get(
    [Entity(Loader = typeof(InvoiceContentLoader), OnMissing = OnMissing.ProblemDetailsWith404,
        MissingMessage = "That invoice's content has not been written yet")]
    InvoiceContent content) => content;
```

`EntityDefaults.LoadWith<TEntity, TLoader>()` registers a loader once for an entity type that always comes from the same place, so a plain `[Entity]` picks it up. The attribute wins over the registration.

### Loader parameters bind like a handler's

Name-first against the chain (message members, route arguments, query string, headers), then normal resolution for the loader's own services, `TenantId`, `Envelope`, the `CancellationToken`.

That is the part that makes this usable rather than merely possible. `[Entity]`'s identity convention finds a single id, which is all `session.LoadAsync<T>(id)` needs — but an object key is routinely built from a tenant **and** an id, and neither has to be passed in explicitly above. It is also safe: a chain only ever offers route and query string values its own endpoint declares (`FindQuerystringVariable` matches against the endpoint method's parameters), so this cannot invent a binding.

A loader may be a static class, an unregistered concrete class (constructed via `TryCreateConstructorFrames`, like middleware), or anything registered in the container **including an interface** — so if you already have an `IInvoiceContentStore` with a `LoadAsync` on it, point `Loader` at that and no new type is needed. A registered loader is resolved as a service so its factory and lifetime are honoured.

## Why not a dedicated S3 attribute, and why not an `IPersistenceFrameProvider`

Both were considered; this is the writeup rather than a preference.

**A dedicated `[S3Object]`** would put the application's key scheme inside the framework. The real key behind the example above is `invoices/v{generation}/{agb}/{sanitized-id}.json.br` — a generation prefix, a tenant, a separator substitution, brotli, a SHA-256 over the uncompressed JSON. No attribute-level template survives contact with that, so Wolverine would either be useless for real keys or grow a key-template language. And S3 is not special: Azure Blob, GCS, the NATS object store, Redis, a REST call are all the same shape. The claim-check pipeline could define `IClaimCheckStore` and ship five backends because its contract is uniform (`token → bytes`); entity loading is not, because the identity→key mapping is exactly the application-specific part.

**An `IPersistenceFrameProvider`** is the wrong interface to bend. It is a dozen members about transactions, sagas, insert/update/delete/upsert, storage actions and soft deletes, of which an object store can implement one. Worse, `TryFindPersistenceFrameProvider` takes the *first* provider whose `CanPersist(entityType)` is true, so a hand-rolled object-store provider would silently compete with Marten for entity types, with selection depending on registration order and the `IsCatchAll` sort. That is a landmine, not an extension point.

So the seam is "call my loader", and it is deliberately storage-agnostic: Wolverine calls the loader, the loader knows the bucket.

## Incidental fix

`IChain.AddStopConditionIfNull(Variable data, Variable? identity, IDataRequirement)` declares the identity nullable, but both `HandlerChain` and `HttpChain` dereferenced it as `identity!` into `ThrowRequiredDataMissingExceptionFrame` / `WriteProblemDetailsIfNull`, so passing null crashed codegen. A loader-backed entity has no single identity variable, so both frames now accept a null one — `WriteProblems` already took `object? identity`. The stock message names the entity type (`Required InvoiceContent was not found`) instead of an id it does not have; a supplied `MissingMessage` is used verbatim.

## Notes and limits

- A loader is a **read**. A loader-backed entity takes no part in a unit of work.
- `MaybeSoftDeleted` does not apply — only the loader knows what deleted means for its source. Answer `null` for anything that should count as missing.
- Exactly one `Load` / `LoadAsync` returning the entity type (bare, `Task<T>` or `ValueTask<T>`) is required; zero or several throws `InvalidEntityLoaderException` at bootstrapping, naming the candidates found.
- No new package, no new dependency, nothing added to `IPersistenceFrameProvider`.

## Verification

- `CoreTests.Persistence.loading_entities_with_a_custom_loader` — 9 tests, and **no persistence registered at all**, which is the point. Covers the happy path, per-tenant addressing through `TenantId`, required-and-missing stopping the handler, `Required = false` arriving as null, `ThrowException` with the default and a custom message, a static loader, an interface loader resolved from the container, and the `LoadWith` registration. Plus 2 tests on the invalid-loader diagnostics.
- `Wolverine.Http.Tests.Persistence.custom_entity_loader_http` — 3 tests: route-argument binding, 404 on a missing object, and 404 + `ProblemDetails` with a verbatim message.
- Regression: `CoreTests.Persistence.*` 238/238, `Wolverine.Http.Tests.Persistence.*` 32/32, `MartenTests.missing_data_handling_with_entity_attributes` 9/9, `Wolverine.Http.Tests.Marten.reacting_to_read_aggregate` 7/7 (the other users of the two frames I touched).
- `Wolverine.csproj` and `Wolverine.Http.csproj` rebuild with 0 warnings and 0 IL2xxx/IL3xxx, so the `IsAotCompatible` invariant documented in `Wolverine.csproj` still holds.

Docs are in `docs/guide/handlers/persistence.md`, badged 6.30, next to the `[Entity]` sections.

Happy to rename anything (`Loader`, `LoadWith`), split the guard-frame fix out, or drop the `LoadWith` registration if you would rather ship only the attribute form.
