### PR TITLE
GH-4083: give the CI sampler a stall watchdog so a wedged job names its own wedge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,12 +90,29 @@ jobs:
           # NOTE: CISlowTests is deliberately NOT here. It is wall-clock bound by design and blew
           # through the 20 minute cap on its first run; it lives in slow-tests.yml as a manual job.
         include:
-          # CIMarten was twice killed outright by the runner ~15 minutes in ("The runner has received a
-          # shutdown signal"), on unrelated diffs, at almost exactly the same elapsed time on both
-          # attempts -- the signature of the VM running out of memory rather than of a test failure.
-          # The worker lanes that caused it are gone (the suite is sharded across these three jobs
-          # instead, one database at a time), so this sampler is now here to *confirm* the footprint
-          # actually dropped and to catch a recurrence with evidence rather than a guess. See #3771.
+          # This sampler was added after CIMarten was twice killed outright by the runner ~15 minutes
+          # in ("The runner has received a shutdown signal"), on unrelated diffs, at almost exactly
+          # the same elapsed time both times -- read at the time as the VM running out of memory.
+          # See #3771.
+          #
+          # IT IS NOT OOM. The sampler caught the recurrence on 2026-08-24 (run 32683981250, job
+          # 97305549745) and disproved that reading outright: the last several minutes of samples are
+          # BYTE-IDENTICAL every 15 seconds -- ~13.7GB available, swap_used=0, the MartenTests process
+          # pinned at 1160MB and not growing. Nothing was starved. The process was idle and making no
+          # progress, and the job hit this workflow's 20 minute cap at 20m16s.
+          #
+          # Two things that cost real time to re-derive, so do not re-derive them:
+          #   * The job's API conclusion is `cancelled`, NOT `failure`, and no step is marked failed.
+          #     `gh pr checks` renders a cancelled job as `fail`, which reads as a test failure and is
+          #     not one. Confirm with
+          #     `gh api repos/JasperFx/wolverine/actions/jobs/<id> --jq '"\(.status) \(.conclusion)"'`.
+          #   * A capped job uploads NO ledger and prints no summary, so the flakiness roll-up reports
+          #     it as unmeasured rather than as clean.
+          #
+          # So the sampler now also carries a stall watchdog (see build/ci-memory-sampler.sh): flat
+          # memory alone was never actionable, because Bobcat 0.6.1 reports per-test results only when
+          # a batch finishes and a batch that never finishes prints nothing. The watchdog captures the
+          # wedged process's async stacks itself, before the cap can take them. Tracked in #4083.
           - target: CIMarten
             memory_telemetry: true
           - target: CIMartenDistribution

--- a/build/ci-memory-sampler.sh
+++ b/build/ci-memory-sampler.sh
@@ -1,26 +1,151 @@
 #!/usr/bin/env bash
 #
-# Samples memory pressure to stdout while a CI test target runs.
+# Samples memory pressure to stdout while a CI test target runs, and -- when the target stops
+# making progress -- captures the async stacks of the wedged process before the 20 minute job cap
+# kills the runner and takes the evidence with it.
 #
-# Why stdout and not a file: the failure this exists to diagnose (GH-3771) is the *runner itself*
-# being killed ~15 minutes in. When that happens every later step is skipped -- the observed run had
-# "Stop containers: skipped" -- so an artifact upload or an `if: failure()` dmesg dump never
-# executes. Anything already streamed to the live job log, on the other hand, survives. So the
-# sampler has to run in the background of the step being diagnosed and print as it goes.
+# Why stdout and not a file: the failures this exists to diagnose are ones where every later step
+# is skipped -- the runner killed outright (GH-3771), or the job cancelled at the workflow's
+# timeout-minutes cap (GH-4083) -- so an artifact upload or an `if: failure()` dmesg dump never
+# executes. Anything already streamed to the live job log, on the other hand, survives. So this has
+# to run in the background of the step being diagnosed and print as it goes, and nothing here may
+# use ::group:: -- a group left unclosed by a cancellation hides everything inside it.
 #
