### PR TITLE
GH-3713: five-node webhook-flood chaos reproduction, and the duplicate rate it measured

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1121,8 +1121,10 @@ partial class Build
     /// A reproduction nothing runs is a reproduction that rots, and GH-3781 is exactly what it caught
     /// the moment anyone did run it: a Balanced-mode host that would not finish <c>StopAsync</c>.
     ///
-    /// <para>Postgres is the only infrastructure the project needs — the SqlServer and Kafka project
-    /// references are transitive, and nothing here opens either.</para>
+    /// <para>Postgres and RabbitMQ are the infrastructure the project needs — the SqlServer and Kafka
+    /// project references are transitive, and nothing here opens either. RabbitMQ arrived with GH-3713's
+    /// five-node webhook flood, whose message path is the broker and whose Postgres usage is node
+    /// coordination only.</para>
     ///
     /// <para>This is deliberately one unsharded job to begin with: the point is to <i>measure</i> what
     /// the suite costs on a hosted runner, against the same 20 minute cap every other job answers to.
@@ -1137,9 +1139,12 @@ partial class Build
 
             // The agent scale classes are wall-clock bound, so overlap the container boot with the
             // compile rather than paying them serially.
-            LaunchDockerServices("postgresql");
+            //
+            // RabbitMQ joined the list with GH-3713's webhook flood reproduction: its message path is the
+            // broker, and Postgres is there only as the cluster's node registry.
+            LaunchDockerServices("postgresql", "rabbitmq");
             BuildTestProjects(slowTests);
-            AwaitDockerServices("postgresql");
+            AwaitDockerServices("postgresql", "rabbitmq");
 
             RunTestProject(slowTests);
         });

--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -135,12 +135,14 @@ Three consequences follow from never acking at receipt, and all three are the po
   `MaximumParallelMessages` — doubled so a lane never starves.
 * **A dying node loses nothing.** Anything queued but not yet completed is still unacknowledged, so closing
   the channel or crashing hands every one of those deliveries back to the broker.
