### PR TITLE
GH-4044: conjoined EF Core tenancy when Marten owns the message store

### DIFF
--- a/docs/guide/durability/efcore/multi-tenancy.md
+++ b/docs/guide/durability/efcore/multi-tenancy.md
@@ -47,7 +47,7 @@ builder.UseWolverine(opts =>
     }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L25-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_postgresql' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L27-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_postgresql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And instead with [multi-tenanted SQL Server](/guide/durability/sqlserver.html#multi-tenancy) storage:
@@ -87,7 +87,7 @@ builder.UseWolverine(opts =>
     }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L56-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L58-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note in both samples how I'm registering the `DbContext` types. There's a fluent interface first to register the multi-tenanted
@@ -172,7 +172,7 @@ builder.UseWolverine(opts =>
     }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L56-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L58-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_static_tenant_registry_with_sqlserver' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Then you can _still_ use those EF Core `DbContext` services with Wolverine messaging including the Wolverine outbox like 
@@ -209,7 +209,7 @@ public class MyMessageHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L185-L214' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_idbcontextoutboxfactory' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L187-L216' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_idbcontextoutboxfactory' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The important thing to note above is just that this pattern and service will work with any .NET code and not just within Wolverine
@@ -255,7 +255,7 @@ public class TenantedItem : ITenanted
     public string? TenantId { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L304-L319' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenanted_entity' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L372-L387' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenanted_entity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and registering the `DbContext` with conjoined tenancy:
@@ -285,7 +285,7 @@ builder.UseWolverine(opts =>
         }, AutoCreate.CreateOrUpdate);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L222-L245' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_postgresql' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L224-L247' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_postgresql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With that registration, Wolverine takes over all the mechanical multi-tenancy chores you would otherwise hand-roll
@@ -559,6 +559,45 @@ public static class CrossTenantWriteDemo
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/ConjoinedMultiTenantedEfCore/Demos/CrossTenantWriteDemo.cs#L28-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_cross_tenant_write_rejection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### With Marten Owning the Message Store <Badge type="tip" text="6.30" />
+
+If Marten owns the message storage through `IntegrateWithWolverine()`, Wolverine's message store is built from
+Marten's `NpgsqlDataSource` and never sees a connection string. `NpgsqlDataSource.ConnectionString` deliberately
+omits the password, so there is no string the conjoined `DbContext` could be configured with that the database
+would actually accept. Use the overload that hands you the `DbDataSource` itself instead:
+
+<!-- snippet: sample_conjoined_tenancy_with_marten_owned_store -->
+<a id='snippet-sample_conjoined_tenancy_with_marten_owned_store'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+
+var configuration = builder.Configuration;
+
+builder.UseWolverine(opts =>
+{
+    // Marten owns the message storage here, so Wolverine's message store is built
+    // from Marten's NpgsqlDataSource rather than from a connection string
+    opts.Services.AddMarten(m =>
+    {
+        m.Connection(configuration.GetConnectionString("main")!);
+    }).IntegrateWithWolverine();
+
+    // ...which means the conjoined DbContext has to be configured from that same
+    // DbDataSource. NpgsqlDataSource.ConnectionString deliberately omits the password,
+    // so the connection string overload cannot authenticate in this setup
+    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.ConjoinedItemsDbContext>(
+        (builder, dataSource) =>
+        {
+            builder.UseNpgsql((NpgsqlDataSource)dataSource);
+        }, AutoCreate.CreateOrUpdate);
+});
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L252-L277' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_marten_owned_store' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Registering the connection string overload in this setup fails fast at startup with an error naming this
+overload, rather than surfacing later as an authentication failure.
+
 ### Tenant Partitioning <Badge type="tip" text="6.21" />
 
 Opt into Weasel-managed **partition-per-tenant** physical partitioning with `PartitionPerTenant()`:
