### PR TITLE
GH-4067: document Pub/Sub effective listener concurrency

### DIFF
--- a/docs/guide/messaging/transports/gcp-pubsub/listening.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/listening.md
@@ -110,17 +110,78 @@ opts.ListenToPubsubTopic("incoming")
 ```
 
 ::: warning
-`MaxOutstandingMessages` is a bound on the **whole** listener. `ListenerCount` does **not** multiply it.
+`MaxOutstandingMessages` is the bound for **one** `SubscriberClient`, and the several inner clients that
+client builds for itself do **not** each get their own allowance.
 
-Google's own API remarks say that a `SubscriberClient` builds several inner clients and that "each will
-observe the flow control settings independently", which reads as though the effective ceiling were
-`ListenerCount × MaxOutstandingMessages`. Measured against the real client library, that is not what
-happens — the client builds a single shared flow controller. Sizing a listener from the documented reading
-will over-provision by a factor of `ListenerCount`. See
-[#4067](https://github.com/JasperFx/wolverine/issues/4067).
+Google's own API remarks say that a `SubscriberClient` creates multiple `SubscriberServiceApiClient`
+instances and that "each will observe the flow control settings independently", which reads as though the
+effective ceiling were `ClientCount × MaxOutstandingMessages`. Measured against the real client library
+(3.24.0), that is not what happens — the SDK builds a single `Flow` and shares it across every inner
+channel. Observed peak in flight tracked the configured limit exactly at 1 → 1, 3 → 3, 8 → 8 and
+1000 → 1000, and with `ClientCount = 4` against a limit of 3 the peak was **3, not 12**. Wolverine never
+sets `ClientCount` itself, so for a single listener `MaxOutstandingMessages` is simply the ceiling.
+See [#4067](https://github.com/JasperFx/wolverine/issues/4067).
 :::
 
-If the subscription was created with message ordering enabled, Pub/Sub additionally serializes delivery per
-ordering key — Wolverine maps `Envelope.GroupId` onto that key. Effective concurrency then becomes the
-*lesser* of `MaxOutstandingMessages` and the number of distinct group ids currently in flight, so an
-endpoint with only a handful of hot group ids will run at that group count no matter how it is sized.
+`ListenerCount` is a different matter. Wolverine builds a separate listener — and therefore a separate
+`SubscriberClient` with its own flow controller — for each one, so it *does* multiply. An endpoint declared
+like this can hold up to 500 messages in flight, not 100:
+
+```cs
+opts.ListenToPubsubTopic("incoming")
+    .ListenerCount(5)
+    .ConfigureListener(client => client.MaxOutstandingMessages = 100);
+```
+
+Size the endpoint on `ListenerCount × MaxOutstandingMessages`, and treat `MaxOutstandingMessages` on its own
+as the per-listener figure.
+
+## Ordering keys cap concurrency at the number of distinct group ids
+
+If you are diagnosing a Pub/Sub listener that runs slower than its flow control settings imply, and the
+numbers above do not explain it, check whether **message ordering** is in play. It is the most common reason
+a correctly-sized listener refuses to use the capacity you gave it, and nothing in the listener's own
+configuration hints at it.
+
+Pub/Sub guarantees ordered delivery per ordering key, and it implements that guarantee by **refusing to
+dispatch a second message for a key while one is still outstanding**. Wolverine maps `Envelope.GroupId` onto
+the ordering key when it publishes (see
+[Publishing](/guide/messaging/transports/gcp-pubsub/publishing)), so any message carrying a group id
+carries an ordering key too.
+
+The consequence is that effective concurrency becomes the *lesser* of `MaxOutstandingMessages` and **the
+number of distinct group ids currently in flight** — the configured bound stops being the binding constraint
+as soon as the group count falls below it. A listener sized for 100 outstanding messages whose traffic is
+concentrated on 3 group ids will process 3 messages at a time. Measured against a subscription with
+`EnableMessageOrdering = true`, publishing 12 messages across 3 ordering keys and holding every callback
+open, exactly 3 callbacks ran; the other 9 messages were never dispatched until their key freed up.
+
+This only applies when the **subscription** has message ordering enabled, which is off by default:
+
+```cs
+opts.ListenToPubsubTopic("incoming")
+    .ConfigurePubsubSubscription(options =>
+    {
+        // false by default -- without this, ordering keys on incoming
+        // messages are carried but not enforced
+        options.EnableMessageOrdering = true;
+    });
+```
+
+That flag is applied when Wolverine *creates* the subscription. If you are listening to a subscription that
+already exists, whether ordering is enforced was decided when that subscription was created, and you will
+need to inspect it in the Google Cloud console rather than infer it from your Wolverine configuration.
+
+::: tip
+To confirm this is what you are hitting, compare the number of messages your listener holds concurrently
+against the number of *distinct* group ids among them. If the two track each other while
+`MaxOutstandingMessages` sits far above both, broker-side ordering is your ceiling. Widening the group id —
+so that traffic spreads over more keys — raises throughput; raising `MaxOutstandingMessages` will not.
+:::
+
+Note that this serialisation overlaps with what
+[`PartitionProcessingByGroupId`](/guide/messaging/partitioning) provides in process: both keep messages
+sharing a group id from running concurrently. When ordering is enabled at the subscription, the broker's
+serialisation is the binding one, because the second message never arrives to be partitioned. How the two
+mechanisms should combine for a future native-ack Pub/Sub endpoint is still open — see
+[#4052](https://github.com/JasperFx/wolverine/issues/4052).

--- a/docs/guide/messaging/transports/gcp-pubsub/publishing.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/publishing.md
@@ -26,3 +26,30 @@ var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L105-L125' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_subscriber_rules_for_pubsub' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Ordering keys and `GroupId`
+
+When Wolverine publishes to a Pub/Sub topic it stamps the outgoing message's `OrderingKey` from the
+envelope's `GroupId`:
+
+```cs
+await bus.PublishAsync(new StatusUpdate(orderId), new DeliveryOptions
+{
+    // becomes the Pub/Sub message's OrderingKey
+    GroupId = orderId.ToString()
+});
+```
+
+A group id also arrives on the envelope automatically when the message is routed through
+[message partitioning](/guide/messaging/partitioning), so endpoints using `MessagePartitioning` publish
+ordering keys whether or not they ask for them explicitly.
+
+::: warning
+Ordering keys are not free. If the receiving **subscription** has `EnableMessageOrdering` turned on, Pub/Sub
+will not dispatch a second message for an ordering key while one is still outstanding — so the consumer's
+effective concurrency drops to the number of distinct group ids in flight, no matter how its flow control is
+sized. This is the usual explanation for a Pub/Sub listener that runs far below the concurrency it was
+configured for. See
+[Ordering keys cap concurrency](/guide/messaging/transports/gcp-pubsub/listening#ordering-keys-cap-concurrency-at-the-number-of-distinct-group-ids)
+for the details and how to confirm it.
+:::


### PR DESCRIPTION
Closes #4067.

Documentation for the two measured facts from the #4052 spike, written for the person diagnosing "why is my Pub/Sub listener slower than I configured it to be". Docs only — no product code changed.

The stale flow-control comment (item 1 of the issue's suggested work) was already fixed by #4071, and #4071 also added a `Concurrency and flow control` section to `listening.md`. This builds on that rather than redoing it.

## 1. Flow control — corrected a knob mix-up

`#4071`'s prose attached the right measurement to the wrong knob. It said:

