### PR TITLE
NativeAck transport adoptions: SQS, Azure Service Bus, NATS JetStream, plus Pub/Sub ordering keys

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -144,15 +144,26 @@ Three consequences follow from never acking at receipt, and all three are the po
 
 **Transport support is opt-in and default-closed.** A transport must settle each delivery individually *and*
 tolerate settling out of order, because the execution block completes messages in handler-completion order
-rather than delivery order. RabbitMQ queues and [Pulsar](/guide/messaging/transports/pulsar.html#native-ack-processing)
-topics qualify and are supported today. Kafka cannot and is out of scope: a cumulative offset commit has no
+rather than delivery order. RabbitMQ queues, [Pulsar](/guide/messaging/transports/pulsar.html#native-ack-processing)
+topics and [Amazon SQS](/guide/messaging/transports/sqs/listening.html#native-ack-processing) queues qualify and
+are supported today. Kafka cannot and is out of scope: a cumulative offset commit has no
 way to express a gap. Calling `ProcessInParallelWithNativeAcks()` on a transport that has not opted in throws
 at configuration time rather than degrading silently.
 
+On a broker where an *unsettled* delivery is on a clock — SQS's visibility timeout, Azure Service Bus's lock
+duration, JetStream's `AckWait` — Wolverine renews that clock for every delivery still sitting in a lane, for
+as long as it sits there. This is unconditional under this mode and not something you opt into: lane queue time
+is unbounded by design, so an un-renewed native-ack endpoint would be a duplicate-delivery generator by
+construction rather than merely at risk under a slow handler. A transport that declares such a clock but does
+not implement renewal is refused at startup.
+
 A transport may also refuse the mode for a *particular* endpoint whose own settings contradict it, again at
-bootstrap rather than at runtime. Pulsar is the example: its acknowledgment strategy is configurable, and
-`AcknowledgeCumulative()` reintroduces exactly the gap-less-commit problem that disqualifies Kafka, so that
-one combination is rejected by name.
+bootstrap rather than at runtime. There are two examples today. Pulsar's acknowledgment strategy is
+configurable, and `AcknowledgeCumulative()` reintroduces exactly the gap-less-commit problem that disqualifies
+Kafka. And an [SQS FIFO queue](/guide/messaging/transports/sqs/listening.html#fifo-queues-do-not-support-native-acks)
+exists to guarantee ordering within a message group, which native-ack lanes deliberately do not preserve — and
+which partitioning by group id does not rescue, because SQS blocks a message group behind its own in-flight
+head. Both combinations are rejected by name.
 
 ## In-Memory Idempotency Guard <Badge type="tip" text="6.30" />
 

--- a/docs/guide/messaging/transports/azureservicebus/performance.md
+++ b/docs/guide/messaging/transports/azureservicebus/performance.md
@@ -33,6 +33,9 @@ prefetch higher than what your workers can settle within the queue's lock durati
 prefetched messages age against their locks while waiting client-side, and an expired lock
 means silent redelivery and a rising delivery count.
 
+`NativeAck` endpoints get a much smaller lane-sized default instead of 0, for exactly that reason —
+see [Native ack endpoints](#native-ack-endpoints) below.
+
 ### Inline endpoints process one message at a time by default
 
 Inline ASB endpoints use a `ServiceBusProcessor`, whose `MaxConcurrentCalls` defaults to **1**.
@@ -53,11 +56,85 @@ to `MaxConcurrentCallsPerSession` instead, which trades away the per-session FIF
 usually the reason for using sessions at all. Leave it alone there unless you mean it — to process
 more sessions at once, use `RequireSessions(n)`.
 
+## Native ack endpoints <Badge type="tip" text="6.30" />
+
+`NativeAck` gives you Buffered's throughput and partitioning with Inline's no-loss behaviour: a
+delivery is enqueued into an in-process execution lane and **left unsettled** until its handler
+reaches a terminal, at which point it is completed, abandoned, or dead lettered natively.
+
+```cs
+opts.ListenToAzureServiceBusQueue("orders")
+    .ProcessInParallelWithNativeAcks()
+    .MaximumParallelMessages(10);
+```
+
+Nothing is completed on receipt, so a node that dies mid-flight acks nothing and the broker hands
+every in-flight delivery to another node once the locks expire. See
+[Native Ack Endpoints](/guide/messaging/listeners#native-ack-endpoints) for the mode itself.
+Available on **queues and subscriptions**; a topic is only ever published to, so it does not
+accept the mode.
+
+### Lock renewal is automatic and mandatory here
+
+A `NativeAck` delivery is held unsettled for lane queue time **plus** handler time, and lane queue
+time is unbounded by design — so without renewal such an endpoint would be a duplicate generator by
+construction rather than merely at risk under a slow handler. Wolverine therefore renews the lock
+on every queued-but-unsettled delivery for the whole time it sits in a lane, ticking at half the
+entity's `LockDuration` and sending nothing at all while the lanes are empty.
+
+::: warning `MaxAutoLockRenewalDuration` does not cover this
+The SDK's automatic renewal only runs while the processor callback is on the stack. Under
+`NativeAck` the receive loop hands the envelope to a lane and moves on immediately, so an endpoint
+configured that way would *look* protected and be renewing nothing for the whole time the envelope
+is queued. It also does not apply to the batched receiver this mode uses at all. Wolverine's own
+renewal is what covers the queued window, and it is not opt-in.
+:::
+
+The clock is the entity's own lock duration, so configure that rather than anything on the
+listener:
+
+```cs
+opts.ListenToAzureServiceBusQueue("orders")
+    .ConfigureQueue(q => q.LockDuration = TimeSpan.FromMinutes(2))
+    .ProcessInParallelWithNativeAcks();
+```
+
+Renewal stops at `MaximumLockRenewalDuration` (default **one hour**), measured from receipt. Unlike
+Amazon SQS — where the equivalent ceiling exists because SQS refuses to keep a message invisible
+past 12 hours — Azure Service Bus imposes no cap on lock renewal at all, so this ceiling is purely
+Wolverine's stop-loss on a wedged handler. Reaching it is deliberately *not* treated as a lost
+lease: the delivery may still finish inside the lock it already holds.
+
+Wolverine reads the lock duration it would *create* the entity with. If a queue or subscription was
+provisioned outside Wolverine with a **shorter** lock duration than the one configured here, renewal
+ticks at half the wrong number and can tick too late — set `Options.LockDuration` to match the
+deployed entity in that case.
+
+### Prefetch is sized differently for this mode
+
+A `NativeAck` endpoint that does not set `PrefetchCount` explicitly (at either the endpoint or the
+transport level) gets a default of **twice its lane count** — `MaximumParallelMessages`, or the
+partition slot count when the endpoint is group-partitioned — rather than the shipping default of 0.
+Enough to keep every lane fed, and deliberately no more: a prefetched message ages against its lock
+from the moment the *client* buffers it, and a prefetched message has no envelope yet, so it is the
+one part of the backlog that lock renewal does **not** protect. An explicit setting at either level
+always wins.
+
+### Sessions are refused
+
+`RequireSessions()` and `ProcessInParallelWithNativeAcks()` cannot be combined, and the pairing is
+rejected at bootstrap in either order. A session listener releases the session lock as soon as it
+has handed its batch off — which under native acks is before any handler has run — so nothing could
+ever be acked. Sessions also exist to give per-session FIFO ordering, which native ack lanes
+deliberately do not preserve. Use `ProcessInline()` with `RequireSessions()` for ordered session
+processing, or a non-session queue with `PartitionProcessingByGroupId(...)` for per-key ordering
+alongside native acks.
+
 ## Lock duration vs. processing window
 
-Wolverine never renews a message lock on the Buffered/Durable (batched receiver) paths. How
-much of your processing the lock has to cover depends on the endpoint mode, because each mode
-settles the message at a different point:
+Wolverine renews message locks on the batched receiver path only for `NativeAck` endpoints (see
+above). How much of your processing the lock has to cover otherwise depends on the endpoint mode,
+because each mode settles the message at a different point:
 
 - **Durable** endpoints complete the message as soon as it has been written to the durable
   inbox — *before* the handler runs. The local backlog lives in your database, not under a
@@ -66,6 +143,8 @@ settles the message at a different point:
   redelivers, and the inbox deduplicates the copy — wasted work, not duplicate side effects.
 - **Buffered** endpoints settle messages as soon as they are buffered — so lock expiry is moot
   for them, but an ungraceful crash loses the buffered backlog (at-most-once on crash).
+- **NativeAck** endpoints hold the lock the longest of all — lane queue time *plus* handler time —
+  and Wolverine renews it for that whole window.
 - **Inline** endpoints hold the lock for the whole handler execution, and rely on the
   processor's automatic lock renewal
   (`ConfigureProcessor(o => o.MaxAutoLockRenewalDuration = ...)`, SDK default 5 minutes).

--- a/docs/guide/messaging/transports/gcp-pubsub/publishing.md
+++ b/docs/guide/messaging/transports/gcp-pubsub/publishing.md
@@ -26,3 +26,73 @@ var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/GCP/Wolverine.Pubsub.Tests/DocumentationSamples.cs#L105-L125' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_subscriber_rules_for_pubsub' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Ordering keys
+
+Every message Wolverine publishes to a Pub/Sub topic can carry an `OrderingKey`, and Wolverine resolves that
+key from three sources with a strict precedence:
+
+| Precedence | Source | Set by |
+| --- | --- | --- |
+| 1 | `Envelope.GroupId` | `DeliveryOptions.GroupId`, or [message partitioning](/guide/messaging/partitioning) |
+| 2 | `OrderMessagesBy()` | Per-topic function on the subscriber configuration |
+| 3 | The message itself | A custom `IPubsubEnvelopeMapper` that stamps `OrderingKey` directly |
+
+A group id on the envelope always wins. The `OrderMessagesBy()` function only applies when there is no group
+id, and a mapper-supplied key only survives when neither of the first two produced anything. If none of the
+three yields a value the message goes out unkeyed, which is the default.
+
+### From the group id
+
+The common case is to let the envelope's `GroupId` become the ordering key:
+
+```cs
+await bus.PublishAsync(new StatusUpdate(orderId), new DeliveryOptions
+{
+    // becomes the Pub/Sub message's OrderingKey
+    GroupId = orderId.ToString()
+});
+```
+
+A group id also arrives on the envelope automatically when the message is routed through
+[message partitioning](/guide/messaging/partitioning), so endpoints using `MessagePartitioning` publish
+ordering keys whether or not they ask for them explicitly.
+
+### From a per-topic function
+
+Sometimes the value you want to order on is not the group id — a tenant id, a header, or something derived
+from the message itself. `OrderMessagesBy()` is the per-topic escape hatch for exactly that, and it does not
+require replacing the endpoint's envelope mapper:
+
+```cs
+var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.UsePubsub("your-project-id");
+
+        opts.PublishMessage<StatusUpdate>()
+            .ToPubsubTopic("status")
+
+            // Order by tenant instead of by group id. Return null to leave
+            // a given message unkeyed.
+            .OrderMessagesBy(e => e.TenantId);
+    }).StartAsync();
+```
+
+The function is evaluated on every publish through that topic, and returning `null` leaves that particular
+message without an ordering key.
+
+Note that this is a **publishing** concern, so it lives on the subscriber (`ToPubsubTopic()`) configuration
+only — there is deliberately no equivalent on `ListenToPubsubTopic()`. Whether a *consumer* enforces ordering
+keys is decided by `EnableMessageOrdering` on the subscription instead, which is reached through
+`ConfigurePubsubSubscription()`.
+
+::: warning
+Ordering keys are not free. If the receiving **subscription** has `EnableMessageOrdering` turned on, Pub/Sub
+will not dispatch a second message for an ordering key while an earlier one is still outstanding. The
+consumer's effective concurrency therefore drops to the number of *distinct* ordering keys in flight, no
+matter how `MaxOutstandingMessages` is sized — a listener sized for 100 outstanding messages whose traffic is
+concentrated on 3 keys will process 3 at a time. This holds however the key was set, including by
+`OrderMessagesBy()`, and it is the usual explanation for a Pub/Sub listener running far below the concurrency
+it was configured for. See [Listening](/guide/messaging/transports/gcp-pubsub/listening) for the details.
+:::

--- a/docs/guide/messaging/transports/nats.md
+++ b/docs/guide/messaging/transports/nats.md
@@ -292,6 +292,101 @@ opts.ListenToNatsSubject("orders.received")
     .UseJetStream("ORDERS", "my-consumer");
 ```
 
+### Native Acks with Parallel Processing <Badge type="tip" text="6.31" />
+
+JetStream listeners support `EndpointMode.NativeAck` (see [GH-3708](https://github.com/JasperFx/wolverine/issues/3708)),
+which combines `BufferedInMemory`'s parallelism and group partitioning with `ProcessInline()`'s no-loss behavior, and
+needs no database at all:
+
+```csharp
+opts.ListenToNatsSubject("webhooks")
+    .UseJetStream("WEBHOOKS", "webhook-processors")
+    .ProcessInParallelWithNativeAcks()
+    .PartitionProcessingByGroupId(PartitionSlots.Seven);
+```
+
+Incoming messages flow through an in-memory (optionally group-partitioned) execution block while the JetStream
+delivery is held **unacknowledged**, and are settled natively — `Ack` on handler success, `Nak` or `AckTerminate`
+on terminal failure — from the completion continuation. JetStream qualifies for this mode because each delivery is
+settled individually against the message's own reply subject, so one delivery can be settled, out of order, from
+whichever worker thread finished it.
+
+The guarantee is the one the mode promises everywhere: **messages sharing a group id never execute concurrently**,
+and nothing is acknowledged until its handler succeeds, so a node that dies mid-flight has every unfinished message
+redelivered. Processing in original stream order is *best effort*, not promised — a failed or redelivered message
+re-enters its lane later, never concurrently. Use `UseDurableInbox()` if you need strict ordering under failure.
+
+::: warning Core NATS cannot use this mode
+`ProcessInParallelWithNativeAcks()` requires JetStream and is **refused at bootstrap** on a core NATS subject. Core
+NATS delivers a message once and forgets it — there is no unacknowledged delivery to hold and no redelivery when a
+node dies — so the crash-safety story the mode exists for does not exist there. Use `BufferedInMemory()` or
+`ProcessInline()` on core NATS.
+:::
+
+#### AckWait is a real clock, and Wolverine renews it
+
+Unlike RabbitMQ, where an unacknowledged delivery lives until the channel closes, JetStream redelivers anything
+still unacknowledged after the consumer's `AckWait`. Under native acks a message is held unsettled for **lane queue
+time plus handler time**, and lane queue time is unbounded by design — so Wolverine keeps the lease alive by sending
+JetStream's `AckProgress` for every queued-but-unsettled message, every half `AckWait`, for as long as it sits in a
+lane ([GH-4048](https://github.com/JasperFx/wolverine/issues/4048)). You do not configure this; it is what the mode
+requires to be correct on this transport.
+
+Each renewal is sent as a **double ack** (a request the server answers) rather than fire-and-forget, because that
+is the only way a lost lease — a deleted consumer, a dead connection — can be detected at all. If a lease is lost
+before a message starts executing, it is dropped from its lane without being settled, so the server's redelivery is
+the only remaining copy rather than a second one.
+
+Two knobs, both optional:
+
+```csharp
+opts.ListenToNatsSubject("webhooks")
+    .UseJetStream("WEBHOOKS", "webhook-processors")
+    .ProcessInParallelWithNativeAcks()
+
+    // How long the server waits before redelivering an unacked message, and therefore how
+    // often Wolverine renews. Default 30 seconds (JetStreamDefaults.AckWait).
+    .AckWait(TimeSpan.FromSeconds(30))
+
+    // Ceiling on how long ONE delivery may be kept alive by renewals, measured from receipt.
+    // Past this Wolverine stops renewing, so a wedged handler cannot pin a MaxAckPending slot
+    // forever. Default 12 hours.
+    .MaximumAckExtension(TimeSpan.FromHours(1));
+```
+
+#### MaxAckPending is the prefetch, and it must cover every lane
+
+`MaxAckPending` — the number of deliveries JetStream will leave unacknowledged before it stops delivering — is this
+transport's prefetch equivalent, and in this mode it *is* the back pressure. Wolverine defaults it to **twice the
+number of lanes that can be busy at once**: the `PartitionProcessingByGroupId()` slot count when the endpoint is
+partitioned, otherwise `MaximumParallelMessages()`. Every other endpoint mode leaves the NATS server default of
+1,000 alone.
+
+Sizing it below the lane count makes the consumer **stall itself** — the server stops delivering while lanes sit
+idle waiting for work. Override it only if you know why:
+
+```csharp
+opts.ListenToNatsSubject("webhooks")
+    .UseJetStream("WEBHOOKS", "webhook-processors")
+    .ProcessInParallelWithNativeAcks()
+    .MaxAckPending(64);
+```
+
+::: warning Don't call `SendInline()` on a subject you also listen to
+A publisher and a listener for the same subject resolve to the **same** endpoint, and `EndpointMode` is a single
+property on it — so `opts.PublishMessage<T>().ToNatsSubject("x").SendInline()` sets `Mode = Inline` and silently
+downgrades a `ProcessInParallelWithNativeAcks()` listener on `"x"` out of native acks. It is also unnecessary: a
+native-ack endpoint already sends through the inline sending agent.
+:::
+
+::: tip Server-side dedup is a different guarantee
+JetStream's `Nats-Msg-Id` duplicate window (see [JetStream Configuration](#jetstream-configuration)) deduplicates on
+**publish**, at stream ingest. It does not deduplicate *redeliveries* — a redelivered message was already accepted
+into the stream, so the window never sees it again. Native acks are at-least-once by design and produce a burst of
+redeliveries on every rolling deploy, so if you want those suppressed, that is what `WithInMemoryIdempotency()` is
+for. The two are complementary, not alternatives.
+:::
+
 ### Named Endpoints
 
 ```csharp

--- a/docs/guide/messaging/transports/sqs/fifo-queues.md
+++ b/docs/guide/messaging/transports/sqs/fifo-queues.md
@@ -77,6 +77,20 @@ opts.ListenToSqsQueue("orders.fifo", queue =>
 });
 ```
 
+## FIFO Queues and Endpoint Modes
+
+A FIFO queue can be listened to with `BufferedInMemory` (the default), `UseDurableInbox()` or
+`ProcessInline()`. Only `ProcessInline()` actually preserves the ordering the queue guarantees —
+the other two hand messages to Wolverine's local execution block, which runs them in parallel.
+
+`ProcessInParallelWithNativeAcks()` is **refused at bootstrap** on a `.fifo` queue, rather than
+silently voiding the guarantee you are paying for. Native-ack lanes do not preserve delivery
+order, and partitioning by group id does not rescue it — SQS blocks a message group behind its
+own in-flight head, so under that mode every group would be stalled at the broker for as long as
+unrelated messages sat ahead of it in a Wolverine lane. See
+[Native Ack Processing](/guide/messaging/transports/sqs/listening#fifo-queues-do-not-support-native-acks)
+for the full reasoning. For ordered processing with throughput, use the sharded topology below.
+
 ## Partitioned Publishing with FIFO Queues
 
 For high-throughput scenarios where you need ordered processing *per group* but want parallelism *across groups*, consider using Wolverine's [partitioned sequential messaging](/guide/messaging/partitioning) with sharded SQS FIFO queues. This distributes messages across multiple queues based on their group id, giving you the best of both worlds — strict ordering within a group and horizontal scaling across groups.

--- a/docs/guide/messaging/transports/sqs/listening.md
+++ b/docs/guide/messaging/transports/sqs/listening.md
@@ -32,3 +32,86 @@ var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Samples/Bootstrapping.cs#L147-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_listen_to_sqs_queue' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Endpoint Modes
+
+Amazon SQS listeners support all four Wolverine [endpoint modes](/guide/messaging/listeners):
+
+| Mode | Configured with | When the message is deleted from SQS |
+| --- | --- | --- |
+| `BufferedInMemory` (default) | `.BufferedInMemory()` | on receipt, **before** the handler runs |
+| `Durable` | `.UseDurableInbox()` | after the inbox insert |
+| `Inline` | `.ProcessInline()` | after the handler succeeds |
+| `NativeAck` | `.ProcessInParallelWithNativeAcks()` | after the handler succeeds |
+
+### Native Ack Processing <Badge type="tip" text="6.30" />
+
+SQS qualifies for [`NativeAck`](/guide/messaging/listeners#native-ack-endpoints) on both counts
+the mode requires. Deliveries are settled individually — `DeleteMessage` against the receipt
+handle carried on the envelope, so there is no cumulative position that could implicitly settle
+a neighbouring message — and a receipt handle stays valid regardless of which thread holds it,
+so the execution block is free to settle in handler-completion order rather than delivery order.
+
+```csharp
+opts.ListenToSqsQueue("webhooks")
+    .ProcessInParallelWithNativeAcks()
+    .PartitionProcessingByGroupId(PartitionSlots.Five)
+    .MaximumParallelMessages(10);
+```
+
+Two SQS-specific things follow.
+
+**The visibility timeout is renewed for you, unconditionally.** Unlike RabbitMQ, where an
+unacknowledged delivery lives until the channel closes, an unsettled SQS message is on a clock.
+Under this mode Wolverine holds it for lane queue time *plus* handler time, and lane queue time
+is unbounded by design — so Wolverine keeps issuing `ChangeMessageVisibilityBatch` for every
+delivery still sitting in a lane, without consulting `ExtendVisibilityWhileHandling()` (which
+remains an `Inline`-only opt-in). Idle lanes cost nothing, and `MaximumVisibilityExtension` is
+still the ceiling. See [Performance and Throughput](/guide/messaging/transports/sqs/performance).
+
+**`MaxNumberOfMessages` is the prefetch equivalent, and it defaults *down* here.** Instead of
+the usual 10, a native-ack endpoint receives twice the number of lanes that can be busy at once
+— the partition slot count when group-partitioned, otherwise `MaximumParallelMessages` — clamped
+to the SQS maximum of 10. Under every other mode the surplus messages in a batch are deleted
+before their handlers run, so a full batch is free and saves API calls; here each one sits in a
+lane holding an unsettled delivery to renew and to redeliver on a crash. Setting the property
+explicitly always wins:
+
+```csharp
+opts.ListenToSqsQueue("webhooks", q => q.MaxNumberOfMessages = 10)
+    .ProcessInParallelWithNativeAcks()
+    .Sequential();
+```
+
+### FIFO queues do not support native acks
+
+::: warning Refused at bootstrap
+Calling `ProcessInParallelWithNativeAcks()` on a `.fifo` queue throws at startup. This is a
+deliberate refusal rather than an oversight.
+:::
+
+The tempting reading is that the SQS `MessageGroupId` is a broker-side analogue of Wolverine's
+`Envelope.GroupId`, so a FIFO queue and `PartitionProcessingByGroupId()` ought to be a natural
+pairing. They are not, and the two halves fail differently:
+
+* **Without partitioning, the ordering is silently lost.** One FIFO receive can return several
+  messages of the same message group, in order. The native-ack execution block runs up to
+  `MaximumParallelMessages` messages concurrently, so those same-group messages execute at the
+  same time. The queue keeps its guarantee right up to the moment Wolverine takes delivery, and
+  then discards it — and a FIFO queue costs more and throughputs less than a standard queue
+  precisely to buy that guarantee.
+
+* **With partitioning, the two schemes stack and the broker-side one is held hostage.** SQS will
+  not deliver another message of a group while any message of that group is in flight. Under this
+  mode "in flight" means lane queue time plus handler time, and the mode's entire premise is that
+  lane depth is unbounded and free. It is not free here: unrelated groups that hash into the same
+  Wolverine slot queue ahead of a group's head, and SQS blocks that whole group for the duration.
+  Every other mode escapes this — `Buffered` and `Durable` delete the message before the handler
+  runs, and `Inline` holds it for exactly one handler — which makes `NativeAck` the only Wolverine
+  mode that converts its own lane depth into broker-side group stalls.
+
+For ordered processing on a FIFO queue, use `ProcessInline()`. For ordered processing *with*
+throughput, shard the topology across several FIFO queues by group id and listen to each one
+inline — see [FIFO Queues](/guide/messaging/transports/sqs/fifo-queues) and
+[partitioned sequential messaging](/guide/messaging/partitioning). Ordering then lives entirely
+on the broker side, where FIFO can actually enforce it.

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/native_ack_mode_4050.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/native_ack_mode_4050.cs
@@ -1,0 +1,195 @@
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration;
+using Wolverine.Runtime.Partitioning;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+/// <summary>
+///     GH-4050. The configuration-time half of the SQS native ack adoption: which endpoints accept the mode, what
+///     the receive batch size defaults to under it, and the FIFO verdict.
+/// </summary>
+public class native_ack_mode_4050
+{
+    private static AmazonSqsQueue queue(string name = "native-ack-defaults")
+    {
+        return new AmazonSqsQueue(name, new AmazonSqsTransport());
+    }
+
+    [Fact]
+    public void sqs_queues_opt_into_native_acks()
+    {
+        queue().SupportsMode(EndpointMode.NativeAck).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_mode_can_actually_be_assigned()
+    {
+        var endpoint = queue();
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+    }
+
+    /// <summary>
+    ///     The mode's back pressure is the broker's delivery window, not a BackPressureAgent counting queued
+    ///     messages -- which for SQS means the receive batch size below is the only lever there is.
+    /// </summary>
+    [Fact]
+    public void native_ack_endpoints_do_not_enforce_in_process_back_pressure()
+    {
+        var endpoint = queue();
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_unsettled_sqs_delivery_is_on_a_clock()
+    {
+        // The premise of the whole lease contract; a regression here would silently stop ListeningAgent from
+        // demanding renewal on a native ack SQS listener.
+        queue().holdsExpiringLease.ShouldBeTrue();
+    }
+
+    #region receive batch size defaults
+
+    [Fact]
+    public void receive_batch_size_default_is_the_sqs_maximum_for_every_other_mode()
+    {
+        foreach (var mode in new[] { EndpointMode.BufferedInMemory, EndpointMode.Durable, EndpointMode.Inline })
+        {
+            var endpoint = queue();
+            endpoint.MaxDegreeOfParallelism = 1;
+            endpoint.Mode = mode;
+
+            // Those modes settle the whole batch before any handler runs, so a full batch costs nothing
+            endpoint.MaxNumberOfMessages.ShouldBe(AmazonSqsQueue.MaximumReceiveBatchSize);
+        }
+    }
+
+    [Fact]
+    public void native_ack_receive_batch_size_covers_twice_the_parallel_lanes()
+    {
+        var endpoint = queue();
+        endpoint.MaxDegreeOfParallelism = 3;
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.MaxNumberOfMessages.ShouldBe(6);
+    }
+
+    /// <summary>
+    ///     The case the arm exists for. A sequential native ack endpoint that received ten at a time would hold
+    ///     nine unsettled deliveries -- nine visibility timeouts to renew, nine redeliveries on a crash -- through
+    ///     nine handler durations it gains no throughput from.
+    /// </summary>
+    [Fact]
+    public void a_sequential_native_ack_endpoint_does_not_drag_in_nine_messages_it_cannot_run()
+    {
+        var endpoint = queue();
+        endpoint.MaxDegreeOfParallelism = 1;
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.MaxNumberOfMessages.ShouldBe(2);
+    }
+
+    [Fact]
+    public void native_ack_receive_batch_size_is_capped_at_the_sqs_maximum()
+    {
+        var endpoint = queue();
+        endpoint.MaxDegreeOfParallelism = 20;
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.MaxNumberOfMessages.ShouldBe(AmazonSqsQueue.MaximumReceiveBatchSize);
+    }
+
+    /// <summary>
+    ///     A group-partitioned endpoint's busy lane count is its slot count, which is independent of
+    ///     MaxDegreeOfParallelism -- the slot count is what has to be covered.
+    /// </summary>
+    [Fact]
+    public void native_ack_receive_batch_size_covers_partition_slots_when_group_partitioned()
+    {
+        var endpoint = queue();
+        endpoint.MaxDegreeOfParallelism = 1;
+        endpoint.GroupShardingSlotNumber = PartitionSlots.Five;
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.MaxNumberOfMessages.ShouldBe(AmazonSqsQueue.MaximumReceiveBatchSize);
+    }
+
+    [Fact]
+    public void an_explicit_receive_batch_size_always_wins()
+    {
+        var endpoint = queue();
+        endpoint.MaxDegreeOfParallelism = 1;
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.MaxNumberOfMessages = 10;
+
+        endpoint.MaxNumberOfMessages.ShouldBe(10);
+    }
+
+    #endregion
+
+    #region the FIFO verdict
+
+    [Fact]
+    public void a_fifo_queue_refuses_native_acks_at_bootstrap()
+    {
+        var endpoint = queue("orders.fifo");
+        endpoint.IsListener = true;
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).ShouldHaveSingleItem();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+        problem.Message.ShouldContain("orders.fifo");
+        problem.Message.ShouldContain("ProcessInParallelWithNativeAcks()");
+        problem.Message.ShouldContain("ProcessInline()");
+    }
+
+    /// <summary>
+    ///     Partitioning by group id is the pairing that looks like it ought to rescue FIFO -- SQS MessageGroupId
+    ///     is the broker-side analogue of Envelope.GroupId. It does not: SQS blocks a message group behind its own
+    ///     in-flight head, and under this mode "in flight" includes unbounded lane queue time behind unrelated
+    ///     groups that hashed into the same slot. The refusal must not have a partitioned escape hatch.
+    /// </summary>
+    [Fact]
+    public void partitioning_by_group_id_does_not_rescue_a_fifo_queue()
+    {
+        var endpoint = queue("orders.fifo");
+        endpoint.IsListener = true;
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.GroupShardingSlotNumber = PartitionSlots.Five;
+
+        ListenerConfigurationValidator.Validate(endpoint)
+            .ShouldHaveSingleItem()
+            .Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+    }
+
+    [Fact]
+    public void a_fifo_queue_is_perfectly_happy_in_every_other_mode()
+    {
+        foreach (var mode in new[] { EndpointMode.BufferedInMemory, EndpointMode.Durable, EndpointMode.Inline })
+        {
+            var endpoint = queue("orders.fifo");
+            endpoint.IsListener = true;
+            endpoint.Mode = mode;
+
+            ListenerConfigurationValidator.Validate(endpoint)
+                .Where(x => x.Message.Contains("FIFO"))
+                .ShouldBeEmpty();
+        }
+    }
+
+    [Fact]
+    public void a_standard_queue_is_accepted()
+    {
+        var endpoint = queue("orders");
+        endpoint.IsListener = true;
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    #endregion
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/native_ack_mode.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/native_ack_mode.cs
@@ -1,0 +1,280 @@
+using System.Collections.Concurrent;
+using Amazon.SQS;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+#region messages, handler and per-node tracking
+
+public record NativeAckSqsWork(int Number);
+
+/// <summary>
+///     One marker per host, so every observation records WHICH node made it. That is what keeps the redelivery
+///     test honest: the first node's parked handlers eventually unwind and record too, and without a node name
+///     those late recordings would satisfy an assertion that is supposed to be about the second node.
+/// </summary>
+public class NativeAckSqsNode(string name, bool parks)
+{
+    public string Name { get; } = name;
+    public bool Parks { get; } = parks;
+}
+
+public static class NativeAckSqsTracking
+{
+    public static readonly ConcurrentBag<(string Node, int Number)> Started = new();
+    public static readonly ConcurrentBag<(string Node, int Number)> Handled = new();
+
+    /// <summary>When set, handlers on a parking node wait here forever -- standing in for a node that dies mid-flight.</summary>
+    public static TaskCompletionSource? Block;
+
+    public static void Reset()
+    {
+        Started.Clear();
+        Handled.Clear();
+        Block = null;
+    }
+
+    public static IEnumerable<int> HandledBy(string node, int start, int count)
+    {
+        return Handled.Where(x => x.Node == node && x.Number >= start && x.Number < start + count)
+            .Select(x => x.Number).Distinct().OrderBy(x => x);
+    }
+
+    public static int StartedOn(string node)
+    {
+        return Started.Where(x => x.Node == node).Select(x => x.Number).Distinct().Count();
+    }
+}
+
+public class NativeAckSqsWorkHandler
+{
+    public async Task Handle(NativeAckSqsWork message, NativeAckSqsNode node)
+    {
+        NativeAckSqsTracking.Started.Add((node.Name, message.Number));
+
+        if (node.Parks && NativeAckSqsTracking.Block is { } block)
+        {
+            await block.Task;
+        }
+
+        NativeAckSqsTracking.Handled.Add((node.Name, message.Number));
+    }
+}
+
+#endregion
+
+/// <summary>
+///     GH-4050. Amazon SQS opts into <see cref="EndpointMode.NativeAck" />. These are the #3708 expectations
+///     against LocalStack -- the mode is really in force, messages flow end to end, and above all a node that dies
+///     with work in its lanes hands every one of those deliveries back to SQS.
+/// </summary>
+/// <remarks>
+///     Every test gets its own queue name. These share one static tracking bag and one broker, and on the RabbitMQ
+///     version of this suite a single shared queue let the redelivery test's messages land in another test's
+///     assertion.
+/// </remarks>
+public class native_ack_mode : IAsyncLifetime
+{
+    // Short enough to keep the redelivery test quick, long enough that LocalStack's second-granularity
+    // visibility clock is not the thing being measured
+    private const int VisibilityTimeoutSeconds = 5;
+
+    private readonly string _modeQueue = uniqueQueue("native-ack-4050-mode");
+    private readonly string _endToEndQueue = uniqueQueue("native-ack-4050-e2e");
+    private readonly string _redeliveryQueue = uniqueQueue("native-ack-4050-redelivery");
+    private readonly string _fifoQueue = uniqueQueue("native-ack-4050-fifo") + ".fifo";
+
+    private static string uniqueQueue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid().ToString("N")[..8]}";
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        NativeAckSqsTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        // Let any handler still parked from a dead node unwind, so the test run does not leak them
+        NativeAckSqsTracking.Block?.TrySetResult();
+        NativeAckSqsTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    private static Task<IHost> startHostAsync(string queueName, string nodeName, bool parks = false,
+        int? maxParallelism = null)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAmazonSqsTransportLocally().AutoProvision();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeAckSqsWorkHandler>();
+                opts.Services.AddSingleton(new NativeAckSqsNode(nodeName, parks));
+
+                // Bound how long a stop can sit on a lane full of parked handlers
+                opts.Durability.DrainTimeout = 2.Seconds();
+
+                opts.ListenToSqsQueue(queueName, q =>
+                    {
+                        q.VisibilityTimeout = VisibilityTimeoutSeconds;
+                        q.WaitTimeSeconds = 1;
+                    })
+                    .Named(queueName)
+                    .ProcessInParallelWithNativeAcks()
+                    .MaximumParallelMessages(maxParallelism ?? Math.Max(Environment.ProcessorCount, 5));
+
+                // Deliberately NOT SendInline(): the listening and sending sides are the same AmazonSqsQueue
+                // object here, and SendInline() would assign EndpointMode.Inline right back over the mode under
+                // test.
+                opts.PublishMessage<NativeAckSqsWork>().ToSqsQueue(queueName);
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task the_endpoint_really_is_in_native_ack_mode()
+    {
+        // Three lanes rather than the default: the derived receive batch size is then 6, which is distinct from
+        // BOTH the SQS maximum of 10 and the default this property has in every other mode. On a machine with five
+        // or more cores the default parallelism would clamp to 10 and this assertion would be true either way.
+        using var host = await startHostAsync(_modeQueue, "only", maxParallelism: 3);
+        try
+        {
+            var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+            var endpoint = runtime.Endpoints.EndpointByName(_modeQueue).ShouldNotBeNull();
+
+            endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+
+            // Back pressure is the broker's delivery window, so no BackPressureAgent is created
+            endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+
+            // ... which makes the receive batch size the whole of the back pressure story on SQS
+            var queue = endpoint.ShouldBeOfType<AmazonSqsQueue>();
+            queue.MaxDegreeOfParallelism.ShouldBe(3);
+            queue.MaxNumberOfMessages.ShouldBe(6);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task messages_are_processed_end_to_end()
+    {
+        using var host = await startHostAsync(_endToEndQueue, "only");
+        try
+        {
+            var bus = host.MessageBus();
+            for (var i = 0; i < 10; i++)
+            {
+                await bus.SendAsync(new NativeAckSqsWork(i));
+            }
+
+            await waitFor(() => NativeAckSqsTracking.HandledBy("only", 0, 10).Count() >= 10, 60.Seconds());
+
+            NativeAckSqsTracking.HandledBy("only", 0, 10).ShouldBe(Enumerable.Range(0, 10));
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    /// <summary>
+    ///     The whole point of the mode, and the one SQS-specific thing worth proving: under BufferedInMemory these
+    ///     messages are deleted the instant they arrive, so a node that dies before its handlers finish loses every
+    ///     one of them. Under NativeAck nothing is deleted until the handler succeeds, so the deliveries are still
+    ///     unsettled when the node goes away and SQS makes them visible again at their visibility timeout.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately asserted per node. When the parked handlers on the dead node eventually unwind they record
+    ///     too, so an assertion that only counted message numbers would pass whether or not SQS redelivered
+    ///     anything. Only the SECOND node's recordings can come from a redelivery.
+    /// </remarks>
+    [Fact]
+    public async Task nothing_is_settled_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    {
+        NativeAckSqsTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstHost = await startHostAsync(_redeliveryQueue, "first", parks: true);
+
+        var bus = firstHost.MessageBus();
+        for (var i = 0; i < 5; i++)
+        {
+            await bus.SendAsync(new NativeAckSqsWork(100 + i));
+        }
+
+        // Let every delivery actually reach a parked handler before killing the node
+        await waitFor(() => NativeAckSqsTracking.StartedOn("first") >= 5, 60.Seconds());
+        NativeAckSqsTracking.StartedOn("first").ShouldBe(5);
+
+        // The node dies mid-flight, having settled nothing
+        await firstHost.StopAsync(TestContext.Current.CancellationToken);
+        firstHost.Dispose();
+
+        NativeAckSqsTracking.HandledBy("first", 100, 5).ShouldBeEmpty();
+
+        // A fresh node picks up every message SQS made visible again. Its handlers do not park -- and the first
+        // node's still do, so anything it records later is still attributed to "first".
+        using var secondHost = await startHostAsync(_redeliveryQueue, "second");
+        try
+        {
+            await waitFor(() => NativeAckSqsTracking.HandledBy("second", 100, 5).Count() >= 5, 90.Seconds());
+
+            NativeAckSqsTracking.HandledBy("second", 100, 5).ShouldBe(Enumerable.Range(100, 5));
+        }
+        finally
+        {
+            await secondHost.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    /// <summary>
+    ///     GH-4050. The FIFO verdict, proved through a real bootstrap rather than only against the validator, so
+    ///     that a rule which stopped being wired in would be caught. See
+    ///     <c>AmazonSqsQueue.FifoQueuesAreIncompatibleWithNativeAcks</c> for the reasoning.
+    /// </summary>
+    [Fact]
+    public async Task a_fifo_queue_refuses_the_mode_at_bootstrap()
+    {
+        var ex = await Should.ThrowAsync<InvalidListenerConfigurationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.UseAmazonSqsTransportLocally().AutoProvision();
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeAckSqsWorkHandler>();
+                    opts.Services.AddSingleton(new NativeAckSqsNode("fifo", false));
+
+                    opts.ListenToSqsQueue(_fifoQueue, q =>
+                        {
+                            q.Configuration.Attributes ??= new Dictionary<string, string>();
+                            q.Configuration.Attributes[QueueAttributeName.FifoQueue] = "true";
+                            q.Configuration.Attributes[QueueAttributeName.ContentBasedDeduplication] = "true";
+                        })
+                        .ProcessInParallelWithNativeAcks();
+                }).StartAsync();
+        });
+
+        ex.Message.ShouldContain(_fifoQueue);
+        ex.Message.ShouldContain("ProcessInline()");
+    }
+
+    private static async Task waitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (!condition() && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -158,11 +158,59 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     public int WaitTimeSeconds { get; set; } = 5;
 
     /// <summary>
+    ///     Hard Amazon SQS limit on the number of messages a single <c>ReceiveMessage</c> can return.
+    /// </summary>
+    public const int MaximumReceiveBatchSize = 10;
+
+    private int? _maxNumberOfMessages;
+
+    /// <summary>
     ///     The maximum number of messages to return. Amazon SQS never returns more messages than
     ///     this value (however, fewer messages might be returned). Valid values: 1 to 10. Default:
-    ///     10.
+    ///     10, except on a <see cref="EndpointMode.NativeAck" /> endpoint -- see the remarks.
     /// </summary>
-    public int MaxNumberOfMessages { get; set; } = 10;
+    /// <remarks>
+    ///     GH-4050. This is the SQS analogue of RabbitMQ's prefetch count, and under
+    ///     <see cref="EndpointMode.NativeAck" /> it is sized the same way: enough to cover every lane that can be
+    ///     busy at once -- the partition slot count when the endpoint is group-partitioned, otherwise
+    ///     <see cref="Endpoint.MaxDegreeOfParallelism" /> -- doubled so a lane is never starved waiting on the next
+    ///     receive, and clamped to the SQS maximum of 10.
+    ///     <para>
+    ///     The direction that actually matters here is <em>downward</em>, which is the opposite of RabbitMQ. SQS
+    ///     caps a receive at 10 either way, so the default can never be raised to cover a wide endpoint; what it can
+    ///     do is stop a narrow one from dragging in work it cannot run. Under every other mode the extra messages in
+    ///     a batch are deleted before their handlers run, so fetching ten of them costs nothing and saves API calls.
+    ///     Under this mode they are not: each one sits in the lane holding an unsettled delivery whose visibility
+    ///     timeout Wolverine has to keep renewing, and which a crash turns into a redelivery. A
+    ///     <c>Sequential()</c> native-ack endpoint receiving ten at a time would hold nine leases open through nine
+    ///     handler durations for no throughput at all.
+    ///     </para>
+    ///     <para>
+    ///     Setting this property explicitly always wins, in either direction.
+    ///     </para>
+    /// </remarks>
+    public int MaxNumberOfMessages
+    {
+        get
+        {
+            if (_maxNumberOfMessages.HasValue)
+            {
+                return _maxNumberOfMessages.Value;
+            }
+
+            if (Mode == EndpointMode.NativeAck)
+            {
+                var lanes = GroupShardingSlotNumber.HasValue
+                    ? Math.Max((int)GroupShardingSlotNumber.Value, MaxDegreeOfParallelism)
+                    : MaxDegreeOfParallelism;
+
+                return Math.Clamp(lanes * 2, 1, MaximumReceiveBatchSize);
+            }
+
+            return MaximumReceiveBatchSize;
+        }
+        set => _maxNumberOfMessages = value;
+    }
 
     /// <summary>
     ///     Hard Amazon SQS limit on the number of entries in a single <c>DeleteMessageBatch</c>
@@ -750,6 +798,10 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         sibling.EnableFairQueueMessageGroups = EnableFairQueueMessageGroups;
         sibling.VisibilityTimeout = VisibilityTimeout;
         sibling.WaitTimeSeconds = WaitTimeSeconds;
+        // GH-4050: deliberately the RESOLVED value, not the explicit override. This runs from BuildListenerAsync,
+        // so the parent's mode and lane counts are already final -- but MaxDegreeOfParallelism and
+        // GroupShardingSlotNumber are not among the properties copied onto a sibling, so letting the sibling
+        // re-derive would give the tenant queue a different receive batch size than the account it mirrors.
         sibling.MaxNumberOfMessages = MaxNumberOfMessages;
         sibling.MessageAttributeNames = MessageAttributeNames;
         sibling.FragmentOversizedMessages = FragmentOversizedMessages;
@@ -789,12 +841,109 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
     }
 
     /// <summary>
+    /// GH-4050. Amazon SQS qualifies for <see cref="EndpointMode.NativeAck" /> on both counts the mode requires.
+    ///
+    /// <para>
+    /// <b>Deliveries are settled individually.</b> <c>SqsListener.CompleteAsync</c> issues a per-message
+    /// <c>DeleteMessage</c> against the receipt handles carried on <c>AmazonSqsEnvelope.SqsMessages</c>, so the
+    /// delivery identity rides the envelope rather than living on the receive loop. There is no cumulative
+    /// position to advance and therefore no way for settling one delivery to implicitly settle another -- which is
+    /// exactly what disqualifies Kafka, whose offset commit cannot express a gap.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>They can be settled out of order, from an arbitrary worker thread.</b> A receipt handle is valid until
+    /// its visibility timeout expires no matter who holds it, so the native-ack execution block is free to
+    /// complete messages in handler-completion order rather than delivery order. The batching delete path
+    /// (GH-3493) is order-independent for the same reason: <c>DeleteMessageBatch</c> takes an unordered set of
+    /// handles.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>What makes it safe is the lease contract from GH-4048</b>, not the settlement model alone. Unlike
+    /// RabbitMQ, where an unacked delivery lives until the channel closes, an unsettled SQS delivery is on a
+    /// clock: it reappears after <see cref="VisibilityTimeout" /> seconds whether or not anybody is still working
+    /// on it. Under this mode the delivery is held unsettled for lane queue time <em>plus</em> handler time, and
+    /// lane queue time is unbounded by design -- so without renewal every native-ack SQS endpoint would be a
+    /// duplicate-delivery generator by construction. <see cref="holdsExpiringLease" /> declares that clock and
+    /// <see cref="SqsListener" /> renews it through <see cref="ISupportLeaseRenewal" />; <c>ListeningAgent</c>
+    /// refuses to start a native-ack listener here that does not.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Standard queues only.</b> FIFO queues are refused in <see cref="validateModeConfiguration" /> -- see
+    /// there for why.
+    /// </para>
+    /// </summary>
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
     /// GH-4048. An unsettled SQS delivery is invisible only for <see cref="VisibilityTimeout" /> seconds, after
     /// which SQS redelivers it -- so a NativeAck endpoint here has to renew that clock for as long as the
     /// envelope sits in an execution lane. <see cref="SqsListener" /> supplies the renewal through
     /// <see cref="ISupportLeaseRenewal" />.
     /// </summary>
     protected internal override bool holdsExpiringLease => true;
+
+    /// <summary>
+    /// GH-4050. A FIFO queue and <see cref="EndpointMode.NativeAck" /> are mutually exclusive. This is checked
+    /// after <see cref="Endpoint.Compile" /> rather than in the <see cref="Endpoint.Mode" /> setter for the same
+    /// reason Pulsar and Azure Service Bus check their pairings there: the mode arrives as delayed listener
+    /// configuration, so the final state -- not the order of the fluent calls -- has to decide.
+    /// </summary>
+    protected internal override IEnumerable<string> validateModeConfiguration()
+    {
+        if (Mode == EndpointMode.NativeAck && IsFifoQueue)
+        {
+            yield return FifoQueuesAreIncompatibleWithNativeAcks(this);
+        }
+    }
+
+    /// <summary>
+    /// GH-4050. The FIFO verdict, stated where a user will actually read it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The tempting reading is that SQS <c>MessageGroupId</c> is a broker-side analogue of
+    /// <see cref="Envelope.GroupId" />, so a FIFO queue and <c>PartitionProcessingByGroupId()</c> ought to be a
+    /// natural pairing. They are not, and the two halves fail differently.
+    /// </para>
+    /// <para>
+    /// <b>Without partitioning the ordering is silently lost.</b> One FIFO receive can return several messages of
+    /// the same message group, in order. The native-ack execution block is a
+    /// <c>Block&lt;Envelope&gt;(MaxDegreeOfParallelism)</c>, so at any parallelism above one those same-group
+    /// messages run concurrently -- the queue keeps its ordering guarantee right up to the moment Wolverine takes
+    /// delivery of it, and then discards it. A FIFO queue costs more and throughputs less than a standard queue
+    /// precisely to buy that guarantee, so voiding it in silence is the worst possible outcome.
+    /// </para>
+    /// <para>
+    /// <b>With partitioning the two schemes stack, and the outer one is held hostage by the inner one.</b> SQS
+    /// FIFO will not deliver another message of a group while any message of that group is in flight. Under this
+    /// mode "in flight" means lane queue time plus handler time, and this mode's entire premise is that lane
+    /// queue depth is unbounded and free. It is not free here: unrelated groups that hash into the same Wolverine
+    /// slot queue ahead of a group's head, and the broker blocks that whole group for the duration. Every other
+    /// mode escapes this -- Buffered and Durable delete the message before the handler runs, and Inline holds it
+    /// for one handler and nothing else -- which makes NativeAck the only Wolverine mode that converts its own
+    /// lane depth into broker-side group stalls.
+    /// </para>
+    /// <para>
+    /// The combination that does work is the one the docs already recommend for FIFO throughput: shard the
+    /// topology across several FIFO queues by group id and listen to each with <c>ProcessInline()</c>. Ordering
+    /// then lives entirely on the broker side, where FIFO can actually enforce it.
+    /// </para>
+    /// </remarks>
+    internal static string FifoQueuesAreIncompatibleWithNativeAcks(AmazonSqsQueue queue)
+    {
+        return
+            $"Invalid listener configuration for endpoint '{queue.Uri}': ProcessInParallelWithNativeAcks() was configured on the " +
+            $"FIFO queue '{queue.QueueName}'. A FIFO queue exists to guarantee ordering within a MessageGroupId, and native ack " +
+            "lanes deliberately do not preserve delivery order -- one FIFO receive can return several messages of the same group, " +
+            "and the execution block would run them concurrently. Partitioning by group id does not rescue it either: SQS blocks a " +
+            "message group behind its own in-flight head, so under this mode every group would be stalled at the broker for as long " +
+            "as unrelated messages sat ahead of it in a Wolverine lane. Use ProcessInline() on this FIFO queue for ordered " +
+            "processing -- sharding the topology across several FIFO queues by group id if you need throughput -- or use a standard " +
+            "(non-.fifo) queue if what you want is native acks with partitioned parallel processing.";
+    }
 
     internal void ConfigureRequest(ReceiveMessageRequest request)
     {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_lease_renewal_4051.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_lease_renewal_4051.cs
@@ -1,0 +1,276 @@
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+/// <summary>
+/// GH-4048/GH-4051. Azure Service Bus puts a clock on an <em>unsettled</em> delivery -- the entity's lock duration --
+/// and a NativeAck lane holds a delivery for queue time plus handler time. Without renewal such an endpoint is a
+/// duplicate generator by construction rather than merely at risk, so this is the load-bearing half of the adoption.
+/// </summary>
+public class native_ack_lease_renewal_4051
+{
+    private const string RenewalQueue = "native-ack-4051-lease";
+
+    /// <summary>
+    /// The one that matters. The handler parks for THREE lock durations, which without renewal is two guaranteed
+    /// redeliveries: the emulator expires a lock exactly on its duration and hands the message straight back out
+    /// (verified directly -- a complete after the lock duration fails with MessageLockLost and the message comes
+    /// back with DeliveryCount 2). Counting handler ENTRIES rather than completions is what makes the redelivery
+    /// visible while the original invocation is still parked.
+    /// </summary>
+    [Fact]
+    public async Task a_parked_delivery_is_not_redelivered_while_its_lease_is_renewed()
+    {
+        AsbNativeAckTracking.Reset();
+        AsbNativeAckTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.UseAzureServiceBusTesting();
+
+                    opts.Services.AddSingleton(new AsbNodeTag("renewing"));
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType<AsbNativeAckWorkHandler>();
+
+                    opts.ListenToAzureServiceBusQueue(RenewalQueue)
+                        .Named(RenewalQueue)
+                        // The renewal tick is half of this, so 10 seconds means a tick every 5 -- short enough to
+                        // keep the test quick, long enough that a slow emulator round trip cannot fake a pass.
+                        .ConfigureQueue(q => q.LockDuration = TimeSpan.FromSeconds(10))
+                        .ProcessInParallelWithNativeAcks();
+
+                    opts.PublishMessage<AsbNativeAckWork>().ToAzureServiceBusQueue(RenewalQueue);
+                }).StartAsync(TestContext.Current.CancellationToken);
+
+            await host.MessageBus().SendAsync(new AsbNativeAckWork(300));
+
+            await native_ack_mode_4051.waitForAsync(() => AsbNativeAckTracking.EnteredCount(300) >= 1,
+                TimeSpan.FromSeconds(60));
+
+            AsbNativeAckTracking.EnteredCount(300).ShouldBe(1);
+
+            // Park across three full lock durations. Nothing here is probabilistic: an un-renewed lock expires on
+            // the tenth second and the broker redelivers immediately.
+            await Task.Delay(TimeSpan.FromSeconds(31), TestContext.Current.CancellationToken);
+
+            AsbNativeAckTracking.EnteredCount(300)
+                .ShouldBe(1, "the delivery was redelivered while it was still being handled, so its lock was not renewed");
+
+            // ...and it still settles cleanly on the lock it has been holding all along
+            AsbNativeAckTracking.Block!.TrySetResult();
+
+            await native_ack_mode_4051.waitForAsync(() => AsbNativeAckTracking.HandledInRange(300, 1).Any(),
+                TimeSpan.FromSeconds(30));
+
+            AsbNativeAckTracking.HandledInRange(300, 1).ShouldBe([300]);
+        }
+        finally
+        {
+            AsbNativeAckTracking.Block?.TrySetResult();
+            AsbNativeAckTracking.Reset();
+        }
+    }
+
+    /// <summary>
+    /// The contract's hard part: <c>RenewLeasesAsync</c> reports the subset it could NOT renew, and core drops those
+    /// without settling them. Reporting a delivery that is actually fine would throw away a perfectly good message,
+    /// so this drives one dead lock and one live one through the same call and pins that only the dead one comes
+    /// back.
+    /// </summary>
+    [Fact]
+    public async Task renew_leases_reports_only_the_deliveries_whose_lock_is_gone()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const string queueName = "native-ack-4051-lost-lock";
+
+        var admin = new ServiceBusAdministrationClient(Servers.AzureServiceBusManagementConnectionString);
+        if ((await admin.QueueExistsAsync(queueName, ct)).Value)
+        {
+            await admin.DeleteQueueAsync(queueName, ct);
+        }
+
+        await admin.CreateQueueAsync(new CreateQueueOptions(queueName) { LockDuration = TimeSpan.FromMinutes(5) },
+            ct);
+
+        await using var client = new ServiceBusClient(Servers.AzureServiceBusConnectionString);
+        var sender = client.CreateSender(queueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("dead-lock"), ct);
+        await sender.SendMessageAsync(new ServiceBusMessage("live-lock"), ct);
+
+        var receiver = client.CreateReceiver(queueName,
+            new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+        // Take both deliveries BEFORE the listener exists, so its receive loop has nothing to compete for
+        var messages = await receiver.ReceiveMessagesAsync(2, TimeSpan.FromSeconds(10), ct);
+        messages.Count.ShouldBe(2);
+
+        var deadMessage = messages[0];
+        var liveMessage = messages[1];
+
+        // Settling one of them is the cheapest way to produce a genuinely invalid lock -- the broker answers a
+        // renewal on it with MessageLockLost, which is exactly what an expired lock looks like too.
+        await receiver.CompleteMessageAsync(deadMessage, ct);
+
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues[queueName];
+
+        await using var listener = new BatchedAzureServiceBusListener(queue,
+            NullLogger<BatchedAzureServiceBusListener>.Instance, Substitute.For<IReceiver>(), receiver,
+            Substitute.For<IAzureServiceBusEnvelopeMapper>(), Substitute.For<ISender>());
+
+        var dead = new AzureServiceBusEnvelope(deadMessage, receiver);
+        var live = new AzureServiceBusEnvelope(liveMessage, receiver);
+
+        var lost = await listener.RenewLeasesAsync([dead, live], ct);
+
+        lost.ShouldHaveSingleItem().ShouldBeSameAs(dead);
+
+        // The live one is not merely absent from the result -- its lock was really pushed out
+        liveMessage.LockedUntil.ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddMinutes(4));
+
+        await receiver.CompleteMessageAsync(liveMessage, ct);
+        await admin.DeleteQueueAsync(queueName, ct);
+    }
+
+    [Fact]
+    public void the_listener_advertises_the_endpoint_s_own_clock()
+    {
+        var transport = new AzureServiceBusTransport();
+        var queue = transport.Queues["lease-durations"];
+        queue.Options.LockDuration = TimeSpan.FromSeconds(45);
+        queue.MaximumLockRenewalDuration = TimeSpan.FromMinutes(20);
+
+        queue.LockDuration.ShouldBe(TimeSpan.FromSeconds(45));
+        ((ISupportLeaseRenewal)listenerFor(queue)).LeaseDuration.ShouldBe(TimeSpan.FromSeconds(45));
+        ((ISupportLeaseRenewal)listenerFor(queue)).MaximumLeaseExtension.ShouldBe(TimeSpan.FromMinutes(20));
+    }
+
+    [Fact]
+    public void queues_and_subscriptions_declare_an_expiring_lease_but_topics_do_not()
+    {
+        var transport = new AzureServiceBusTransport();
+
+        transport.Queues["holds-a-lease"].holdsExpiringLease.ShouldBeTrue();
+
+        var topic = transport.Topics["lease-topic"];
+        new AzureServiceBusSubscription(transport, topic, "holds-a-lease").holdsExpiringLease.ShouldBeTrue();
+
+        // A topic is only ever published to, so there is no unsettled delivery to expire
+        topic.holdsExpiringLease.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void maximum_lock_renewal_duration_must_be_positive()
+    {
+        var queue = new AzureServiceBusTransport().Queues["bad-ceiling"];
+
+        queue.MaximumLockRenewalDuration.ShouldBe(TimeSpan.FromHours(1));
+        Should.Throw<ArgumentOutOfRangeException>(() => queue.MaximumLockRenewalDuration = TimeSpan.Zero);
+        Should.Throw<ArgumentOutOfRangeException>(() => queue.MaximumLockRenewalDuration = TimeSpan.FromSeconds(-1));
+    }
+
+    /// <summary>
+    /// Builds a listener over a client that is never connected to anything. Only the two duration properties are
+    /// read, and neither of them touches the broker.
+    /// </summary>
+    private static BatchedAzureServiceBusListener listenerFor(AzureServiceBusEndpoint endpoint)
+    {
+        var client = new ServiceBusClient(Servers.AzureServiceBusConnectionString);
+        return new BatchedAzureServiceBusListener(endpoint, NullLogger<BatchedAzureServiceBusListener>.Instance,
+            Substitute.For<IReceiver>(), client.CreateReceiver("never-used"),
+            Substitute.For<IAzureServiceBusEnvelopeMapper>(), Substitute.For<ISender>());
+    }
+}
+
+/// <summary>
+/// GH-4051. Prefetch is the one part of a NativeAck endpoint's backlog that lease renewal does not protect: an
+/// Azure Service Bus message ages against its lock from the moment the CLIENT buffers it, and a prefetched message
+/// has no Envelope yet, so nothing is tracking it. The mode default is therefore sized to the lanes rather than for
+/// raw throughput -- and an explicit setting at either level always wins over it.
+/// </summary>
+public class native_ack_prefetch_defaults_4051
+{
+    private static AzureServiceBusQueue queueWith(EndpointMode mode, Action<AzureServiceBusTransport>? configureTransport = null)
+    {
+        var transport = new AzureServiceBusTransport();
+        configureTransport?.Invoke(transport);
+
+        var queue = transport.Queues["prefetch-" + mode];
+        queue.Mode = mode;
+        return queue;
+    }
+
+    [Fact]
+    public void native_ack_sizes_prefetch_to_the_lanes()
+    {
+        var queue = queueWith(EndpointMode.NativeAck);
+        queue.MaxDegreeOfParallelism = 7;
+
+        queue.PrefetchCount.ShouldBe(14);
+    }
+
+    [Fact]
+    public void a_group_partitioned_native_ack_endpoint_covers_every_slot()
+    {
+        var queue = queueWith(EndpointMode.NativeAck);
+        queue.MaxDegreeOfParallelism = 2;
+        queue.GroupShardingSlotNumber = (PartitionSlots)9;
+
+        // Every slot is a lane that can be busy at once, so the slot count is the floor
+        queue.PrefetchCount.ShouldBe(18);
+    }
+
+    [Fact]
+    public void every_other_mode_keeps_the_shipping_default_of_zero()
+    {
+        queueWith(EndpointMode.BufferedInMemory).PrefetchCount.ShouldBe(0);
+        queueWith(EndpointMode.Inline).PrefetchCount.ShouldBe(0);
+        queueWith(EndpointMode.Durable).PrefetchCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void an_explicit_endpoint_setting_wins()
+    {
+        var queue = queueWith(EndpointMode.NativeAck);
+        queue.MaxDegreeOfParallelism = 7;
+        queue.PrefetchCount = 3;
+
+        queue.PrefetchCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void an_explicit_transport_wide_setting_wins_too()
+    {
+        var queue = queueWith(EndpointMode.NativeAck, t => t.PrefetchCount = 5);
+        queue.MaxDegreeOfParallelism = 7;
+
+        queue.PrefetchCount.ShouldBe(5);
+    }
+
+    /// <summary>
+    /// Zero is a legitimate transport-wide choice -- it is what turns prefetch off altogether -- so it has to be
+    /// distinguishable from "nobody chose anything", which is the case the mode default is for.
+    /// </summary>
+    [Fact]
+    public void an_explicit_transport_wide_zero_is_still_a_choice()
+    {
+        var queue = queueWith(EndpointMode.NativeAck, t => t.PrefetchCount = 0);
+        queue.MaxDegreeOfParallelism = 7;
+
+        queue.PrefetchCount.ShouldBe(0);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_mode_4051.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_mode_4051.cs
@@ -1,0 +1,284 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+#region messages and handler
+
+public record AsbNativeAckWork(int Number);
+
+/// <summary>
+/// Identifies WHICH host handled a message. Registered as a singleton per host and injected into the handler.
+/// Without it these tests are vacuous: the tracking bag is static and process-wide, so a handler parked inside a
+/// host that has since been disposed still resumes in this process and still records its message. A "the dead
+/// node's messages came back" assertion written over untagged numbers is therefore satisfied by the DEAD node
+/// finishing its own work, and passes just as happily under BufferedInMemory -- which is exactly what it is
+/// supposed to rule out. (Confirmed the hard way: the first version of this file passed its own red baseline.)
+/// </summary>
+public class AsbNodeTag(string name)
+{
+    public string Name { get; } = name;
+}
+
+public static class AsbNativeAckTracking
+{
+    /// <summary>Every (node, number) whose handler RAN TO COMPLETION -- one entry per completion.</summary>
+    public static readonly ConcurrentBag<(string Node, int Number)> Handled = new();
+
+    /// <summary>
+    /// Every (node, number) whose handler was ENTERED, one entry per entry. A redelivery shows up here even while
+    /// the original invocation is still parked and has therefore recorded nothing in <see cref="Handled" />, which
+    /// is what lets the lease renewal test see a redelivery as it happens.
+    /// </summary>
+    public static readonly ConcurrentBag<(string Node, int Number)> Entered = new();
+
+    /// <summary>When set, handlers park here forever -- standing in for a node that dies mid-flight.</summary>
+    public static TaskCompletionSource? Block;
+
+    public static void Reset()
+    {
+        Handled.Clear();
+        Entered.Clear();
+        Block = null;
+    }
+
+    /// <summary>Distinct numbers handled by anyone.</summary>
+    public static IEnumerable<int> HandledInRange(int start, int count)
+    {
+        return Handled.Select(x => x.Number).Where(x => x >= start && x < start + count).Distinct().OrderBy(x => x);
+    }
+
+    /// <summary>Distinct numbers handled by THIS node specifically.</summary>
+    public static IEnumerable<int> HandledBy(string node, int start, int count)
+    {
+        return Handled.Where(x => x.Node == node && x.Number >= start && x.Number < start + count)
+            .Select(x => x.Number).Distinct().OrderBy(x => x);
+    }
+
+    /// <summary>How many times a handler was entered for this number, across every node.</summary>
+    public static int EnteredCount(int number)
+    {
+        return Entered.Count(x => x.Number == number);
+    }
+
+    /// <summary>Total handler completions in this range, counting repeats -- a redelivery makes this exceed the range.</summary>
+    public static int TotalCompletionsInRange(int start, int count)
+    {
+        return Handled.Count(x => x.Number >= start && x.Number < start + count);
+    }
+}
+
+public class AsbNativeAckWorkHandler
+{
+    public async Task Handle(AsbNativeAckWork message, AsbNodeTag node)
+    {
+        AsbNativeAckTracking.Entered.Add((node.Name, message.Number));
+
+        if (AsbNativeAckTracking.Block != null)
+        {
+            await AsbNativeAckTracking.Block.Task;
+        }
+
+        AsbNativeAckTracking.Handled.Add((node.Name, message.Number));
+    }
+}
+
+#endregion
+
+/// <summary>
+/// GH-4051. Azure Service Bus's adoption of <see cref="EndpointMode.NativeAck" />. The guarantee under test is the
+/// one the mode exists for -- Buffered's throughput with Inline's no-loss behaviour -- plus the Azure Service Bus
+/// specific half of it, which is that the broker's message lock survives the whole time an envelope is queued
+/// (see native_ack_lease_renewal_4051).
+/// </summary>
+/// <remarks>
+/// Every test gets its OWN queue. These share one static tracking bag and one emulator, so a shared queue lets the
+/// redelivery test's messages land in another test's assertion.
+/// </remarks>
+public class native_ack_mode_4051 : IAsyncLifetime
+{
+    private const string ModeQueue = "native-ack-4051-mode";
+    private const string EndToEndQueue = "native-ack-4051-e2e";
+    private const string RedeliveryQueue = "native-ack-4051-redelivery";
+    private const string SubscriptionTopic = "native-ack-4051-topic";
+    private const string SubscriptionName = "native-ack-4051-sub";
+
+    public ValueTask InitializeAsync()
+    {
+        AsbNativeAckTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        AsbNativeAckTracking.Block?.TrySetResult();
+        AsbNativeAckTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// A short lock duration keeps the redelivery test honest without making it slow: once the first node is gone
+    /// nothing is renewing these locks, so this is how long the broker waits before handing the messages to the
+    /// replacement node.
+    /// </summary>
+    internal static Task<IHost> startQueueHostAsync(string queueName, string node = "only")
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting();
+
+                opts.Services.AddSingleton(new AsbNodeTag(node));
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<AsbNativeAckWorkHandler>();
+
+                opts.ListenToAzureServiceBusQueue(queueName)
+                    .Named(queueName)
+                    .ConfigureQueue(q => q.LockDuration = TimeSpan.FromSeconds(10))
+                    .ProcessInParallelWithNativeAcks();
+
+                opts.PublishMessage<AsbNativeAckWork>().ToAzureServiceBusQueue(queueName);
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task the_endpoint_really_is_in_native_ack_mode()
+    {
+        using var host = await startQueueHostAsync(ModeQueue);
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = runtime.Endpoints.EndpointByName(ModeQueue).ShouldNotBeNull();
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+
+        // Nothing is acked until the handler succeeds, so the unacked window is the back pressure
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+
+        // GH-4048. An Azure Service Bus delivery expires on its own, so this endpoint has to declare the clock --
+        // and because it does, ListeningAgent refuses to start it at all unless the listener it built can renew.
+        // That this host started is therefore itself part of the assertion.
+        var queue = endpoint.ShouldBeOfType<AzureServiceBusQueue>();
+        queue.holdsExpiringLease.ShouldBeTrue();
+        queue.LockDuration.ShouldBe(TimeSpan.FromSeconds(10));
+    }
+
+    /// <summary>
+    /// End to end, and specifically that handler completion really does SETTLE the broker delivery. The quiet
+    /// period after the last handler is longer than the queue's lock duration, so a delivery that was handled but
+    /// never completed would come back inside it and show up as an eleventh completion.
+    /// </summary>
+    [Fact]
+    public async Task messages_are_processed_end_to_end_and_settled_exactly_once()
+    {
+        using var host = await startQueueHostAsync(EndToEndQueue);
+        var bus = host.MessageBus();
+
+        for (var i = 0; i < 10; i++)
+        {
+            await bus.SendAsync(new AsbNativeAckWork(i));
+        }
+
+        await waitForAsync(() => AsbNativeAckTracking.HandledInRange(0, 10).Count() >= 10, TimeSpan.FromSeconds(60));
+
+        AsbNativeAckTracking.HandledInRange(0, 10).ShouldBe(Enumerable.Range(0, 10));
+
+        // Longer than the 10 second lock duration these queues are configured with
+        await Task.Delay(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+
+        AsbNativeAckTracking.TotalCompletionsInRange(0, 10)
+            .ShouldBe(10, "a delivery was redelivered after its handler finished, so completion did not settle it");
+    }
+
+    /// <summary>
+    /// The whole point of the mode. Under BufferedInMemory these messages are completed the instant they arrive, so
+    /// a node that dies before the handler finishes loses every one of them. Under NativeAck nothing is completed
+    /// until the handler succeeds, so the broker's lock expires and it hands them all to the next node.
+    /// </summary>
+    [Fact]
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    {
+        AsbNativeAckTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstHost = await startQueueHostAsync(RedeliveryQueue, "first");
+        var bus = firstHost.MessageBus();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await bus.SendAsync(new AsbNativeAckWork(100 + i));
+        }
+
+        // Let the deliveries actually reach the parked handlers before killing the node
+        await waitForAsync(() => AsbNativeAckTracking.Entered.Count(x => x.Node == "first" && x.Number >= 100) >= 5,
+            TimeSpan.FromSeconds(60));
+
+        // The node dies mid-flight, having acked nothing
+        firstHost.Dispose();
+
+        AsbNativeAckTracking.HandledInRange(100, 5).ShouldBeEmpty();
+
+        // Releasing the park lets the DEAD node's own handlers run to completion inside this process. That is a
+        // red herring by construction and the assertion below deliberately ignores it: what has to be proved is
+        // that the broker handed these deliveries to a DIFFERENT node, which only happens if nothing acked them.
+        AsbNativeAckTracking.Block!.TrySetResult();
+        AsbNativeAckTracking.Block = null;
+
+        using var secondHost = await startQueueHostAsync(RedeliveryQueue, "second");
+
+        await waitForAsync(() => AsbNativeAckTracking.HandledBy("second", 100, 5).Count() >= 5,
+            TimeSpan.FromSeconds(90));
+
+        AsbNativeAckTracking.HandledBy("second", 100, 5).ShouldBe(Enumerable.Range(100, 5));
+    }
+
+    /// <summary>
+    /// Subscriptions opt into the mode separately from queues (deliberately -- a topic shares their base class and
+    /// must never pick native acks up by inheritance), so the claim is tested separately too.
+    /// </summary>
+    [Fact]
+    public async Task subscriptions_work_in_native_ack_mode_too()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseAzureServiceBusTesting();
+
+                opts.Services.AddSingleton(new AsbNodeTag("subscriber"));
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<AsbNativeAckWorkHandler>();
+
+                opts.ListenToAzureServiceBusSubscription(SubscriptionName)
+                    .FromTopic(SubscriptionTopic)
+                    .Named(SubscriptionName)
+                    .ProcessInParallelWithNativeAcks();
+
+                opts.PublishMessage<AsbNativeAckWork>().ToAzureServiceBusTopic(SubscriptionTopic);
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var endpoint = runtime.Endpoints.EndpointByName(SubscriptionName).ShouldNotBeNull();
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+        endpoint.ShouldBeOfType<AzureServiceBusSubscription>().holdsExpiringLease.ShouldBeTrue();
+
+        var bus = host.MessageBus();
+        for (var i = 200; i < 205; i++)
+        {
+            await bus.SendAsync(new AsbNativeAckWork(i));
+        }
+
+        await waitForAsync(() => AsbNativeAckTracking.HandledInRange(200, 5).Count() >= 5, TimeSpan.FromSeconds(60));
+
+        AsbNativeAckTracking.HandledInRange(200, 5).ShouldBe(Enumerable.Range(200, 5));
+    }
+
+    internal static async Task waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (!condition() && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_with_sessions_4049.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_with_sessions_4049.cs
@@ -18,10 +18,11 @@ namespace Wolverine.AzureServiceBus.Tests;
 public class native_ack_with_sessions_4049
 {
     /// <summary>
-    /// Azure Service Bus has NOT opted into native acks yet -- see <see cref="the_shipping_queue_still_refuses_native_acks_in_the_mode_setter" />.
-    /// These subclasses open only that one gate, so the tests below prove the SESSION rejection specifically and
-    /// can never pass on the strength of the mode gate's own InvalidOperationException, which is a different
-    /// exception type raised from a different place at a different time.
+    /// These subclasses predate GH-4051, when Azure Service Bus had not yet opted into native acks and the mode gate
+    /// would otherwise have thrown before any of these tests reached the session rejection. They are kept because
+    /// <see cref="NativeAckCapableQueue.SessionsRequiredWhenTheModeWasChecked" /> is still the only way to observe
+    /// what a guard living in the Mode setter would have been able to see -- see
+    /// <see cref="a_guard_in_the_mode_setter_would_be_ordering_dependent" />.
     /// </summary>
     private class NativeAckCapableQueue : AzureServiceBusQueue
     {
@@ -232,19 +233,27 @@ public class native_ack_with_sessions_4049
     }
 
     /// <summary>
-    /// Pins the reason the subclasses above exist. Until Azure Service Bus opts into the mode (the follow-up half of
-    /// GH-4049's parent issue -- prefetch sizing plus the compliance suite), a real queue refuses native acks in the
-    /// Mode setter, with an InvalidOperationException rather than the session rejection. The two rejections must not
-    /// be confusable for each other.
+    /// GH-4051 replaced this test's original assertion. It used to pin that a shipping queue refused native acks in
+    /// the Mode setter, which is what made the subclasses above necessary. Azure Service Bus has since adopted the
+    /// mode, so a real queue now accepts it -- and the session rejection above still has to be the ONLY thing that
+    /// refuses the pairing, which is exactly what this now checks.
     /// </summary>
     [Fact]
-    public void the_shipping_queue_still_refuses_native_acks_in_the_mode_setter()
+    public void the_shipping_queue_now_accepts_native_acks()
     {
         var transport = new AzureServiceBusTransport();
-        var queue = transport.Queues["not-yet-adopted"];
+        var queue = transport.Queues["adopted-in-4051"];
 
-        var ex = Should.Throw<InvalidOperationException>(() => queue.Mode = EndpointMode.NativeAck);
-        ex.ShouldNotBeOfType<InvalidListenerConfigurationException>();
-        ex.Message.ShouldContain("does not support EndpointMode.NativeAck");
+        Should.NotThrow(() => queue.Mode = EndpointMode.NativeAck);
+        queue.Mode.ShouldBe(EndpointMode.NativeAck);
+
+        // ...and a real subscription too
+        var topic = transport.Topics["adopted-topic-4051"];
+        var subscription = new AzureServiceBusSubscription(transport, topic, "adopted-subscription-4051");
+        Should.NotThrow(() => subscription.Mode = EndpointMode.NativeAck);
+
+        // ...but never a topic, which is only ever published to
+        Should.Throw<InvalidOperationException>(() => topic.Mode = EndpointMode.NativeAck)
+            .Message.ShouldContain("does not support EndpointMode.NativeAck");
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -126,7 +126,14 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     /// </summary>
     public bool SystemQueuesEnabled { get; set; } = true;
 
-    private int _prefetchCount;
+    private int? _prefetchCount;
+
+    /// <summary>
+    /// GH-4051. Null unless a transport-wide prefetch was actually configured. An endpoint needs to tell "the user
+    /// chose 0" from "nobody chose anything", because a NativeAck endpoint substitutes a lane-sized default in the
+    /// second case only -- an explicit choice, at either level, always wins.
+    /// </summary>
+    internal int? ExplicitPrefetchCount => _prefetchCount;
 
     /// <summary>
     ///     The transport-wide default for the number of messages that the underlying Azure Service
@@ -138,7 +145,7 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     /// </summary>
     public int PrefetchCount
     {
-        get => _prefetchCount;
+        get => _prefetchCount ?? 0;
         set
         {
             if (value < 0)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -71,7 +71,38 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
     /// </summary>
     public int PrefetchCount
     {
-        get => _prefetchCount ?? Parent.PrefetchCount;
+        get
+        {
+            if (_prefetchCount.HasValue)
+            {
+                return _prefetchCount.Value;
+            }
+
+            // An explicit transport-wide setting is a deliberate choice and outranks any mode default
+            if (Parent.ExplicitPrefetchCount.HasValue)
+            {
+                return Parent.ExplicitPrefetchCount.Value;
+            }
+
+            // GH-4051. Azure Service Bus's shipping default is 0 -- no prefetch at all -- which leaves a NativeAck
+            // endpoint fetching one batch per network round trip and starving its lanes between receives. Sizing it
+            // to the lanes is the same reasoning as RabbitMqQueue.PreFetchCount's NativeAck arm, but the ceiling
+            // matters far more here than it does there: an Azure Service Bus message starts aging against its lock
+            // the moment the CLIENT buffers it, and a prefetched message has no Envelope yet, so it is not being
+            // tracked by LeaseRenewalTracker and cannot be renewed. Prefetch is therefore the one part of a
+            // NativeAck endpoint's backlog that renewal does NOT protect -- which is exactly why this is a small
+            // multiple of the lane count rather than the large buffer a throughput-only tuning would pick.
+            if (Mode == EndpointMode.NativeAck)
+            {
+                var lanes = GroupShardingSlotNumber.HasValue
+                    ? Math.Max((int)GroupShardingSlotNumber.Value, MaxDegreeOfParallelism)
+                    : MaxDegreeOfParallelism;
+
+                return lanes * 2;
+            }
+
+            return Parent.PrefetchCount;
+        }
         set
         {
             if (value < 0)
@@ -81,6 +112,49 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
             }
 
             _prefetchCount = value;
+        }
+    }
+
+    /// <summary>
+    /// GH-4051. How long Azure Service Bus holds the lock on one unsettled delivery from this endpoint. This is the
+    /// clock <see cref="EndpointMode.NativeAck" /> has to keep alive: a NativeAck delivery stays unsettled for lane
+    /// queue time <em>plus</em> handler time, and past this the broker takes the message back and redelivers it.
+    /// Read from the entity's own <c>LockDuration</c> (Azure's default is one minute, its maximum five).
+    /// </summary>
+    /// <remarks>
+    /// Wolverine reads the value it would <em>create</em> the entity with, which is the value the broker reports for
+    /// any entity Wolverine provisioned. If an entity was created outside Wolverine with a SHORTER lock duration than
+    /// the one configured here, renewal ticks at half of this rather than half of the real clock and can therefore
+    /// tick too late; configure <c>Options.LockDuration</c> to match the deployed entity in that case.
+    /// </remarks>
+    internal virtual TimeSpan LockDuration => TimeSpan.FromMinutes(1);
+
+    private TimeSpan _maximumLockRenewalDuration = TimeSpan.FromHours(1);
+
+    /// <summary>
+    ///     The longest a single delivery's lock is kept alive from its receipt under
+    ///     <see cref="EndpointMode.NativeAck" /> before Wolverine stops renewing it and lets Azure Service Bus
+    ///     redeliver. Default one hour.
+    /// </summary>
+    /// <remarks>
+    ///     Unlike Amazon SQS -- where the equivalent ceiling exists because SQS refuses to keep a message invisible
+    ///     for more than 12 hours -- Azure Service Bus imposes no cap on lock renewal at all; a message's lock can be
+    ///     renewed until the message's own time-to-live runs out. This ceiling is therefore purely Wolverine's
+    ///     stop-loss on a wedged handler, so that one stuck message cannot hold a broker lock forever. Reaching it is
+    ///     deliberately NOT treated as a lost lease: the delivery may still finish inside the lock it already holds.
+    /// </remarks>
+    public TimeSpan MaximumLockRenewalDuration
+    {
+        get => _maximumLockRenewalDuration;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    "MaximumLockRenewalDuration must be greater than zero");
+            }
+
+            _maximumLockRenewalDuration = value;
         }
     }
 
@@ -95,6 +169,16 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
     ///     default of 1. Does not apply to the default Buffered/Durable batch receive loop, which
     ///     scales through MaximumParallelMessages instead. See GH-3494.
     /// </summary>
+    /// <remarks>
+    ///     GH-4051 considered giving this a <see cref="EndpointMode.NativeAck" /> default alongside
+    ///     <see cref="PrefetchCount" /> and deliberately did not. This setting only reaches a
+    ///     <c>ServiceBusProcessor</c> or <c>ServiceBusSessionProcessor</c>, and NativeAck runs on
+    ///     <see cref="BatchedAzureServiceBusListener" />, which is built over a plain
+    ///     <c>ServiceBusReceiver</c> and never sees these options at all. A default here would have been
+    ///     inert configuration that reads as though it were doing something. NativeAck's lane count is
+    ///     <c>MaximumParallelMessages</c> (or the partition slot count), and the only broker-side number that
+    ///     has to keep up with it is the prefetch.
+    /// </remarks>
     public int? MaximumConcurrentCalls
     {
         get => _maximumConcurrentCalls;

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -109,6 +109,36 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
 
     internal override bool RequiresSessions => Options.RequiresSession;
 
+    /// <summary>
+    /// GH-4051. Azure Service Bus qualifies on both counts <see cref="EndpointMode.NativeAck" /> requires.
+    /// Settlement is per message -- <c>ServiceBusReceiver.CompleteMessageAsync</c> takes one message and settles
+    /// exactly that lock, with no cumulative or ordered semantics anywhere in the peek-lock model -- and settling
+    /// out of delivery order is expressible, because a lock is held per message rather than over a position in a
+    /// stream. That is the difference from Kafka, which cannot express a gap in a cumulative offset commit.
+    ///
+    /// <para>
+    /// Only queues and subscriptions, never topics: native acks are a listening concept and a topic is only ever
+    /// published to. <see cref="AzureServiceBusSubscription" /> declares this separately rather than inheriting it
+    /// from a shared base, so that the topic cannot pick it up by accident.
+    /// </para>
+    ///
+    /// <para>
+    /// Sessions are the one Azure Service Bus configuration this mode cannot serve, and they are refused after
+    /// compilation rather than here -- see <see cref="AzureServiceBusEndpoint.validateModeConfiguration" />.
+    /// </para>
+    /// </summary>
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
+    /// GH-4048. An unsettled Azure Service Bus delivery is locked only for the queue's <c>LockDuration</c>, after
+    /// which the broker hands the message to someone else -- so a NativeAck endpoint here has to renew that lock for
+    /// as long as the envelope sits in an execution lane. <see cref="BatchedAzureServiceBusListener" /> supplies the
+    /// renewal through <see cref="Wolverine.Transports.ISupportLeaseRenewal" />.
+    /// </summary>
+    protected internal override bool holdsExpiringLease => true;
+
+    internal override TimeSpan LockDuration => Options.LockDuration;
+
     private async Task purgeWithSessions(ServiceBusClient client)
     {
         using var cancellation = new CancellationTokenSource();

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSubscription.cs
@@ -227,6 +227,29 @@ public class AzureServiceBusSubscription : AzureServiceBusEndpoint, IBrokerQueue
 
     internal override bool RequiresSessions => Options.RequiresSession;
 
+    /// <summary>
+    /// GH-4051. Declared here rather than inherited from <see cref="AzureServiceBusEndpoint" /> on purpose, so that
+    /// <see cref="AzureServiceBusTopic" /> -- which shares that base and is only ever published to -- cannot pick
+    /// native acks up by accident.
+    ///
+    /// <para>
+    /// The analysis is the same one that qualifies <see cref="AzureServiceBusQueue" />, and it genuinely does carry
+    /// over: a subscription is consumed through an ordinary <c>ServiceBusReceiver</c> built over
+    /// (topic, subscription) instead of (queue), settled through the same per-message peek-lock calls, and served by
+    /// the same <see cref="BatchedAzureServiceBusListener" />. Nothing about fanning out to several subscriptions
+    /// couples their settlement: each subscription gets its own copy of the message with its own lock.
+    /// </para>
+    /// </summary>
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
+    /// GH-4048. A subscription's unsettled delivery expires on the subscription's own <c>LockDuration</c>, exactly
+    /// as a queue's does.
+    /// </summary>
+    protected internal override bool holdsExpiringLease => true;
+
+    internal override TimeSpan LockDuration => Options.LockDuration;
+
     internal async ValueTask InitializeAsync(ServiceBusAdministrationClient client, ILogger logger)
     {
         if (Parent.AutoProvision)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -11,7 +11,7 @@ using Wolverine.Transports.Sending;
 namespace Wolverine.AzureServiceBus.Internal;
 
 public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue, ISupportNativeScheduling,
-    IReportConnectionState
+    IReportConnectionState, ISupportLeaseRenewal
 {
     private readonly CancellationTokenSource _cancellation = new();
 
@@ -151,6 +151,93 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
     {
         envelope.ScheduledTime = time;
         await _defer.PostAsync(envelope);
+    }
+
+    /// <summary>
+    /// GH-4048. The entity's own lock duration is the clock on an unsettled Azure Service Bus delivery, and
+    /// <c>LeaseRenewalTracker</c> ticks at half of it.
+    /// </summary>
+    public TimeSpan LeaseDuration => _endpoint.LockDuration;
+
+    public TimeSpan MaximumLeaseExtension => _endpoint.MaximumLockRenewalDuration;
+
+    /// <summary>
+    /// GH-4048/GH-4051. Re-arm the broker's lock on these queued-but-unsettled deliveries.
+    ///
+    /// <para>
+    /// This is deliberately NOT <c>ServiceBusProcessorOptions.MaxAutoLockRenewalDuration</c>, which is the obvious
+    /// thing to reach for and is useless here: the SDK's auto-renewal runs only while the processor's callback is on
+    /// the stack. Under <see cref="EndpointMode.NativeAck" /> the delivery is handed to an execution lane and the
+    /// receive loop moves on immediately, so an endpoint configured that way would LOOK protected and be renewing
+    /// nothing for the whole time the envelope is queued. It also does not apply to this class at all, which uses a
+    /// <c>ServiceBusReceiver</c> rather than a processor.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Azure Service Bus has no batch lock-renewal call, so this is one round trip per envelope, issued serially --
+    /// the tick only ever covers what is actually in the lanes, and the lane count is bounded by
+    /// <c>MaxDegreeOfParallelism</c> (or the partition slot count).
+    ///
+    /// <para>
+    /// Only a refusal that means the lock is GONE is reported as a lost lease. Everything else -- a throttle, a
+    /// timeout, a dropped AMQP link -- leaves the envelope tracked so the next tick retries it, which is what the
+    /// contract asks for, and is why this catches per envelope rather than letting one bad call abandon the rest of
+    /// the batch.
+    /// </para>
+    /// </remarks>
+    public async ValueTask<IReadOnlyList<Envelope>> RenewLeasesAsync(IReadOnlyList<Envelope> envelopes,
+        CancellationToken token)
+    {
+        List<Envelope>? lost = null;
+
+        foreach (var envelope in envelopes)
+        {
+            if (envelope is not AzureServiceBusEnvelope e) continue;
+
+            // Nothing to renew on a delivery that has already been settled by a terminal that has not yet
+            // untracked it
+            if (e.IsCompleted) continue;
+
+            token.ThrowIfCancellationRequested();
+
+            try
+            {
+                await _receiver.RenewMessageLockAsync(e.AzureMessage, token);
+            }
+            catch (Exception ex) when (isLockLost(ex))
+            {
+                // The broker owns this delivery again and is going to redeliver it. Core decides what happens
+                // next; all this can do is report it accurately.
+                (lost ??= []).Add(envelope);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Transient by elimination. Explicitly NOT a lost lease -- reporting one here would make core drop
+                // a delivery whose lock is very probably still perfectly good.
+                _logger.LogDebug(ex,
+                    "Transient failure renewing the Azure Service Bus lock on message {Id} at {Uri}; it stays tracked and the next tick will retry it",
+                    e.AzureMessage.MessageId, _endpoint.Uri);
+            }
+        }
+
+        return lost ?? (IReadOnlyList<Envelope>)[];
+    }
+
+    /// <summary>
+    /// Does this failure mean the lock is gone for good? <c>MessageLockLost</c> is the direct answer and
+    /// <c>MessageNotFound</c> means the message is no longer there to hold a lock at all. The message-text check
+    /// is the same defensive one <see cref="AzureServiceBusEnvelope.CompleteAsync" /> already carries, for
+    /// implementations that report an expired lock without setting the typed reason.
+    /// </summary>
+    private static bool isLockLost(Exception ex)
+    {
+        return ex is ServiceBusException e && (e.Reason is ServiceBusFailureReason.MessageLockLost
+                                                   or ServiceBusFailureReason.MessageNotFound
+                                               || e.Message.ContainsIgnoreCase("The lock supplied is invalid"));
     }
 
     private async Task listenForMessages()

--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/ordering_key_configuration_4087.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/ordering_key_configuration_4087.cs
@@ -1,0 +1,217 @@
+using Google.Api.Gax;
+using Google.Cloud.PubSub.V1;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Pubsub.Internal;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+/// <summary>
+///     GH-4087. <see cref="PubsubTopicOptions.OrderBy" /> is consulted on every publish but used to have no
+///     configuration surface at all. These cover the new <c>OrderMessagesBy()</c> fluent method and, more
+///     importantly, the three step precedence the publish path actually implements:
+///     <c>GroupId</c> -> <c>OrderBy</c> -> whatever the envelope mapper stamped on the message.
+/// </summary>
+public class ordering_key_configuration_4087
+{
+    private static PubsubTransport createTransport()
+    {
+        return new PubsubTransport
+        {
+            ProjectId = "wolverine",
+            PublisherApiClient = Substitute.For<PublisherServiceApiClient>(),
+            SubscriberApiClient = Substitute.For<SubscriberServiceApiClient>(),
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        };
+    }
+
+    /// <summary>
+    ///     Publishes the envelope through the real <see cref="PubsubEndpoint.SendMessageAsync" /> path against a
+    ///     stubbed publisher client, and hands back the <see cref="PubsubMessage" /> that would have gone to GCP.
+    /// </summary>
+    private static async Task<PubsubMessage> publishAndCapture(PubsubEndpoint endpoint, Envelope envelope)
+    {
+        var publisher = Substitute.For<PublisherServiceApiClient>();
+
+        publisher
+            .PublishAsync(Arg.Any<PublishRequest>())
+            .ReturnsForAnyArgs(Task.FromResult(new PublishResponse()));
+
+        var clients = new PubsubClientSet
+        {
+            ProjectId = "wolverine",
+            EmulatorDetection = EmulatorDetection.EmulatorOnly,
+            PublisherApiClient = publisher
+        };
+
+        await endpoint.SendMessageAsync(envelope, NullLogger.Instance, clients);
+
+        var call = publisher
+            .ReceivedCalls()
+            .Single(x => x.GetMethodInfo().Name == nameof(PublisherServiceApiClient.PublishAsync));
+
+        var request = call.GetArguments().OfType<PublishRequest>().Single();
+
+        return request.Messages.Single();
+    }
+
+    [Fact]
+    public void order_by_defaults_to_returning_null()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+
+        endpoint.Server.Topic.OrderBy(ObjectMother.Envelope()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void order_messages_by_reaches_the_topic_options()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        var configuration = new PubsubTopicSubscriberConfiguration(endpoint);
+
+        configuration.OrderMessagesBy(e => e.TenantId);
+
+        // delayed configuration -- nothing is assigned until the endpoint is compiled
+        endpoint.Server.Topic.OrderBy(new Envelope { TenantId = "tenant1" }).ShouldBeNull();
+
+        ((IDelayedEndpointConfiguration)configuration).Apply();
+
+        endpoint.Server.Topic.OrderBy(new Envelope { TenantId = "tenant1" }).ShouldBe("tenant1");
+    }
+
+    [Fact]
+    public void order_messages_by_rejects_a_null_function()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        var configuration = new PubsubTopicSubscriberConfiguration(endpoint);
+
+        Should.Throw<ArgumentNullException>(() => configuration.OrderMessagesBy(null!));
+    }
+
+    [Fact]
+    public void order_messages_by_is_fluent()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        var configuration = new PubsubTopicSubscriberConfiguration(endpoint);
+
+        configuration.OrderMessagesBy(e => e.TenantId).ShouldBeSameAs(configuration);
+    }
+
+    [Fact]
+    public async Task order_by_supplies_the_ordering_key_when_there_is_no_group_id()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        endpoint.Server.Topic.OrderBy = e => "from-order-by";
+
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = null;
+
+        var message = await publishAndCapture(endpoint, envelope);
+
+        message.OrderingKey.ShouldBe("from-order-by");
+    }
+
+    [Fact]
+    public async Task group_id_beats_order_by()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        endpoint.Server.Topic.OrderBy = e => "from-order-by";
+
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = "from-group-id";
+
+        var message = await publishAndCapture(endpoint, envelope);
+
+        message.OrderingKey.ShouldBe("from-group-id");
+    }
+
+    [Fact]
+    public async Task order_by_beats_the_envelope_mapper()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        endpoint.EnvelopeMapper = new OrderingKeyStampingMapper("from-mapper");
+        endpoint.Server.Topic.OrderBy = e => "from-order-by";
+
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = null;
+
+        var message = await publishAndCapture(endpoint, envelope);
+
+        message.OrderingKey.ShouldBe("from-order-by");
+    }
+
+    [Fact]
+    public async Task the_envelope_mapper_is_the_last_resort()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        endpoint.EnvelopeMapper = new OrderingKeyStampingMapper("from-mapper");
+
+        // no GroupId, and OrderBy left at its default of e => null
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = null;
+
+        var message = await publishAndCapture(endpoint, envelope);
+
+        message.OrderingKey.ShouldBe("from-mapper");
+    }
+
+    [Fact]
+    public async Task group_id_beats_the_envelope_mapper_too()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+        endpoint.EnvelopeMapper = new OrderingKeyStampingMapper("from-mapper");
+
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = "from-group-id";
+
+        var message = await publishAndCapture(endpoint, envelope);
+
+        message.OrderingKey.ShouldBe("from-group-id");
+    }
+
+    [Fact]
+    public async Task no_ordering_key_at_all_by_default()
+    {
+        var endpoint = new PubsubEndpoint("foo", createTransport());
+
+        var envelope = ObjectMother.Envelope();
+        envelope.GroupId = null;
+
+        var message = await publishAndCapture(endpoint, envelope);
+
+        // protobuf string fields are never null, so "unset" is the empty string here
+        message.OrderingKey.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     Stands in for a user supplied <see cref="IPubsubEnvelopeMapper" /> that sets the ordering key itself --
+    ///     the lowest rung of the precedence chain.
+    /// </summary>
+    internal class OrderingKeyStampingMapper : IPubsubEnvelopeMapper
+    {
+        private readonly string _orderingKey;
+
+        public OrderingKeyStampingMapper(string orderingKey)
+        {
+            _orderingKey = orderingKey;
+        }
+
+        public void MapEnvelopeToOutgoing(Envelope envelope, PubsubMessage outgoing)
+        {
+            outgoing.OrderingKey = _orderingKey;
+        }
+
+        public void MapIncomingToEnvelope(Envelope envelope, PubsubMessage incoming)
+        {
+        }
+
+        public void MapOutgoingToMessage(OutgoingMessageBatch outgoing, PubsubMessage message)
+        {
+        }
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
@@ -449,6 +449,9 @@ public class PubsubEndpoint : Endpoint<IPubsubEnvelopeMapper, PubsubEnvelopeMapp
         EnvelopeMapper ??= new PubsubEnvelopeMapper(this);
         EnvelopeMapper.MapEnvelopeToOutgoing(envelope, message);
 
+        // GH-4087: ordering key precedence. An explicit GroupId on the envelope wins, then the per-topic
+        // function supplied to PubsubTopicSubscriberConfiguration.OrderMessagesBy(), and finally whatever a
+        // custom IPubsubEnvelopeMapper already stamped onto the message itself.
         message.OrderingKey = envelope.GroupId ?? orderBy ?? message.OrderingKey;
 
         await clients.PublisherApiClient.PublishAsync(new PublishRequest

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubOptions.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubOptions.cs
@@ -13,6 +13,12 @@ public class PubsubTopicOptions
 {
     public CreateTopicOptions Options = new();
     public TopicName Name { get; set; } = default!;
+
+    /// <summary>
+    ///     Derives the Pub/Sub <c>OrderingKey</c> for an outgoing message. Configure through
+    ///     <see cref="PubsubTopicSubscriberConfiguration.OrderMessagesBy" />. Consulted on every publish, but
+    ///     only used when the envelope carries no <see cref="Envelope.GroupId" /> — see GH-4087.
+    /// </summary>
     public Func<Envelope, string?> OrderBy = e => null;
 }
 

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubTopicSubscriberConfiguration.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubTopicSubscriberConfiguration.cs
@@ -22,4 +22,35 @@ public class
 
         return this;
     }
+
+    /// <summary>
+    ///     Derive the Google Cloud Pub/Sub <c>OrderingKey</c> for each outgoing message on this topic from
+    ///     the outgoing <see cref="Envelope" />. Return <c>null</c> to leave the message unkeyed.
+    ///     <para>
+    ///     The ordering key is resolved with a three step precedence: an explicit
+    ///     <see cref="Envelope.GroupId" /> wins, then the function supplied here, and finally whatever a
+    ///     custom <see cref="IPubsubEnvelopeMapper" /> already stamped onto the message. This is therefore
+    ///     the per-topic escape hatch for "key on something other than the group id" without having to
+    ///     replace the envelope mapper.
+    ///     </para>
+    ///     <para>
+    ///     Be aware of the throughput cost. Pub/Sub serializes delivery per ordering key, so any message
+    ///     that carries one — by this route or any other — caps the consumer's effective concurrency at the
+    ///     number of distinct keys in flight, regardless of how <c>MaxOutstandingMessages</c> is sized.
+    ///     </para>
+    /// </summary>
+    /// <param name="orderBy">Function returning the ordering key for an outgoing envelope, or null for none</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public PubsubTopicSubscriberConfiguration OrderMessagesBy(Func<Envelope, string?> orderBy)
+    {
+        if (orderBy is null)
+        {
+            throw new ArgumentNullException(nameof(orderBy));
+        }
+
+        add(e => e.Server.Topic.OrderBy = orderBy);
+
+        return this;
+    }
 }

--- a/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
@@ -347,8 +347,16 @@ public class native_ack_mode : IAsyncLifetime
 /// once and forgets it -- there is no unacknowledged delivery to hold and nothing to hand back when a node dies
 /// -- so a "native ack" core listener would be BufferedInMemory with a false no-loss promise.
 /// </summary>
+[Collection("NATS Integration")]
 public class core_nats_rejects_native_ack
 {
+    private readonly NatsContainerFixture _fixture;
+
+    public core_nats_rejects_native_ack(NatsContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     [Fact]
     public async Task a_core_nats_listener_refuses_the_mode_at_bootstrap()
     {
@@ -357,7 +365,7 @@ public class core_nats_rejects_native_ack
             using var host = await Host.CreateDefaultBuilder()
                 .UseWolverine(opts =>
                 {
-                    opts.UseNats("nats://localhost:4222");
+                    opts.UseNats(_fixture.ConnectionString);
                     opts.Policies.DisableConventionalLocalRouting();
 
                     // No UseJetStream() -- this is a plain core NATS subject
@@ -388,7 +396,7 @@ public class core_nats_rejects_native_ack
             using var host = await Host.CreateDefaultBuilder()
                 .UseWolverine(opts =>
                 {
-                    opts.UseNats(NatsTestHelpers.ResolveUrl())
+                    opts.UseNats(_fixture.ConnectionString)
                         .AutoProvision()
                         .DefineWorkQueueStream(stream, _ => { }, subject);
 
@@ -420,7 +428,7 @@ public class core_nats_rejects_native_ack
         using var host = Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
-                opts.UseNats("nats://localhost:4222");
+                opts.UseNats(_fixture.ConnectionString);
                 opts.Policies.DisableConventionalLocalRouting();
                 opts.ListenToNatsSubject("core.no.lease");
             }).Build();

--- a/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
@@ -1,0 +1,508 @@
+using System.Collections.Concurrent;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+using NATS.Net;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Nats.Internal;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.Nats.Tests;
+
+#region messages and handler
+
+public record NativeAckWork(int Number);
+
+/// <summary>
+/// Every execution is recorded WITH THE HOST THAT RAN IT, and each host is parked independently.
+/// </summary>
+/// <remarks>
+/// Both of those exist because the obvious shape of this fixture -- one shared bag of numbers and one shared
+/// <c>TaskCompletionSource</c> -- makes the dead-node test vacuous, and it was caught passing under
+/// <c>BufferedInMemory()</c>, the very mode it claims to distinguish itself from. <c>IHost.Dispose()</c> does not
+/// run <c>StopAsync</c>, so the "dead" host's handlers are still parked in-process; releasing one shared gate
+/// then let the ZOMBIE FIRST HOST fill in the numbers the test was attributing to a redelivery on the second.
+/// Keyed by service name, "the second host handled it" is a claim the first host cannot satisfy.
+/// </remarks>
+public static class NativeAckWorkTracking
+{
+    /// <summary>Every execution, including a duplicate one -- the redelivery tests count entries, not distinct values.</summary>
+    public static readonly ConcurrentBag<(string Service, int Number)> Handled = new();
+
+    private static readonly ConcurrentDictionary<string, TaskCompletionSource> Blocks = new();
+
+    /// <summary>Park every handler running in this host until <see cref="Release" /> -- a node that dies mid-flight.</summary>
+    public static void Block(string service)
+    {
+        Blocks[service] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public static void Release(string service)
+    {
+        if (Blocks.TryGetValue(service, out var tcs)) tcs.TrySetResult();
+    }
+
+    public static Task GateFor(string service) =>
+        Blocks.TryGetValue(service, out var tcs) ? tcs.Task : Task.CompletedTask;
+
+    public static void Reset()
+    {
+        Handled.Clear();
+        foreach (var tcs in Blocks.Values) tcs.TrySetResult();
+        Blocks.Clear();
+    }
+
+    public static int CountOf(int number) => Handled.Count(x => x.Number == number);
+
+    public static IEnumerable<int> DistinctNumbersFor(string service, int start, int count)
+    {
+        return Handled
+            .Where(x => x.Service == service && x.Number >= start && x.Number < start + count)
+            .Select(x => x.Number)
+            .Distinct()
+            .OrderBy(x => x);
+    }
+}
+
+public class NativeAckWorkHandler
+{
+    public async Task Handle(NativeAckWork message, IWolverineRuntime runtime)
+    {
+        var service = runtime.Options.ServiceName;
+
+        await NativeAckWorkTracking.GateFor(service);
+
+        NativeAckWorkTracking.Handled.Add((service, message.Number));
+    }
+}
+
+#endregion
+
+/// <summary>
+/// GH-4053. NATS JetStream opts into <see cref="EndpointMode.NativeAck" />. The guarantee under test is the one
+/// the mode exists for -- Buffered's throughput with Inline's no-loss behaviour -- plus the two things that are
+/// specific to this transport: <c>AckWait</c> is a real clock that has to be renewed with <c>AckProgress</c>
+/// while an envelope waits in a lane (GH-4048), and <c>MaxAckPending</c> is the prefetch that has to cover every
+/// lane or the consumer stalls itself.
+/// </summary>
+/// <remarks>
+/// Every test gets its own stream, subject and consumer name. These share one static tracking bag and one
+/// broker, and the redelivery tests deliberately produce extra deliveries -- a shared subject would let one
+/// test's redelivery land in another test's assertion.
+/// </remarks>
+[Collection("NATS Integration")]
+public class native_ack_mode : IAsyncLifetime
+{
+    private readonly NatsContainerFixture _fixture;
+
+    public native_ack_mode(NatsContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        NativeAckWorkTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        NativeAckWorkTracking.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed record Topology(string Stream, string Subject, string Consumer);
+
+    private static Topology topologyFor(string label)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        return new Topology($"NACK_{label}_{suffix}".ToUpperInvariant(), $"nack.{label}.{suffix}",
+            $"nack-{label}-{suffix}");
+    }
+
+    private Task<IHost> startHostAsync(Topology topology, string serviceName, TimeSpan? ackWait = null,
+        Action<Wolverine.Nats.Configuration.NatsListenerConfiguration>? configure = null)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = serviceName;
+
+                opts.UseNats(_fixture.ConnectionString)
+                    .AutoProvision()
+                    .DefineWorkQueueStream(topology.Stream, _ => { }, topology.Subject);
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeAckWorkHandler>();
+                opts.Policies.DisableConventionalLocalRouting();
+
+                var listener = opts.ListenToNatsSubject(topology.Subject)
+                    .UseJetStream(topology.Stream, topology.Consumer)
+                    .ProcessInParallelWithNativeAcks();
+
+                if (ackWait.HasValue)
+                {
+                    listener.AckWait(ackWait.Value);
+                }
+
+                configure?.Invoke(listener);
+
+                // Deliberately NOT SendInline(). Publishing to a subject this host also listens to resolves to
+                // the SAME NatsEndpoint, and EndpointMode is one property on it -- so SendInline() would set
+                // Mode = Inline and silently downgrade the listener out of NativeAck. It is also unnecessary:
+                // NativeAck already sends through the inline sending agent (Endpoint.SendsInline, GH-4073).
+                opts.PublishMessage<NativeAckWork>().ToNatsSubject(topology.Subject)
+                    .UseJetStream(topology.Stream);
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task the_endpoint_really_is_in_native_ack_mode()
+    {
+        var topology = topologyFor("mode");
+        using var host = await startHostAsync(topology, "mode-host");
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = runtime.Endpoints
+            .ActiveListeners()
+            .Select(x => x.Endpoint)
+            .OfType<NatsEndpoint>()
+            .Single(x => x.Subject == topology.Subject);
+
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+
+        // MaxAckPending IS the back pressure for this mode, so no in-process BackPressureAgent
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+
+        // GH-4048: AckWait is a real clock, so this endpoint has to declare the lease -- and having declared it,
+        // ListeningAgent.assertLeaseRenewalContract refuses to START a NativeAck listener that cannot renew.
+        // The successful bootstrap above is therefore the real assertion that NatsListener implements
+        // ISupportLeaseRenewal; these two name the halves so a regression says which one broke.
+        endpoint.holdsExpiringLease.ShouldBeTrue();
+        typeof(ISupportLeaseRenewal).IsAssignableFrom(typeof(NatsListener)).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// MaxAckPending is this transport's prefetch equivalent, and the value has to reach the SERVER -- asserting
+    /// the endpoint property alone would pass even if the consumer config never carried it.
+    /// </summary>
+    [Fact]
+    public async Task max_ack_pending_covers_every_lane_and_reaches_the_server()
+    {
+        var topology = topologyFor("pending");
+        using var host = await startHostAsync(topology, "pending-host",
+            configure: l => l.MaximumParallelMessages(6).PartitionProcessingByGroupId(PartitionSlots.Five));
+
+        var config = await consumerConfigAsync(topology);
+
+        // Six parallel lanes beats five partition slots, doubled so no lane waits on the next delivery
+        config.MaxAckPending.ShouldBe(12);
+    }
+
+    [Fact]
+    public async Task ack_wait_override_reaches_the_server()
+    {
+        var topology = topologyFor("ackwait");
+        using var host = await startHostAsync(topology, "ackwait-host", 7.Seconds());
+
+        var config = await consumerConfigAsync(topology);
+        config.AckWait.ShouldBe(7.Seconds());
+    }
+
+    [Fact]
+    public async Task messages_are_processed_end_to_end()
+    {
+        var topology = topologyFor("e2e");
+        using var host = await startHostAsync(topology, "e2e-host");
+        var bus = host.MessageBus();
+
+        for (var i = 0; i < 10; i++)
+        {
+            await bus.SendAsync(new NativeAckWork(i));
+        }
+
+        await waitForAsync(() => NativeAckWorkTracking.DistinctNumbersFor("e2e-host", 0, 10).Count() >= 10,
+            30.Seconds());
+
+        NativeAckWorkTracking.DistinctNumbersFor("e2e-host", 0, 10).ShouldBe(Enumerable.Range(0, 10));
+    }
+
+    /// <summary>
+    /// GH-4048 for this transport. A NativeAck delivery is held unsettled for lane queue time PLUS handler time,
+    /// and JetStream redelivers anything still unacked after <c>AckWait</c>. With <c>AckProgress</c> renewal a
+    /// handler that runs for several times <c>AckWait</c> is still exactly one execution; without it the server
+    /// hands the same message out again while the first copy is still running.
+    /// </summary>
+    [Fact]
+    public async Task a_delivery_held_far_past_ack_wait_is_not_redelivered()
+    {
+        var topology = topologyFor("lease");
+        NativeAckWorkTracking.Block("lease-host");
+
+        // AckWait of 3s means the renewal tick is 1.5s, and parking for 12s spans four AckWait windows
+        using var host = await startHostAsync(topology, "lease-host", 3.Seconds());
+        var bus = host.MessageBus();
+
+        await bus.SendAsync(new NativeAckWork(42));
+
+        // Let it reach the parked handler, then hold it there well past several AckWait windows
+        await waitForAsync(() => queueDepth(host, topology) > 0 || NativeAckWorkTracking.CountOf(42) > 0,
+            15.Seconds());
+        await Task.Delay(12.Seconds(), TestContext.Current.CancellationToken);
+
+        // Nothing has run yet -- the handler is still parked, and the lease has been renewed the whole time
+        NativeAckWorkTracking.CountOf(42).ShouldBe(0);
+
+        NativeAckWorkTracking.Release("lease-host");
+
+        await waitForAsync(() => NativeAckWorkTracking.CountOf(42) >= 1, 15.Seconds());
+
+        // Give any redelivery the server was going to make time to show up before asserting "exactly one"
+        await Task.Delay(5.Seconds(), TestContext.Current.CancellationToken);
+
+        NativeAckWorkTracking.CountOf(42).ShouldBe(1);
+    }
+
+    /// <summary>
+    /// The whole point of the mode. Under BufferedInMemory these messages are acked the instant they arrive, so a
+    /// node that dies before the handler finishes loses every one of them. Under NativeAck nothing is acked until
+    /// the handler succeeds, so once the dead node stops renewing, JetStream redelivers all of them at AckWait.
+    /// </summary>
+    [Fact]
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    {
+        var topology = topologyFor("redelivery");
+
+        // The dying node's handlers park FOREVER and are never released. That is what makes the final assertion
+        // unfakeable: IHost.Dispose() does not run StopAsync, so those handlers are still sitting in this
+        // process, and a shared release gate would let them -- not the second host -- satisfy the assertion.
+        NativeAckWorkTracking.Block("dying-host");
+
+        var firstHost = await startHostAsync(topology, "dying-host", 3.Seconds());
+        var bus = firstHost.MessageBus();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await bus.SendAsync(new NativeAckWork(100 + i));
+        }
+
+        // Let the deliveries actually reach the parked handlers before killing the node
+        await waitForAsync(() => queueDepth(firstHost, topology) > 0, 20.Seconds());
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
+
+        // The node dies mid-flight, having acked nothing
+        firstHost.Dispose();
+
+        NativeAckWorkTracking.Handled.ShouldBeEmpty();
+
+        // A fresh node -- which is NOT parked -- picks up every redelivered message
+        using var secondHost = await startHostAsync(topology, "surviving-host", 3.Seconds());
+
+        await waitForAsync(() => NativeAckWorkTracking.DistinctNumbersFor("surviving-host", 100, 5).Count() >= 5,
+            60.Seconds());
+
+        NativeAckWorkTracking.DistinctNumbersFor("surviving-host", 100, 5).ShouldBe(Enumerable.Range(100, 5));
+
+        // ...and the dead node never handled any of them, so nothing above can be explained by the zombie
+        NativeAckWorkTracking.DistinctNumbersFor("dying-host", 100, 5).ShouldBeEmpty();
+    }
+
+    private async Task<ConsumerConfig> consumerConfigAsync(Topology topology)
+    {
+        await using var connection = new NatsConnection(new NatsOpts { Url = _fixture.ConnectionString });
+        await connection.ConnectAsync();
+
+        var js = connection.CreateJetStreamContext();
+        var consumer = await js.GetConsumerAsync(topology.Stream, topology.Consumer,
+            TestContext.Current.CancellationToken);
+
+        return consumer.Info.Config;
+    }
+
+    private static int queueDepth(IHost host, Topology topology)
+    {
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        var circuit = runtime.Endpoints.FindListenerCircuit(new Uri($"nats://subject/{topology.Subject}"));
+        return circuit?.QueueCount ?? 0;
+    }
+
+    private static async Task waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (!condition() && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+    }
+}
+
+/// <summary>
+/// GH-4053. Core NATS is out of scope for this mode and has to say so. A core subscription delivers a message
+/// once and forgets it -- there is no unacknowledged delivery to hold and nothing to hand back when a node dies
+/// -- so a "native ack" core listener would be BufferedInMemory with a false no-loss promise.
+/// </summary>
+public class core_nats_rejects_native_ack
+{
+    [Fact]
+    public async Task a_core_nats_listener_refuses_the_mode_at_bootstrap()
+    {
+        var ex = await Should.ThrowAsync<InvalidListenerConfigurationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.UseNats("nats://localhost:4222");
+                    opts.Policies.DisableConventionalLocalRouting();
+
+                    // No UseJetStream() -- this is a plain core NATS subject
+                    opts.ListenToNatsSubject("core.native.ack").ProcessInParallelWithNativeAcks();
+                }).StartAsync();
+        });
+
+        ex.Message.ShouldContain("JetStream");
+        ex.Message.ShouldContain("Core NATS");
+    }
+
+    /// <summary>
+    /// The refusal has to survive the fluent calls being written in either order. Both <c>UseJetStream()</c> and
+    /// <c>ProcessInParallelWithNativeAcks()</c> are applied as delayed configuration, so answering the JetStream
+    /// question inside the <c>Mode</c> setter's predicate would make it order-dependent -- accepting one spelling
+    /// and refusing the identical other. GH-4047's validateModeConfiguration hook runs over the FINAL state,
+    /// which is why this passes both ways round.
+    /// </summary>
+    [Fact]
+    public async Task native_acks_are_accepted_whichever_order_the_fluent_calls_are_written_in()
+    {
+        foreach (var nativeAcksFirst in new[] { true, false })
+        {
+            var suffix = Guid.NewGuid().ToString("N")[..8];
+            var subject = $"nack.order.{suffix}";
+            var stream = $"NACK_ORDER_{suffix}".ToUpperInvariant();
+
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.UseNats(NatsTestHelpers.ResolveUrl())
+                        .AutoProvision()
+                        .DefineWorkQueueStream(stream, _ => { }, subject);
+
+                    opts.Policies.DisableConventionalLocalRouting();
+
+                    var listener = opts.ListenToNatsSubject(subject);
+                    if (nativeAcksFirst)
+                    {
+                        listener.ProcessInParallelWithNativeAcks().UseJetStream(stream, $"nack-order-{suffix}");
+                    }
+                    else
+                    {
+                        listener.UseJetStream(stream, $"nack-order-{suffix}").ProcessInParallelWithNativeAcks();
+                    }
+                }).StartAsync(TestContext.Current.CancellationToken);
+
+            var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+            runtime.Endpoints.ActiveListeners()
+                .Select(x => x.Endpoint)
+                .OfType<NatsEndpoint>()
+                .Single(x => x.Subject == subject)
+                .Mode.ShouldBe(EndpointMode.NativeAck);
+        }
+    }
+
+    [Fact]
+    public void a_core_nats_endpoint_declares_no_expiring_lease()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.UseNats("nats://localhost:4222");
+                opts.Policies.DisableConventionalLocalRouting();
+                opts.ListenToNatsSubject("core.no.lease");
+            }).Build();
+
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+        var endpoint = options.Transports.AllEndpoints()
+            .OfType<NatsEndpoint>()
+            .Single(x => x.Subject == "core.no.lease");
+
+        endpoint.UseJetStream.ShouldBeFalse();
+
+        // There is no clock on a core NATS delivery, so there is nothing to renew and nothing to assert about
+        endpoint.holdsExpiringLease.ShouldBeFalse();
+    }
+}
+
+/// <summary>
+/// GH-4053. Evidence for the DoubleAck decision in <c>NatsListener.RenewLeasesAsync</c>, taken straight against
+/// the NATS client rather than through Wolverine.
+///
+/// <para>
+/// <c>ISupportLeaseRenewal.RenewLeasesAsync</c> has to return the subset it could NOT renew. A bare
+/// <c>AckProgressAsync</c> cannot ever produce that subset: it publishes to the message's reply subject and
+/// returns, so it succeeds identically whether the consumer is alive or was deleted a minute ago. With
+/// <c>DoubleAck</c> the same call becomes a request the server has to answer, and a lease that no longer exists
+/// surfaces as an exception.
+/// </para>
+/// </summary>
+[Collection("NATS Integration")]
+public class jetstream_ack_progress_semantics
+{
+    private readonly NatsContainerFixture _fixture;
+
+    public jetstream_ack_progress_semantics(NatsContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task double_ack_is_what_makes_a_dead_lease_observable()
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var stream = $"WPI_{suffix}".ToUpperInvariant();
+        var subject = $"wpi.{suffix}";
+        var consumerName = $"wpi-{suffix}";
+
+        var token = TestContext.Current.CancellationToken;
+
+        await using var connection = new NatsConnection(new NatsOpts { Url = _fixture.ConnectionString });
+        await connection.ConnectAsync();
+        var js = connection.CreateJetStreamContext();
+
+        await js.CreateStreamAsync(new StreamConfig(stream, [subject]), token);
+        await js.CreateOrUpdateConsumerAsync(stream, new ConsumerConfig
+        {
+            Name = consumerName,
+            DurableName = consumerName,
+            AckPolicy = ConsumerConfigAckPolicy.Explicit,
+            AckWait = 5.Minutes()
+        }, token);
+
+        await js.PublishAsync(subject, new byte[] { 1, 2, 3 }, cancellationToken: token);
+
+        var consumer = await js.GetConsumerAsync(stream, consumerName, token);
+        var message = await consumer.NextAsync<byte[]>(cancellationToken: token);
+        message.ShouldNotBeNull();
+
+        // While the consumer is alive, a DoubleAck AckProgress round trips cleanly
+        await Should.NotThrowAsync(async () =>
+            await message!.AckProgressAsync(new AckOpts { DoubleAck = true }, token));
+
+        // Now the lease is gone -- there is no consumer to extend AckWait on any more
+        await js.DeleteConsumerAsync(stream, consumerName, token);
+
+        // Fire-and-forget cannot tell. This is the assertion that rules the cheaper option out: it is not a
+        // weaker signal, it is NO signal, and RenewLeasesAsync would report an empty refusal list forever.
+        await Should.NotThrowAsync(async () => await message!.AckProgressAsync(cancellationToken: token));
+
+        // DoubleAck can tell, which is the whole reason NatsListener pays for the round trip
+        await Should.ThrowAsync<Exception>(async () =>
+            await message!.AckProgressAsync(new AckOpts { DoubleAck = true }, token));
+
+        await js.DeleteStreamAsync(stream, token);
+    }
+}

--- a/src/Transports/NATS/Wolverine.Nats/AssemblyAttributes.cs
+++ b/src/Transports/NATS/Wolverine.Nats/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wolverine.Nats.Tests")]

--- a/src/Transports/NATS/Wolverine.Nats/Configuration/NatsListenerConfiguration.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Configuration/NatsListenerConfiguration.cs
@@ -46,6 +46,62 @@ public class NatsListenerConfiguration
     }
 
     /// <summary>
+    /// GH-4053. Override the JetStream consumer's <c>AckWait</c> for this listener -- how long the server waits
+    /// for an unacknowledged delivery before redelivering it. Defaults to the transport-wide
+    /// <c>JetStreamDefaults.AckWait</c> (30 seconds).
+    ///
+    /// <para>
+    /// Under <c>ProcessInParallelWithNativeAcks()</c> this is the lease Wolverine renews with <c>AckProgress</c>
+    /// for as long as an envelope sits in an execution lane, and the renewal tick is half of it. Shortening it
+    /// makes a genuinely dead node's messages come back faster, at the cost of more renewal round trips.
+    /// </para>
+    /// </summary>
+    public NatsListenerConfiguration AckWait(TimeSpan ackWait)
+    {
+        if (ackWait <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ackWait), "Must be greater than zero");
+        }
+
+        add(e => e.AckWait = ackWait);
+        return this;
+    }
+
+    /// <summary>
+    /// GH-4053. The longest a single delivery may be kept alive by <c>AckProgress</c> renewals under
+    /// <c>ProcessInParallelWithNativeAcks()</c>, measured from its receipt. Past this Wolverine stops renewing and
+    /// lets JetStream redeliver, so one wedged handler cannot pin a <c>MaxAckPending</c> slot forever.
+    /// Default 12 hours.
+    /// </summary>
+    public NatsListenerConfiguration MaximumAckExtension(TimeSpan maximum)
+    {
+        add(e => e.MaximumAckExtension = maximum);
+        return this;
+    }
+
+    /// <summary>
+    /// GH-4053. Override the JetStream consumer's <c>MaxAckPending</c> -- the number of deliveries the server
+    /// leaves unacknowledged before it stops delivering. This is JetStream's prefetch equivalent.
+    ///
+    /// <para>
+    /// Under <c>ProcessInParallelWithNativeAcks()</c> it defaults to twice the number of lanes that can be busy at
+    /// once (the <c>PartitionProcessingByGroupId()</c> slot count, otherwise <c>MaximumParallelMessages()</c>), and
+    /// it must cover every one of them: sized lower, the consumer stops delivering while lanes sit idle. Every
+    /// other mode leaves the NATS server default of 1,000 alone.
+    /// </para>
+    /// </summary>
+    public NatsListenerConfiguration MaxAckPending(int maximum)
+    {
+        if (maximum < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximum), "Must be at least 1");
+        }
+
+        add(e => e.MaxAckPending = maximum);
+        return this;
+    }
+
+    /// <summary>
     /// Use a queue group for load balancing (Core NATS only)
     /// </summary>
     public NatsListenerConfiguration UseQueueGroup(string queueGroup)

--- a/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/JetStreamSubscriber.cs
@@ -71,8 +71,18 @@ internal class JetStreamSubscriber : INatsSubscriber
         {
             AckPolicy = ConsumerConfigAckPolicy.Explicit,
             MaxDeliver = _endpoint.EffectiveMaxDeliveryAttempts,
-            AckWait = _endpoint.JetStreamDefaults.AckWait
+            AckWait = _endpoint.EffectiveAckWait
         };
+
+        // GH-4053: MaxAckPending is JetStream's prefetch equivalent, and under NativeAck it is the whole of the
+        // back pressure -- nothing is acked until a handler succeeds, so the unacked window is what bounds the
+        // in-memory execution block. Sized under the number of lanes that can be busy at once, the consumer
+        // stalls itself; see NatsEndpoint.EffectiveMaxAckPending. Null for every other mode, which leaves the
+        // NATS server default of 1,000 exactly where it was.
+        if (_endpoint.EffectiveMaxAckPending is { } maxAckPending)
+        {
+            config.MaxAckPending = maxAckPending;
+        }
 
         // Apply the per-endpoint or transport-wide DeliverPolicy override when set.
         // Leaving the property unset on the ConsumerConfig instance falls through to
@@ -176,9 +186,19 @@ internal class JetStreamSubscriber : INatsSubscriber
                 // duplicate inbox inserts. Measured on the rig as a durable listener freezing for 30s at
                 // a time and ~4,000 duplicate inserts per minute. Buffered/Inline keep the client default:
                 // they ack on receipt, so their in-flight window stays small without help.
-                var consumeOpts = _endpoint.Mode == EndpointMode.Durable
-                    ? new NatsJSConsumeOpts { MaxMsgs = Math.Max(1, _endpoint.MaximumMessagesToReceive) }
-                    : null;
+                //
+                // GH-4053 extends the same reasoning to NativeAck, which needs it more than Durable does: a
+                // NativeAck delivery is unacked for lane queue time PLUS handler time, so a 1,000-message client
+                // pull would park the whole pull window against MaxAckPending. Bounding the pull to the same
+                // number of lanes MaxAckPending is sized for keeps the two consistent.
+                var consumeOpts = _endpoint.Mode switch
+                {
+                    EndpointMode.Durable => new NatsJSConsumeOpts
+                        { MaxMsgs = Math.Max(1, _endpoint.MaximumMessagesToReceive) },
+                    EndpointMode.NativeAck when _endpoint.EffectiveMaxAckPending is { } pending =>
+                        new NatsJSConsumeOpts { MaxMsgs = Math.Max(1, pending) },
+                    _ => null
+                };
 
                 await foreach (
                     var msg in _consumer!.ConsumeAsync<byte[]>(opts: consumeOpts, cancellationToken: consumeToken)

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsEndpoint.cs
@@ -107,6 +107,89 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
     internal int EffectiveMaxDeliveryAttempts => MaxDeliveryAttempts ?? JetStreamDefaults.MaxDeliver;
 
     /// <summary>
+    /// GH-4053. Per-endpoint override for the JetStream consumer's <c>AckWait</c> -- how long the server will
+    /// wait for an unacknowledged delivery before redelivering it. When null the transport-wide
+    /// <see cref="Configuration.JetStreamDefaults.AckWait"/> applies. This is the clock
+    /// <see cref="EndpointMode.NativeAck"/> renews through <c>ISupportLeaseRenewal</c>.
+    /// </summary>
+    public TimeSpan? AckWait { get; set; }
+
+    /// <summary>
+    /// Resolved <c>AckWait</c> for this endpoint: per-endpoint <see cref="AckWait"/> wins over the
+    /// transport-wide <see cref="Configuration.JetStreamDefaults.AckWait"/>.
+    /// </summary>
+    [IgnoreDescription]
+    internal TimeSpan EffectiveAckWait => AckWait ?? JetStreamDefaults.AckWait;
+
+    private TimeSpan _maximumAckExtension = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// GH-4053. The longest a single JetStream delivery is kept alive by <c>AckProgress</c> renewals, measured
+    /// from its receipt, before Wolverine stops renewing and lets the server redeliver. Unlike SQS there is no
+    /// server-side cap on JetStream renewal, so this exists purely as Wolverine's own ceiling on how long one
+    /// unsettled delivery may pin a consumer's <see cref="MaxAckPending"/> slot. Default 12 hours, matching the
+    /// SQS ceiling. Only consulted under <see cref="EndpointMode.NativeAck"/>.
+    /// </summary>
+    public TimeSpan MaximumAckExtension
+    {
+        get => _maximumAckExtension;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaximumAckExtension), "Must be greater than zero");
+            }
+
+            _maximumAckExtension = value;
+        }
+    }
+
+    /// <summary>
+    /// GH-4053. Explicit override for the JetStream consumer's <c>MaxAckPending</c> -- the number of deliveries
+    /// the server will leave unacknowledged before it stops delivering. Null leaves the NATS server default
+    /// (1,000) in place for every mode except <see cref="EndpointMode.NativeAck"/>, which computes its own
+    /// value. See <see cref="EffectiveMaxAckPending"/>.
+    /// </summary>
+    public int? MaxAckPending { get; set; }
+
+    /// <summary>
+    /// GH-4053. Resolved <c>MaxAckPending</c>, or null to leave the server default alone.
+    /// </summary>
+    /// <remarks>
+    /// <c>MaxAckPending</c> is JetStream's prefetch equivalent, and under <see cref="EndpointMode.NativeAck"/>
+    /// it IS the back pressure: nothing is acked until the handler succeeds, so the unacked window is what
+    /// bounds the in-memory execution block. It therefore has to cover every lane that can be busy at once --
+    /// the partition slot count when the endpoint is group-partitioned and <see cref="Endpoint.MaxDegreeOfParallelism"/>
+    /// otherwise, doubled so a lane is never starved waiting on the next delivery. Sized under that, the consumer
+    /// stalls itself: the server stops delivering while lanes sit idle. This mirrors
+    /// <c>RabbitMqQueue.PreFetchCount</c>'s NativeAck arm exactly.
+    /// </remarks>
+    [IgnoreDescription]
+    internal int? EffectiveMaxAckPending
+    {
+        get
+        {
+            if (MaxAckPending.HasValue)
+            {
+                return MaxAckPending.Value;
+            }
+
+            if (Mode != EndpointMode.NativeAck)
+            {
+                // Every other mode settles on receipt (Buffered/Durable) or one at a time (Inline), so the
+                // server default has never been the binding constraint. Don't change what they see.
+                return null;
+            }
+
+            var lanes = GroupShardingSlotNumber.HasValue
+                ? Math.Max((int)GroupShardingSlotNumber.Value, MaxDegreeOfParallelism)
+                : MaxDegreeOfParallelism;
+
+            return lanes * 2;
+        }
+    }
+
+    /// <summary>
     /// Suffix appended to the destination subject to form the NATS JetStream scheduling subject for native
     /// scheduled sends. Must keep the schedule subject covered by the stream (e.g. a <c>prefix.&gt;</c>
     /// filter covers <c>{subject}.scheduled</c>). Defaults to <c>.scheduled</c>.
@@ -159,9 +242,76 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
             EndpointMode.Inline => true,
             EndpointMode.BufferedInMemory => true,
             EndpointMode.Durable => UseJetStream,
+
+            // GH-4053. A deliberate arm rather than a leak: this switch's `_ => false` correctly refused
+            // NativeAck before this issue, so the mode had to be admitted explicitly. JetStream-only, and the
+            // JetStream half of that decision is made in validateModeConfiguration() below rather than here.
+            EndpointMode.NativeAck => true,
             _ => false
         };
     }
+
+    /// <summary>
+    /// GH-4053. JetStream settles each delivery individually (<c>Ack</c> / <c>Nak</c> / <c>AckTerminate</c> off
+    /// <see cref="NatsEnvelope.JetStreamMsg"/>) and does not care what order the acks arrive in, so out-of-order
+    /// settlement from a worker thread is expressible -- which is what <see cref="EndpointMode.NativeAck"/> requires.
+    /// </summary>
+    /// <remarks>
+    /// Answering the JetStream question HERE, in the <see cref="Endpoint.Mode"/> setter's predicate, would make the
+    /// answer depend on the order the user happened to write two fluent calls: <c>UseJetStream()</c> and
+    /// <c>ProcessInParallelWithNativeAcks()</c> are both applied as delayed configuration, so
+    /// <c>.ProcessInParallelWithNativeAcks().UseJetStream("X")</c> would be refused while
+    /// <c>.UseJetStream("X").ProcessInParallelWithNativeAcks()</c> was accepted -- for identical configurations.
+    /// GH-4047's <see cref="validateModeConfiguration"/> exists for exactly this shape of question and runs over
+    /// the FINAL state after <see cref="Endpoint.Compile"/>, so core NATS is refused deterministically and with a
+    /// message that says why. Azure Service Bus resolved the same ordering problem the same way for
+    /// <c>RequireSessions()</c> in GH-4049.
+    /// </remarks>
+    protected override bool supportsNativeAck => true;
+
+    /// <summary>
+    /// GH-4053. Native acks are JetStream-only. Core NATS has no redelivery-on-unacked semantics at all -- a core
+    /// subscription is fire-and-forget, there is nothing to leave unsettled and nothing to hand back -- so the
+    /// crash-safety story the mode exists to provide does not exist there. A core NATS "native ack" endpoint would
+    /// be BufferedInMemory with extra steps and a false no-loss promise, which is worse than refusing it.
+    /// </summary>
+    protected internal override IEnumerable<string> validateModeConfiguration()
+    {
+        if (Mode != EndpointMode.NativeAck) yield break;
+
+        if (!UseJetStream)
+        {
+            yield return
+                $"Invalid listener configuration for endpoint '{Uri}': ProcessInParallelWithNativeAcks() requires JetStream. " +
+                "Core NATS delivers a message once and forgets it -- there is no unacknowledged delivery to hold and no " +
+                "redelivery when a node dies mid-flight -- so EndpointMode.NativeAck cannot deliver the no-loss guarantee " +
+                "it promises. Add UseJetStream(...) to this listener, or use BufferedInMemory()/ProcessInline() on core NATS.";
+
+            yield break;
+        }
+
+        if (!_transport.Configuration.EnableJetStream)
+        {
+            yield return
+                $"Invalid listener configuration for endpoint '{Uri}': ProcessInParallelWithNativeAcks() requires JetStream, " +
+                "but JetStream has been disabled transport-wide, so this listener falls back to core NATS and would settle " +
+                "nothing. Re-enable JetStream on the transport, or drop ProcessInParallelWithNativeAcks() from this listener.";
+        }
+    }
+
+    /// <summary>
+    /// GH-4048/GH-4053. A JetStream delivery is only unacknowledged for <see cref="EffectiveAckWait"/> before the
+    /// server redelivers it, so a NativeAck endpoint here has to renew that clock for as long as the envelope sits
+    /// in an execution lane. <see cref="NatsListener"/> supplies the renewal through <c>ISupportLeaseRenewal</c>,
+    /// and <c>ListeningAgent</c> refuses to start a NativeAck listener that does not.
+    ///
+    /// <para>
+    /// False for core NATS, where an un-acked message simply does not exist as a concept -- there is no clock and
+    /// nothing to renew. That combination is refused outright by <see cref="validateModeConfiguration"/> anyway;
+    /// this keeps the two answers consistent rather than asserting a lease core NATS does not have.
+    /// </para>
+    /// </summary>
+    protected internal override bool holdsExpiringLease => UseJetStream;
 
     protected override ISender CreateSender(IWolverineRuntime runtime)
     {
@@ -499,10 +649,17 @@ public class NatsEndpoint : Endpoint, IBrokerEndpoint
                 DurableName = ConsumerName,
                 FilterSubject = Subject,
                 AckPolicy = ConsumerConfigAckPolicy.Explicit,
-                AckWait = JetStreamDefaults.AckWait,
+                AckWait = EffectiveAckWait,
                 MaxDeliver = EffectiveMaxDeliveryAttempts,
                 ReplayPolicy = ConsumerConfigReplayPolicy.Instant
             };
+
+            // GH-4053: JetStream's prefetch equivalent, and under NativeAck the only thing bounding the
+            // unacked window. Left unset (server default 1,000) for every other mode.
+            if (EffectiveMaxAckPending is { } maxAckPending)
+            {
+                consumerConfig.MaxAckPending = maxAckPending;
+            }
 
             await js.CreateOrUpdateConsumerAsync(StreamName, consumerConfig);
             logger.LogInformation(

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsListener.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsListener.cs
@@ -8,7 +8,7 @@ using Wolverine.Transports.Sending;
 
 namespace Wolverine.Nats.Internal;
 
-public class NatsListener : IListener, ISupportDeadLetterQueue, IReportConnectionState
+public class NatsListener : IListener, ISupportDeadLetterQueue, IReportConnectionState, ISupportLeaseRenewal
 {
     private readonly NatsEndpoint _endpoint;
     private readonly IWolverineRuntime _runtime;
@@ -152,6 +152,126 @@ public class NatsListener : IListener, ISupportDeadLetterQueue, IReportConnectio
         if (envelope is NatsEnvelope natsEnvelope)
         {
             await _defer.PostAsync(natsEnvelope);
+        }
+    }
+
+    /// <summary>
+    /// GH-4048/GH-4053. The JetStream consumer's <c>AckWait</c>: how long the server leaves one delivery
+    /// unacknowledged before redelivering it. Every successful <c>AckProgress</c> re-arms it for exactly this
+    /// long again, which is the contract <c>LeaseRenewalTracker</c> assumes.
+    /// </summary>
+    public TimeSpan LeaseDuration => _endpoint.EffectiveAckWait;
+
+    public TimeSpan MaximumLeaseExtension => _endpoint.MaximumAckExtension;
+
+    /// <summary>
+    /// GH-4053. Re-arm <c>AckWait</c> on deliveries that are still sitting in a native-ack execution lane, by
+    /// sending JetStream's <c>AckProgress</c> (<c>+WPI</c>) for each one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Every renewal is a DoubleAck.</b> A bare <c>AckProgressAsync</c> is fire-and-forget -- it publishes to
+    /// the message's <c>$JS.ACK.*</c> reply subject and returns without waiting for the server -- so it can
+    /// neither fail nor report which messages the server refused. That is not merely a weaker signal, it defeats
+    /// BOTH of the tracker's loss detectors at once: <c>RenewLeasesAsync</c> would return an empty refusal list
+    /// on every tick, and because it also never threw, <c>LeaseRenewalTracker</c> would stamp <c>LastRenewedAt</c>
+    /// on every envelope every tick, so its inferred-loss detector ("no renewal has succeeded for a full lease
+    /// duration") could never fire either. A NativeAck endpoint would then hold envelopes in lanes with no
+    /// working lease at all -- exactly the silent duplicate generator GH-4048 exists to prevent. <c>DoubleAck</c>
+    /// turns the publish into a request/reply the server answers, so a dead connection or a deleted
+    /// stream/consumer surfaces as an exception per message.
+    /// </para>
+    /// <para>
+    /// The cost is one round trip per unsettled envelope per tick (tick = <c>AckWait</c>/2), and JetStream has no
+    /// batch ack API to amortize it. That is affordable precisely because this mode bounds the unacked window with
+    /// <c>MaxAckPending</c> (see <see cref="NatsEndpoint.EffectiveMaxAckPending" />): the renewal fan-out is
+    /// twice the lane count, not the pull batch size. Renewals are issued concurrently so one slow reply cannot
+    /// push a tick past its interval.
+    /// </para>
+    /// <para>
+    /// <b>What this cannot detect:</b> JetStream has no negative reply for "you are too late". If <c>AckWait</c>
+    /// has already expired and the message was redelivered, the server still accepts and answers the
+    /// <c>AckProgress</c> for the stale delivery attempt. That case is covered by
+    /// <see cref="MaximumLeaseExtension" /> and by the tracker's inferred-loss detector rather than here, which
+    /// is why the ceiling matters on this transport.
+    /// </para>
+    /// </remarks>
+    public async ValueTask<IReadOnlyList<Envelope>> RenewLeasesAsync(IReadOnlyList<Envelope> envelopes,
+        CancellationToken token)
+    {
+        // Only JetStream deliveries have a clock. A core NATS envelope has no INatsJSMsg and nothing to renew --
+        // NatsEndpoint refuses that combination at bootstrap, so this is belt and braces.
+        var candidates = envelopes
+            .OfType<NatsEnvelope>()
+            .Where(x => x.JetStreamMsg != null)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return [];
+        }
+
+        if (_subscriber.ConnectionState == TransportConnectionState.Disconnected)
+        {
+            // Transient by contract, and cheaper to say up front than to fan out N doomed requests and wait for
+            // each to time out. The tracker retries on the next tick and infers loss if this persists past a
+            // full AckWait.
+            throw new InvalidOperationException(
+                $"The NATS connection for {Address} is disconnected, so no JetStream lease could be renewed");
+        }
+
+        // Bound a tick: NATS's own request timeout defaults to 5s, which can exceed the tick interval on a short
+        // AckWait. A quarter of the lease leaves the tracker room to run its inferred-loss pass in the same tick.
+        var budget = TimeSpan.FromTicks(Math.Max(TimeSpan.FromSeconds(1).Ticks, LeaseDuration.Ticks / 4));
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(token);
+        timeout.CancelAfter(budget);
+
+        var results = await Task.WhenAll(candidates.Select(e => renewOneAsync(e, timeout.Token)));
+
+        var failed = new List<Envelope>();
+        for (var i = 0; i < candidates.Length; i++)
+        {
+            if (!results[i])
+            {
+                failed.Add(candidates[i]);
+            }
+        }
+
+        if (failed.Count == candidates.Length)
+        {
+            // Every single renewal failing is the signature of a connection- or consumer-level fault, not of N
+            // independently lost leases. Report it as transient: keeping the envelopes is the conservative
+            // choice (a deleted consumer redelivers nothing, so dropping them would lose messages outright),
+            // and the tracker's inferred-loss detector still marks them lost a full AckWait later if it
+            // really is permanent.
+            throw new InvalidOperationException(
+                $"Could not renew the JetStream lease on any of {candidates.Length} in-flight envelopes at {Address}");
+        }
+
+        // A PARTIAL failure is per-message, so report it as a lost lease. Erring this way is deliberate: a
+        // false "lost" costs one redelivery after AckWait (the envelope is dropped from its lane unsettled,
+        // never lost), while a false "renewed" is a handler running twice.
+        return failed;
+    }
+
+    /// <summary>
+    /// One <c>AckProgress</c>, returning false when the server would not answer it. Failures are logged at Debug
+    /// and never rethrown from here -- <see cref="RenewLeasesAsync"/> owns the transient-vs-lost decision, and it
+    /// needs to see the whole tick's outcome to make it.
+    /// </summary>
+    private async Task<bool> renewOneAsync(NatsEnvelope envelope, CancellationToken token)
+    {
+        try
+        {
+            await envelope.JetStreamMsg!.AckProgressAsync(new AckOpts { DoubleAck = true }, token);
+            return true;
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e,
+                "JetStream would not extend the AckWait on envelope {EnvelopeId} at {Uri}; no longer keeping it alive",
+                envelope.Id, Address);
+            return false;
         }
     }
 

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_mode.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_mode.cs
@@ -16,7 +16,14 @@ public record NativeAckWork(int Number);
 
 public static class NativeAckWorkTracking
 {
-    public static readonly ConcurrentBag<int> Handled = new();
+    /// <summary>
+    /// GH-4050. Records (node, message number), NOT just the number. Attribution is load-bearing for the
+    /// dead-node test: the Block gate below is static and process-wide, so releasing it unparks the DEAD host's
+    /// handlers too. They then complete in-process and record. A bag of bare numbers is therefore satisfied by
+    /// the dead node's own tasks unwinding, whether or not the broker redelivered anything to the new node --
+    /// which is precisely the thing the test exists to prove.
+    /// </summary>
+    public static readonly ConcurrentBag<(string Node, int Number)> Handled = new();
 
     /// <summary>When set, handlers park here forever -- standing in for a node that dies mid-flight.</summary>
     public static TaskCompletionSource? Block;
@@ -30,14 +37,14 @@ public static class NativeAckWorkTracking
 
 public class NativeAckWorkHandler
 {
-    public async Task Handle(NativeAckWork message)
+    public async Task Handle(NativeAckWork message, IWolverineRuntime runtime)
     {
         if (NativeAckWorkTracking.Block != null)
         {
             await NativeAckWorkTracking.Block.Task;
         }
 
-        NativeAckWorkTracking.Handled.Add(message.Number);
+        NativeAckWorkTracking.Handled.Add((runtime.Options.ServiceName, message.Number));
     }
 }
 
@@ -68,11 +75,12 @@ public class native_ack_mode : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    private static Task<IHost> startHostAsync(string queueName)
+    private static Task<IHost> startHostAsync(string queueName, string nodeName = "node")
     {
         return Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
+                opts.ServiceName = nodeName;
                 opts.UseRabbitMq("host=localhost;port=5672").AutoProvision();
 
                 opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeAckWorkHandler>();
@@ -128,7 +136,7 @@ public class native_ack_mode : IAsyncLifetime
     {
         NativeAckWorkTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var firstHost = await startHostAsync(RedeliveryQueue);
+        var firstHost = await startHostAsync(RedeliveryQueue, "dead-node");
         var bus = firstHost.MessageBus();
 
         for (var i = 0; i < 5; i++)
@@ -152,21 +160,35 @@ public class native_ack_mode : IAsyncLifetime
         NativeAckWorkTracking.Block!.TrySetResult();
         NativeAckWorkTracking.Block = null;
 
-        using var secondHost = await startHostAsync(RedeliveryQueue);
+        using var secondHost = await startHostAsync(RedeliveryQueue, "fresh-node");
 
         deadline = DateTimeOffset.UtcNow.AddSeconds(30);
-        while (handledInRange(100, 5).Count() < 5 && DateTimeOffset.UtcNow < deadline)
+        while (handledByNode("fresh-node", 100, 5).Count() < 5 && DateTimeOffset.UtcNow < deadline)
         {
             await Task.Delay(50, TestContext.Current.CancellationToken);
         }
 
-        handledInRange(100, 5).ShouldBe(Enumerable.Range(100, 5));
+        // Asserted against the FRESH node specifically. Counting bare message numbers here would be satisfied by
+        // the dead node's own parked handlers unwinding when the static gate was released above -- which proves
+        // nothing about redelivery, the single thing this test exists to establish.
+        handledByNode("fresh-node", 100, 5).ShouldBe(Enumerable.Range(100, 5));
     }
 
     private static IEnumerable<int> handledInRange(int start, int count)
     {
         return NativeAckWorkTracking.Handled
+            .Select(x => x.Number)
             .Where(x => x >= start && x < start + count)
+            .Distinct()
+            .OrderBy(x => x);
+    }
+
+    /// <summary>Messages in the range handled specifically BY the named node.</summary>
+    private static IEnumerable<int> handledByNode(string node, int start, int count)
+    {
+        return NativeAckWorkTracking.Handled
+            .Where(x => x.Node == node && x.Number >= start && x.Number < start + count)
+            .Select(x => x.Number)
             .Distinct()
             .OrderBy(x => x);
     }


### PR DESCRIPTION
Batched deliberately rather than split into five PRs, because the GitHub Actions queue is backed up today. Closes #4050, #4051, #4053 and #4087.

Every branch was developed and verified independently, then merged here and **re-verified on the merged result** — four green branches are not the same as a green combination, which is the assumption that produced the #4061/#4056 stale-base regression earlier in this cycle.

## What is in it

| Issue | Transport | Branch |
| --- | --- | --- |
| #4050 | Amazon SQS adopts `EndpointMode.NativeAck` | `gh-4050/native-ack-sqs` |
| #4051 | Azure Service Bus adopts it | `gh-4051/native-ack-asb` |
| #4053 | NATS JetStream adopts it | `gh-4053/native-ack-jetstream` |
| #4087 | `PubsubTopicOptions.OrderBy` gets a configuration surface | `gh-4087/pubsub-orderby` |
| — | RabbitMQ dead-node test gains node attribution | `gh-4050/rabbit-dead-node-attribution` |

**No changes under `src/Wolverine/`.** Every hook these needed — `supportsNativeAck`, `holdsExpiringLease`, `validateModeConfiguration`, `ISupportLeaseRenewal` — already existed from #4032, #4048 and #4057. Each transport stayed inside its own directory, which is why four of the five merges were clean.

## Findings worth a reviewer's attention

**SQS refuses FIFO queues, for two independent reasons.** Without partitioning, one FIFO receive can return several messages of a group in order, and the execution block then runs them concurrently — the queue keeps its guarantee right up to the moment Wolverine takes delivery, then discards it. With partitioning, the two schemes stack badly: SQS will not deliver more of a group while any of it is in flight, and here "in flight" includes unbounded lane queue time, so unrelated groups hashing into the same slot stall a group at the broker. **NativeAck is the only Wolverine mode that converts its own lane depth into broker-side group stalls** — Buffered and Durable delete before the handler runs, and Inline holds one message per handler. Rejected at configuration time rather than left to be discovered.

**JetStream pairs `AckProgressAsync` with `DoubleAck`, and it is load-bearing.** Without it there is no failure signal at all, and it breaks *both* of `LeaseRenewalTracker`'s detectors at once: `RenewLeasesAsync` could only ever return an empty refusal list, and since the fire-and-forget call never throws, the tracker would stamp `LastRenewedAt` every tick so inferred-loss could never fire either. The endpoint would hold envelopes in lanes with no working lease. Proved empirically — `double_ack_is_what_makes_a_dead_lease_observable` deletes a consumer and shows the bare call still succeeding while the DoubleAck form throws.

**JetStream deviates from its issue's literal wording, deliberately.** #4053 said to gate `supportsNativeAck` on JetStream. That would make acceptance depend on fluent-call order, because `UseJetStream()` and `ProcessInParallelWithNativeAcks()` are both delayed configuration — confirmed by red baseline, not assumption: with the gate on `supportsNativeAck`, `.ProcessInParallelWithNativeAcks().UseJetStream(...)` throws while the reverse order works, for identical config. It uses `validateModeConfiguration()` instead, matching the #4047 hook's purpose and ASB's `RequireSessions()` precedent. Core NATS is still refused, deterministically and with a better message.

**ASB declares the mode separately on queue and subscription**, not on the shared base, so `AzureServiceBusTopic` cannot inherit it. It also deliberately gives `MaximumConcurrentCalls` no mode default — that setting only reaches a processor, so a default there would be inert config that reads as meaningful.

**`Nats-Msg-Id` does not replace the in-memory idempotency guard.** Investigated per #4053: that dedup window is *publish-side*, and a redelivery is not a publish — the message was already accepted into the stream, so the window is never consulted again. Redelivery is exactly what this mode generates by design. `WithInMemoryIdempotency()` (#3710) remains the answer on JetStream.

## On the tests

**Two of the three dead-node tests were vacuous on first draft**, and both agents caught their own. The tracking bag is process-wide, so releasing the shared gate unparks the *disposed* host's handlers, which then record in-process and satisfy "the messages came back" with zero redelivery. Both now attribute every observation to the host that produced it.

The RabbitMQ counterpart was checked for the same hole and **did not have it** — switching that endpoint to `BufferedInMemory` makes even the original number-only assertion fail, so disposal does stop those handlers recording. Its attribution change is kept anyway, as robustness rather than a fix: it makes the claim explicit and removes an unpinned dependency on host-disposal semantics that would go vacuous silently if it ever changed. The commit message records the refutation.

Red baselines across the batch: SQS 4, ASB 5, JetStream 6, Pub/Sub 4 — each break confirmed to fail the specific test claiming that behaviour, with the others still green.

## Verification

On the **merged** branch:

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings, 0 errors
- CoreTests — **2636 total, 0 failed**, 2 skipped (identical to `main` at `a3c8339f2`)

Per branch, before merging: SQS suite 338/0 plus SNS 127/0; ASB suite 350/0 uncontended; NATS suite 163/163; Pub/Sub suite 207/0.

One correction to a per-branch report: the JetStream branch reported CoreTests as "200 failed, matching an origin/main baseline". That is wrong — `main` is 2636/0, verified directly, as is this branch. Its stash-and-compare control shared whatever contaminated its environment, so the comparison could not reveal it. Its NATS suite result against a real broker is unaffected.

## Follow-ups filed, not fixed here

- **#4091** — `NativeAckReceiver` tracks a delivered batch one envelope at a time, so the rest sit untracked with leases running while the block is full. Core-level; affects SQS and ASB identically.
- On NATS, a publisher and listener for the same subject resolve to one endpoint, so `SendInline()` silently downgrades a native-ack listener. Documented on the transport page rather than changed — the general form is #4059, which is a known limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)