-* **Shutdown trades duplicates for safety.** Graceful drain processes what it can within the drain timeout;
-  whatever it cannot is simply never settled and gets redelivered. A rolling deploy therefore produces
-  duplicate deliveries bounded by the prefetch depth. Your handlers should already be idempotent under
-  at-least-once delivery, but it is worth knowing the number is not zero. The
-  [in-memory idempotency guard](#in-memory-idempotency-guard) below takes the edge off that for a *running*
-  process.
+* **Shutdown redelivers, but redelivery is not the same as duplicate execution.** Graceful drain finishes the
+  handlers already running and settles them; whatever it never started is simply not settled, and the broker
+  redelivers it. Those redeliveries are bounded by the prefetch window — but almost all of them are messages
+  that had not run yet, so they execute for the *first* time, and your handler cannot tell them from any other
+  first delivery. A **duplicate execution** — the same message running twice — needs something narrower: a
+  handler that finished while its acknowledgement was in flight, on a connection that died before the ack
+  landed. See [What a redeployment actually costs](#what-a-redeployment-actually-costs) for the measured
+  numbers.
 
 **Transport support is opt-in and default-closed.** A transport must settle each delivery individually *and*
 tolerate settling out of order, because the execution block completes messages in handler-completion order
@@ -153,6 +155,41 @@ A transport may also refuse the mode for a *particular* endpoint whose own setti
 bootstrap rather than at runtime. Pulsar is the example: its acknowledgment strategy is configurable, and
 `AcknowledgeCumulative()` reintroduces exactly the gap-less-commit problem that disqualifies Kafka, so that
 one combination is rejected by name.
+
+### What a redeployment actually costs
+
+Earlier versions of this page said a rolling deploy produced "duplicate deliveries bounded by the prefetch
+depth." That was honest reasoning, but it was never measured, and measuring it showed the figure is the wrong
+one to quote: it is the bound on *redeliveries*, and it overstates handler-visible duplicates by more than an
+order of magnitude.
+
+The numbers below come from `webhook_flood_native_ack_chaos` in `SlowTests` — a five node cluster,
+group-partitioned across five RabbitMQ slots, under a sustained flood, with the broker's own
+`messages_unacknowledged` read at the moment of each disruption:
+
+| Scenario | Unacked at disruption | Duplicate executions | Rate |
+| --- | --- | --- | --- |
+| Steady state, no disruption | 0 | 0 | 0% |
+| Rolling deploy, all 5 nodes drained and replaced | 180 | **0** | 0% |
+| One node killed outright mid-flood | 180 | **4** | 0.100% |
+| Two hard kills plus two rolling replacements | 180 | **8** | 0.050% |
+
+Two things follow, and both matter more than the headline percentage:
+
+* **A graceful rolling deploy costs zero duplicate executions.** Draining settles the handlers that were
+  already running, so nothing runs twice. The prefetch window is still redelivered — it simply had not been
+  executed yet, so those are first executions.
+* **A hard kill costs about one duplicate per busy lane, not one per unacked message.** Only handlers that
+  were *mid-flight* when the connection died can run twice, and that population is the partition slot count,
+  not the prefetch depth. In the runs above that was 4 per killed node against an unacked window of 180 — a
+  factor of roughly 45.
+
+None of this weakens the guarantee. Every duplicate still enters its group's sequential lane, so a duplicate
+never runs concurrently with the original, and the intra-group concurrency invariant held across every kill
+and every handoff in all of the runs above. Handlers must still be idempotent — at-least-once is the contract,
+and 0.1% of a flood is not a small number of messages — but size that work against in-flight lanes rather than
+against prefetch. The [in-memory idempotency guard](#in-memory-idempotency-guard) below removes the remainder
+within a *running* process; it cannot help across a node's death, because the guard dies with it.
 
 ## In-Memory Idempotency Guard <Badge type="tip" text="6.30" />
 

--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -164,15 +164,16 @@ one to quote: it is the bound on *redeliveries*, and it overstates handler-visib
 order of magnitude.
 
 The numbers below come from `webhook_flood_native_ack_chaos` in `SlowTests` — a five node cluster,
-group-partitioned across five RabbitMQ slots, under a sustained flood, with the broker's own
-`messages_unacknowledged` read at the moment of each disruption:
+group-partitioned across five RabbitMQ slots, under a sustained flood deep enough that the broker was holding
+a full unacked window at every disruption, with the broker's own `messages_unacknowledged` read at that
+instant. The ranges are across four consecutive runs:
 
 | Scenario | Unacked at disruption | Duplicate executions | Rate |
 | --- | --- | --- | --- |
-| Steady state, no disruption | 0 | 0 | 0% |
+| Steady state, no disruption | 0 | **0** | 0% |
 | Rolling deploy, all 5 nodes drained and replaced | 180 | **0** | 0% |
-| One node killed outright mid-flood | 180 | **4** | 0.100% |
-| Two hard kills plus two rolling replacements | 180 | **8** | 0.050% |
+| One node killed outright mid-flood | 180 | **3–4** | ~0.1% |
+| Two hard kills plus two rolling replacements | 180 | **7–9** | ~0.05% |
 
 Two things follow, and both matter more than the headline percentage:
 
@@ -181,8 +182,8 @@ Two things follow, and both matter more than the headline percentage:
   executed yet, so those are first executions.
 * **A hard kill costs about one duplicate per busy lane, not one per unacked message.** Only handlers that
   were *mid-flight* when the connection died can run twice, and that population is the partition slot count,
-  not the prefetch depth. In the runs above that was 4 per killed node against an unacked window of 180 — a
-  factor of roughly 45.
+  not the prefetch depth. In the runs above that was three or four per killed node against an unacked window
+  of 180 — a factor of roughly 45, and it barely moved between runs.
 
 None of this weakens the guarantee. Every duplicate still enters its group's sequential lane, so a duplicate
 never runs concurrently with the original, and the intra-group concurrency invariant held across every kill

--- a/src/Testing/SlowTests/Partitioning/DuplicateExecutionReport.cs
+++ b/src/Testing/SlowTests/Partitioning/DuplicateExecutionReport.cs
@@ -1,0 +1,92 @@
+using JasperFx.Core;
+using Wolverine.ComplianceTests.Partitioning;
+
+namespace SlowTests.Partitioning;
+
+/// <summary>
+/// GH-3713. The measurement this reproduction exists to produce: how many times a webhook event that the
+/// cluster had <i>already executed</i> got executed again, in steady state, across a hard node kill, and
+/// across a rolling deploy.
+/// </summary>
+/// <remarks>
+/// <para><b>Duplicate execution, not duplicate delivery.</b> These are not the same quantity and the
+/// difference is the whole point of the measurement. An unacked delivery that a dying node never got around
+/// to running is redelivered and then runs for the <i>first</i> time -- a duplicate delivery in the broker's
+/// accounting, but not a duplicate execution, and nothing a user's handler can tell apart from a normal
+/// first delivery. A duplicate <i>execution</i> only happens when the handler completed and the ack did not
+/// reach the broker, which is a strictly smaller set. Handler-visible at-least-once behaviour is the second
+/// quantity, so that is the one reported here.</para>
+///
+/// <para>Both are compared against the prefetch window, which is what
+/// <c>docs/guide/messaging/listeners.md</c> names as the bound.</para>
+/// </remarks>
+internal sealed record DuplicateExecutionReport(
+    string Phase,
+    int Published,
+    int DistinctExecuted,
+    int TotalExecutions,
+    int DuplicateExecutions,
+    int PrefetchPerSlot,
+    int SlotCount,
+    int DisruptedNodes,
+    int PeakBacklog,
+    int UnackedAtDisruption)
+{
+    /// <summary>
+    /// Duplicate executions as a percentage of the events that were executed at all.
+    /// </summary>
+    public double DuplicateRatePercent =>
+        DistinctExecuted == 0 ? 0 : 100.0 * DuplicateExecutions / DistinctExecuted;
+
+    /// <summary>
+    /// The bound the documentation currently claims, read as generously as it can honestly be read: every
+    /// slot that changed hands could have had its whole prefetch window unacked at that instant.
+    /// </summary>
+    public int DocumentedPrefetchBound => PrefetchPerSlot * Math.Max(1, DisruptedNodes) * SlotCount;
+
+    /// <summary>
+    /// Read the ledger and compute the report. <paramref name="disruptedNodes" /> is how many nodes went away
+    /// during the phase -- zero for a steady-state run, which the bound treats as one so that the comparison
+    /// is still meaningful rather than zero.
+    /// </summary>
+    public static DuplicateExecutionReport From(string phase,
+        IReadOnlyCollection<(string GroupId, int Sequence)> published, int prefetchPerSlot, int slotCount,
+        int disruptedNodes, int peakBacklog, int unackedAtDisruption)
+    {
+        var handled = NativeAckPartitionedProcessing.Ledger.Handled;
+        var distinct = handled.Select(x => (x.GroupId, x.Sequence)).Distinct().Count();
+
+        return new DuplicateExecutionReport(phase, published.Count, distinct, handled.Count,
+            handled.Count - distinct, prefetchPerSlot, slotCount, disruptedNodes, peakBacklog,
+            unackedAtDisruption);
+    }
+
+    /// <summary>
+    /// A single grep-able block, because the number is the deliverable and it has to survive being read out
+    /// of a CI log rather than out of a debugger.
+    /// </summary>
+    public string Describe()
+    {
+        var lines = new List<string>
+        {
+            "",
+            "=== GH-3713 DUPLICATE EXECUTION REPORT ===============================",
+            $"  phase                      : {Phase}",
+            $"  nodes disrupted            : {DisruptedNodes}",
+            $"  slots x prefetch per slot  : {SlotCount} x {PrefetchPerSlot}",
+            $"  published (accepted)       : {Published}",
+            $"  peak broker backlog        : {PeakBacklog}   (proves the flood saturated)",
+            $"  broker unacked at chaos    : {UnackedAtDisruption}   (the prefetch window the docs bound by)",
+            $"  distinct events executed   : {DistinctExecuted}",
+            $"  total handler executions   : {TotalExecutions}",
+            $"  DUPLICATE EXECUTIONS       : {DuplicateExecutions}",
+            $"  DUPLICATE RATE             : {DuplicateRatePercent:F3}%",
+            $"  documented prefetch bound  : {DocumentedPrefetchBound}",
+            $"  within documented bound    : {(DuplicateExecutions <= DocumentedPrefetchBound ? "yes" : "NO")}",
+            "====================================================================",
+            ""
+        };
+
+        return lines.Join(Environment.NewLine);
+    }
+}

--- a/src/Testing/SlowTests/Partitioning/RabbitBrokerProbe.cs
+++ b/src/Testing/SlowTests/Partitioning/RabbitBrokerProbe.cs
@@ -1,0 +1,141 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace SlowTests.Partitioning;
+
+/// <summary>
+/// GH-3713. Reads the broker's own view of the slot queues through the RabbitMQ management API.
+/// </summary>
+/// <remarks>
+/// <para>The documentation's duplicate claim is stated in terms of the <b>prefetch depth</b> -- the unacked
+/// window. That is a broker-side quantity, and nothing inside Wolverine reports it: an unacknowledged delivery
+/// that no handler has started yet is by construction invisible to the handler. So the only way to compare a
+/// measured duplicate rate against the claimed bound honestly is to ask the broker.</para>
+///
+/// <para><c>messages_unacknowledged</c> is the number of deliveries the broker has handed out and is still
+/// waiting to be settled -- exactly the population that gets requeued when a node dies.
+/// <c>messages_ready</c> is the backlog nobody has been given yet, which is what proves the flood was
+/// actually a flood rather than a trickle the cluster kept up with.</para>
+///
+/// <para>The management plugin is part of the <c>rabbitmq:4-management</c> image the repo's compose file
+/// pins, so this works in CI on the same container the tests already require. A probe that cannot reach the
+/// API returns nulls rather than throwing -- a broken measurement must not fail an invariant test.</para>
+/// </remarks>
+internal sealed class RabbitBrokerProbe : IDisposable
+{
+    private readonly HttpClient _client;
+    private readonly string[] _queueNames;
+
+    public RabbitBrokerProbe(string baseName, int slotCount, string host = "localhost", int managementPort = 15672)
+    {
+        _queueNames = Enumerable.Range(1, slotCount).Select(i => $"{baseName}{i}").ToArray();
+
+        _client = new HttpClient { BaseAddress = new Uri($"http://{host}:{managementPort}/") };
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes("guest:guest")));
+        _client.Timeout = TimeSpan.FromSeconds(5);
+    }
+
+    public void Dispose() => _client.Dispose();
+
+    /// <summary>
+    /// A point-in-time reading across every slot queue. Null when the broker could not be reached.
+    /// </summary>
+    public async Task<BrokerReading?> ReadAsync(CancellationToken token = default)
+    {
+        var ready = 0;
+        var unacked = 0;
+
+        foreach (var queue in _queueNames)
+        {
+            try
+            {
+                using var response = await _client.GetAsync($"api/queues/%2F/{queue}", token);
+                if (!response.IsSuccessStatusCode) return null;
+
+                using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(token));
+
+                ready += readInt(document.RootElement, "messages_ready");
+                unacked += readInt(document.RootElement, "messages_unacknowledged");
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        return new BrokerReading(ready, unacked);
+    }
+
+    private static int readInt(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.TryGetInt32(out var number) ? number : 0;
+
+    /// <summary>
+    /// Force the broker to drop every connection whose client-provided name is
+    /// <paramref name="clientName" />, and report how many it dropped.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>This is what makes a hard kill hard.</b> Disposing the <c>IHost</c> is not a kill:
+    /// <c>WolverineRuntime</c>'s <c>DisposeAsync</c> calls <c>StopAsync</c> when the runtime has not already
+    /// stopped, so the listeners <i>drain</i> -- in-flight handlers finish and their acks go out. A node that
+    /// shut itself down tidily is a rolling deploy, not a crash, and measuring one while calling it the other
+    /// is how a suite ends up reporting a number that is true of a scenario nobody asked about.</para>
+    ///
+    /// <para>Closing the connection from the broker side is the real thing. Every unacknowledged delivery on
+    /// it is requeued immediately, and a handler that was mid-flight completes into a channel that no longer
+    /// exists -- so its work happened but its acknowledgement never lands. That is precisely the situation a
+    /// duplicate execution comes from, and nothing short of it produces one.</para>
+    /// </remarks>
+    public async Task<int> ForceCloseConnectionsAsync(string clientName, CancellationToken token = default)
+    {
+        var closed = 0;
+
+        try
+        {
+            using var response = await _client.GetAsync("api/connections", token);
+            if (!response.IsSuccessStatusCode) return 0;
+
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(token));
+
+            foreach (var connection in document.RootElement.EnumerateArray())
+            {
+                if (!connection.TryGetProperty("client_properties", out var properties)) continue;
+                if (!properties.TryGetProperty("connection_name", out var name)) continue;
+                if (name.GetString() != clientName) continue;
+
+                var id = connection.GetProperty("name").GetString();
+                if (id is null) continue;
+
+                using var delete = await _client.DeleteAsync($"api/connections/{Uri.EscapeDataString(id)}", token);
+                if (delete.IsSuccessStatusCode) closed++;
+            }
+        }
+        catch (Exception)
+        {
+            return closed;
+        }
+
+        return closed;
+    }
+
+    /// <summary>
+    /// Poll until the ready backlog reaches <paramref name="depth" />, so that chaos is introduced against a
+    /// genuinely saturated cluster. Returns the reading that satisfied it, or null on timeout.
+    /// </summary>
+    public async Task<BrokerReading?> WaitForBacklogAsync(int depth, TimeSpan timeout, CancellationToken token = default)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var reading = await ReadAsync(token);
+            if (reading is not null && reading.Ready >= depth) return reading;
+
+            await Task.Delay(200, token);
+        }
+
+        return null;
+    }
+
+    internal sealed record BrokerReading(int Ready, int Unacknowledged);
+}