@@ -579,7 +618,7 @@ opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.
         partitioning.AllowPartitionSharing = true;
     }));
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L257-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_partitioning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L289-L302' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenancy_with_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With partitioning enabled:
@@ -611,7 +650,7 @@ await partitions.AddTenantAsync("small-tenant-b", "shared_bucket");
 // Dropping a tenant's partition removes its rows
 await partitions.DropTenantAsync("tenant1", deleteData: true);
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L271-L285' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_partitioning_tenant_management' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L308-L324' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_partitioning_tenant_management' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that with partitioning enabled, a tenant's partition must exist before rows can be written for that tenant.
@@ -666,7 +705,28 @@ succeed — one table's DDL failing does not roll back the tables that already r
 `TenantPartitionResult` reporting the outcome per table, so callers can surface partial failures instead of
 inferring success from the absence of an exception:
 
-snippet: sample_conjoined_partitioning_status_reporting
+<!-- snippet: sample_conjoined_partitioning_status_reporting -->
+<a id='snippet-sample_conjoined_partitioning_status_reporting'></a>
+```cs
+// Partition DDL is applied per table with failures isolated, so a batch
+// can partially succeed -- check the result rather than relying on the
+// absence of an exception
+var result = await partitions.AddTenantsAsync(new Dictionary<string, string?>
+{
+    ["tenant2"] = null,
+    ["tenant3"] = null
+});
+
+if (!result.Succeeded)
+{
+    foreach (var table in result.Failures)
+    {
+        Console.WriteLine($"{table.TableName} => {table.Status}");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L326-L343' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_partitioning_status_reporting' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 On SQL Server the result also carries the `tenant_id -> ordinal` map that was assigned. On PostgreSQL, which
 partitions by list on the tenant id itself, `Ordinals` is empty.
@@ -682,7 +742,19 @@ managed set — a newly deployed service, or a newly mapped `ITenanted` entity �
 registered before that table existed**. `MigrateTenantPartitionsAsync()` reconciles every partitioned table
 against the full registered tenant set:
 
-snippet: sample_conjoined_partitioning_back_fill
+<!-- snippet: sample_conjoined_partitioning_back_fill -->
+<a id='snippet-sample_conjoined_partitioning_back_fill'></a>
+```cs
+// Back-fill: reconcile every partitioned table against the full registered
+// tenant set. Needed when a table joins an existing managed set -- a newly
+// deployed service, or a newly mapped ITenanted entity -- because routine
+// migrations deliberately leave managed partitions alone, so the new table
+// would have no partition for any tenant registered before it existed
+var backFill = await partitions.MigrateTenantPartitionsAsync();
+Console.WriteLine($"Back-fill reconciled {backFill.Tables.Count} table(s)");
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L345-L353' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_partitioning_back_fill' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 The back-fill is a reconcile rather than a one-shot, so it is safe to run on every deploy. It also repairs a
 partitioned table that is missing a partition for an already-registered tenant.
