### PR TITLE
GH-4091: track a delivered batch up front instead of one envelope at a time

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/lease_renewal_4048.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/lease_renewal_4048.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -361,6 +362,61 @@ public class lease_renewal_4048 : IAsyncLifetime
     #endregion
 
     #region enforcement in the lane -- the assertions that matter
+
+    /// <summary>
+    ///     GH-4091. The receiver used to walk a delivered batch one envelope at a time, registering each lease
+    ///     immediately before posting it. <c>PostAsync</c> blocks once the execution block is at capacity, so
+    ///     every envelope behind the blocked one sat UNTRACKED -- with its broker lease already running -- for
+    ///     as long as the ones ahead took to be admitted.
+    /// </summary>
+    /// <remarks>
+    ///     The window opened precisely when the block was full, which is the saturation this mode exists to
+    ///     serve, and it was invisible: a lease that expires while untracked just looks like ordinary
+    ///     at-least-once redelivery. Tracking the whole batch before posting any of it closes the window.
+    /// </remarks>
+    [Fact]
+    public async Task every_envelope_in_a_batch_is_tracked_even_while_the_block_is_full()
+    {
+        var receiver = receiverFor(e => e.MaxDegreeOfParallelism = 1);
+        var listener = new FakeLeaseListener();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        LeasePingHandler.Gate = gate;
+        LeasePingHandler.Entered = entered;
+
+        // Saturate the block first. One lane, and the handler never returns, so everything posted after this
+        // is queued; once the queue reaches its bound, PostAsync itself blocks
+        var capacity = Block<Envelope>.DefaultBoundedCapacity;
+        var filler = Enumerable.Range(0, capacity + 1).Select(i => pingEnvelope($"filler-{i}")).ToArray();
+        await receiver.ReceivedAsync(listener, filler);
+
+        await entered.Task.WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        receiver.Leases.ShouldNotBeNull();
+        var tracker = receiver.Leases!;
+        await waitUntil(() => tracker.InFlightCount == filler.Length);
+
+        // Now a second batch arrives at a block that cannot take it. This call will NOT complete -- its first
+        // post blocks -- which is the whole point, so it is deliberately not awaited here
+        var batch = Enumerable.Range(0, 5).Select(i => pingEnvelope($"batch-{i}")).ToArray();
+        var receiving = receiver.ReceivedAsync(listener, batch).AsTask();
+
+        // Every envelope in that batch must be registered even though only the first one could be posted.
+        // Before the fix this settled at filler.Length + 1 and stayed there
+        await waitUntil(() => tracker.InFlightCount == filler.Length + batch.Length);
+
+        foreach (var envelope in batch)
+        {
+            tracker.WasLeaseLost(envelope).ShouldBeFalse();
+        }
+
+        // Let the whole thing unwind so the receiver is not left holding a blocked post
+        gate.SetResult();
+        LeasePingHandler.Gate = null;
+
+        await receiving.WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+    }
+
 
     /// <summary>
     ///     The single most important assertion in GH-4048. A lease-lost envelope that has not started executing is

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using JasperFx.Blocks;
 using JasperFx.Core;
@@ -149,23 +150,45 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
 
         var now = DateTimeOffset.Now;
 
+        // GH-4091. TWO passes, deliberately. Posting blocks once the execution block is at capacity, so a
+        // single admit-then-post loop leaves every envelope after the first blocked one untracked -- with its
+        // broker lease already running -- for as long as the ones ahead of it take to be admitted. Tracking
+        // the whole batch first closes that window. The exposure was bounded by batch size rather than lane
+        // depth, but it opened precisely when the block was full, which is the flood this mode exists for.
+        var admitted = new List<(Envelope Envelope, Activity? Activity)>(messages.Length);
+
         foreach (var envelope in messages)
         {
-            await receiveOneAsync(listener, envelope, now).ConfigureAwait(false);
+            if (await admitAsync(listener, envelope, now).ConfigureAwait(false) is { } entry)
+            {
+                admitted.Add(entry);
+            }
         }
+
+        await postAllAsync(admitted).ConfigureAwait(false);
 
         _logger.IncomingBatchReceived(Uri, messages);
     }
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
-        await receiveOneAsync(listener, envelope, DateTimeOffset.Now).ConfigureAwait(false);
+        if (await admitAsync(listener, envelope, DateTimeOffset.Now).ConfigureAwait(false) is { } entry)
+        {
+            await postAllAsync([entry]).ConfigureAwait(false);
+        }
+
         _logger.IncomingReceived(envelope, Uri);
     }
 