--- a/src/Testing/SlowTests/Partitioning/WebhookFloodDriver.cs
+++ b/src/Testing/SlowTests/Partitioning/WebhookFloodDriver.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.ComplianceTests.Partitioning;
+
+namespace SlowTests.Partitioning;
+
+/// <summary>
+/// GH-3713. The webhook-flood publisher: a sustained, skewed stream of grouped events pushed at the cluster
+/// from whichever nodes are alive at that instant.
+/// </summary>
+/// <remarks>
+/// <para><b>Why it picks a live host per send.</b> The chaos phases deliberately take nodes away mid-flood,
+/// and a publisher pinned to one host would simply die with it. Picking from the currently-live set each time
+/// keeps the flood sustained <i>across</i> the disruption, which is the only way the disruption is genuinely
+/// mid-flood rather than between floods.</para>
+///
+/// <para><b>Why a send is only counted after it returns.</b> Completeness is asserted against this list, so a
+/// send that threw because its host was being disposed underneath it must not be counted -- Wolverine never
+/// accepted it, so nothing is entitled to deliver it. Counting it would manufacture phantom message loss.</para>
+///
+/// <para><b>Pacing, and why the chaos phases do not use it.</b> <see cref="TimeSpan.Zero" /> means publish as
+/// fast as the senders can go; anything else spreads the arrivals evenly across that span. The first cut of
+/// this suite paced every phase, and it measured a duplicate rate of exactly zero in all of them -- for the
+/// uninteresting reason that a paced arrival rate well under the cluster's capacity leaves the queues empty,
+/// so a node killed "mid-flood" was killed with almost nothing unacknowledged. A flood is a burst, and only a
+/// burst produces the deep unacked window the measurement is about, so the chaos phases publish unpaced.</para>
+/// </remarks>
+internal sealed class WebhookFloodDriver
+{
+    /// <summary>A body in the size range a real webhook delivery carries, rather than an empty record.</summary>
+    private const string WebhookPayload =
+        """
+        {"event":"invoice.payment_succeeded","api_version":"2026-01-31","livemode":true,"data":{"object":
+        {"amount_paid":249900,"currency":"usd","status":"paid","lines":{"total_count":3},"metadata":
+        {"source":"webhook-flood-repro","tier":"enterprise"}}},"pending_webhooks":1,"request":{"key":null}}
+        """;
+
+    private readonly string[] _entityStream;
+    private readonly Func<IReadOnlyList<IHost>> _liveHosts;
+    private readonly ConcurrentQueue<(string GroupId, int Sequence)> _published = new();
+    private readonly ConcurrentQueue<Exception> _rejected = new();
+    private readonly ConcurrentDictionary<string, int> _sequences = new();
+    private readonly TimeSpan _targetDuration;
+
+    public WebhookFloodDriver(string[] entityStream, Func<IReadOnlyList<IHost>> liveHosts, TimeSpan targetDuration)
+    {
+        _entityStream = entityStream;
+        _liveHosts = liveHosts;
+        _targetDuration = targetDuration;
+    }
+
+    /// <summary>Every event the cluster actually accepted, as (entity id, sequence) identity pairs.</summary>
+    public IReadOnlyList<(string GroupId, int Sequence)> Published => _published.ToArray();
+
+    /// <summary>
+    /// Sends refused because their host was going away. Not message loss -- see the class remarks.
+    /// </summary>
+    public int RejectedSends => _rejected.Count;
+
+    /// <summary>
+    /// A skewed entity stream: a hot tenth of the entities takes half the traffic, the rest spread over the
+    /// long tail. Flat traffic would put roughly one message per entity in flight at a time and make
+    /// intra-group overlap nearly impossible to hit by accident, which would make a passing invariant
+    /// assertion meaningless.
+    /// </summary>
+    public static string[] BuildSkewedEntityStream(int entityCount, int totalMessages, int seed)
+    {
+        if (entityCount < 10)
+        {
+            throw new ArgumentOutOfRangeException(nameof(entityCount), "Need at least ten entities to skew");
+        }
+
+        var random = new Random(seed);
+        var run = Guid.NewGuid().ToString("N")[..8];
+        var entities = Enumerable.Range(0, entityCount).Select(i => $"entity-{run}-{i:D4}").ToArray();
+
+        var hotCount = Math.Max(1, entityCount / 10);
+
+        return Enumerable.Range(0, totalMessages)
+            .Select(_ => random.NextDouble() < 0.5
+                ? entities[random.Next(hotCount)]
+                : entities[hotCount + random.Next(entityCount - hotCount)])
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Run the flood to completion. Publishes on several concurrent senders so the send path is not itself
+    /// the bottleneck that the measurement ends up measuring.
+    /// </summary>
+    public async Task RunAsync(int senderCount, CancellationToken token)
+    {
+        var unpaced = _targetDuration <= TimeSpan.Zero;
+        var perMessageDelay = unpaced ? 0 : _targetDuration.TotalMilliseconds / Math.Max(1, _entityStream.Length);
+        var started = Stopwatch.StartNew();
+
+        var chunks = Enumerable.Range(0, senderCount)
+            .Select(offset => _entityStream.Where((_, i) => i % senderCount == offset).ToArray())
+            .ToArray();
+
+        await Task.WhenAll(chunks.Select((chunk, index) => Task.Run(async () =>
+        {
+            for (var i = 0; i < chunk.Length; i++)
+            {
+                if (token.IsCancellationRequested) return;
+
+                // Pace against the elapsed wall clock rather than sleeping a fixed slice per message, so a
+                // sender that fell behind during a disruption catches back up instead of stretching the
+                // flood out behind the very chaos it was supposed to overlap.
+                if (!unpaced)
+                {
+                    var due = perMessageDelay * (i * senderCount + index);
+                    var behind = due - started.Elapsed.TotalMilliseconds;
+                    if (behind > 1)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(behind), CancellationToken.None);
+                    }
+                }
+
+                await publishAsync(chunk[i]);
+            }
+        }, CancellationToken.None)));
+    }
+
+    private async Task publishAsync(string entityId)
+    {
+        var hosts = _liveHosts();
+        if (hosts.Count == 0)
+        {
+            return;
+        }
+
+        var sequence = _sequences.AddOrUpdate(entityId, 0, (_, current) => current + 1);
+        var host = hosts[Random.Shared.Next(hosts.Count)];
+
+        try
+        {
+            await host.MessageBus().PublishAsync(new NativeAckLetter(entityId, sequence, WebhookPayload));
+            _published.Enqueue((entityId, sequence));
+        }
+        catch (Exception e)
+        {
+            // The host was being disposed underneath this send. Deliberately NOT counted as published.
+            _rejected.Enqueue(e);
+        }
+    }
+}