@@ -711,7 +783,7 @@ await tenants.EnableTenantAsync("tenant1");
 // tenant's partition is dropped along with its rows
 await tenants.RemoveTenantAsync("tenant1");
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L287-L301' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenant_registry' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs#L355-L369' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_conjoined_tenant_registry' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Disabled tenants are rejected at `SaveChanges` time with `UnknownTenantIdException`. Removing a tenant deletes its

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/MartenOwnedStoreModel.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/MartenOwnedStoreModel.cs
@@ -1,0 +1,67 @@
+using JasperFx.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.Attributes;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+// GH-4044. A conjoined EF model in a database where Marten owns envelope storage. Its own
+// DbContext type so the conjoined model cache cannot conflate it with the other batteries.
+public class MartenOwnedItem : ITenanted
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? TenantId { get; set; }
+}
+
+public record CreateMartenOwnedItem(Guid Id, string Name);
+
+[WolverineIgnore]
+public class MartenOwnedItemHandler
+{
+    public static void Handle(CreateMartenOwnedItem command, MartenOwnedItemsDbContext db)
+    {
+        db.Items.Add(new MartenOwnedItem { Id = command.Id, Name = command.Name });
+    }
+}
+
+public class MartenOwnedItemsDbContext : DbContext
+{
+    public const string SchemaName = "gh4044_ef";
+
+    public MartenOwnedItemsDbContext(DbContextOptions<MartenOwnedItemsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<MartenOwnedItem> Items { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MartenOwnedItem>(map =>
+        {
+            map.ToTable("marten_owned_items", SchemaName);
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+        });
+    }
+}
+
+// GH-4044. Its own type so the connection-string pin cannot reuse a cached model from the
+// DbDataSource-configured context above
+public class StringConfiguredDbContext : DbContext
+{
+    public StringConfiguredDbContext(DbContextOptions<StringConfiguredDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<MartenOwnedItem> Items { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MartenOwnedItem>(map =>
+        {
+            map.ToTable("string_configured_items", MartenOwnedItemsDbContext.SchemaName);
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+        });
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/marten_owned_store_with_conjoined_efcore_tenancy.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/marten_owned_store_with_conjoined_efcore_tenancy.cs
@@ -1,0 +1,147 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.EntityFrameworkCore.Internals;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace EfCoreTests.MultiTenancy.ConjoinedTenancy;
+
+/// <summary>
+/// GH-4044. Marten owning the message store through IntegrateWithWolverine() alongside
+/// Wolverine-managed conjoined EF Core tenancy against the same Postgres database.
+///
+/// <para>Marten hands Wolverine an NpgsqlDataSource, never a connection string, and
+/// NpgsqlDataSource.ConnectionString deliberately drops the password -- so the connection-string
+/// form of the conjoined registration cannot work here no matter what the message store surfaces.
+/// The DbDataSource overload carries the credentials through intact; the connection-string form is
+/// pinned below to fail with an error that says so.</para>
+/// </summary>
+[Collection("multi-tenancy")]
+public class marten_owned_store_with_conjoined_efcore_tenancy : IAsyncLifetime
+{
+    private const string MartenSchema = "gh4044_marten";
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"DROP SCHEMA IF EXISTS {MartenOwnedItemsDbContext.SchemaName} CASCADE; " +
+            $"DROP SCHEMA IF EXISTS {MartenSchema} CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static Task<IHost> startHostAsync()
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<MartenOwnedItemHandler>();
+
+                opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<MartenOwnedItemsDbContext>(
+                    (builder, dataSource) => builder.UseNpgsql((NpgsqlDataSource)dataSource),
+                    AutoCreate.CreateOrUpdate,
+                    tenancy => tenancy.PartitionPerTenant());
+
+                // Marten, not PersistMessagesWithPostgresql(), owns envelope storage here
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = MartenSchema;
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddResourceSetupOnStartup();
+                opts.PublishAllMessages().Locally();
+            }).StartAsync();
+    }
+
+    [Fact]
+    public async Task the_host_starts_and_the_conjoined_db_context_resolves_a_connection_string()
+    {
+        using var host = await startHostAsync();
+
+        var builder = host.Services.GetRequiredService<IDbContextBuilder<MartenOwnedItemsDbContext>>();
+        var context = await builder.BuildAsync(CancellationToken.None);
+
+        // Marten's data source is the one thing the conjoined builder can read here, so prove it
+        // arrived rather than settling for "the host did not throw"
+        context.Database.GetConnectionString()
+            .ShouldNotBeNullOrEmpty();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task the_connection_string_overload_explains_why_it_cannot_work_here()
+    {
+        // Red baseline for the fix: without the DbDataSource overload the only string available is
+        // the data source's, which has no password, so this used to die on a SCRAM login failure a
+        // long way from the cause
+        var ex = await Should.ThrowAsync<Exception>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+                    opts.Discovery.DisableConventionalDiscovery();
+
+                    opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<StringConfiguredDbContext>(
+                        (builder, connectionString) => builder.UseNpgsql(connectionString.Value),
+                        AutoCreate.CreateOrUpdate);
+
+                    opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = MartenSchema;
+                        m.DisableNpgsqlLogging = true;
+                    }).IntegrateWithWolverine();
+
+                    opts.UseEntityFrameworkCoreTransactions();
+                    opts.Services.AddResourceSetupOnStartup();
+                }).StartAsync();
+        });
+
+        ex.ToString().ShouldContain("AddDbContextWithWolverineManagedConjoinedTenancy overload that takes a DbDataSource");
+    }
+
+    [Fact]
+    public async Task tenanted_writes_round_trip_through_the_conjoined_db_context()
+    {
+        using var host = await startHostAsync();
+
+        var partitions = host.Services.GetRequiredService<IConjoinedTenantPartitions<MartenOwnedItemsDbContext>>();
+        await partitions.AddTenantAsync("red", TestContext.Current.CancellationToken);
+        await partitions.AddTenantAsync("blue", TestContext.Current.CancellationToken);
+
+        var id = Guid.NewGuid();
+        await host.ExecuteAndWaitAsync(c => c.InvokeForTenantAsync("red", new CreateMartenOwnedItem(id, "red one")));
+
+        var builder = host.Services.GetRequiredService<IDbContextBuilder<MartenOwnedItemsDbContext>>();
+        var red = await builder.BuildAsync("red", CancellationToken.None);
+        (await EntityFrameworkQueryableExtensions.SingleAsync(red.Items, x => x.Id == id, TestContext.Current.CancellationToken)).TenantId.ShouldBe("red");
+
+        // ...and the tenant filter still holds, so this is conjoined tenancy and not just a DbContext
+        var blue = await builder.BuildAsync("blue", CancellationToken.None);
+        (await EntityFrameworkQueryableExtensions.AnyAsync(blue.Items, x => x.Id == id, TestContext.Current.CancellationToken)).ShouldBeFalse();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/mixed_efcore_and_marten_conjoined_tenancy.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/ConjoinedTenancy/mixed_efcore_and_marten_conjoined_tenancy.cs
@@ -70,12 +70,11 @@ public class mixed_efcore_and_marten_conjoined_tenancy : IAsyncLifetime
                 }).ApplyAllDatabaseChangesOnStartup();
 
                 // NOTE: deliberately NOT .IntegrateWithWolverine() here -- see GH-3531. Handing the