-# Each line is prefixed [mem] so the curve can be pulled out of a noisy log with a single grep:
+# Each line is prefixed [mem] or [stall] so the curve and the diagnostic can be pulled out of a
+# noisy log with a single grep:
 #
-#   gh run view <id> --log | grep '\[mem\]'
+#   gh run view <id> --log | grep -E '\[mem\]|\[stall\]'
 #
-# Reads as: if MemAvailable trends toward zero and swap fills just before the kill, this is the OOM
-# killer taking the runner service and the fix is footprint (lane count, per-lane hosts). If memory
-# is flat at the moment of death, it is not OOM and lane tuning would be treating the wrong thing.
+# THE MEMORY CURVE reads as: if MemAvailable trends toward zero and swap fills just before the
+# kill, this is the OOM killer taking the runner service and the fix is footprint (lane count,
+# per-lane hosts). If memory is flat at the moment of death, it is not OOM and lane tuning would be
+# treating the wrong thing.
+#
+# THE STALL WATCHDOG exists because "memory is flat" turned out to be the answer, and on its own it
+# is not actionable. On the GH-4083 occurrence the samples were byte-identical for the last several
+# minutes -- 13.7GB available, no swap, the test host pinned at 1160MB -- which says the process was
+# idle, not starved, but says nothing about WHICH test was wedged. Bobcat 0.6.1 reports per-test
+# results only when a batch finishes, so a batch that never finishes prints nothing at all: the last
+# line of that job was "275 test(s): 275 batched, 0 isolated", 18m33s before the cap. The watchdog
+# closes that gap by dumping the async stacks itself. Per the repo's convention, that means
+# dotnet-dump + `dumpasync`, NOT dotnet-stack: the wedge is an await living on the GC heap, and a
+# thread report just shows pool workers parked on a semaphore.
+#
+# Sizing, from 116 green Marten shard jobs: avg 380s, worst 476s. The stall threshold and deadline
+# below sit well clear of that and well clear of the 20 minute cap, so a healthy run can never pay
+# for the diagnostic and a wedged one always gets it with time to spare.
 
 set -uo pipefail
 
 interval="${MEMORY_SAMPLE_INTERVAL:-15}"
 
+# Consecutive seconds of a genuinely idle watched process before the watchdog fires.
+stall_after="${STALL_AFTER_SECONDS:-300}"
+
+# Don't watch for stalls until the build/restore phase is behind us. VBCSCompiler is the largest
+# process on the box while a project compiles and idles between compilations, which is not a stall.
+stall_arm_after="${STALL_ARM_AFTER_SECONDS:-240}"
+
+# Unconditional backstop: fire this many seconds in whatever the CPU says, because a wedge with a
+# live poller in it (a durability agent, a Marten daemon) burns enough CPU to never look idle. Set
+# below the workflow's timeout-minutes cap with room for the capture itself to finish and print.
+stall_deadline="${STALL_DEADLINE_SECONDS:-780}"
+
+# A watched process using less than this share of one core across a whole interval is idle.
+stall_cpu_percent="${STALL_CPU_PERCENT:-2}"
+
+# The async stack of a wedged test host is worth having; all 40,000 lines of it are not.
+stall_dump_lines="${STALL_DUMP_LINES:-400}"
+
+clock_tick="$(getconf CLK_TCK 2>/dev/null || echo 100)"
+idle_jiffy_floor=$(( clock_tick * interval * stall_cpu_percent / 100 ))
+
+started="${SECONDS}"
+fired=0
+prev_pid=""
+prev_rss=""
+prev_cpu=""
+idle_for=0
+
 echo "[mem] sampling every ${interval}s -- total/used/free/available in MB, plus the largest RSS consumers"