--- a/src/Testing/SlowTests/Partitioning/webhook_flood_ledger_red_baseline.cs
+++ b/src/Testing/SlowTests/Partitioning/webhook_flood_ledger_red_baseline.cs
@@ -1,0 +1,147 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests.Partitioning;
+using Wolverine.RabbitMQ;
+using Xunit;
+
+namespace SlowTests.Partitioning;
+
+/// <summary>
+/// GH-3713. The red baseline for <see cref="webhook_flood_native_ack_chaos" />.
+/// </summary>
+/// <remarks>
+/// <para>An invariant assertion that cannot fail is worth nothing, and "no intra-group concurrency" is
+/// exactly the kind of assertion that passes vacuously -- if the flood never overlaps, if the ledger is
+/// cleared at the wrong moment, if the handler is never actually reached, the suite goes green while testing
+/// nothing. So this class deliberately breaks the guarantee and asserts that the ledger <b>catches</b> it.</para>
+///
+/// <para><b>How the guarantee is broken.</b> The cluster-wide half of the guarantee is "exactly one consumer
+/// per slot", enforced by <c>ExclusiveListenerFamily</c>. Take the message store away and, per GH-4072,
+/// <c>WolverineRuntime.startAgentsAsync</c> returns early, no <c>NodeAgentController</c> is built, no
+/// exclusive listener is ever assigned, and the durability mode has to be Solo -- where
+/// <c>Endpoint.ShouldAutoStartAsListener</c> starts <i>every</i> listener on <i>every</i> node. Three such
+/// nodes means three competing consumers on every slot, so two events sharing an entity id can and do run at
+/// the same time on different nodes. That is precisely the configuration GH-4072 measured 37 violations on.</para>
+///
+/// <para>Nothing here is a bug report against Wolverine. It is a statement about the <i>detector</i>: run the
+/// same ledger against a topology that genuinely violates the invariant and it must go red. If this test ever
+/// starts passing with an empty violation list, the chaos suite next door has stopped proving anything and
+/// should not be trusted.</para>
+/// </remarks>
+[Collection("webhook_flood")]
+public class webhook_flood_ledger_red_baseline : IAsyncLifetime
+{
+    private const string BaseName = "webhookredbaseline";
+    private const int SlotCount = 3;
+
+    private readonly List<IHost> _hosts = [];
+    private readonly ITestOutputHelper _output;
+
+    public webhook_flood_ledger_red_baseline(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        NativeAckPartitionedProcessing.Ledger.Clear();
+
+        // Wide enough that competing consumers genuinely overlap rather than merely interleave.
+        NativeAckPartitionedProcessing.Dwell = 250.Milliseconds();
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var host in _hosts.ToArray())
+        {
+            try
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+            catch (Exception)
+            {
+                // Nothing useful to do about a host that will not shut down cleanly during teardown
+            }
+        }
+
+        _hosts.Clear();
+        NativeAckPartitionedProcessing.Ledger.Clear();
+        NativeAckPartitionedProcessing.Dwell = 50.Milliseconds();
+    }
+
+    /// <summary>
+    /// A storeless Solo node. Every slot listener starts here, and on every one of its siblings -- which is
+    /// the broken part.
+    /// </summary>
+    private async Task<IHost> startCompetingHostAsync(string nodeName, bool purgeOnStartup)
+    {
+        var builder = Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Solo;
+
+            var rabbit = opts.UseRabbitMq("host=localhost;port=5672").AutoProvision();
+            if (purgeOnStartup)
+            {
+                // Only the first node purges, and only before anything has been published -- purging on a
+                // later node would delete this run's own in-flight events.
+                rabbit.AutoPurgeOnStartup();
+            }
+
+            opts.UseNativeAckLetters(nodeName, topology =>
+            {
+                topology.ProcessInParallelWithNativeAcks();
+                topology.UseShardedRabbitQueues(BaseName, SlotCount);
+            });
+        });
+
+        var host = await builder.StartAsync();
+        _hosts.Add(host);
+
+        return host;
+    }
+
+    /// <summary>
+    /// Three competing consumers per slot must produce intra-group concurrency, and
+    /// <c>AssertNoIntraGroupConcurrency</c> must be the thing that notices.
+    /// </summary>
+    [Fact]
+    public async Task the_ledger_catches_intra_group_concurrency_when_slot_exclusivity_is_removed()
+    {
+        var first = await startCompetingHostAsync("RedBaseline1", purgeOnStartup: true);
+        await startCompetingHostAsync("RedBaseline2", purgeOnStartup: false);
+        await startCompetingHostAsync("RedBaseline3", purgeOnStartup: false);
+
+        // Few entities, many events each: the overlap window per entity is what is being provoked, so
+        // concentrating traffic on a handful of group ids is the point rather than a shortcut.
+        var published = await NativeAckPartitionedProcessing.PumpOutLettersAsync(
+            [first.MessageBus], groupCount: 12, messagesPerGroup: 12);
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(published, 120.Seconds()))
+            .ShouldBeTrue("Not every letter was handled, so the run cannot be judged either way");
+
+        var violations = NativeAckPartitionedProcessing.Ledger.Violations;
+
+        _output.WriteLine($"{published.Count} published, "
+                          + $"{NativeAckPartitionedProcessing.Ledger.Handled.Count} executions, "
+                          + $"{violations.Count} intra-group concurrency violations detected");
+
+        foreach (var violation in violations.Take(10))
+        {
+            _output.WriteLine("  " + violation);
+        }
+
+        violations.ShouldNotBeEmpty(
+            "Three competing consumers per slot produced no detected intra-group concurrency. Either the "
+            + "cluster somehow serialised anyway, or the ledger has stopped detecting overlap -- in which "
+            + "case webhook_flood_native_ack_chaos is passing vacuously and must not be trusted.");
+
+        // And the assertion the chaos suite actually calls has to be the thing that goes red, not merely the
+        // raw violation list.
+        Should.Throw<Exception>(NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency);
+    }
+}