-                // Wolverine message store to Marten leaves the conjoined EF builder unable to resolve
-                // a connection string ("Unable to determine the database connection string for the
-                // conjoined multi-tenanted DbContext"), because it reads it from the message store's
-                // database settings and Marten's store does not surface one. That interaction is a
-                // finding in its own right; these tests are about partition and tenant OWNERSHIP
-                // between the two engines, which does not depend on who owns envelope storage.
+                // Wolverine message store to Marten means the conjoined EF builder has to be
+                // registered with the DbDataSource overload instead (GH-4044, covered by
+                // marten_owned_store_with_conjoined_efcore_tenancy). These tests are about partition
+                // and tenant OWNERSHIP between the two engines, which does not depend on who owns
+                // envelope storage, so they keep the simpler connection string registration.
 
                 opts.UseEntityFrameworkCoreTransactions();
                 opts.UseEntityFrameworkCoreWolverineManagedMigrations();

--- a/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
+++ b/src/Persistence/EfCoreTests.MultiTenancy/MultiTenancyDocumentationSamples.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.MultiTenancy;
+using Marten;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,7 @@ using Wolverine.ComplianceTests;
 using Wolverine.ComplianceTests.Scheduling;
 using Wolverine.EntityFrameworkCore;
 using Wolverine.EntityFrameworkCore.Internals;
+using Wolverine.Marten;
 using Wolverine.Postgresql;
 using Wolverine.SqlServer;
 
