### PR TITLE
GH-4083: Bobcat 0.7.0, and narrate the supervised run test-by-test in CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <!-- Drives test-host executables as supervised worker processes from the Nuke build
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
-    <PackageVersion Include="Bobcat.Supervisor" Version="0.6.1" />
+    <PackageVersion Include="Bobcat.Supervisor" Version="0.7.0" />
     <PackageVersion Include="JasperFx" Version="2.54.0" />
     <PackageVersion Include="JasperFx.Events" Version="2.54.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.54.0" />

--- a/build/SupervisedTests.cs
+++ b/build/SupervisedTests.cs
@@ -156,6 +156,12 @@ partial class Build
 
         if (!DisableTestRetry) supervisor.AddFailurePolicy(new RetryFailuresInFreshProcess());
 
+        // Only under Actions: locally the run finishes and prints its summary, and `dotnet run --
+        // --output Detailed` is the per-test view. In CI the summary is exactly what a wedged job
+        // never reaches. Same GITHUB_ACTIONS check the ledger uses.
+        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
+            supervisor.AddObserver(new NarrateTestsAsTheyStart());
+
         var results = supervisor.Run().GetAwaiter().GetResult();
 
         return report(projectName, framework, results, shardFilter is not null);
@@ -179,6 +185,34 @@ partial class Build
 
             return Disposition.RetryInFreshProcess(
                 "a failure is retried in a fresh process, within the budget, to separate flaky from broken");
+        }
+    }
+
+    /// <summary>
+    /// Prints one line per test as the worker picks it up, so a run that never finishes still says
+    /// what it was doing when it stopped.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The supervisor reports per-test results when a batch FINISHES. A batch that wedges never
+    /// finishes, so it reports nothing at all: on JasperFx/wolverine#4083 a CIMarten job's last
+    /// line was "275 test(s): 275 batched, 0 isolated", printed 18m33s before the 20 minute cap
+    /// cancelled the job, and the log could not name the test that hung. This is the cheap half of
+    /// the fix — the sampler's stack dump (build/ci-memory-sampler.sh) is the evidence, this is the
+    /// bookmark that says where to look.
+    /// </para>
+    /// <para>
+    /// In-progress updates only. The terminal update carries the same verdict the end-of-run
+    /// summary already prints, and doubling every line would bury the one that matters — the LAST
+    /// one. Bobcat fires these from the worker client's I/O thread, so lines from different lanes
+    /// interleave; the lane number is on each one for that reason.
+    /// </para>
+    /// </remarks>
+    class NarrateTestsAsTheyStart : ISupervisorObserver
+    {
+        public void TestUpdated(WorkerLaunchContext worker, WorkerTestUpdate update)
+        {
+            if (update.InProgress) Log.Information("  [lane {Lane}] -> {Test}", worker.Lane, update.DisplayName);
         }
     }
 


### PR DESCRIPTION
Closes the first follow-up on #4083.

The supervisor reports per-test results when a batch **finishes**. A batch that wedges never
finishes, so it reports nothing at all — on #4083 a `CIMarten` job's last line was
`275 test(s): 275 batched, 0 isolated`, printed **18m33s** before the 20 minute cap cancelled it,
and the log could not name the test that hung.

`Bobcat.Supervisor` **0.6.1** was cut on 2026-07-31, *before* `ISupervisorObserver`
(JasperFx/bobcat#96) and the tap on MTP's `testing/testUpdates/tests` (JasperFx/bobcat#99, #119)
landed, so there was no way to observe a run while it was still going. **Bobcat 0.7.0 is cut from
that work** (JasperFx/bobcat@v0.7.0); this moves the pin onto it and uses it.

## What it does

One line per test, as a worker picks it up:

```
  [lane 0] -> MartenTests.Bugs.Bug_2318_ancillary_dlq_replay.replayed_dlq_message_should_not_be_stuck_in_incoming
```

So a wedged job now ends with **the name of the test it wedged on** as its last line of output.

That is the bookmark, not the evidence — the stall watchdog's `dumpasync` capture (#4084) is still
what says *why* it hung. But the bookmark is what turns eighteen minutes of silence into a starting
point, and it costs nothing.

## Three deliberate choices

**In-progress updates only.** The terminal update carries the same verdict the end-of-run summary
already prints, and doubling every line would bury the one line that matters — the last one.

**The lane number is on every line.** Bobcat fires these from the worker client's I/O thread, so
lines from different lanes interleave; without the lane they'd be unreadable on a multi-worker
target.

**Gated on `GITHUB_ACTIONS`**, the same check `RetryLedger` already uses. Locally a run reaches its
summary, and `dotnet run -- --output Detailed` is the per-test view — this exists for the case where
the summary is never reached.

## Verification

Built against the **published** package rather than a local feed, so this is what CI will resolve:

```
build/obj/project.assets.json -> "Bobcat.Supervisor/0.7.0"
build -> build/bin/Release/build.dll
Build succeeded.  0 Error(s)
```

Worth knowing for anyone reproducing locally: a global `~/.nuget/NuGet/NuGet.Config` that maps
`Bobcat.*` to a local feed will fail this restore with `NU1102 ... Versions from nuget.org were not
considered`, because package source mapping is most-specific-wins. There is no repo-level
`NuGet.config`, so CI is unaffected.

Build-script only — no product code, no test code.

Refs #4083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