--- a/src/Testing/SlowTests/Partitioning/webhook_flood_native_ack_chaos.cs
+++ b/src/Testing/SlowTests/Partitioning/webhook_flood_native_ack_chaos.cs
@@ -1,0 +1,647 @@
+using System.Diagnostics;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using RabbitMQ.Client;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.ComplianceTests.Partitioning;
+using Wolverine.Configuration;
+using Wolverine.Postgresql;
+using Wolverine.RabbitMQ;
+using Wolverine.RabbitMQ.Internal;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace SlowTests.Partitioning;
+
+/// <summary>
+/// GH-3713. The capstone reproduction for the native-ack partitioning wave (#3706 -> #3708 -> #3709 -> #3710):
+/// the reporting client's actual shape -- a sustained webhook flood, grouped by an entity id, across a
+/// <b>five node</b> cluster -- put under chaos, with the intra-group concurrency invariant asserted
+/// cluster-wide throughout and the duplicate-execution rate measured rather than assumed.
+/// </summary>
+/// <remarks>
+/// <para><b>The guarantee under test, stated exactly:</b> no two messages sharing a group id execute
+/// concurrently. Within a node the sequential lane inside the slot's own receiver enforces it; across the
+/// cluster the exclusive slot listener enforces it, because exactly one node consumes a given slot.</para>
+///
+/// <para>Ordering is per-slot <b>best effort</b>, not per-group guaranteed. Redelivery and requeue may
+/// reorder, and the ordering unit is the slot rather than the group, so two entities hashing to the same slot
+/// serialize against each other. Nothing here asserts ordering, and an assertion that presumed it would fail
+/// for reasons that are not bugs.</para>
+///
+/// <para><b>Why there is a database here at all, and what it is emphatically not doing.</b> The message path
+/// is storage-free: every slot is <see cref="EndpointMode.NativeAck" />, so no envelope is ever written to an
+/// inbox, no outbox is involved, and no webhook event touches Postgres at any point.
+/// <see cref="no_webhook_event_ever_touches_the_database" /> asserts that against the incoming table rather
+/// than claiming it. Postgres is present purely as the cluster's <i>node registry</i>, because dynamic
+/// one-consumer-per-slot assignment runs through <c>NodeAgentController</c>, which
+/// <c>WolverineRuntime.startAgentsAsync</c> skips entirely when the store is a <c>NullMessageStore</c> -- so a
+/// genuinely storeless cluster has no <c>ExclusiveListenerFamily</c>, falls back to Solo, and starts every
+/// listener on every node. That limitation is GH-4072, and it is the reason this suite coordinates through a
+/// store while still keeping the message path free of one. Nothing here should be read as contradicting the
+/// storage-free claim; the storage-free single-node and static-ownership shapes are covered by
+/// <c>native_ack_global_partitioning_cluster</c> in the RabbitMQ suite.</para>
+///
+/// <para><b>Gating.</b> This suite is wall-clock bound by construction -- it waits out health checks, stale
+/// node detection and slot reassignment five times over -- and it lives in <c>SlowTests</c>, which runs only
+/// from the manual <c>slow-tests.yml</c> workflow. It is deliberately not on the pull request path. The
+/// default flood is a few thousand events; set <c>WOLVERINE_WEBHOOK_FLOOD_SIZE</c> to run the client's real
+/// 50k scale.</para>
+/// </remarks>
+[Collection("webhook_flood")]
+public class webhook_flood_native_ack_chaos : IAsyncLifetime
+{
+    private const string SchemaName = "webhook_flood";
+    private const string BaseName = "webhookflood";
+    private const int SlotCount = 5;
+    private const int NodeCount = 5;
+    private const int EntityCount = 500;
+
+    /// <summary>
+    /// How deep the broker's ready backlog has to get before chaos counts as landing "mid-flood". Comfortably
+    /// more than the whole cluster's total prefetch window (5 slots x 36), so every consuming node is holding
+    /// a full unacked window at the moment it is disturbed.
+    /// </summary>
+    private const int SaturationDepth = 400;
+
+    /// <summary>
+    /// <c>ExclusiveListenerFamily.SchemeName</c>. Repeated rather than referenced because that type is
+    /// internal to Wolverine and this assembly has no internals access.
+    /// </summary>
+    private const string ListenerAgentScheme = "wolverine-listener";
+
+    private readonly List<IHost> _hosts = [];
+    private readonly ITestOutputHelper _output;
+    private readonly RabbitBrokerProbe _probe = new(BaseName, SlotCount);
+    private int _generation;
+    private int _peakBacklog;
+    private int _unackedAtDisruption;
+
+    public webhook_flood_native_ack_chaos(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// The client's report was a flood, so the default is a real one -- but a five node cluster plus slot
+    /// reassignment is already minutes of wall clock, so the 50k scale is opt-in rather than the default.
+    /// </summary>
+    private static int floodSize =>
+        int.TryParse(Environment.GetEnvironmentVariable("WOLVERINE_WEBHOOK_FLOOD_SIZE"), out var size)
+            ? size
+            : 4000;
+
+    public async ValueTask InitializeAsync()
+    {
+        NativeAckPartitionedProcessing.Ledger.Clear();
+        _peakBacklog = 0;
+        _unackedAtDisruption = 0;
+
+        // Wide enough that a handler is genuinely still in flight when its node is taken away -- the window a
+        // duplicate execution has to land in is exactly this wide, so a dwell near zero measures zero
+        // duplicates and proves nothing. It also caps the cluster's throughput at
+        // slots x lanes / dwell = 5 x 5 / 250ms = 100 events/sec, which is what lets an unpaced burst of a
+        // few thousand events keep the queues genuinely saturated for the whole chaos window.
+        NativeAckPartitionedProcessing.Dwell = 250.Milliseconds();
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.CloseAsync();
+
+        // Stateful broker discipline: residue from an earlier run would be counted as this run's duplicates
+        // and would silently corrupt the one number this suite exists to produce.
+        await deleteSlotQueuesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _hosts.Reverse();
+        foreach (var host in _hosts.ToArray())
+        {
+            try
+            {
+                await stopHostAsync(host);
+            }
+            catch (Exception)
+            {
+                // Nothing useful to do about a host that will not shut down cleanly during teardown
+            }
+        }
+
+        _hosts.Clear();
+        _probe.Dispose();
+        NativeAckPartitionedProcessing.Ledger.Clear();
+        NativeAckPartitionedProcessing.Dwell = 50.Milliseconds();
+    }
+
+    private static async Task deleteSlotQueuesAsync()
+    {
+        await using var connection = await new ConnectionFactory { HostName = "localhost", Port = 5672 }
+            .CreateConnectionAsync();
+
+        for (var i = 1; i <= SlotCount; i++)
+        {
+            // A channel per queue: deleting a queue that does not exist yet kills the channel it was tried on.
+            try
+            {
+                await using var channel = await connection.CreateChannelAsync();
+                await channel.QueueDeleteAsync($"{BaseName}{i}", false, false);
+            }
+            catch (Exception)
+            {
+                // First run on a clean broker -- nothing to delete
+            }
+        }
+    }
+
+    // ---- cluster lifecycle -------------------------------------------------------------------------
+
+    private async Task<IHost> startHostAsync(string nodeName)
+    {
+        var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Balanced;
+            opts.Durability.HealthCheckPollingTime = 1.Seconds();
+            opts.Durability.NodeReassignmentPollingTime = 1.Seconds();
+            opts.Durability.CheckAssignmentPeriod = 1.Seconds();
+            opts.Durability.StaleNodeTimeout = 3.Seconds();
+
+            // Named per node so the broker can be asked to drop exactly this host's connections -- see
+            // RabbitBrokerProbe.ForceCloseConnectionsAsync, which is what makes killHostAsync a real kill.
+            opts.UseRabbitMq(factory =>
+                {
+                    factory.HostName = "localhost";
+                    factory.Port = 5672;
+                    factory.ClientProvidedName = nodeName;
+                })
+                .EnableWolverineControlQueues()
+                .AutoProvision();
+
+            // Node/agent coordination only. No webhook event is ever written here -- asserted by
+            // no_webhook_event_ever_touches_the_database.
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName);
+
+            opts.UseNativeAckLetters(nodeName, topology =>
+            {
+                topology.ProcessInParallelWithNativeAcks();
+                topology.UseShardedRabbitQueues(BaseName, SlotCount);
+            });
+
+            opts.Services.AddResourceSetupOnStartup();
+        }).StartAsync();
+
+        _hosts.Add(host);
+
+        return host;
+    }
+
+    /// <summary>Graceful shutdown -- the drain half of a drain-and-replace rolling deploy.</summary>
+    private async Task stopHostAsync(IHost host)
+    {
+        host.GetRuntime().Agents.DisableHealthChecks();
+        await host.StopAsync();
+        host.Dispose();
+        _hosts.Remove(host);
+    }
+
+    /// <summary>
+    /// A genuine hard kill: the broker drops this node's connections out from under it, and only then is the
+    /// host torn down.
+    /// </summary>
+    /// <remarks>
+    /// <para>The obvious implementation -- just <c>host.Dispose()</c> -- is <b>not</b> a kill, and an earlier
+    /// version of this suite made exactly that mistake. <c>WolverineRuntime</c>'s <c>DisposeAsync</c> calls
+    /// <c>StopAsync</c> when the runtime has not already stopped, so disposal takes the full graceful path and
+    /// the listeners drain: in-flight handlers finish and their acknowledgements go out. The suite duly
+    /// measured zero duplicate executions on a "hard kill" -- a true number about a graceful shutdown, and a
+    /// misleading one about a crash.</para>
+    ///
+    /// <para>Closing the connections broker-side first is what makes the difference. Everything unacknowledged
+    /// on them is requeued at once, and the handlers that were mid-flight complete into a channel that no
+    /// longer exists -- their work happened, their acknowledgement did not. That is the only way a duplicate
+    /// execution is produced, so it is the only honest way to measure how many.</para>
+    /// </remarks>
+    private async Task killHostAsync(IHost host)
+    {
+        var nodeName = host.GetRuntime().Options.ServiceName;
+
+        var closed = await _probe.ForceCloseConnectionsAsync(nodeName);
+        _output.WriteLine($"  broker force-closed {closed} connection(s) belonging to {nodeName}");
+
+        closed.ShouldBeGreaterThan(0,
+            $"No broker connection was force-closed for {nodeName}, so this was not a hard kill and any "
+            + "duplicate measurement taken from it would describe a graceful shutdown instead.");
+
+        _hosts.Remove(host);
+        host.Dispose();
+    }
+
+    private static Uri slotAgentUri(int slotNumber) =>
+        new($"{ListenerAgentScheme}://rabbitmq/{BaseName}{slotNumber}");
+
+    private IReadOnlyList<Uri> slotAgentsOn(IHost host)
+    {
+        var running = host.RunningAgents().ToHashSet();
+        return Enumerable.Range(1, SlotCount).Select(slotAgentUri).Where(running.Contains).ToArray();
+    }
+
+    /// <summary>Every slot consumed by exactly one node -- never zero, never two.</summary>
+    private bool everySlotOwnedExactlyOnce()
+    {
+        return Enumerable.Range(1, SlotCount)
+            .All(slot => _hosts.Count(h => slotAgentsOn(h).Contains(slotAgentUri(slot))) == 1);
+    }
+
+    private async Task waitForFullSlotOwnershipAsync(TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (everySlotOwnedExactlyOnce())
+            {
+                // Has to hold across a health check cycle to count as settled rather than mid-flap.
+                await Task.Delay(1500.Milliseconds());
+                if (everySlotOwnedExactlyOnce()) return;
+            }
+
+            await Task.Delay(250.Milliseconds());
+        }
+
+        var report = _hosts.Select(h =>
+            $"{h.GetRuntime().Options.ServiceName}=[{slotAgentsOn(h).Select(x => x.ToString()).Join(", ")}]").Join("; ");
+
+        throw new TimeoutException($"The {SlotCount} slot listeners never settled one-per-node. Saw: {report}");
+    }
+
+    private async Task<IHost> startClusterAsync(string prefix)
+    {
+        var leader = await startHostAsync($"{prefix}1");
+        for (var i = 2; i <= NodeCount; i++)
+        {
+            await startHostAsync($"{prefix}{i}");
+        }
+
+        (await leader.WaitUntilAssumesLeadershipAsync(60.Seconds()))
+            .ShouldBeTrue("The first host never assumed leadership");
+
+        assertSlotsAreNativeAck(leader);
+        await waitForFullSlotOwnershipAsync(120.Seconds());
+
+        return leader;
+    }
+
+    private void assertSlotsAreNativeAck(IHost host)
+    {
+        var runtime = host.GetRuntime();
+
+        for (var i = 1; i <= SlotCount; i++)
+        {
+            var endpoint = runtime.Endpoints.EndpointFor(new Uri($"rabbitmq://queue/{BaseName}{i}"))
+                .ShouldNotBeNull($"No endpoint was built for slot {BaseName}{i}");
+
+            endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+            endpoint.ListenerScope.ShouldBe(ListenerScope.Exclusive);
+        }
+    }
+
+    /// <summary>
+    /// The prefetch window per slot, read off the endpoint rather than recomputed here -- the documentation's
+    /// claimed duplicate bound is stated in terms of this number, so the comparison has to use the real one.
+    /// </summary>
+    private int prefetchPerSlot(IHost host)
+    {
+        var queue = (RabbitMqQueue)host.GetRuntime().Endpoints
+            .EndpointFor(new Uri($"rabbitmq://queue/{BaseName}1"))!;
+
+        return queue.PreFetchCount;
+    }
+
+    // ---- the flood ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A flood. <see cref="TimeSpan.Zero" /> -- the default -- publishes unpaced, which is what actually
+    /// saturates the cluster; see <see cref="WebhookFloodDriver" /> for why pacing produced a vacuous
+    /// measurement.
+    /// </summary>
+    private WebhookFloodDriver buildFlood(int sizeMultiplier = 1, TimeSpan duration = default)
+    {
+        var stream = WebhookFloodDriver.BuildSkewedEntityStream(EntityCount, floodSize * sizeMultiplier,
+            seed: 3713);
+
+        return new WebhookFloodDriver(stream, () => _hosts.ToArray(), duration);
+    }
+
+    /// <summary>
+    /// Block until the broker is genuinely backed up, so that chaos introduced afterwards lands on a
+    /// saturated cluster with a full unacked window rather than on one that is keeping up.
+    /// </summary>
+    /// <remarks>
+    /// This gate replaced an earlier one that waited on a handled-event count. That version passed happily
+    /// against a cluster whose queues were empty the whole time, and the suite duly measured a duplicate rate
+    /// of zero in every phase -- a vacuous result. Saturation is the precondition for the measurement meaning
+    /// anything, so it is asserted here rather than assumed.
+    /// </remarks>
+    private async Task<RabbitBrokerProbe.BrokerReading> waitForSaturatedBacklogAsync(int depth, TimeSpan timeout)
+    {
+        var reading = await _probe.WaitForBacklogAsync(depth, timeout);
+
+        if (reading is null)
+        {
+            var latest = await _probe.ReadAsync();
+            throw new TimeoutException(
+                $"The broker backlog never reached {depth} within {timeout.TotalSeconds:N0}s "
+                + $"(latest reading: {(latest is null ? "unreachable" : $"{latest.Ready} ready, {latest.Unacknowledged} unacked")}). "
+                + "Without a saturated cluster the duplicate measurement is vacuous.");
+        }
+
+        recordBrokerReading(reading);
+
+        return reading;
+    }
+
+    private void recordBrokerReading(RabbitBrokerProbe.BrokerReading reading)
+    {
+        _peakBacklog = Math.Max(_peakBacklog, reading.Ready);
+    }
+
+    /// <summary>
+    /// Snapshot the broker's unacked window at the instant chaos is introduced. That number is the population
+    /// that gets requeued, and it is the quantity the documentation's "bounded by prefetch depth" claim is
+    /// about -- so it is measured rather than inferred from configuration.
+    /// </summary>
+    private async Task captureUnackedAtDisruptionAsync()
+    {
+        var reading = await _probe.ReadAsync();
+        if (reading is null) return;
+
+        recordBrokerReading(reading);
+        _unackedAtDisruption = Math.Max(_unackedAtDisruption, reading.Unacknowledged);
+
+        _output.WriteLine(
+            $"  broker at disruption: {reading.Ready} ready, {reading.Unacknowledged} unacknowledged");
+    }
+
+    /// <summary>
+    /// The assertions every phase makes, in the issue's priority order. Concurrency first and hard, then
+    /// completeness, then routing. Ordering is deliberately absent.
+    /// </summary>
+    private DuplicateExecutionReport settleAndAssert(string phase, WebhookFloodDriver flood, IHost witness,
+        int disruptedNodes)
+    {
+        var published = flood.Published;
+
+        NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency();
+        NativeAckPartitionedProcessing.AssertEveryLetterWasHandled(published);
+        NativeAckPartitionedProcessing.AssertGroupsNeverStraddleSlots();
+        NativeAckPartitionedProcessing.AssertEverySlotWasUsed(SlotCount);
+
+        var report = DuplicateExecutionReport.From(phase, published, prefetchPerSlot(witness), SlotCount,
+            disruptedNodes, _peakBacklog, _unackedAtDisruption);
+
+        _output.WriteLine(report.Describe());
+        _output.WriteLine($"  rejected sends (not published, not lost): {flood.RejectedSends}");
+        _output.WriteLine(
+            $"  nodes that did work: {NativeAckPartitionedProcessing.Ledger.Handled.Select(x => x.NodeName).Distinct().OrderBy(x => x).Join(", ")}");
+
+        return report;
+    }
+
+    // ---- phase 1: steady state ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The control run. Five nodes, a sustained flood, no chaos at all. Whatever duplicate rate this
+    /// produces is the floor -- it is the cost of the mode itself rather than the cost of a disruption.
+    /// </summary>
+    [Fact]
+    public async Task steady_state_flood_holds_the_invariant_and_measures_duplicates()
+    {
+        var leader = await startClusterAsync("Steady");
+
+        var flood = buildFlood();
+        var token = TestContext.Current.CancellationToken;
+        var pump = Task.Run(() => flood.RunAsync(senderCount: 4, token), token);
+
+        // Even with no chaos, the control run has to be a genuine flood -- otherwise its duplicate rate is
+        // the floor for an idle cluster rather than a loaded one.
+        var saturated = await waitForSaturatedBacklogAsync(SaturationDepth, 90.Seconds());
+        _output.WriteLine($"  saturated at {saturated.Ready} ready, {saturated.Unacknowledged} unacknowledged");
+
+        await pump;
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(flood.Published, 300.Seconds()))
+            .ShouldBeTrue("Not every published webhook event was handled inside the timeout");
+
+        var report = settleAndAssert("steady state (no chaos)", flood, leader, disruptedNodes: 0);
+
+        // The control run is the one place a near-zero duplicate rate is a real claim rather than an
+        // accident of scale, so it is asserted and not merely printed.
+        report.DuplicateExecutions.ShouldBeLessThanOrEqualTo(report.DocumentedPrefetchBound);
+    }
+
+    // ---- phase 2: hard node kill -------------------------------------------------------------------
+
+    /// <summary>
+    /// A node dies outright mid-flood, taking its in-flight handlers with it, and a replacement joins. Its
+    /// slots have to be reassigned, everything it had unacked has to come back, and the invariant has to hold
+    /// across the handoff.
+    /// </summary>
+    [Fact]
+    public async Task hard_node_kill_mid_flood_holds_the_invariant_and_measures_duplicates()
+    {
+        var leader = await startClusterAsync("Killed");
+
+        var flood = buildFlood();
+        var token = TestContext.Current.CancellationToken;
+        var pump = Task.Run(() => flood.RunAsync(senderCount: 4, token), token);
+
+        await waitForSaturatedBacklogAsync(SaturationDepth, 90.Seconds());
+
+        // Kill a non-leader that is actually consuming slots, so this is a slot handoff rather than an
+        // election.
+        var victim = _hosts.Skip(1).First(h => slotAgentsOn(h).Any());
+        var victimName = victim.GetRuntime().Options.ServiceName;
+        var orphaned = slotAgentsOn(victim);
+
+        _output.WriteLine($"Hard killing {victimName}, which owns {orphaned.Select(x => x.ToString()).Join(", ")}");
+        await captureUnackedAtDisruptionAsync();
+        await killHostAsync(victim);
+
+        var replacement = await startHostAsync($"KilledReplacement{++_generation}");
+        await waitForFullSlotOwnershipAsync(120.Seconds());
+
+        // Processing has to keep going on the survivors, not merely resume owning the slots.
+        var before = NativeAckPartitionedProcessing.Ledger.Handled.Count;
+        await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
+        NativeAckPartitionedProcessing.Ledger.Handled.Count.ShouldBeGreaterThan(before,
+            "Nothing was processed after the node was killed");
+
+        await pump;
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(flood.Published, 300.Seconds()))
+            .ShouldBeTrue("Events unacked by the killed node were never redelivered and handled");
+
+        settleAndAssert("hard node kill", flood, replacement, disruptedNodes: 1);
+
+        // The kill has to have actually moved work, or none of the above was tested.
+        var nodes = NativeAckPartitionedProcessing.Ledger.Handled.Select(x => x.NodeName).Distinct().ToArray();
+        nodes.ShouldContain(victimName, "The killed node never handled anything before it died");
+
+        var orphanedQueues = orphaned.Select(x => x.Segments.Last()).ToHashSet();
+        NativeAckPartitionedProcessing.Ledger.Handled
+            .Where(x => x.NodeName != victimName && orphanedQueues.Contains(x.Destination!.Segments.Last()))
+            .ShouldNotBeEmpty("No survivor ever processed a message from one of the reassigned slots");
+    }
+
+    // ---- phase 3: rolling deploy -------------------------------------------------------------------
+
+    /// <summary>
+    /// The shape the documentation makes its duplicate claim about: a rolling deploy, replacing one node at a
+    /// time, gracefully, while the flood keeps arriving. Every node in the cluster is replaced.
+    /// </summary>
+    [Fact]
+    public async Task rolling_deploy_mid_flood_holds_the_invariant_and_measures_duplicates()
+    {
+        await startClusterAsync("Rolling");
+
+        // Five sequential drain-and-replace cycles take minutes, so the flood has to be big enough that the
+        // cluster is still grinding through it when the last node is replaced.
+        var flood = buildFlood(sizeMultiplier: 4);
+        var token = TestContext.Current.CancellationToken;
+        var pump = Task.Run(() => flood.RunAsync(senderCount: 4, token), token);
+
+        await waitForSaturatedBacklogAsync(SaturationDepth, 90.Seconds());
+
+        // Replace the whole cluster one node at a time. The publisher picks from the live set each send, so
+        // the flood follows the deploy around rather than dying with the first node drained.
+        for (var i = 0; i < NodeCount; i++)
+        {
+            var outgoing = _hosts[0];
+            var outgoingName = outgoing.GetRuntime().Options.ServiceName;
+
+            _output.WriteLine($"Rolling deploy: draining {outgoingName} " +
+                              $"(owns {slotAgentsOn(outgoing).Select(x => x.ToString()).Join(", ")})");
+
+            await captureUnackedAtDisruptionAsync();
+            await stopHostAsync(outgoing);
+            await startHostAsync($"RollingReplacement{++_generation}");
+            await waitForFullSlotOwnershipAsync(120.Seconds());
+        }
+
+        await pump;
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(flood.Published, 300.Seconds()))
+            .ShouldBeTrue("Not every published webhook event survived the rolling deploy");
+
+        var witness = _hosts[0];
+        settleAndAssert("rolling deploy (all 5 nodes replaced)", flood, witness, disruptedNodes: NodeCount);
+
+        // Every original node has to have been replaced, or this was not a rolling deploy.
+        _hosts.ShouldAllBe(h => h.GetRuntime().Options.ServiceName.StartsWith("RollingReplacement"));
+
+        // Both generations have to have done real work, otherwise the handoffs were never entered.
+        var nodes = NativeAckPartitionedProcessing.Ledger.Handled.Select(x => x.NodeName).Distinct().ToArray();
+        nodes.ShouldContain(x => x.StartsWith("Rolling") && !x.StartsWith("RollingReplacement"));
+        nodes.ShouldContain(x => x.StartsWith("RollingReplacement"));
+    }
+
+    // ---- phase 4: combined chaos -------------------------------------------------------------------
+
+    /// <summary>
+    /// The acceptance run: a hard kill and a rolling replacement in the same flood, overlapping. This is the
+    /// one the issue asks to pass repeatedly.
+    /// </summary>
+    [Fact]
+    public async Task combined_chaos_flood_holds_the_invariant_cluster_wide()
+    {
+        await startClusterAsync("Chaos");
+
+        var flood = buildFlood(sizeMultiplier: 4);
+        var token = TestContext.Current.CancellationToken;
+        var pump = Task.Run(() => flood.RunAsync(senderCount: 4, token), token);
+
+        await waitForSaturatedBacklogAsync(SaturationDepth, 90.Seconds());
+
+        // 1. A node dies outright.
+        var victim = _hosts.Skip(1).First(h => slotAgentsOn(h).Any());
+        _output.WriteLine($"Combined chaos: hard killing {victim.GetRuntime().Options.ServiceName}");
+        await captureUnackedAtDisruptionAsync();
+        await killHostAsync(victim);
+        await startHostAsync($"ChaosReplacement{++_generation}");
+        await waitForFullSlotOwnershipAsync(120.Seconds());
+
+        // 2. Two more are drained and replaced while the flood is still arriving.
+        for (var i = 0; i < 2; i++)
+        {
+            var outgoing = _hosts.Skip(1).First();
+            _output.WriteLine($"Combined chaos: draining {outgoing.GetRuntime().Options.ServiceName}");
+            await captureUnackedAtDisruptionAsync();
+            await stopHostAsync(outgoing);
+            await startHostAsync($"ChaosReplacement{++_generation}");
+            await waitForFullSlotOwnershipAsync(120.Seconds());
+        }
+
+        // 3. And another hard kill on the far side of the deploy.
+        var second = _hosts.Skip(1).First(h => slotAgentsOn(h).Any());
+        _output.WriteLine($"Combined chaos: hard killing {second.GetRuntime().Options.ServiceName}");
+        await captureUnackedAtDisruptionAsync();
+        await killHostAsync(second);
+        await startHostAsync($"ChaosReplacement{++_generation}");
+        await waitForFullSlotOwnershipAsync(120.Seconds());
+
+        await pump;
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(flood.Published, 420.Seconds()))
+            .ShouldBeTrue("Not every published webhook event survived the combined chaos run");
+
+        settleAndAssert("combined chaos (2 kills + 2 rolling replacements)", flood, _hosts[0], disruptedNodes: 4);
+    }
+
+    // ---- the storage-free claim --------------------------------------------------------------------
+
+    /// <summary>
+    /// The claim that separates this mode from the Durable topology the client was complaining about: the
+    /// database carries node coordination and nothing else. Asserted against the incoming table, because
+    /// "no database on the message path" is exactly the sort of claim that quietly stops being true.
+    /// </summary>
+    [Fact]
+    public async Task no_webhook_event_ever_touches_the_database()
+    {
+        await startClusterAsync("Storeless");
+
+        var flood = buildFlood(sizeMultiplier: 1, duration: 20.Seconds());
+        await flood.RunAsync(senderCount: 4, TestContext.Current.CancellationToken);
+
+        (await NativeAckPartitionedProcessing.WaitForCompletionAsync(flood.Published, 300.Seconds()))
+            .ShouldBeTrue("Not every published webhook event was handled inside the timeout");
+
+        NativeAckPartitionedProcessing.AssertNoIntraGroupConcurrency();
+        NativeAckPartitionedProcessing.AssertEveryLetterWasHandled(flood.Published);
+
+        var token = TestContext.Current.CancellationToken;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(token);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText = $"select count(*) from {SchemaName}.wolverine_incoming_envelopes";
+        var incoming = (long)(await command.ExecuteScalarAsync(token))!;
+
+        await conn.CloseAsync();
+
+        incoming.ShouldBe(0,
+            $"{incoming} envelopes reached the durable inbox. The native-ack message path must never write one.");
+
+        // And the nodes table proves the store really was in use -- otherwise the count above is zero for the
+        // trivial reason that nothing was configured at all.
+        NativeAckPartitionedProcessing.Ledger.Handled.Select(x => x.NodeName).Distinct().Count()
+            .ShouldBeGreaterThan(1, "Only one node did any work, so cluster coordination was never exercised");
+    }
+}

