### PR TITLE
GH-4068: stop the session listener double-settling a message the receiver already completed

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/session_listener_settlement.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/session_listener_settlement.cs
@@ -1,0 +1,127 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.ErrorHandling;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// GH-4068. A session-enabled queue always gets an inline-style listener, because
+/// buildListenerForQueue takes the RequiresSession branch before it looks at Mode. In the default
+/// BufferedInMemory mode that listener is paired with a BufferedReceiver, which completes the
+/// message on receipt -- so the listener's own _defer used to settle an already-settled message.
+/// On a session entity that second settle comes back as SessionLockLost rather than the invalid-lock
+/// error CompleteAsync swallows, so it escaped, the RetryBlock burned its attempts re-running the
+/// whole lambda, and the _requeue.SendAsync on the next line never ran: the retry was silently lost.
+/// </summary>
+public class session_listener_settlement : IAsyncLifetime
+{
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync() => await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
+
+    [Fact]
+    public async Task requeue_survives_the_buffered_receivers_settle_on_receipt()
+    {
+        SessionSettlementHandler.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting().AutoProvision().AutoPurgeOnStartup();
+
+                // No ProcessInline() on purpose -- the endpoint stays in the default
+                // BufferedInMemory mode, which is what pairs the inline session listener with a
+                // BufferedReceiver. Any ConfigureSessionProcessor customization is what opts this
+                // endpoint into InlineAzureServiceBusSessionListener.
+                opts.ListenToAzureServiceBusQueue("session-settle-requeue")
+                    .ConfigureSessionProcessor(_ => { });
+
+                opts.PublishMessage<SessionSettlementMessage>()
+                    .ToAzureServiceBusQueue("session-settle-requeue");
+
+                opts.Policies.OnException<SessionSettlementException>().Requeue(3);
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.MessageBus().SendAsync(new SessionSettlementMessage("requeue me"),
+            new DeliveryOptions { GroupId = "session-1" });
+
+        await SessionSettlementHandler.Succeeded.Task
+            .WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        SessionSettlementHandler.Attempts.ShouldBe(2);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task scheduled_retry_is_delivered_on_an_inline_session_listener()
+    {
+        SessionSettlementHandler.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting().AutoProvision().AutoPurgeOnStartup();
+
+                opts.ListenToAzureServiceBusQueue("session-settle-scheduled")
+                    // A short idle timeout makes the processor let go of the session soon after the
+                    // retry copy is handled. Releasing the session releases any message left
+                    // unsettled in it -- which is how an unsettled original comes back as a
+                    // duplicate, and what makes the third invocation observable inside a test.
+                    .ConfigureSessionProcessor(o => o.SessionIdleTimeout = 5.Seconds())
+                    .ProcessInline();
+
+                opts.PublishMessage<SessionSettlementMessage>()
+                    .ToAzureServiceBusQueue("session-settle-scheduled");
+
+                opts.Policies.OnException<SessionSettlementException>().ScheduleRetry(1.Seconds());
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.MessageBus().SendAsync(new SessionSettlementMessage("schedule me"),
+            new DeliveryOptions { GroupId = "session-1" });
+
+        // GH-4062: MoveToScheduledUntilAsync now settles the original through _defer. If that settle
+        // throws instead, the copy on the next line is never sent and this never completes.
+        await SessionSettlementHandler.Succeeded.Task
+            .WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        // Now let the session go idle and be re-accepted. An original that was never settled
+        // becomes visible again here and the handler runs a third time.
+        await Task.Delay(20.Seconds(), TestContext.Current.CancellationToken);
+
+        SessionSettlementHandler.Attempts.ShouldBe(2);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}
+
+public record SessionSettlementMessage(string Name);
+
+public class SessionSettlementException() : Exception("Fail the first attempt on purpose");
+
+public class SessionSettlementHandler
+{
+    private static int _attempts;
+
+    public static TaskCompletionSource Succeeded { get; private set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static int Attempts => _attempts;
+
+    public static void Reset()
+    {
+        _attempts = 0;
+        Succeeded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Handle(SessionSettlementMessage message)
+    {
+        if (Interlocked.Increment(ref _attempts) == 1)
+        {
+            throw new SessionSettlementException();
+        }
+
+        Succeeded.TrySetResult();
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelope.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelope.cs
@@ -50,6 +50,11 @@ public class AzureServiceBusEnvelope : Envelope
             {
                 await SessionReceiver.CompleteMessageAsync(AzureMessage, token);
             }
+
+            // GH-4068: mark the settle here rather than in each caller. Only the _defer blocks used
+            // to set this, so the "already completed" guards never saw a completion that came from
+            // a _complete block -- most importantly the one BufferedReceiver issues on receipt.
+            IsCompleted = true;
         }
         catch (ServiceBusException e)
         {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -50,10 +50,9 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
             // inline listener already does. Leaving it unsettled meant the message stayed locked
             // until the lock expired and Azure Service Bus redelivered it -- so every deferral
             // produced a duplicate on top of the copy this block sends.
-            if (envelope is AzureServiceBusEnvelope e && !e.IsCompleted)
+            if (envelope is AzureServiceBusEnvelope { IsCompleted: false } e)
             {
                 await e.CompleteAsync(_cancellation.Token);
-                e.IsCompleted = true;
             }
 
             await _requeue.SendAsync(envelope);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
@@ -48,7 +48,6 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
             if (envelope is { IsCompleted: false } e)
             {
                 await e.CompleteAsync(_cancellation.Token);
-                e.IsCompleted = true;
             }
 
             await _requeue.SendAsync(envelope);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusSessionListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusSessionListener.cs
@@ -52,10 +52,9 @@ public class InlineAzureServiceBusSessionListener : IListener, ISupportDeadLette
 
         _defer = new RetryBlock<AzureServiceBusEnvelope>(async (envelope, _) =>
         {
-            if (envelope is { } e)
+            if (envelope is { IsCompleted: false } e)
             {
                 await e.CompleteAsync(_cancellation.Token);
-                e.IsCompleted = true;
             }
 
             await _requeue.SendAsync(envelope);
@@ -140,6 +139,17 @@ public class InlineAzureServiceBusSessionListener : IListener, ISupportDeadLette
     public async Task MoveToScheduledUntilAsync(Envelope envelope, DateTimeOffset time)
     {
         envelope.ScheduledTime = time;
+
+        // GH-4062: settle the original before sending the scheduled copy, exactly like _defer above.
+        // This only re-sent the copy, so on an inline session listener the original delivery was
+        // never settled and came back as a duplicate. Held back from the GH-4062 fix until GH-4068
+        // stopped _defer from double-settling a message the BufferedReceiver had already completed.
+        if (envelope is AzureServiceBusEnvelope e)
+        {
+            await _defer.PostAsync(e);
+            return;
+        }
+
         await _requeue.SendAsync(envelope);
     }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/SessionSpecificListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/SessionSpecificListener.cs
@@ -157,10 +157,9 @@ internal class SessionSpecificListener : IListener, ISupportDeadLetterQueue
 
         _defer = new RetryBlock<AzureServiceBusEnvelope>(async (envelope, _) =>
         {
-            if (envelope is { } e)
+            if (envelope is { IsCompleted: false } e)
             {
                 await e.CompleteAsync(_cancellation.Token);
-                e.IsCompleted = true;
             }
 
             await requeue.SendAsync(envelope);


### PR DESCRIPTION
Fixes #4068. Also closes out the session half of #4062, which was blocked on it.

## The bug

`buildListenerForQueue` takes the `RequiresSession` branch **before** it looks at `Mode`:

```csharp
if (queue.Options.RequiresSession)
{
    if (queue.ConfigureSessionProcessor != null)
    {
        ... return new InlineAzureServiceBusSessionListener(...);   // regardless of Mode
    }
    return new AzureServiceBusSessionListener(...);
}

if (queue.Mode == EndpointMode.Inline) { ... }   // never reached for a session queue
```

So a session-enabled queue always gets an **inline-style** listener — but the `IReceiver` handed to it is still built from the endpoint's `Mode`, which defaults to `BufferedInMemory`. `BufferedReceiver.ReceivedAsync` completes the message **on receipt**, so the listener's own `_defer` then settled an already-settled message.

Instrumented, one message, default config:

```
DIAG received:                    lockedUntil=11:05:09.03 now=11:04:09.06 remaining=60.0s
DIAG IListener.CompleteAsync called
    at BufferedReceiver.<>c.<.ctor>b__13_1(Envelope, CancellationToken)   <-- settle #1
DIAG _complete block firing:      remaining=59.9s
DIAG about to complete in _defer: remaining=59.1s                         <-- settle #2
    SessionLockLost
```

The session lock had **59 seconds left** when the broker reported it lost — never expiry.

On a **non-session** queue the second settle returns `"The lock supplied is invalid"`, which `AzureServiceBusEnvelope.CompleteAsync` already swallows, so it was harmless and invisible (this is why `can_apply_requeue_mechanics` passes). On a **session** entity it returns `SessionLockLost`, which is *not* in that catch — so it escaped, the `RetryBlock` burned its attempts re-running the whole lambda, and the `_requeue.SendAsync` on the next line never ran. **Every requeue on a session listener was silently dropped.**

## Why the existing guards missed it

`IsCompleted` was assigned in exactly four places, and **every one was inside a `_defer` block**. Nothing set it on the `_complete` path, so no guard ever saw a completion issued by a `_complete` block — including GH-3494 (AO8)'s `&& !e.IsCompleted` on the batched listener, which reads as though it guards the buffered pre-complete but only ever stopped a `_defer` *retry* from re-completing.

## The fix

Set `IsCompleted` inside `AzureServiceBusEnvelope.CompleteAsync` itself, so every settle path marks the envelope exactly once and the guards start working. Then give the two session listeners (`InlineAzureServiceBusSessionListener`, `SessionSpecificListener`) the `IsCompleted: false` guard they never had, and drop the four now-redundant assignments so there is a single place that marks a settle.

With the double-settle gone, `InlineAzureServiceBusSessionListener.MoveToScheduledUntilAsync` now routes through `_defer` the way the non-session listener does after #4078 — the session half of #4062, held back there because routing into a block that could not settle would have traded a duplicate for no retry at all.

**Deliberately not done:** tolerating `SessionLockLost` in `CompleteAsync`. A genuinely lost lock means redelivery is already coming, so swallowing it and sending the copy anyway would reintroduce a duplicate. And worth deciding separately, out of scope here: whether a session queue in buffered mode should be getting an inline listener at all, or whether `buildListenerForQueue` ought to honour `Mode` inside the session branch.

## Coverage

`session_listener_settlement.cs`. Both are genuine red/green — verified by stashing only the product change and re-running:

| test | on `main` | with fix |
|---|---|---|
| `requeue_survives_the_buffered_receivers_settle_on_receipt` | red — `SessionLockLost` x4, retry lost | green |
| `scheduled_retry_is_delivered_on_an_inline_session_listener` | red — `should be 2 but was 3` | green |

The second one needs a note: a first version that only asserted "the retry arrived" **passed on unmodified `main`**, because that was never the session bug. It carries a short `SessionIdleTimeout` so the session is released and an unsettled original resurfaces as the third invocation, which is what makes the duplicate observable.

## Verification

- Full `Wolverine.AzureServiceBus.Tests`: **320/320, 0 failures**, zero `SessionLockLost`.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.
- Emulator only (`servicebus-emulator:2.0.1`); real Azure Service Bus is expected to behave the same since the settle sequence is broker-agnostic, but that is not confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
