### PR TITLE
GH-4089: run the CI sampler on every target, and stop it watching the wrong process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,12 +113,45 @@ jobs:
           # memory alone was never actionable, because Bobcat 0.6.1 reports per-test results only when
           # a batch finishes and a batch that never finishes prints nothing. The watchdog captures the
           # wedged process's async stacks itself, before the cap can take them. Tracked in #4083.
-          - target: CIMarten
-            memory_telemetry: true
-          - target: CIMartenDistribution
-            memory_telemetry: true
-          - target: CIMartenTenancy
-            memory_telemetry: true
+          #
+          # THE SAMPLER NOW RUNS ON EVERY TARGET, so there is no per-target flag here any more. It
+          # costs a `free`/`ps` pair every 15 seconds and installs nothing unless it actually fires.
+          # It was widened because #4089 -- MartenTests retains ~35MB per test and a GREEN CIMarten
+          # ends with 243MB free on a 16GB runner -- cannot be answered for the other suites without
+          # measuring them, and the suites that hold the most memory are not necessarily the ones
+          # that take the longest.
+          #
+          # What IS per-target is the watchdog's unconditional deadline, and it has to be, because
+          # the honest runtime of the heaviest suites already runs past it. Measured over 12 green
+          # `main` runs (max of 12):
+          #
+          #   CIRabbitMQ 859s   CIEfCore 821s   CISqlServer 810s   CIPersistence 807s
+          #   CIPubsub   779s   CIAzureServiceBus 775s   CIRedis 629s   CIKafka 625s
+          #
+          # ...against a 780s default. On these there is no daylight between "healthy" and "about to
+          # be capped" for a time trigger to sit in, and a spurious capture costs ~2 minutes inside a
+          # 20 minute cap on a job already at 14 -- it would turn a green job red. So they set the
+          # deadline to 0 and run the idle detector alone, which does not care how long a suite
+          # takes: a healthy suite is never idle for five minutes.
+          #
+          # Re-measure before trusting these numbers; they are a snapshot of 2026-08-24. Anything
+          # whose green max climbs past ~620s belongs on this list.
+          - target: CIRabbitMQ
+            stall_deadline: 0
+          - target: CIEfCore
+            stall_deadline: 0
+          - target: CISqlServer
+            stall_deadline: 0
+          - target: CIPersistence
+            stall_deadline: 0
+          - target: CIPubsub
+            stall_deadline: 0
+          - target: CIAzureServiceBus
+            stall_deadline: 0
+          - target: CIRedis
+            stall_deadline: 0
+          - target: CIKafka
+            stall_deadline: 0
 
     steps:
       - name: Checkout
@@ -133,24 +166,26 @@ jobs:
 
       - name: Run Tests
         env:
-          MEMORY_TELEMETRY: ${{ matrix.memory_telemetry }}
+          # Empty for every target that does not override it, which the sampler reads as its default.
+          STALL_DEADLINE_SECONDS: ${{ matrix.stall_deadline }}
           # Names this job in the retry ledger (build/RetryLedger.cs). GITHUB_JOB is the matrix's
           # job id -- the same string, "test", for all thirty of these -- so it cannot be used.
           CI_JOB_NAME: ${{ matrix.target }}
         run: |
           # The sampler has to live inside this step: when the runner is killed, later steps are
           # skipped, so only what has already been streamed to this step's log survives. See #3771.
-          if [ "${MEMORY_TELEMETRY:-}" = "true" ]; then
-            ./build/ci-memory-sampler.sh &
-            sampler_pid=$!
-            trap 'kill "${sampler_pid}" 2>/dev/null || true' EXIT
-          fi
+          # It must also be backgrounded from THIS shell -- it picks the process to watch out of its
+          # own parent's process tree, which is how it tells the test host from a service container.
+          ./build/ci-memory-sampler.sh &
+          sampler_pid=$!
+          trap 'kill "${sampler_pid}" 2>/dev/null || true' EXIT
+
           ./build.sh ${{ matrix.target }} --framework net9.0
 
       # Only reachable when the runner itself survived. If the OOM killer took a *test* process
       # rather than the runner service, the kill is recorded here and nowhere else.
       - name: Kernel OOM report
-        if: failure() && matrix.memory_telemetry == true
+        if: failure()
         run: |
           echo "::group::dmesg (OOM / kill events)"
           sudo dmesg | grep -iE "out of memory|oom-kill|killed process" || echo "no OOM events in dmesg"

--- a/build/ci-memory-sampler.sh
+++ b/build/ci-memory-sampler.sh
@@ -31,9 +31,15 @@
 # dotnet-dump + `dumpasync`, NOT dotnet-stack: the wedge is an await living on the GC heap, and a
 # thread report just shows pool workers parked on a semaphore.
 #