+echo "[stall] watchdog armed at +${stall_arm_after}s: dumps async stacks after ${stall_after}s idle, or at +${stall_deadline}s regardless"
+
+# Everything the kernel will tell us for free, printed before anything slow is attempted so that a
+# capture truncated by the cap still leaves the cheap half behind.
+cheap_evidence() {
+    local pid="$1"
+
+    echo "[stall] --- process tree ---"
+    ps -eo pid,ppid,stat,wchan:24,etime,time,rss,comm --sort=-rss | head -15 | sed 's/^/[stall] /'
+
+    if [ -r "/proc/${pid}/status" ]; then
+        echo "[stall] --- /proc/${pid} ---"
+        grep -E '^(Name|State|Threads|VmRSS|voluntary_ctxt_switches|nonvoluntary_ctxt_switches):' \
+            "/proc/${pid}/status" 2>/dev/null | sed 's/^/[stall] /'
+        echo "[stall] open fds: $(ls "/proc/${pid}/fd" 2>/dev/null | wc -l)"
+
+        # A thread histogram separates "every thread parked" (the await wedge this is looking for)
+        # from "one thread spinning" (a livelock, which needs a different tool).
+        echo -n "[stall] thread states: "
+        for t in "/proc/${pid}"/task/*/stat; do
+            rest="$(cat "$t" 2>/dev/null)"; rest="${rest#*) }"
+            echo "${rest%% *}"
+        done | sort | uniq -c | tr '\n' ' '
+        echo
+    fi
+
+    # Which sockets it is holding is often the whole answer: a test host parked on a connection to
+    # Postgres is a very different bug from one parked on nothing at all.
+    echo "[stall] --- sockets ---"
+    ss -tnp 2>/dev/null | grep -E "pid=${pid}[,)]" | head -20 | sed 's/^/[stall] /' \
+        || echo "[stall] (no sockets attributed to ${pid})"
+
+    echo "[stall] --- memory ---"
+    free -m | sed 's/^/[stall] /'
+}
+
+# dotnet-dump + dumpasync. Installed lazily: a healthy run must not pay ~20s to install a tool it
+# will never use. Every stage is bounded by `timeout` so a capture that goes wrong cannot itself be
+# the thing that eats the remaining budget.
+async_stacks() {
+    local pid="$1"
+    local dump="${RUNNER_TEMP:-/tmp}/stall-${pid}.dmp"
+
+    export PATH="${PATH}:${HOME}/.dotnet/tools"
+    if ! command -v dotnet-dump >/dev/null 2>&1; then
+        echo "[stall] installing dotnet-dump..."
+        timeout 120 dotnet tool install -g dotnet-dump >/dev/null 2>&1 \
+            || { echo "[stall] dotnet-dump install FAILED -- cheap evidence above is all there is"; return 1; }
+    fi
+
+    echo "[stall] collecting a dump of pid ${pid}..."
+    timeout 240 dotnet-dump collect -p "${pid}" -o "${dump}" >/dev/null 2>&1 \
+        || { echo "[stall] dotnet-dump collect FAILED"; rm -f "${dump}"; return 1; }
+
+    echo "[stall] --- dumpasync --coalesce (first ${stall_dump_lines} lines) ---"
+    # Long-form flag only: `printf` with the short forms gets mangled into "Unrecognized argument".
+    printf 'dumpasync --coalesce\nexit\n' \
+        | timeout 300 dotnet-dump analyze "${dump}" 2>&1 \
+        | head -n "${stall_dump_lines}" \
+        || true
+    echo "[stall] --- end dumpasync ---"
+
+    rm -f "${dump}"
+}
+
+fire() {
+    local pid="$1" why="$2"
+    fired=1
+
+    echo "[stall] ================================================================"
+    echo "[stall] NO PROGRESS: ${why} (pid ${pid}, $(( SECONDS - started ))s into this step)"
+    echo "[stall] ================================================================"
+
+    cheap_evidence "${pid}"
+    async_stacks "${pid}"
+
+    echo "[stall] capture complete; sampling continues"
+}
 
 while true; do
     # `free -m` line 2 is the physical memory row; column 7 is "available", which is the number that
@@ -32,7 +157,48 @@ while true; do
     # rather than just observed in aggregate.
     top="$(ps -eo rss=,comm= --sort=-rss | head -3 | awk '{printf "%s=%dMB ", $2, $1/1024}')"
 
-    echo "[mem] $(date -u +%H:%M:%S) total=${total} used=${used} free=${free} available=${available} swap_used=${swap_used} | ${top}"
+    # The largest process is the one worth watching: on every Marten shard that is the test host
+    # from the moment it starts, and a wedge is by definition something that has already started.
+    read -r pid rss _ <<<"$(ps -eo pid=,rss=,comm= --sort=-rss | head -1)"
+
+    cpu=""
+    # The pid guard is not paranoia: "/proc/${pid}/stat" with an empty pid collapses to the
+    # system-wide /proc/stat, whose twelfth field is the string "cpu0" -- which bash then evaluates
+    # as an unbound variable and kills the sampler outright.
+    if [[ "${pid}" =~ ^[0-9]+$ ]] && [ -r "/proc/${pid}/stat" ]; then
+        # comm can contain spaces and parens, so cut everything through ") " before splitting;
+        # what remains starts at field 3 (state), putting utime/stime at offsets 12 and 13.
+        stat_rest="$(cat "/proc/${pid}/stat" 2>/dev/null)"; stat_rest="${stat_rest#*) }"
+        # shellcheck disable=SC2086
+        set -- ${stat_rest}
+        cpu=$(( ${12:-0} + ${13:-0} ))
+    fi
+
+    cpu_delta="n/a"
+    if [ -n "${cpu}" ] && [ "${pid}" = "${prev_pid}" ] && [ -n "${prev_cpu}" ]; then
+        cpu_delta=$(( cpu - prev_cpu ))
+        if [ "${rss}" = "${prev_rss}" ] && [ "${cpu_delta}" -le "${idle_jiffy_floor}" ]; then
+            idle_for=$(( idle_for + interval ))
+        else
+            idle_for=0
+        fi
+    else
+        idle_for=0
+    fi
+
+    echo "[mem] $(date -u +%H:%M:%S) total=${total} used=${used} free=${free} available=${available} swap_used=${swap_used} | ${top}| watching pid ${pid} cpu_jiffies+${cpu_delta} idle_for=${idle_for}s"
+
+    if [ "${fired}" -eq 0 ] && [ $(( SECONDS - started )) -ge "${stall_arm_after}" ]; then
+        if [ "${idle_for}" -ge "${stall_after}" ]; then
+            fire "${pid}" "watched process idle for ${idle_for}s (RSS unchanged, under ${stall_cpu_percent}% of one core)"
+        elif [ $(( SECONDS - started )) -ge "${stall_deadline}" ]; then
+            fire "${pid}" "still running ${stall_deadline}s in -- the worst green Marten shard on record finished in 476s"
+        fi
+    fi
+
+    prev_pid="${pid}"
+    prev_rss="${rss}"
+    prev_cpu="${cpu}"
 
     sleep "${interval}"
 done


### PR DESCRIPTION
Closes the diagnostic gap behind #4083.

`CIMarten` intermittently goes red. It is a **wedge cancelled at the workflow's 20 minute cap**, not
the runner running out of memory — the sampler added in #3771 caught the recurrence
([run 32683981250](https://github.com/JasperFx/wolverine/actions/runs/32683981250/job/97305549745))
and disproved that reading outright. The last several minutes of samples are **byte-identical every
15 seconds**: ~13.7 GB available, swap at zero, the test host pinned at 1160 MB. Nothing was starved.

Flat memory on its own is not actionable, because it cannot name the test. `Bobcat.Supervisor`
**0.6.1** — the newest published version, and what `Directory.Packages.props` pins — reports per-test
results only when a batch finishes, so a batch that never finishes prints nothing at all. The job's
last line was `275 test(s): 275 batched, 0 isolated`, **18m33s** before the cap. Bobcat's live
per-test stream (`ISupervisorObserver` / `TestUpdated`) landed after 0.6.1 was cut, so per-test
progress in CI is blocked on a Bobcat release; that's a follow-up on the issue, not this PR.

## What changed

**`build/ci-memory-sampler.sh`** now watches for the flat-and-idle signature and captures the wedged
process's async stacks itself, before the cap can take them.

- Samples **CPU jiffies from `/proc/<pid>/stat`** alongside RSS. Every `[mem]` line now carries
  `watching pid N cpu_jiffies+D idle_for=Ns`, so the signature is legible in the log without
  reconstructing it afterwards.
- Fires **once**, on either of two triggers: **300s** of a genuinely idle process (RSS unchanged
  *and* under 2% of one core), or a hard **780s** deadline regardless of CPU — a wedge with a live
  poller in it (a durability agent, a Marten daemon) never *looks* idle. Armed only after **+240s**
  so the build phase can't trip it.
- Prints **cheap kernel evidence first** — process tree with `wchan`, thread-state histogram, fd
  count, sockets, `free` — so a capture truncated by the cap still leaves the useful half behind.
  The thread histogram alone separates "every thread parked" from "one thread spinning".
- Then `dotnet-dump collect` + **`dumpasync --coalesce`**, this repo's tool for async wedges;
  `dotnet-stack` only shows pool workers parked on a semaphore. `dotnet-dump` is installed **lazily**
  so a healthy run pays nothing, and every stage is bounded by `timeout`.
- **No `::group::` anywhere** — a group left unclosed by a cancellation hides everything inside it.

**`.github/workflows/tests.yml`** — rewrites the now-disproved OOM comment on the `CIMarten` matrix
entry, and records the two things that cost real time here:

- the job's API conclusion is **`cancelled`**, not `failure`, and `gh pr checks` renders that as
  `fail`, which reads as a test failure and is not one;
- a capped job uploads **no ledger**, so the flakiness roll-up reports it as *unmeasured* rather than
  as clean.

## Why these thresholds

Measured across **116 green Marten shard jobs**: avg **380s**, worst **476s**, against the 20 minute
cap. A healthy run cannot reach either trigger, and the wedged job would have been captured at
~03:43 with **13 minutes to spare**.

## Verification

- `bash -n` clean.
- Workflow YAML re-parsed after the edit (3 matrix `include` entries, unchanged).
- **End-to-end in an `mcr.microsoft.com/dotnet/sdk:9.0` container** against a deliberately wedged
  host: the watchdog detected the stall, printed `thread states: 10 S`, installed `dotnet-dump`,
  collected a dump, and `dumpasync` named the await chain exactly —

  ```
  [stall] --- dumpasync --coalesce (first 60 lines) ---
  STACKS 1
  [1] 0000ffff5b3eb778 System.Threading.Tasks.Task
    [1] 0000ffff5b5d5be8 (0) Program+<WaitOnANeverCompletingTask>d__2
      [1] 0000ffff5b5a30a0 (1) Program+<SomeTestThatWedges>d__1
        [1] 0000ffff5b5d1448 (0) Program+<Main>d__0
  ```

  That container run also caught a real bug in the first draft: `/proc/${pid}/stat` with an **empty**
  pid silently collapses to the system-wide `/proc/stat`, whose twelfth field is the string `cpu0`,
  which bash then evaluates as an unbound variable and kills the sampler. Guarded, with the reason
  written down at the guard.

This is CI instrumentation only — no product code, no test code, and nothing under
`src/Transports/Azure/` (unrelated work is in flight there on #4064).

Refs #3771. Refs #4083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