@@ -239,6 +241,36 @@ public class ConjoinedTenancyDocumentationSamples
                 (builder, connectionString) =>
                 {
                     builder.UseNpgsql(connectionString.Value);
+                }, AutoCreate.CreateOrUpdate);
+        });
+
+        #endregion
+    }
+
+    public async Task conjoined_tenancy_with_marten_owned_message_store()
+    {
+        #region sample_conjoined_tenancy_with_marten_owned_store
+
+        var builder = Host.CreateApplicationBuilder();
+
+        var configuration = builder.Configuration;
+
+        builder.UseWolverine(opts =>
+        {
+            // Marten owns the message storage here, so Wolverine's message store is built
+            // from Marten's NpgsqlDataSource rather than from a connection string
+            opts.Services.AddMarten(m =>
+            {
+                m.Connection(configuration.GetConnectionString("main")!);
+            }).IntegrateWithWolverine();
+
+            // ...which means the conjoined DbContext has to be configured from that same
+            // DbDataSource. NpgsqlDataSource.ConnectionString deliberately omits the password,
+            // so the connection string overload cannot authenticate in this setup
+            opts.Services.AddDbContextWithWolverineManagedConjoinedTenancy<ConjoinedTenancy.ConjoinedItemsDbContext>(
+                (builder, dataSource) =>
+                {
+                    builder.UseNpgsql((NpgsqlDataSource)dataSource);
                 }, AutoCreate.CreateOrUpdate);
         });
 

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/ConjoinedDbContextBuilder.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FastExpressionCompiler;
@@ -27,7 +28,8 @@ namespace Wolverine.EntityFrameworkCore.Internals;
     Justification = "FastExpressionCompiler emits IL at registration time; AOT consumers register an explicit factory. See AOT guide / #2755.")]
 public class ConjoinedDbContextBuilder<T> : IDbContextBuilder<T> where T : DbContext
 {
-    private readonly Action<DbContextOptionsBuilder<T>, ConnectionString> _configuration;
+    private readonly Action<DbContextOptionsBuilder<T>, ConnectionString>? _configuration;
+    private readonly Action<DbContextOptionsBuilder<T>, DbDataSource>? _dataSourceConfiguration;
     private readonly Func<DbContextOptions<T>, T> _constructor;
     private readonly IMessageDatabase _database;
     private readonly IDomainEventScraper[] _domainScrapers;
@@ -37,10 +39,31 @@ public class ConjoinedDbContextBuilder<T> : IDbContextBuilder<T> where T : DbCon
     public ConjoinedDbContextBuilder(IServiceProvider serviceProvider, IMessageDatabase database,
         Action<DbContextOptionsBuilder<T>, ConnectionString> configuration,
         IEnumerable<IDomainEventScraper> domainScrapers)
+        : this(serviceProvider, database, domainScrapers)
+    {
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// GH-4044. Configures the shared DbContext from the message store's own DbDataSource rather than
+    /// from a connection string. Necessary whenever the store was built from a data source instead of
+    /// a connection string -- Marten's IntegrateWithWolverine() is the common case -- because
+    /// NpgsqlDataSource.ConnectionString deliberately omits the password, so the string round trip
+    /// cannot produce credentials the database will accept.
+    /// </summary>
+    public ConjoinedDbContextBuilder(IServiceProvider serviceProvider, IMessageDatabase database,
+        Action<DbContextOptionsBuilder<T>, DbDataSource> configuration,
+        IEnumerable<IDomainEventScraper> domainScrapers)
+        : this(serviceProvider, database, domainScrapers)
+    {
+        _dataSourceConfiguration = configuration;
+    }
+
+    private ConjoinedDbContextBuilder(IServiceProvider serviceProvider, IMessageDatabase database,
+        IEnumerable<IDomainEventScraper> domainScrapers)
     {
         _serviceProvider = serviceProvider;
         _database = database;
-        _configuration = configuration;
         _domainScrapers = domainScrapers.ToArray();
 
         var optionsType = typeof(DbContextOptions<T>);
@@ -138,21 +161,40 @@ public class ConjoinedDbContextBuilder<T> : IDbContextBuilder<T> where T : DbCon
 
     private DbContextOptions<T> buildOptions()
     {
-        var connectionString = _database.Settings.ConnectionString ?? _database.Settings.DataSource?.ConnectionString;
-        if (connectionString.IsEmpty())
-        {
-            throw new InvalidOperationException(
-                $"Unable to determine the database connection string for the conjoined multi-tenanted DbContext {typeof(T).FullNameInCode()}");
-        }
-
         var builder = new DbContextOptionsBuilder<T>();
         builder.UseApplicationServiceProvider(_serviceProvider);
         builder.ReplaceService<IModelCustomizer, ConjoinedTenancyModelCustomizer>();
         // Cache models per (context type, wolverine schema) -- GH-3497
         builder.ReplaceService<IModelCacheKeyFactory, WolverineModelCacheKeyFactory>();
         builder.AddInterceptors(TenantStampingInterceptor.Instance);
-        _configuration(builder, new ConnectionString(connectionString!));
+
+        if (_dataSourceConfiguration != null)
+        {
+            _dataSourceConfiguration(builder, _database.DataSource);
+        }
+        else
+        {
+            _configuration!(builder, new ConnectionString(determineConnectionString()));
+        }
 
         return builder.Options;
     }
+
+    private string determineConnectionString()
+    {
+        var connectionString = _database.Settings.ConnectionString ?? _database.Settings.DataSource?.ConnectionString;
+        if (connectionString.IsEmpty())
+        {
+            throw new InvalidOperationException(
+                $"Unable to determine the database connection string for the conjoined multi-tenanted DbContext {typeof(T).FullNameInCode()}. {dataSourceAdvice}");
+        }
+
+        return connectionString!;
+    }
+
+    // GH-4044. A store built from a DbDataSource cannot hand back a usable connection string --
+    // NpgsqlDataSource.ConnectionString drops the password -- so the failure surfaces as a login
+    // error a long way from its cause. Point at the overload that carries credentials.
+    private static string dataSourceAdvice =>
+        $"Wolverine's message store was built from a {nameof(DbDataSource)} rather than a connection string, which is what Marten's IntegrateWithWolverine() does. Register the conjoined DbContext with the AddDbContextWithWolverineManagedConjoinedTenancy overload that takes a {nameof(DbDataSource)} instead.";
 }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/WolverineEntityCoreExtensions.cs
@@ -126,6 +126,36 @@ public static class WolverineEntityCoreExtensions
         Action<DbContextOptionsBuilder<T>, ConnectionString> dbContextConfiguration, AutoCreate autoCreate = AutoCreate.None,
         Action<ConjoinedTenancyOptions>? tenancy = null) where T : DbContext
     {
+        return services.addConjoinedTenancy<T>(
+            (s, database) => new ConjoinedDbContextBuilder<T>(s, database, dbContextConfiguration,
+                s.GetServices<IDomainEventScraper>()), autoCreate, tenancy);
+    }
+
+    /// <summary>
+    /// Register a DbContext type that should use Wolverine managed conjoined multi-tenancy, configured from the
+    /// message store's own DbDataSource rather than from a connection string. Use this overload whenever Wolverine's
+    /// message store was itself built from a DbDataSource -- Marten's IntegrateWithWolverine() being the common case --
+    /// because a DbDataSource does not expose a connection string that still carries credentials
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="dbContextConfiguration"></param>
+    /// <param name="autoCreate">Should this application try to create the database and apply missing migrations at application startup? Default is None, all other options will create the database.</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static IServiceCollection AddDbContextWithWolverineManagedConjoinedTenancy<T>(this IServiceCollection services,
+        Action<DbContextOptionsBuilder<T>, DbDataSource> dbContextConfiguration, AutoCreate autoCreate = AutoCreate.None,
+        Action<ConjoinedTenancyOptions>? tenancy = null) where T : DbContext
+    {
+        return services.addConjoinedTenancy<T>(
+            (s, database) => new ConjoinedDbContextBuilder<T>(s, database, dbContextConfiguration,
+                s.GetServices<IDomainEventScraper>()), autoCreate, tenancy);
+    }
+
+    private static IServiceCollection addConjoinedTenancy<T>(this IServiceCollection services,
+        Func<IServiceProvider, IMessageDatabase, IDbContextBuilder<T>> builderSource, AutoCreate autoCreate,
+        Action<ConjoinedTenancyOptions>? tenancy) where T : DbContext
+    {
         var conjoinedOptions = new ConjoinedTenancyOptions();
         tenancy?.Invoke(conjoinedOptions);
         ConjoinedTenancy.SetOptions(typeof(T), conjoinedOptions);
@@ -175,7 +205,7 @@ public static class WolverineEntityCoreExtensions
                     $"Conjoined multi-tenancy for {typeof(T).FullNameInCode()} requires Wolverine to be configured with relational database message storage");
             }
 