-# Sizing, from 116 green Marten shard jobs: avg 380s, worst 476s. The stall threshold and deadline
-# below sit well clear of that and well clear of the 20 minute cap, so a healthy run can never pay
-# for the diagnostic and a wedged one always gets it with time to spare.
+# Sizing is measured, per target, over 12 green `main` runs -- see the note on `stall_deadline`
+# below. The idle threshold is safe for every suite regardless of how long it takes (a healthy suite
+# is never idle for five minutes); the deadline is not, and is turned off for the targets whose
+# honest runtime is already close to the cap.
+#
+# This runs on EVERY target, not just the Marten shards it was written for. The suites that hold the
+# most memory are not necessarily the ones that take the longest, and #4089 asks a question -- does
+# any other suite retain the way MartenTests does -- that can only be answered by measuring rather
+# than by guessing which ones to instrument.
 
 set -uo pipefail
 
@@ -49,6 +55,13 @@ stall_arm_after="${STALL_ARM_AFTER_SECONDS:-240}"
 # Unconditional backstop: fire this many seconds in whatever the CPU says, because a wedge with a
 # live poller in it (a durability agent, a Marten daemon) burns enough CPU to never look idle. Set
 # below the workflow's timeout-minutes cap with room for the capture itself to finish and print.
+#
+# **0 disables it**, and several targets need that. Measured over 12 green `main` runs, the heaviest
+# suites legitimately run PAST this: CIRabbitMQ 859s, CIEfCore 821s, CISqlServer 810s, CIPersistence
+# 807s, CIPubsub 779s, CIAzureServiceBus 775s. There is not enough daylight between "healthy" and
+# "about to be capped" on those for an unconditional time trigger to mean anything, and a spurious
+# capture costs ~2 minutes inside a 20 minute cap on a job already at 14 -- it would turn a green job
+# red. Those targets run the idle detector alone, which does not care how long a suite takes.
 stall_deadline="${STALL_DEADLINE_SECONDS:-780}"
 
 # A watched process using less than this share of one core across a whole interval is idle.
@@ -60,6 +73,10 @@ stall_dump_lines="${STALL_DUMP_LINES:-400}"
 clock_tick="$(getconf CLK_TCK 2>/dev/null || echo 100)"
 idle_jiffy_floor=$(( clock_tick * interval * stall_cpu_percent / 100 ))
 
+# The shell that backgrounded this sampler. Everything the step runs descends from it; the service
+# containers do not. See the watched-process selection in the loop.
+step_root="${PPID}"
+
 started="${SECONDS}"
 fired=0
 prev_pid=""
@@ -68,7 +85,11 @@ prev_cpu=""
 idle_for=0
 
 echo "[mem] sampling every ${interval}s -- total/used/free/available in MB, plus the largest RSS consumers"
-echo "[stall] watchdog armed at +${stall_arm_after}s: dumps async stacks after ${stall_after}s idle, or at +${stall_deadline}s regardless"
+if [ "${stall_deadline}" -gt 0 ]; then
+    echo "[stall] watchdog armed at +${stall_arm_after}s: dumps async stacks after ${stall_after}s idle, or at +${stall_deadline}s regardless"
+else
+    echo "[stall] watchdog armed at +${stall_arm_after}s: dumps async stacks after ${stall_after}s idle (deadline trigger disabled for this target)"
+fi
 
 # Everything the kernel will tell us for free, printed before anything slow is attempted so that a
 # capture truncated by the cap still leaves the cheap half behind.
@@ -157,9 +178,26 @@ while true; do
     # rather than just observed in aggregate.
     top="$(ps -eo rss=,comm= --sort=-rss | head -3 | awk '{printf "%s=%dMB ", $2, $1/1024}')"
 
-    # The largest process is the one worth watching: on every Marten shard that is the test host
-    # from the moment it starts, and a wedge is by definition something that has already started.
-    read -r pid rss _ <<<"$(ps -eo pid=,rss=,comm= --sort=-rss | head -1)"
+    # The largest process IN THIS STEP'S OWN TREE -- deliberately not the largest on the box.
+    # `ps -e` on a runner also sees the service containers, and several of them are both huge and
+    # idle: sqlservr alone holds multiple GB and can sit still for minutes while the test host is
+    # working perfectly well. Watching it would report a stall that is not happening, on exactly the
+    # suites (CISqlServer, CIPersistence, CIPolecat) this was turned on for. Everything the step
+    # actually runs -- Nuke's `build`, the MTP test host -- descends from the shell that backgrounded
+    # this sampler, and no container process does.
+    read -r pid rss watched <<<"$(ps -eo pid=,ppid=,rss=,comm= | awk -v root="${step_root}" '
+        { ppid[$1] = $2; rss[$1] = $3; comm[$1] = $4; seen[NR] = $1 }
+        END {
+            for (i = 1; i <= NR; i++) {
+                p = seen[i]; cur = p; hops = 0
+                while (cur != "" && cur != "1" && hops < 64) {
+                    if (cur == root) break
+                    cur = ppid[cur]; hops++
+                }
+                if (cur == root && rss[p] > best) { best = rss[p]; bp = p; bc = comm[p] }
+            }
+            if (bp != "") print bp, best, bc
+        }')"
 
     cpu=""
     # The pid guard is not paranoia: "/proc/${pid}/stat" with an empty pid collapses to the