--- a/src/Testing/SlowTests/SlowTests.csproj
+++ b/src/Testing/SlowTests/SlowTests.csproj
@@ -22,8 +22,12 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj"/>
+        <ProjectReference Include="..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj"/>
         <ProjectReference Include="..\..\Persistence\Wolverine.SqlServer\Wolverine.SqlServer.csproj"/>
         <ProjectReference Include="..\..\Transports\Kafka\Wolverine.Kafka\Wolverine.Kafka.csproj"/>
+        <!-- GH-3713. The webhook flood reproduction needs a real broker for the message path and Postgres
+             purely as the cluster's node registry. -->
+        <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj"/>
         <ProjectReference Include="..\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
     </ItemGroup>
 

--- a/src/Testing/Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs
@@ -164,7 +164,12 @@ public static class NativeAckPartitionedProcessing
     }
 }
 
-public record NativeAckLetter(string GroupId, int Sequence);
+/// <summary>
+/// <paramref name="Payload" /> is optional and carries nothing the harness reads. It exists so GH-3713's
+/// webhook flood can send bodies in the size range a real webhook delivery has, rather than measuring broker
+/// behaviour against an empty record.
+/// </summary>
+public record NativeAckLetter(string GroupId, int Sequence, string? Payload = null);
 
 /// <summary>
 /// Injected per host so the ledger can name which node executed a message. All hosts in a multi-node test