> `MaxOutstandingMessages` is a bound on the **whole** listener. `ListenerCount` does **not** multiply it.

The measurement is about the SDK's internal `ClientCount` — the several `SubscriberServiceApiClient` instances *inside one* `SubscriberClient`, which share a single `Flow`. Wolverine never sets `ClientCount`.

Wolverine's `ListenerCount` is a different thing and **does** multiply: `ListeningAgent.cs:430-437` calls `BuildListenerAsync` once per listener, and each `PubsubListener` builds its own `SubscriberClientBuilder` with its own `Settings` (`BatchedPubsubListener.cs:21-25`, `InlinePubsubListener.cs:27-31`) — hence its own flow controller. So `ListenerCount(5)` with `MaxOutstandingMessages = 100` is a 500-message ceiling, not 100.

Both halves are now stated separately, and the measured numbers (1→1, 3→3, 8→8, 1000→1000; `ClientCount = 4` against a limit of 3 peaked at **3, not 12**) are in the docs rather than only in a code comment.

## 2. Ordering keys — promoted to its own section

This is the invisible one, so it was promoted from a trailing paragraph to `## Ordering keys cap concurrency at the number of distinct group ids`. Nothing in the listener's configuration surface hints that setting a group id changes the throughput ceiling.

Covers: the mechanism (Pub/Sub will not dispatch a second message for a key while one is outstanding); the measurement (12 messages across 3 ordering keys with every callback held → exactly 3 ran, the other 9 undispatched); that `EnableMessageOrdering` is **off by default** and is fixed when the subscription is *created*, so an existing subscription must be checked in the console; how to confirm it (compare in-flight count against *distinct* group ids); and that widening the group id is the fix, not raising `MaxOutstandingMessages`.

## 3. Sending side

`GroupId` → `OrderingKey` (`PubsubEndpoint.cs:452`) was documented nowhere, which made the consumer-side section hard to act on. `publishing.md` now documents it, notes that message partitioning supplies a group id automatically, and points at the consumer-side consequence.

## Deliberately out of scope

The ordering-keys-versus-partition-lanes design question is **not** settled here — that belongs to #4052. The docs describe the interaction as it exists today and note the question is open, without picking a winner or changing any default, flow-control value, or `ClientCount` behaviour.

## Note for follow-up (not addressed here)

`PubsubTopicOptions.OrderBy` (`PubsubOptions.cs:16`) participates in the ordering key precedence chain but has **no fluent configuration surface** — `ConfigurePubsubTopic` only exposes `CreateTopicOptions` (`e.Server.Topic.Options`), not `PubsubTopicOptions`. It is unreachable through normal configuration, so it is intentionally left undocumented rather than described as a knob users can turn.

## Verification

`dotnet build wolverine.slnx -c Release -f net9.0` — succeeded, 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