-    private async ValueTask receiveOneAsync(IListener listener, Envelope envelope, DateTimeOffset now)
+    /// <summary>
+    /// Everything that happens to a delivery BEFORE it is posted to the execution block: the terminal cases
+    /// that never reach a lane at all, and -- for the ones that do -- registering the lease. Returns null when
+    /// the envelope is not going any further.
+    /// </summary>
+    private async ValueTask<(Envelope Envelope, Activity? Activity)?> admitAsync(IListener listener,
+        Envelope envelope, DateTimeOffset now)
     {
-        if (envelope.IsPing()) return;
+        if (envelope.IsPing()) return null;
 
         envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
 
@@ -173,7 +196,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
         {
             // Nothing will ever handle it, so settle it rather than leaving the broker to redeliver forever.
             await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
-            return;
+            return null;
         }
 
         // GH-3710. Ack-and-drop a redelivery of something this process already handled (or is handling right
@@ -188,7 +211,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
                 envelope.Id, envelope.MessageType, Uri);
 
             await _completeBlock.PostAsync(envelope).ConfigureAwait(false);
-            return;
+            return null;
         }
 
         var activity = _endpoint.TelemetryEnabled ? WolverineTracing.StartReceiving(envelope) : null;
@@ -198,11 +221,43 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
         // running. Untracked in executeAsync's finally.
         leasesFor(listener)?.Track(envelope);
 
-        // NOTE the absence of a _completeBlock.PostAsync here. That single line is what separates this mode
-        // from BufferedInMemory: the delivery stays unacknowledged until the pipeline settles it.
-        await _receivingBlock.PostAsync(envelope).ConfigureAwait(false);
+        return (envelope, activity);
+    }
 
-        activity?.Stop();
+    /// <summary>
+    /// The second pass. NOTE the absence of a <c>_completeBlock.PostAsync</c> here -- that single omission is
+    /// what separates this mode from BufferedInMemory: the delivery stays unacknowledged until the pipeline
+    /// settles it.
+    /// </summary>
+    private async ValueTask postAllAsync(IReadOnlyList<(Envelope Envelope, Activity? Activity)> admitted)
+    {
+        for (var i = 0; i < admitted.Count; i++)
+        {
+            var (envelope, activity) = admitted[i];
+
+            try
+            {
+                await _receivingBlock.PostAsync(envelope).ConfigureAwait(false);
+            }
+            catch
+            {
+                // GH-4091. Tracking ahead of posting means a failed post -- a completed block during a drain,
+                // most likely -- leaves envelopes registered that executeAsync will now never untrack. This one
+                // and everything behind it are in that position, so release them here. The deliveries stay
+                // unsettled, which is the mode's whole point: the broker redelivers them.
+                for (var j = i; j < admitted.Count; j++)
+                {
+                    var (stranded, strandedActivity) = admitted[j];
+                    _leases?.Untrack(stranded);
+                    _idempotency?.Release(stranded);
+                    strandedActivity?.Stop();
+                }
+
+                throw;
+            }
+
+            activity?.Stop();
+        }
     }
 
     private LeaseRenewalTracker? leasesFor(IListener listener)


### PR DESCRIPTION
Closes #4091.

`NativeAckReceiver.ReceivedAsync(IListener, Envelope[])` walked a delivered batch one envelope at a time, registering each lease immediately before posting it. `PostAsync` blocks once the execution block is at capacity, so every envelope **behind** the blocked one sat untracked — with its broker lease already running — for as long as the ones ahead took to be admitted.

The exposure was bounded by batch size rather than lane depth, but the condition that opened it is the one this mode exists for: a full block means the lanes are saturated, which is the flood `EndpointMode.NativeAck` was built to serve. It was also invisible — a lease that expires while untracked looks like ordinary at-least-once redelivery rather than a defect.

## The fix

Option 1 from the issue: **two passes** — admit and track the whole batch, then post it.

The issue's parenthetical about that option turned out to be the substantive part:

> an envelope that is never posted (expired, or a drain in between) would need untracking on that path too — worth checking that carefully rather than assuming

Tracking ahead of posting means a failed post — a completed block during a drain, most likely — strands envelopes that `executeAsync` will now never untrack. Left unhandled, the fix would have traded a bounded window for a **permanent leak**. `postAllAsync` releases the failing envelope and everything behind it, lease and idempotency guard both, before rethrowing. The deliveries stay unsettled, which is the mode's whole point: the broker redelivers them.

The single-envelope `ReceivedAsync` overload routes through the same admit/post pair, so the two paths cannot drift.

## Test

`every_envelope_in_a_batch_is_tracked_even_while_the_block_is_full` saturates the block — one lane, gated handler, `Block<Envelope>.DefaultBoundedCapacity + 1` envelopes — then delivers a second batch to a block that cannot accept it. That second `ReceivedAsync` is deliberately **not awaited**, because its first post blocks by design; that is the state under test. It asserts all five are tracked while only one could be posted.

**Red baseline**: reverted to the single-pass loop, the test fails — it settles at `filler.Length + 1` and never reaches `+ batch.Length`, which is precisely the reported defect.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| CoreTests | **2637 / 0 failed** |

2637 is the 2636 baseline plus the one new test.

Affects every lease-based transport identically — Azure Service Bus and Amazon SQS today, NATS JetStream and GCP Pub/Sub if they adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)