### PR DESCRIPTION
Closes #3713

The capstone reproduction for the native-ack partitioning wave (#3706 → #3708 → #3709 → #3710): the reporting client's actual shape — a sustained webhook flood, grouped by entity id, across a **five node** cluster — put under chaos, with the intra-group concurrency invariant asserted cluster-wide and the duplicate rate **measured** rather than assumed.

## The headline: the documented duplicate bound was the wrong number

`docs/guide/messaging/listeners.md` told users:

> a rolling deploy produces duplicate deliveries bounded by the prefetch depth

Honest reasoning, but unmeasured — and measuring it shows the figure is the wrong one to quote. Four consecutive runs, five nodes, five slots, a flood deep enough that the broker held a full unacked window at every disruption:

| Scenario | Unacked at disruption | Duplicate executions | Rate |
| --- | --- | --- | --- |
| Steady state, no disruption | 0 | **0** | 0% |
| Rolling deploy, all 5 nodes drained and replaced | 180 | **0** | 0% |
| One node killed outright mid-flood | 180 | **3–4** | ~0.1% |
| Two hard kills + two rolling replacements | 180 | **7–9** | ~0.05% |

The prefetch window (180) bounds **redeliveries**, and nearly all of those are messages that had not executed yet — so they run for the *first* time, and a handler cannot tell them from any other first delivery. A **duplicate execution** needs something much narrower: a handler that finished while its ack was in flight on a connection that then died. That population is the number of busy lanes — the slot count — not the prefetch depth. Measured, that is 3–4 per killed node against 180 unacked, a factor of roughly 45.

And the specific claim the docs made is wrong in the other direction too: **a graceful rolling deploy costs zero duplicate executions**, not "not zero". Draining settles the handlers already running.

`listeners.md` is corrected in this PR with the measured table and both conclusions.

## Two measurement mistakes, both caught, both worth recording

The first cut of this suite was green, clean, and meaningless — it reported **zero duplicates in every phase**. Twice, for two different reasons:

1. **The flood was not a flood.** Publishing was paced well under the cluster's capacity, so the queues sat empty and there was essentially nothing in flight to duplicate. The chaos now waits on a real broker backlog (`RabbitBrokerProbe`, via the management API) before it fires, and the gate fails loudly rather than proceeding against an idle cluster.
2. **The hard kill was not a kill.** It was `host.Dispose()` — and `WolverineRuntime.DisposeAsync` calls `StopAsync` when the runtime has not already stopped, so disposal takes the *graceful* path and the listeners drain. The suite was measuring a tidy shutdown and calling it a crash. A kill is now the broker force-closing that node's connections, so in-flight handlers complete into a channel that no longer exists — the only way a duplicate execution is actually produced.

Both are documented in the code at the point where the mistake would be repeated.

## Red baseline

`webhook_flood_ledger_red_baseline` is committed, not run once by hand. It removes slot exclusivity (storeless Solo nodes, so every node consumes every slot — the GH-4072 configuration) and asserts the ledger **catches** the violation. It detects **66**, and asserts that `AssertNoIntraGroupConcurrency` itself throws. If that test ever goes green with an empty violation list, the chaos suite next door has stopped proving anything.

## What is asserted

In the issue's priority order — concurrency first and hard, then completeness, then routing. **Ordering is deliberately not asserted**: it is per-slot best effort, not per-group guaranteed, and an assertion presuming it would fail for reasons that are not bugs.

- **No intra-group concurrency, cluster-wide**, across every kill and every handoff. Held in every run.
- **At-least-once completeness** — every accepted event handled at least once.
- **Storage-free message path** — `no_webhook_event_ever_touches_the_database` asserts zero rows in the inbox table.

## Why there is a database here

The message path is storage-free: every slot is `EndpointMode.NativeAck` and no envelope is ever written to an inbox. Postgres is present **purely as the cluster's node registry**, because dynamic one-consumer-per-slot assignment runs through `NodeAgentController`, which `startAgentsAsync` skips entirely without a message store. That is #4072, and it is not a contradiction of the storage-free claim — the genuinely storeless single-node and static-ownership shapes stay covered by `native_ack_global_partitioning_cluster`.

## Gating

**`SlowTests`, which runs only from the manual `slow-tests.yml` workflow** — deliberately not on the PR path. This suite is wall-clock bound by construction (it waits out stale-node detection and slot reassignment up to five times per test) at ~13 minutes per run; putting that on every push would be a flake generator for everyone. `CISlowTests` now starts `rabbitmq` alongside `postgresql`. The default flood is 4,000 events per phase; `WOLVERINE_WEBHOOK_FLOOD_SIZE` opens it up to the client's 50k scale.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean.
- Full CoreTests — **2622 passed, 0 failed**, 2 skipped.
- #4069's RabbitMQ native-ack suites (`native_ack_mode`, `..._cluster`, `..._failover`) — **7/7 green**, confirming the optional `Payload` added to the shared `NativeAckLetter` broke nothing.
- The chaos suite: **four consecutive full-class runs of the final configuration, 5/5 green each**, ~13 minutes per run. What varied between them was only the chaos timing and slot-ownership layout, which the cluster negotiates fresh each run; the duplicate counts moved by at most one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