-            return new ConjoinedDbContextBuilder<T>(s, database, dbContextConfiguration, s.GetServices<IDomainEventScraper>());
+            return builderSource(s, database);
         });
 
         services.AddSingleton<IDbContextBuilder>(s => s.GetRequiredService<IDbContextBuilder<T>>());

--- a/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
+++ b/src/Persistence/Wolverine.Marten/WolverineOptionsMartenExtensions.cs
@@ -26,6 +26,7 @@ using Wolverine.Persistence.Sagas;
 using Wolverine.Postgresql;
 using Wolverine.RDBMS;
 using Wolverine.RDBMS.MultiTenancy;
+using Wolverine.Postgresql.MultiTenancy;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
 using MultiTenantedMessageStore = Wolverine.Persistence.Durability.MultiTenantedMessageStore;
@@ -121,6 +122,12 @@ public static class WolverineOptionsMartenExtensions
         expression.Services
             .TryAddSingleton<IDocumentSessionFactory<IDocumentSession, IQuerySession>>(s =>
                 (IDocumentSessionFactory<IDocumentSession, IQuerySession>)s.GetRequiredService<IDocumentStore>());
+
+        // GH-4044. Conjoined EF Core tenant partitioning finds its provider through this factory, and
+        // PersistMessagesWithPostgresql() is the only other thing that registers it -- which an
+        // application letting Marten own the message store never calls
+        expression.Services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<ITenantPartitioningProviderFactory, PostgresqlTenantPartitioningProviderFactory>());
 
         // Gotta have at least a placeholder just in case a user also has
         // EF Core


