### PR TITLE
GH-4095: a real crash test for NativeAck, and stop calling a drain a dead node

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/native_ack_mode.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/native_ack_mode.cs
@@ -201,7 +201,7 @@ public class native_ack_mode : IAsyncLifetime
     ///     anything. Only the SECOND node's recordings can come from a redelivery.
     /// </remarks>
     [Fact]
-    public async Task nothing_is_settled_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    public async Task nothing_is_settled_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {
         NativeAckSqsTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_mode_4051.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_mode_4051.cs
@@ -199,7 +199,7 @@ public class native_ack_mode_4051 : IAsyncLifetime
     /// until the handler succeeds, so the broker's lock expires and it hands them all to the next node.
     /// </summary>
     [Fact]
-    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {
         AsbNativeAckTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -215,7 +215,8 @@ public class native_ack_mode_4051 : IAsyncLifetime
         await waitForAsync(() => AsbNativeAckTracking.Entered.Count(x => x.Node == "first" && x.Number >= 100) >= 5,
             TimeSpan.FromSeconds(60));
 
-        // The node dies mid-flight, having acked nothing
+        // The node shuts down mid-flight, having acked nothing. GH-4095: Dispose() DRAINS --
+        // WolverineRuntime.DisposeAsync calls StopAsync -- so this is a tidy shutdown, not a crash
         firstHost.Dispose();
 
         AsbNativeAckTracking.HandledInRange(100, 5).ShouldBeEmpty();

--- a/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
@@ -275,7 +275,7 @@ public class native_ack_mode : IAsyncLifetime
     /// the handler succeeds, so once the dead node stops renewing, JetStream redelivers all of them at AckWait.
     /// </summary>
     [Fact]
-    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {
         var topology = topologyFor("redelivery");
 
@@ -296,7 +296,8 @@ public class native_ack_mode : IAsyncLifetime
         await waitForAsync(() => queueDepth(firstHost, topology) > 0, 20.Seconds());
         await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
 
-        // The node dies mid-flight, having acked nothing
+        // The node shuts down mid-flight, having acked nothing. GH-4095: Dispose() DRAINS --
+        // WolverineRuntime.DisposeAsync calls StopAsync -- so this is a tidy shutdown, not a crash
         firstHost.Dispose();
 
         NativeAckWorkTracking.Handled.ShouldBeEmpty();

--- a/src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_ack_mode.cs
+++ b/src/Transports/Pulsar/Wolverine.Pulsar.Tests/native_ack_mode.cs
@@ -325,7 +325,7 @@ public class native_ack_mode : IAsyncLifetime
     /// the handler succeeds, so the broker hands them all back when the consumer drops.
     /// </summary>
     [Fact]
-    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {
         var batch = Guid.NewGuid().ToString("N");
         var topic = uniqueTopic("nativeack-redelivery");

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitManagementProbe.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/RabbitManagementProbe.cs
@@ -1,0 +1,119 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+/// <summary>
+/// GH-4095. Kills a node the way a crash does, by asking the broker to drop its connections.
+/// </summary>
+/// <remarks>
+/// <para>Disposing an <c>IHost</c> is not a kill. <c>WolverineRuntime.DisposeAsync</c> calls
+/// <c>StopAsync</c> when the runtime has not already stopped, so listeners drain, in-flight handlers
+/// are awaited, and their acknowledgements go out. A node that shut itself down tidily is a rolling
+/// deploy, not a crash.</para>
+///
+/// <para>Closing the connection from the broker side is the real thing: every unacknowledged delivery
+/// on it is requeued immediately, and a handler still running completes into a channel that no longer
+/// exists, so its work happened but its acknowledgement never lands.</para>
+///
+/// <para>A trimmed-down sibling of SlowTests' <c>RabbitBrokerProbe</c> from GH-3713, kept here so the
+/// per-transport suites get crash coverage on the PR path -- SlowTests runs in no CI workflow. The
+/// management plugin ships in the <c>rabbitmq:4-management</c> image the repo's compose file pins.</para>
+/// </remarks>
+internal sealed class RabbitManagementProbe : IDisposable
+{
+    private readonly HttpClient _client;
+
+    public RabbitManagementProbe(string host = "localhost", int managementPort = 15672)
+    {
+        _client = new HttpClient { BaseAddress = new Uri($"http://{host}:{managementPort}/") };
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes("guest:guest")));
+        _client.Timeout = TimeSpan.FromSeconds(5);
+    }
+
+    public void Dispose() => _client.Dispose();
+
+    public async Task<bool> IsAvailableAsync(CancellationToken token = default)
+    {
+        try
+        {
+            using var response = await _client.GetAsync("api/overview", token);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Poll until the broker lists a connection with this client-provided name. The management plugin's
+    /// stats collector lags the actual connection by seconds, so a kill issued the instant traffic flows
+    /// finds nothing to close and silently degrades into "no kill happened".
+    /// </summary>
+    public async Task<bool> WaitForConnectionAsync(string clientName, TimeSpan timeout,
+        CancellationToken token = default)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await HasConnectionAsync(clientName, token)) return true;
+            await Task.Delay(250, token);
+        }
+
+        return false;
+    }
+
+    public async Task<bool> HasConnectionAsync(string clientName, CancellationToken token = default)
+    {
+        try
+        {
+            using var response = await _client.GetAsync("api/connections", token);
+            if (!response.IsSuccessStatusCode) return false;
+
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(token));
+            foreach (var connection in document.RootElement.EnumerateArray())
+            {
+                if (!connection.TryGetProperty("client_properties", out var properties)) continue;
+                if (!properties.TryGetProperty("connection_name", out var name)) continue;
+                if (name.GetString() == clientName) return true;
+            }
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Drop every connection whose client-provided name matches, and report how many were dropped.
+    /// </summary>
+    public async Task<int> ForceCloseConnectionsAsync(string clientName, CancellationToken token = default)
+    {
+        var closed = 0;
+
+        using var response = await _client.GetAsync("api/connections", token);
+        if (!response.IsSuccessStatusCode) return 0;
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(token));
+
+        foreach (var connection in document.RootElement.EnumerateArray())
+        {
+            if (!connection.TryGetProperty("client_properties", out var properties)) continue;
+            if (!properties.TryGetProperty("connection_name", out var name)) continue;
+            if (name.GetString() != clientName) continue;
+
+            var id = connection.GetProperty("name").GetString();
+            if (id is null) continue;
+
+            using var delete = await _client.DeleteAsync($"api/connections/{Uri.EscapeDataString(id)}", token);
+            if (delete.IsSuccessStatusCode) closed++;
+        }
+
+        return closed;
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_mode.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_mode.cs
@@ -28,9 +28,18 @@ public static class NativeAckWorkTracking
     /// <summary>When set, handlers park here forever -- standing in for a node that dies mid-flight.</summary>
     public static TaskCompletionSource? Block;
 
+    /// <summary>
+    /// GH-4095. Recorded BEFORE the handler parks on <see cref="Block" />, so a test can wait until deliveries
+    /// have genuinely reached handlers before killing the node. The obvious signal -- the listener circuit's
+    /// QueueCount -- is always 0 under NativeAck, because NativeAckReceiver holds the delivery unacknowledged
+    /// rather than queueing it. Waiting on that is waiting on something that never happens.
+    /// </summary>
+    public static readonly ConcurrentBag<(string Node, int Number)> Started = new();
+
     public static void Reset()
     {
         Handled.Clear();
+        Started.Clear();
         Block = null;
     }
 }
@@ -39,6 +48,8 @@ public class NativeAckWorkHandler
 {
     public async Task Handle(NativeAckWork message, IWolverineRuntime runtime)
     {
+        NativeAckWorkTracking.Started.Add((runtime.Options.ServiceName, message.Number));
+
         if (NativeAckWorkTracking.Block != null)
         {
             await NativeAckWorkTracking.Block.Task;
@@ -61,6 +72,7 @@ public class native_ack_mode : IAsyncLifetime
     private const string ModeQueue = "native-ack-3708-mode";
     private const string EndToEndQueue = "native-ack-3708-e2e";
     private const string RedeliveryQueue = "native-ack-3708-redelivery";
+    private const string HardKillQueue = "native-ack-4095-hard-kill";
 
     public ValueTask InitializeAsync()
     {
@@ -81,7 +93,15 @@ public class native_ack_mode : IAsyncLifetime
             .UseWolverine(opts =>
             {
                 opts.ServiceName = nodeName;
-                opts.UseRabbitMq("host=localhost;port=5672").AutoProvision();
+
+                // GH-4095. Named per node so the broker can be asked to drop exactly this host's
+                // connections -- that is what makes the hard kill test an actual kill
+                opts.UseRabbitMq(factory =>
+                {
+                    factory.HostName = "localhost";
+                    factory.Port = 5672;
+                    factory.ClientProvidedName = nodeName;
+                }).AutoProvision();
 
                 opts.Discovery.DisableConventionalDiscovery().IncludeType<NativeAckWorkHandler>();
 
@@ -128,11 +148,19 @@ public class native_ack_mode : IAsyncLifetime
 
     /// <summary>
     /// The whole point of the mode. Under BufferedInMemory these messages are acked the instant they arrive, so
-    /// a node that dies before the handler finishes loses every one of them. Under NativeAck nothing is acked
-    /// until the handler succeeds, so closing the channel hands them all back to the broker.
+    /// a node that stops before the handler finishes loses every one of them. Under NativeAck nothing is acked
+    /// until the handler succeeds, so the deliveries go back to the broker instead.
     /// </summary>
+    /// <remarks>
+    /// GH-4095. This is the GRACEFUL half: <c>host.Dispose()</c> drains, because
+    /// <c>WolverineRuntime.DisposeAsync</c> calls <c>StopAsync</c> when the runtime has not already stopped.
+    /// What it establishes is that nothing is acknowledged ahead of its handler, so work parked in a lane at
+    /// shutdown comes back rather than vanishing. It says nothing about a crash -- see
+    /// <see cref="a_hard_killed_node_loses_nothing_when_the_broker_drops_its_connection" /> for that, which has
+    /// different guarantees: a drain produces no duplicates, an abrupt loss can.
+    /// </remarks>
     [Fact]
-    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {
         NativeAckWorkTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -144,14 +172,20 @@ public class native_ack_mode : IAsyncLifetime
             await bus.SendAsync(new NativeAckWork(100 + i));
         }
 
-        // Let the deliveries actually reach the parked handlers before killing the node
+        // Let the deliveries actually reach the parked handlers before stopping the node. GH-4095: this used
+        // to wait on the listener circuit's QueueCount, which is ALWAYS 0 under NativeAck -- the receiver holds
+        // the delivery unacknowledged rather than queueing it -- so it burned the full 15s every run and then
+        // proceeded regardless. Gate on the handlers actually starting instead
         var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
-        while (queueCount(firstHost, RedeliveryQueue) == 0 && DateTimeOffset.UtcNow < deadline)
+        while (startedByNode("dead-node", 100, 5).Count() == 0 && DateTimeOffset.UtcNow < deadline)
         {
             await Task.Delay(50, TestContext.Current.CancellationToken);
         }
 
-        // The node dies mid-flight, having acked nothing
+        startedByNode("dead-node", 100, 5).Count().ShouldBeGreaterThan(0);
+
+        // The node shuts down mid-flight, having acked nothing. GH-4095: Dispose() DRAINS --
+        // WolverineRuntime.DisposeAsync calls StopAsync -- so this is a tidy shutdown, not a crash
         firstHost.Dispose();
 
         handledInRange(100, 5).ShouldBeEmpty();
@@ -174,6 +208,90 @@ public class native_ack_mode : IAsyncLifetime
         handledByNode("fresh-node", 100, 5).ShouldBe(Enumerable.Range(100, 5));
     }
 
+    /// <summary>
+    /// GH-4095. The ABRUPT half. Disposing the host is a tidy shutdown, so every "dead node" test in these
+    /// suites was really measuring a drain. Here the broker drops the node's connection underneath it: nothing
+    /// gets to finish, no ack goes out, and every unacknowledged delivery on that connection is requeued
+    /// immediately. That is the scenario the docs lean on when they say a dying node loses nothing, and until
+    /// now it was only covered by GH-3713's chaos suite in SlowTests, which does not run on the PR path.
+    /// </summary>
+    [Fact]
+    public async Task a_hard_killed_node_loses_nothing_when_the_broker_drops_its_connection()
+    {
+        using var probe = new RabbitManagementProbe();
+        if (!await probe.IsAvailableAsync(TestContext.Current.CancellationToken))
+        {
+            // The management plugin is part of the rabbitmq:4-management image the repo's compose file pins,
+            // so this should not happen in CI. Failing loudly beats silently not testing the thing
+            throw new InvalidOperationException(
+                "The RabbitMQ management API is not reachable on localhost:15672, so a hard kill cannot be performed.");
+        }
+
+        NativeAckWorkTracking.Block = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstHost = await startHostAsync(HardKillQueue, "killed-node");
+        var bus = firstHost.MessageBus();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await bus.SendAsync(new NativeAckWork(200 + i));
+        }
+
+        // Wait until the deliveries have actually reached the parked handlers. Killing an idle node proves
+        // nothing -- there has to be an unacknowledged window for the broker to requeue. Gate on the event
+        // itself rather than racing it: QueueCount is always 0 in this mode, so waiting on it just burns the
+        // timeout and then kills an idle node
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (startedByNode("killed-node", 200, 5).Count() == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        startedByNode("killed-node", 200, 5).Count().ShouldBeGreaterThan(0);
+
+        // The kill. NOT host.Dispose() -- the broker severs the connection, so the listener never drains
+        (await probe.WaitForConnectionAsync("killed-node", 30.Seconds(), TestContext.Current.CancellationToken))
+            .ShouldBeTrue();
+
+        var closed = await probe.ForceCloseConnectionsAsync("killed-node", TestContext.Current.CancellationToken);
+        closed.ShouldBeGreaterThan(0);
+
+        handledInRange(200, 5).ShouldBeEmpty();
+
+        // Release the gate only AFTER the connection is gone, so the killed node's handlers complete into a
+        // channel that no longer exists -- their acks cannot land, which is the real crash shape
+        NativeAckWorkTracking.Block!.TrySetResult();
+        NativeAckWorkTracking.Block = null;
+
+        using var secondHost = await startHostAsync(HardKillQueue, "survivor-node");
+
+        deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (handledByNode("survivor-node", 200, 5).Count() < 5 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        // Attribution matters for exactly the reason the graceful test documents: the gate is process-wide, so
+        // the killed host's own handlers unwind and record. Counting bare numbers would be satisfied by that
+        // and would prove nothing about redelivery
+        handledByNode("survivor-node", 200, 5).ShouldBe(Enumerable.Range(200, 5));
+
+        // Deliberately NOT asserting zero duplicates. GH-3713 measured that an abrupt loss produces up to one
+        // duplicate per in-flight lane, because a handler can finish after its ack path is gone. No loss is the
+        // guarantee; exactly-once is not
+        firstHost.Dispose();
+    }
+
+    /// <summary>Messages in the range whose handler STARTED on the named node, gate or no gate.</summary>
+    private static IEnumerable<int> startedByNode(string node, int start, int count)
+    {
+        return NativeAckWorkTracking.Started
+            .Where(x => x.Node == node && x.Number >= start && x.Number < start + count)
+            .Select(x => x.Number)
+            .Distinct()
+            .OrderBy(x => x);
+    }
+
     private static IEnumerable<int> handledInRange(int start, int count)
     {
         return NativeAckWorkTracking.Handled
@@ -193,10 +311,4 @@ public class native_ack_mode : IAsyncLifetime
             .OrderBy(x => x);
     }
 
-    private static int queueCount(IHost host, string queueName)
-    {
-        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
-        var circuit = runtime.Endpoints.FindListenerCircuit(new Uri($"rabbitmq://queue/{queueName}"));
-        return circuit?.QueueCount ?? 0;
-    }
 }

--- a/src/Transports/Redis/Wolverine.Redis.Tests/native_ack_mode.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/native_ack_mode.cs
@@ -363,7 +363,7 @@ public class native_ack_mode : IAsyncLifetime
     /// when the node dies, and XAUTOCLAIM hands them to the node that replaces it.
     /// </summary>
     [Fact]
-    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_dead_node_loses_nothing()
+    public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {
         var sessionId = Guid.NewGuid();
         var session = startSession(sessionId);
@@ -384,7 +384,8 @@ public class native_ack_mode : IAsyncLifetime
         // Let the entries actually reach the parked handlers before killing the node
         await waitFor(async () => await pendingCountAsync(streamKey, group) == 5, 30.Seconds());
 
-        // The node dies mid-flight, having acked nothing
+        // The node shuts down mid-flight, having acked nothing. GH-4095: Dispose() DRAINS --
+        // WolverineRuntime.DisposeAsync calls StopAsync -- so this is a tidy shutdown, not a crash
         firstHost.Dispose();
 
         session.Handled.ShouldBeEmpty();

--- a/src/Transports/Redis/Wolverine.Redis.Tests/native_ack_mode.cs
+++ b/src/Transports/Redis/Wolverine.Redis.Tests/native_ack_mode.cs
@@ -358,10 +358,27 @@ public class native_ack_mode : IAsyncLifetime
 
     /// <summary>
     /// The whole point of the mode. Under BufferedInMemory these entries are XACKed the instant they are read,
-    /// so a node that dies before the handler finishes loses every one of them. Under NativeAck nothing is
+    /// so a node that stops before the handler finishes loses every one of them. Under NativeAck nothing is
     /// acked until the handler succeeds, so they are all still in the consumer group's pending entries list
-    /// when the node dies, and XAUTOCLAIM hands them to the node that replaces it.
+    /// when the node goes away, and XAUTOCLAIM hands them to the node that replaces it.
     /// </summary>
+    /// <remarks>
+    /// <para>GH-4095. This is the GRACEFUL case: <c>host.Dispose()</c> drains, because
+    /// <c>WolverineRuntime.DisposeAsync</c> calls <c>StopAsync</c>. What it establishes is that nothing is
+    /// acknowledged ahead of its handler.</para>
+    ///
+    /// <para><b>There is deliberately no hard-kill counterpart here, and it is not an oversight.</b> The
+    /// obvious approach -- <c>CLIENT KILL</c> on the node's connections, mirroring what the RabbitMQ suite
+    /// does through the management API -- does not produce a crash on this transport, and that was measured
+    /// rather than assumed. <c>CLIENT KILL</c> does break the multiplexer: the very next command throws
+    /// <c>RedisConnectionException: SocketClosed</c>. But StackExchange.Redis reconnects transparently, so by
+    /// the time a released handler finishes its work the connection has healed and the XACK lands normally --
+    /// the PEL drains to 0 with no replacement node involved. A test built on it passes whether or not the
+    /// kill happens, which makes it exactly the kind of vacuous test GH-4095 exists to remove.</para>
+    ///
+    /// <para>Reaching the crash shape on Redis -- work completed, acknowledgement lost -- needs the process
+    /// killed, not the socket. That is a different kind of harness than these in-process suites support.</para>
+    /// </remarks>
     [Fact]
     public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {


### PR DESCRIPTION
Closes #4095.

Every "dead node loses nothing" test in the NativeAck suites killed its node with `host.Dispose()`. That is a **graceful shutdown** — `WolverineRuntime.DisposeAsync` calls `StopAsync` when the runtime has not already stopped — so listeners drain, in-flight handlers are awaited, and their acks go out. None of them tested the failure mode their names described.

**Six transports had the test, not the four the issue names** — Redis and Pulsar too.

## What this does

- **Renames all six** to `..._so_a_draining_node_loses_nothing`, which is what they verify. They aren't worthless — each establishes that nothing is acknowledged ahead of its handler — they were just misnamed.
- **Adds the missing abrupt case for RabbitMQ**, following GH-3713 / #4094: the broker is asked to drop the node's connection, so nothing finishes, no ack goes out, and every unacknowledged delivery is requeued. `RabbitManagementProbe` is a trimmed sibling of SlowTests' `RabbitBrokerProbe`, kept in the transport suite because **SlowTests runs in no CI workflow** — which is exactly why this gap survived.

## Two defects found while building it

Both of the "waiting on something that never happens" kind:

1. **The wait before the kill gated on the listener circuit's `QueueCount`, which is always 0 under NativeAck** — `NativeAckReceiver` holds the delivery unacknowledged rather than queueing it. The graceful test therefore burned its full 15s timeout every run and then proceeded regardless. Handlers now record entry *before* parking and both tests gate on that event. The graceful test drops **45s → 30s**, and the dead `queueCount` helper is gone.

2. **RabbitMQ's management plugin lags the connection by seconds.** A kill issued the instant traffic flows finds nothing to close and degrades silently into "no kill happened" — which is how this test would have joined the vacuous ones. It now polls for the named connection and asserts the close count.

The hard-kill test deliberately does **not** assert zero duplicates: #3713 measured that abrupt loss produces up to one duplicate per in-flight lane. No loss is the guarantee; exactly-once is not.

## Redis: a measured negative result

The second commit documents why Redis gets no hard-kill counterpart, in the file where the next person will look for it.

`CLIENT KILL` **does** break the multiplexer — the next command throws `RedisConnectionException: SocketClosed`, which is what made the approach look viable. But **StackExchange.Redis reconnects transparently**, so by the time a released handler finishes its work the connection has healed and the `XACK` lands normally: the PEL drains to 0 with no replacement node involved.

The first draft of that test passed. It also passed **with the kill removed entirely** — a vacuous test of exactly the kind this issue exists to remove. Reaching the crash shape on Redis needs the process killed, not the socket.

## Still open

SQS, Azure Service Bus and NATS JetStream have no abrupt case yet. SQS has no persistent connection to sever at all (HTTP polling against a visibility timeout). For ASB and NATS I'd rather measure than predict — Redis just demonstrated that client-library reconnection can silently defeat this entire technique, and the RabbitMQ result holds precisely because the broker-side close is authoritative there.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| RabbitMQ `native_ack_mode` | 4 / 4 |
| Redis `native_ack_mode` | 8 / 8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)