### PR TITLE
docs: fix three typos

### DIFF
--- a/docs/guide/messaging/transports/mqtt.md
+++ b/docs/guide/messaging/transports/mqtt.md
@@ -431,7 +431,7 @@ packet, and re-authenticates on the configured refresh period while the client i
 different method name are covered [below](#custom-authentication-methods).
 
 ::: info
-You don't need to configure `AuthenticationMethod` and `AuthenticationData` by yourself. These are overriden when the `MqttJwtAuthenticationOptions` parameter is set.
+You don't need to configure `AuthenticationMethod` and `AuthenticationData` by yourself. These are overridden when the `MqttJwtAuthenticationOptions` parameter is set.
 :::
 
 Minimal configuration example:

--- a/docs/guide/messaging/transports/signalr.md
+++ b/docs/guide/messaging/transports/signalr.md
@@ -304,7 +304,7 @@ document.getElementById("sendButton").addEventListener("click", function (event)
 
 Note that the method `ReceiveMessage` is hard coded into the `WolverineHub` service.
 
-Also note that messages are sent and recieved as raw json strings. You need to `JSON.parse` incoming messages and `JSON.stringify` outgoing messages yourself. 
+Also note that messages are sent and received as raw json strings. You need to `JSON.parse` incoming messages and `JSON.stringify` outgoing messages yourself. 
 
 Our vision for this usage is that you probably integrate directly with a client side state tracking tool like [Pinia](https://pinia.vuejs.org/)
 (how we're using the SignalR transport to build "CritterWatch").

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -402,7 +402,7 @@ All Marten/Wolverine integration options are available by this one syntax call n
 
 ### Wolverine.RabbitMq
 
-The RabbitMq transport recieved a significant overhaul for 3.0.
+The RabbitMq transport received a significant overhaul for 3.0.
 
 #### RabbitMq Client v7
 


### PR DESCRIPTION
Three typo fixes:

- `docs/guide/messaging/transports/mqtt.md:434` — `overriden` → `overridden`
- `docs/guide/messaging/transports/signalr.md:307` — `recieved` → `received`
- `docs/guide/migration.md:405` — `recieved` → `received`

Docs only.