@@ -186,13 +224,13 @@ while true; do
         idle_for=0
     fi
 
-    echo "[mem] $(date -u +%H:%M:%S) total=${total} used=${used} free=${free} available=${available} swap_used=${swap_used} | ${top}| watching pid ${pid} cpu_jiffies+${cpu_delta} idle_for=${idle_for}s"
+    echo "[mem] $(date -u +%H:%M:%S) total=${total} used=${used} free=${free} available=${available} swap_used=${swap_used} | ${top}| watching ${watched:-?}(${pid:-?}) cpu_jiffies+${cpu_delta} idle_for=${idle_for}s"
 
     if [ "${fired}" -eq 0 ] && [ $(( SECONDS - started )) -ge "${stall_arm_after}" ]; then
         if [ "${idle_for}" -ge "${stall_after}" ]; then
             fire "${pid}" "watched process idle for ${idle_for}s (RSS unchanged, under ${stall_cpu_percent}% of one core)"
-        elif [ $(( SECONDS - started )) -ge "${stall_deadline}" ]; then
-            fire "${pid}" "still running ${stall_deadline}s in -- the worst green Marten shard on record finished in 476s"
+        elif [ "${stall_deadline}" -gt 0 ] && [ $(( SECONDS - started )) -ge "${stall_deadline}" ]; then
+            fire "${pid}" "still running ${stall_deadline}s in, past this target's measured green ceiling"
         fi
     fi
 


### PR DESCRIPTION
Widens the memory sampler from the three Marten shards to **all 34 test targets**, so the open
question in #4089 — *does any other suite retain memory the way `MartenTests` does?* — can be
answered by measurement rather than by guessing which suites to instrument.

Picking "the heavy suites" by hand would have prejudged it: **the suites that hold the most memory
are not necessarily the ones that take the longest.** The sampler costs a `free`/`ps` pair every 15
seconds and installs nothing unless it actually fires, so there is no longer a per-target telemetry
flag — it just runs.

Two things had to change first, and neither was optional.

## 1. Watch the step's own process tree, not the box's largest process

`ps -e` on a runner also sees the **service containers**, and several are both huge and idle —
`sqlservr` alone holds multiple GB and can sit still for minutes while the test host is working
perfectly well. The old "largest RSS on the box" selection would have watched *that*, gone
`idle_for=300s`, and reported a stall that was not happening — on exactly the suites this PR turns
the sampler on for (`CISqlServer`, `CIPersistence`, `CIPolecat`).

Everything the step actually runs — Nuke's `build`, the MTP test host — descends from the shell that
backgrounds the sampler, and no container process does. So the watched process is now the largest
RSS *in that subtree*.

Verified in a container with a **408 MB idle** process outside the tree and a **68 MB busy** one
inside it:

```
[mem] ... | python3=408MB python3=68MB ps=3MB | watching python3(2625) cpu_jiffies+301 idle_for=0s
```

It reports the 408 MB process in the box-wide curve (which is what that column is for) and watches
the 68 MB one. Under the old code this scenario fired a false stall.

## 2. The unconditional deadline is now per-target, and off for the heavy suites

Measured over **12 green `main` runs**, the heaviest suites legitimately run **past** the 780s
deadline:

| target | green max | | target | green max |
|---|---|---|---|---|
| `CIRabbitMQ` | **859s** | | `CIPubsub` | **779s** |
| `CIEfCore` | **821s** | | `CIAzureServiceBus` | **775s** |
| `CISqlServer` | **810s** | | `CIRedis` | 629s |
| `CIPersistence` | **807s** | | `CIKafka` | 625s |

On these there is no daylight between "healthy" and "about to be capped" for an unconditional time
trigger to sit in, and a spurious capture costs ~2 minutes inside a 20 minute cap on a job already
at 14 — **it would turn a green job red.** Those eight set `stall_deadline: 0` and run the idle
detector alone, which does not care how long a suite takes: a healthy suite is never idle for five
minutes.

`STALL_DEADLINE_SECONDS` uses `:-` so the empty string GitHub renders for a non-overriding target
falls back to the default. All three cases verified:

```
empty env  -> ... or at +780s regardless
explicit 0 -> ... (deadline trigger disabled for this target)
unset      -> ... or at +780s regardless
```

The measured numbers are written into the workflow comment **with the date they were taken** and the
~620s threshold for joining that list, because they will rot.

## Checks

- `bash -n` clean; workflow YAML re-parsed.
- All 8 `include` targets already exist in the base matrix, so they **merge** extra keys onto
  existing combinations rather than creating new jobs — still 34 test jobs, confirmed by parsing.
- Container-tested: tree selection, the disabled-deadline banner, and the three env cases.

CI instrumentation only — no product or test code.

Refs #4083. Refs #4089.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