### PR DESCRIPTION
Closes #4044.

Combining Marten's `IntegrateWithWolverine()` with Wolverine-managed **conjoined** EF Core tenancy died at host startup with `Unable to determine the database connection string for the conjoined multi-tenanted DbContext`.

## The suggested fix doesn't work, and it's measurable

The issue proposed setting `DataSource` on the message store's `DatabaseSettings` in `BuildSinglePostgresqlMessageStore`, so the conjoined builder's existing fallback (`Settings.ConnectionString ?? Settings.DataSource?.ConnectionString`) could read a string off it.

That is not sufficient. `NpgsqlDataSource.ConnectionString` **deliberately omits the password**, so the fallback yields a string the server rejects — the startup failure just moves to `No password has been provided but the backend requires one (in SASL/SCRAM-SHA-256)`, much further from its cause. Probed directly:

```
ORIGINAL:      Host=localhost;Port=5433;Database=postgres;Username=postgres;password=postgres
DS.ConnString: Host=localhost;Port=5433;Database=postgres;Username=postgres
Conn.ConnStr:  Host=localhost;Port=5433;Database=postgres;Username=postgres
```

Marten's `MartenDatabase` exposes only `DataSource` — there is no recoverable connection string anywhere on that path. Applying the suggested change would have made the error *worse* (an obscure login failure instead of a clear "cannot determine"), so it is deliberately **not** part of this PR.

## What this does instead — carry the data source itself

- **A `DbDataSource` overload of `AddDbContextWithWolverineManagedConjoinedTenancy`**, mirroring the shape `TenantedDbContextBuilderByDbDataSource` already uses for database-per-tenant. `ConjoinedDbContextBuilder` gains the matching constructor and configures from `IMessageDatabase.DataSource`, credentials intact. The registration body is now shared by both overloads via a private `addConjoinedTenancy<T>` taking a builder factory.

- **The connection-string overload now explains itself.** When the store has no connection string of its own, the error names the overload to use instead of failing with a bare "unable to determine".

- **A second, independent defect on the same path.** `IntegrateWithWolverine()` never registered `PostgresqlTenantPartitioningProviderFactory` — only `PersistMessagesWithPostgresql()` did, which an application letting Marten own the store never calls. So `PartitionPerTenant()` failed with `No tenant partitioning support is registered for EF Core provider 'Npgsql.EntityFrameworkCore.PostgreSQL'`. Not mentioned in the issue; it only surfaced once the first fix let the host get further.

Also refreshes the stale comment in `mixed_efcore_and_marten_conjoined_tenancy` that recorded this interaction as an unsolved finding, and documents the new overload with an mdsnippets sample.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| MartenTests | 617 / 617 |
| EfCoreTests | 205 / 205 |
| EfCoreTests.MultiTenancy | 200 total, 52 failed — **identical 52 to an `origin/main` worktree** (197 / 52) |

Those 52 are stale local SQL Server state (`Cannot insert the value NULL into column 'Name'`), confirmed against a clean detached `origin/main` worktree rather than assumed. Three new tests pass.

Red baseline: both positive tests failed on unmodified source at `ConjoinedDbContextBuilder.cs:144`, and `the_connection_string_overload_explains_why_it_cannot_work_here` pins the pre-fix behaviour so the string form can never silently start "working".

Rebased onto `main` after #4093 and #4097 merged; full solution build and the conjoined suites re-run green on that base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)