### PR TITLE
GH-3797: un-skip Pulsar requeue, scheduled retry and dead-letter compliance

### DIFF
--- a/docs/guide/messaging/transports/pulsar.md
+++ b/docs/guide/messaging/transports/pulsar.md
@@ -295,6 +295,33 @@ In other words the native path only claims a failure it can actually act on; eve
 through to the policies you configured. Chain-level rules (`chain.OnException<T>()`) always sort
 ahead of global rules, so those take precedence even on a natively-configured Pulsar endpoint.
 
+### Where each policy actually lands on a plain Pulsar listener
+
+On a Pulsar listener with no native retry-letter or dead-letter topic configured (row two above),
+Wolverine's own error policies behave exactly as on any other broker transport. This is the
+configuration the Pulsar transport compliance suite runs, so each of these is covered end to end:
+
+| Policy | On a plain Pulsar listener |
+| --- | --- |
+| `RetryTimes()`, `RetryWithCooldown()` | ✅ Retried in the handler lane; the message never leaves the process |
+| `ScheduleRetry()` | ✅ Rescheduled in memory, or in the durable inbox if a message store is configured |
+| `Requeue()`, `RequeueIndefinitely()`, `MaximumAttempts()` | ✅ The listener acknowledges the message and re-publishes it to the same topic, carrying its `attempts` header forward. Turn this off with [`DisableRequeue()`](#read-only-subscriptions) if the topic is read-only to your application, or prefer [`UseNativeRedelivery()`](#per-message-redelivery) to redeliver in place instead of re-publishing a copy. |
+| `MoveToErrorQueue()` | ✅ The envelope is moved to **Wolverine's durable dead letter table** — see the note below |
+
+::: warning `MoveToErrorQueue()` needs either a native DLQ topic or a message store
+Pulsar dead-lettering is deliberately *not* wired through an endpoint-level dead letter sender, so
+there are exactly two destinations for a dead-lettered message and you have to pick one:
+
+- Configure a native dead-letter topic with `DeadLetterQueueing(new DeadLetterTopic(DeadLetterTopicMode.Native))`,
+  and failures land on the `{topic}-DLQ` topic with the full diagnostic headers, or
+- Configure a durable message store, and they land in Wolverine's `wolverine_dead_letters` table.
+
+With **neither** configured, a `MoveToErrorQueue()` is logged and the message is then discarded —
+there is nowhere for it to go. That is the same behaviour as any other transport running without a
+message store, but it is easy to miss on Pulsar because the native DLQ looks like it should apply
+and does not until you ask for it explicitly.
+:::
+
 ::: warning
 On a hot-tail listener your error policies do run, but requeue-shaped ones (`Requeue()`,
 `RequeueIndefinitely()`, `PauseThenRequeue()`, `MaximumAttempts()`) still cannot redeliver anything —

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/InlinePulsarTransportComplianceTests.cs
@@ -42,20 +42,9 @@ public class InlinePulsarTransportFixture : TransportComplianceFixture, IAsyncLi
 [Collection("acceptance")]
 public class InlinePulsarTransportComplianceTests : TransportCompliance<InlinePulsarTransportFixture>
 {
-    // GH-3763. These four are not flaky -- they fail deterministically, every run, in all three Pulsar
-    // compliance fixtures, with "No ending activity detected" / "Expected ending activity was not
-    // detected". They are the requeue, retry-scheduling and dead-letter behaviours the transport has not
-    // implemented. Skipping just these restores the other 55 tests in this file's three fixtures, which
-    // pass; the whole classes used to be excluded for them. See GH-3797.
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_requeue_and_increment_attempts() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task can_schedule_retry() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_move_to_dead_letter_queue_without_any_exception_match() => Task.CompletedTask;
+    // GH-3797. The requeue, scheduled-retry and two dead-letter compliance tests used to be skipped here
+    // as unimplemented Pulsar behaviour. They were not: UsePulsar()'s global failure rule swallowed the
+    // fixture's own error policies and handed the failure to a continuation that did nothing on an
+    // endpoint with no native resiliency configured. GH-4079/#4080 fixed that, and all four now run
+    // unmodified from the base class. The full write-up is on PulsarTransportComplianceTests.
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarTransportComplianceTests.cs
@@ -45,20 +45,25 @@ public class PulsarTransportFixture : TransportComplianceFixture, IAsyncLifetime
 [Collection("acceptance")]
 public class PulsarTransportComplianceTests : TransportCompliance<PulsarTransportFixture>
 {
-    // GH-3763. These four are not flaky -- they fail deterministically, every run, in all three Pulsar
-    // compliance fixtures, with "No ending activity detected" / "Expected ending activity was not
-    // detected". They are the requeue, retry-scheduling and dead-letter behaviours the transport has not
-    // implemented. Skipping just these restores the other 55 tests in this file's three fixtures, which
-    // pass; the whole classes used to be excluded for them. See GH-3797.
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_requeue_and_increment_attempts() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task can_schedule_retry() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_move_to_dead_letter_queue_without_any_exception_match() => Task.CompletedTask;
+    // GH-3797. will_requeue_and_increment_attempts, can_schedule_retry and the two dead-letter tests
+    // carried a skip here (and in the two sibling Pulsar fixtures) reading "Pulsar does not implement
+    // this compliance behaviour yet". That diagnosis was wrong -- none of the three was a missing
+    // transport feature.
+    //
+    // UsePulsar() registers PulsarNativeResiliencyPolicy's failure rule *globally*, with an
+    // AlwaysMatches condition, so it sorted ahead of every opts.Policies.OnException<T>() rule the
+    // compliance fixture configures. Its source claimed the failure for any PulsarListener whatsoever,
+    // and PulsarNativeResiliencyContinuation then did nothing at all when the endpoint had no
+    // retry-letter topic, no native dead-letter topic and no UseNativeRedelivery() -- which is exactly
+    // this fixture. The message simply vanished, hence "No ending activity detected". The fixture's
+    // Requeue() / ScheduleRetry() / MoveToErrorQueue() policies were never reached, so they were never
+    // actually under test.
+    //
+    // GH-4079/#4080 made a continuation source able to decline: the Pulsar source now claims a failure
+    // only when there is native resiliency to hand it to. With that in place all four behaviours work
+    // over Pulsar and run unmodified from the base class, so there is nothing to override here.
+    //
+    // Red-baselined: restoring the pre-#4080 predicate (`envelope.Listener is PulsarListener`, without
+    // the HasNativeResiliency check) fails all twelve -- these four across all three fixtures --
+    // deterministically, and restoring it passes all twelve.
 }

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/WithCloudEvents.cs
@@ -50,24 +50,14 @@ public class PulsarWithCloudEventsFixture : TransportComplianceFixture, IAsyncLi
 [Collection("acceptance")]
 public class with_cloud_events : TransportCompliance<PulsarWithCloudEventsFixture>
 {
-    // GH-3800 removed the CloudEvents-specific reason this test used to carry: ErrorCausingMessage
-    // now records an exception TYPE NAME rather than a live Exception, so it survives
-    // System.Text.Json and CloudEvents no longer corrupts it.
+    // GH-3797. The requeue, scheduled-retry and two dead-letter compliance tests used to be skipped here
+    // as unimplemented Pulsar behaviour. They were not: UsePulsar()'s global failure rule swallowed the
+    // fixture's own error policies and handed the failure to a continuation that did nothing on an
+    // endpoint with no native resiliency configured. GH-4079/#4080 fixed that, and all four now run
+    // unmodified from the base class. The full write-up is on PulsarTransportComplianceTests.
     //
-    // It stays skipped, but for the same reason as its two sibling fixtures below rather than a
-    // serialization one -- Pulsar has not implemented dead-letter routing. When GH-3797 lands this
-    // skip goes with the others, not separately.
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_move_to_dead_letter_queue_with_exception_match() => Task.CompletedTask;
-
-    // GH-3763. Deterministic failures shared with the other two Pulsar compliance fixtures -- the
-    // requeue, retry-scheduling and dead-letter behaviours the transport has not implemented. See GH-3797.
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_requeue_and_increment_attempts() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task can_schedule_retry() => Task.CompletedTask;
-
-    [Fact(Skip = "Pulsar does not implement this compliance behaviour yet -- see GH-3797. Skipped rather than tagged Flaky: it fails deterministically, on every run, alone or in a suite.")]
-    public override Task will_move_to_dead_letter_queue_without_any_exception_match() => Task.CompletedTask;
+    // will_move_to_dead_letter_queue_with_exception_match had also carried a CloudEvents-specific
+    // serialization reason before that, which GH-3800 removed: ErrorCausingMessage records an exception
+    // TYPE NAME rather than a live Exception, so it survives System.Text.Json and CloudEvents no longer
+    // corrupts it. Neither reason applies now, so it too runs from the base class.
 }


### PR DESCRIPTION
Closes #3797.

## The premise was stale

The issue tracked four behaviours as unimplemented Pulsar transport work. They were never unimplemented. **All twelve tests pass on current `main` with no transport change at all** — the whole of this PR is deleting the skips and writing down why.

Baseline, per test, un-skipped and run against `origin/main` (`28f826c05`):

| Test | `PulsarTransportComplianceTests` | `InlinePulsar…` | `with_cloud_events` |
|---|---|---|---|
| `will_requeue_and_increment_attempts` | ✅ passes | ✅ passes | ✅ passes |
| `can_schedule_retry` | ✅ passes | ✅ passes | ✅ passes |
| `will_move_to_dead_letter_queue_without_any_exception_match` | ✅ passes | ✅ passes | ✅ passes |
| `will_move_to_dead_letter_queue_with_exception_match` | ✅ passes | ✅ passes | ✅ passes |

## What was actually broken

`UsePulsar()` registers `PulsarNativeResiliencyPolicy`'s failure rule **globally**, with an `AlwaysMatches` condition, so it sorted ahead of every `opts.Policies.OnException<T>()` rule the compliance fixture configures. Its source claimed the failure for *any* `PulsarListener`, and `PulsarNativeResiliencyContinuation` then did nothing at all when the endpoint had no retry-letter topic, no native dead-letter topic and no `UseNativeRedelivery()` — which is exactly what all three fixtures configure. The message vanished, hence `"No ending activity detected"`.

So the fixtures' own `Requeue()` / `ScheduleRetry()` / `MoveToErrorQueue()` policies were never reached. The behaviours were not missing; they were unreachable.

#4080 (GH-4079) fixed that by letting a continuation source decline, and the Pulsar source now claims a failure only when there is native resiliency to hand it to. Nothing needed implementing on top of it.

## Red baseline

Restoring the pre-#4080 predicate — `envelope.Listener is PulsarListener`, without the `HasNativeResiliency` check — fails **all twelve deterministically**; restoring it passes all twelve. Ran that in both directions.

One stale-build false negative got caught in between and is worth flagging: `sed -i.bak` restores the *original* mtime, so MSBuild considered the source older than the DLL, skipped the rebuild, and re-ran the broken binary. That looked exactly like flakiness and was not.

## What about the native DLQ?

Left alone, deliberately. `PulsarEndpoint.TryBuildDeadLetterSender` still returns false (#3186) and that is still correct — returning a sender would make `BufferedReceiver`/`DurableReceiver` report `NativeDeadLetterQueueEnabled`, which `MessageContext.tryGetDeadLetterQueue` prefers over the listener, hijacking the richer native path and dropping the reconsume metadata. Dead-lettering on Pulsar has exactly two supported destinations: the native `{topic}-DLQ` topic via `DeadLetterQueueing(...)`, or Wolverine's durable dead letter table. With **neither** configured a `MoveToErrorQueue()` is logged and then discarded, because there is nowhere for it to go.

That is the same as any other transport running without a message store, but it is easy to miss on Pulsar because the native DLQ looks like it should apply and does not until you ask for it. The transport page now says so explicitly, alongside a table of where each error policy actually lands on a plain Pulsar listener.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors
- CoreTests: **2636 total / 0 failed** (matches the known-clean `main` count)
- `Wolverine.Pulsar.Tests`: **250 total / 0 failed / 0 skipped**, twice. `main` discovers the same 250 with 12 skipped — same discovery count, twelve more actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
