### PR TITLE
GH-3764: document mapping Marten concurrency conflicts to 409 ProblemDetails

### DIFF
--- a/docs/guide/http/exception-handling.md
+++ b/docs/guide/http/exception-handling.md
@@ -32,7 +32,7 @@ public static class OnExceptionEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L21-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_handler_level' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L22-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_handler_level' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Key behaviors:
@@ -87,7 +87,7 @@ public static class MultipleExceptionEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L47-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_specific' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L48-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_specific' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Async Exception Handlers
@@ -120,7 +120,7 @@ public static class AsyncExceptionEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L90-L114' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_async' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L91-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Combining with Finally
@@ -161,7 +161,7 @@ public static class ExceptionWithFinallyEndpoints
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L116-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_with_finally' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/OnExceptionEndpoints.cs#L117-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_on_exception_with_finally' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The execution order is: Handler (throws) -> OnException -> Finally
@@ -206,6 +206,97 @@ app.MapWolverineEndpoints(opts =>
         chain => chain.Method.HandlerType.Namespace == "MyApp.Api");
 });
 ```
+
+## Recipe: Marten Concurrency Conflicts as 409 <Badge type="tip" text="6.30" />
+
+An endpoint using `[WriteAggregate]`, `[Aggregate]`, or any chain that commits a Marten session can lose an
+optimistic concurrency race -- two clients posting to the same aggregate at the same time. Without a handler
+the exception escapes the endpoint as an unhandled **500**, even though nothing went wrong with the data:
+optimistic concurrency did its job. **409 Conflict** is the honest status for that.
+
+The `OnException` middleware convention is all you need. There are two exception types to cover, and the
+second one is easy to miss:
+
+<!-- snippet: sample_marten_concurrency_exception_middleware -->
+<a id='snippet-sample_marten_concurrency_exception_middleware'></a>
+```cs
+/// <summary>
+/// Maps Marten's commit time concurrency failures onto a 409 ProblemDetails response
+/// instead of letting them escape as an unhandled 500
+/// </summary>
+public static class MartenConcurrencyExceptionMiddleware
+{
+    // Marten's optimistic concurrency failures -- EventStreamUnexpectedMaxEventIdException from
+    // the event store, and document level concurrency violations -- all derive from
+    // JasperFx.ConcurrencyException, so one handler covers them
+    public static ProblemDetails OnException(ConcurrencyException ex)
+    {
+        return new ProblemDetails
+        {
+            Status = 409,
+            Title = "Conflict",
+            Detail = ex.Message
+        };
+    }
+
+    // StreamLockedException does NOT derive from ConcurrencyException -- it is a MartenException --
+    // so the FetchForExclusiveWriting path needs its own handler. Catching only ConcurrencyException
+    // silently misses it
+    public static ProblemDetails OnException(StreamLockedException ex)
+    {
+        return new ProblemDetails
+        {
+            Status = 409,
+            Title = "Conflict",
+            Detail = ex.Message
+        };
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/ConcurrencyEndpoints.cs#L32-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_marten_concurrency_exception_middleware' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning `StreamLockedException` is not a `ConcurrencyException`
+`EventStreamUnexpectedMaxEventIdException` and Marten's document level concurrency violations derive from
+`JasperFx.ConcurrencyException`, so a single handler covers both. But `Marten.Exceptions.StreamLockedException`
+-- what `FetchForExclusiveWriting` throws on a contended stream -- derives from `MartenException` instead.
+A recipe that catches only `ConcurrencyException` silently leaves the exclusive locking path returning 500s.
+:::
+
+Register it across the endpoints that commit Marten sessions:
+
+```csharp
+app.MapWolverineEndpoints(opts =>
+{
+    opts.AddMiddleware(typeof(MartenConcurrencyExceptionMiddleware),
+        chain => chain.IsTransactional);
+});
+```
+
+If you would rather advertise the conflict in your OpenAPI document -- so generated clients know 409 is a
+possible response -- add a small `IHttpPolicy` that stamps the metadata on the same chains:
+
+```csharp
+public class ConcurrencyProblemPolicy : IHttpPolicy
+{
+    public void Apply(IReadOnlyList<HttpChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains.Where(x => x.IsTransactional))
+        {
+            chain.Metadata.ProducesProblem(409);
+        }
+    }
+}
+```
+
+Applications that adopt client supplied `If-Match` preconditions may prefer **412 Precondition Failed** to 409
+-- the status is just a number in your own handler, so use whichever dialect your API speaks.
+
+::: tip Give exclusive locking a short timeout
+`FetchForExclusiveWriting` waits on a database lock rather than failing immediately, and only surfaces
+`StreamLockedException` once the command times out -- **30 seconds** by default, which no HTTP request should
+ever spend. Open the session with a short `SessionOptions.Timeout` so a contended stream becomes a prompt 409.
+:::
 
 ## Return Value Semantics
 

--- a/src/Http/Wolverine.Http.Tests/Marten/marten_concurrency_problem_details.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/marten_concurrency_problem_details.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Alba;
+using JasperFx;
+using Marten;
+using Marten.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+/// <summary>
+/// GH-3764. A [WriteAggregate] style endpoint that loses an optimistic concurrency race used to
+/// surface EventStreamUnexpectedMaxEventIdException as an unhandled 500 -- data integrity held,
+/// but the HTTP contract leaked the internal failure.
+///
+/// <para>The fix is the OnException middleware convention rather than anything in the codegen
+/// pipeline, so these tests exercise the documented recipe end to end. The second one matters
+/// most: StreamLockedException is a MartenException, NOT a ConcurrencyException, so a recipe that
+/// catches only ConcurrencyException silently misses the FetchForExclusiveWriting path.</para>
+/// </summary>
+public class marten_concurrency_problem_details(AppFixture fixture) : IntegrationContext(fixture)
+{
+    private async Task<Guid> createSeatHoldAsync()
+    {
+        var result = await Host.Scenario(x =>
+        {
+            x.Post.Url("/seatholds/create");
+            x.StatusCodeShouldBeOk();
+        });
+
+        return JsonSerializer.Deserialize<Guid>(await result.ReadAsTextAsync());
+    }
+
+    [Fact]
+    public async Task optimistic_concurrency_failure_becomes_a_409_problem_details()
+    {
+        var id = await createSeatHoldAsync();
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Post.Url($"/seatholds/{id}/optimistic-conflict");
+            x.StatusCodeShouldBe(409);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        // EventStreamUnexpectedMaxEventIdException names the stream it could not append to
+        (await result.ReadAsTextAsync()).ShouldContain("Unexpected starting version number");
+    }
+
+    [Fact]
+    public async Task stream_locked_failure_becomes_a_409_problem_details()
+    {
+        var id = await createSeatHoldAsync();
+
+        var store = Host.Services.GetRequiredService<IDocumentStore>();
+
+        // Hold the exclusive lock on a separate connection for the duration of the request, so the
+        // endpoint's own FetchForExclusiveWriting genuinely loses the race rather than being told
+        // to throw. Marten uses a non-blocking try-lock here, so this fails fast
+        await using var holder = store.LightweightSession();
+        await holder.Events.FetchForExclusiveWriting<SeatHold>(id, TestContext.Current.CancellationToken);
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Post.Url($"/seatholds/{id}/exclusive");
+            x.StatusCodeShouldBe(409);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        // Assert on the text StreamLockedException actually produces, so this cannot quietly start
+        // passing on some other exception that also maps to 409
+        (await result.ReadAsTextAsync()).ShouldContain("may be locked for updates");
+    }
+
+    [Fact]
+    public void the_two_exception_types_are_unrelated_which_is_why_both_handlers_exist()
+    {
+        // Pins the reason the middleware needs two OnException methods. If Marten ever moves
+        // StreamLockedException under ConcurrencyException this test should fail loudly rather
+        // than leaving a redundant handler in the docs
+        typeof(StreamLockedException).IsAssignableTo(typeof(ConcurrencyException)).ShouldBeFalse();
+        typeof(global::JasperFx.Events.EventStreamUnexpectedMaxEventIdException)
+            .IsAssignableTo(typeof(ConcurrencyException)).ShouldBeTrue();
+    }
+}

--- a/src/Http/WolverineWebApi/Marten/ConcurrencyEndpoints.cs
+++ b/src/Http/WolverineWebApi/Marten/ConcurrencyEndpoints.cs
@@ -1,0 +1,111 @@
+using JasperFx;
+using Marten;
+using Marten.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Wolverine.Http;
+
+namespace WolverineWebApi.Marten;
+
+// GH-3764. A small aggregate of its own so the concurrency endpoints cannot disturb, or be
+// disturbed by, the Order battery that most of the other Marten HTTP tests share.
+public record SeatHoldStarted(string Name);
+
+public record SeatHoldConfirmed;
+
+public class SeatHold
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public int Confirmations { get; set; }
+
+    public void Apply(SeatHoldStarted e)
+    {
+        Name = e.Name;
+    }
+
+    public void Apply(SeatHoldConfirmed _)
+    {
+        Confirmations++;
+    }
+}
+
+#region sample_marten_concurrency_exception_middleware
+
+/// <summary>
+/// Maps Marten's commit time concurrency failures onto a 409 ProblemDetails response
+/// instead of letting them escape as an unhandled 500
+/// </summary>
+public static class MartenConcurrencyExceptionMiddleware
+{
+    // Marten's optimistic concurrency failures -- EventStreamUnexpectedMaxEventIdException from
+    // the event store, and document level concurrency violations -- all derive from
+    // JasperFx.ConcurrencyException, so one handler covers them
+    public static ProblemDetails OnException(ConcurrencyException ex)
+    {
+        return new ProblemDetails
+        {
+            Status = 409,
+            Title = "Conflict",
+            Detail = ex.Message
+        };
+    }
+
+    // StreamLockedException does NOT derive from ConcurrencyException -- it is a MartenException --
+    // so the FetchForExclusiveWriting path needs its own handler. Catching only ConcurrencyException
+    // silently misses it
+    public static ProblemDetails OnException(StreamLockedException ex)
+    {
+        return new ProblemDetails
+        {
+            Status = 409,
+            Title = "Conflict",
+            Detail = ex.Message
+        };
+    }
+}
+
+#endregion
+
+public static class ConcurrencyEndpoints
+{
+    [WolverinePost("/seatholds/create")]
+    public static async Task<Guid> Create(IDocumentSession session)
+    {
+        var id = session.Events.StartStream<SeatHold>(new SeatHoldStarted("Table for two")).Id;
+        await session.SaveChangesAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// Asserts a stale expected version on purpose, so SaveChangesAsync throws
+    /// EventStreamUnexpectedMaxEventIdException -- a JasperFx.ConcurrencyException
+    /// </summary>
+    [WolverinePost("/seatholds/{id}/optimistic-conflict")]
+    public static async Task<string> OptimisticConflict(Guid id, IDocumentSession session)
+    {
+        // The stream already has one event, so appending a second one lands it at version 2.
+        // Claiming 1 is the losing side of an optimistic concurrency race
+        session.Events.Append(id, 1, new SeatHoldConfirmed());
+        await session.SaveChangesAsync();
+
+        return "no conflict";
+    }
+
+    /// <summary>
+    /// Takes the exclusive lock the same way a real endpoint would. If something else already
+    /// holds it, Marten throws StreamLockedException rather than waiting
+    /// </summary>
+    [WolverinePost("/seatholds/{id}/exclusive")]
+    public static async Task<string> Exclusive(Guid id, IDocumentStore store)
+    {
+        // The exclusive lock waits on the database rather than failing instantly, so it surfaces as
+        // StreamLockedException only once the command times out -- 30 seconds by default, which no
+        // HTTP request should ever spend. A short timeout turns a contended stream into a prompt 409
+        await using var session = store.LightweightSession(new global::Marten.Services.SessionOptions { Timeout = 2 });
+        var stream = await session.Events.FetchForExclusiveWriting<SeatHold>(id);
+        stream.AppendOne(new SeatHoldConfirmed());
+        await session.SaveChangesAsync();
+
+        return "locked and written";
+    }
+}

--- a/src/Http/WolverineWebApi/Program.cs
+++ b/src/Http/WolverineWebApi/Program.cs
@@ -374,6 +374,11 @@ public class Program
 
             opts.AddPolicy<StreamCollisionExceptionPolicy>();
 
+            // GH-3764. Scoped to the concurrency endpoints so the 409 mapping cannot change the
+            // status codes the rest of this application's tests assert on
+            opts.AddMiddleware(typeof(MartenConcurrencyExceptionMiddleware),
+                chain => chain.Method.HandlerType == typeof(ConcurrencyEndpoints));
+
             opts.AddPolicy<FrameRearrangeMiddleware.HttpPolicy>();
 
             #region sample_adding_custom_parameter_handling


### PR DESCRIPTION
Closes #3764.

A `[WriteAggregate]` / `[Aggregate]` HTTP endpoint that loses an optimistic concurrency race surfaced `EventStreamUnexpectedMaxEventIdException` as an unhandled **500**. Data integrity held — optimistic concurrency did its job — but the HTTP contract leaked the internal failure.

## Following the decision already made, not the issue body

The issue proposes an opt-in `UseProblemDetailsForConcurrencyExceptions()` policy built on `chain.GetOrCreateTryCatchFinallyFrame().AddCatchBlock(...)`, and offers the reporter's draft PR #3765 as a starting point.

That PR was closed on 2026-08-01 with:

> We're just going to make the docs suggest using an exception filter. Really cleaner than trying to do this in the codegen pipeline IMO

So this PR adds **no new API**. It documents the `OnException` middleware convention that already exists, and backs the recipe with tests so it can't rot.

## The part that is easy to get wrong

Verified by walking the actual runtime hierarchies rather than trusting the docs:

```
EventStreamUnexpectedMaxEventIdException  ->  JasperFx.ConcurrencyException  ->  Exception
Marten.Exceptions.StreamLockedException   ->  Marten.Exceptions.MartenException  ->  Exception
```

`StreamLockedException` is **not** a `ConcurrencyException`. A recipe that catches only `ConcurrencyException` — the obvious one — silently leaves the `FetchForExclusiveWriting` path returning 500s. The middleware therefore has two `OnException` methods, and `the_two_exception_types_are_unrelated_which_is_why_both_handlers_exist` pins the relationship so the second one can't later be tidied away as redundant.

## A timeout caveat found while testing

`FetchForExclusiveWriting` waits on a database lock rather than failing fast, so `StreamLockedException` only surfaces once the command times out — **30 seconds** by default. The live contended test took 31s until the endpoint was given a short `SessionOptions.Timeout`; it now takes ~3s. That's the right shape for an HTTP endpoint regardless of testing, so it's documented as a tip.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| `Wolverine.Http.Tests` | **996 / 0 failed** |
| `origin/main` worktree baseline | 993 / 0 failed |

996 − 993 = exactly the three new tests, no regression.

**Red baseline**: with the middleware registration removed and a forced rebuild, both endpoints return `500` `text/plain` — the reported defect. The 409 assertions are on text specific to each exception (`"may be locked for updates"`, `"Unexpected starting version number"`) so they cannot pass on some other exception that also maps to 409.

Worth noting the full-suite run earned its keep: the first draft named the aggregate `Reservation`, which collided with the existing `WolverineWebApi.Reservation` on the Marten document alias `http.reservation`. That threw during `AddResourceSetupOnStartup` and took out six unrelated `using_efcore` tests as collateral. It passed in isolation. Renamed to `SeatHold`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)