### PR TITLE
GH-4095: record why ASB, NATS and SQS get no hard-kill test

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/native_ack_mode.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/native_ack_mode.cs
@@ -200,6 +200,24 @@ public class native_ack_mode : IAsyncLifetime
     ///     too, so an assertion that only counted message numbers would pass whether or not SQS redelivered
     ///     anything. Only the SECOND node's recordings can come from a redelivery.
     /// </remarks>
+    /// <remarks>
+    /// <para>GH-4095. This is the GRACEFUL case: <c>host.Dispose()</c> drains, because
+    /// <c>WolverineRuntime.DisposeAsync</c> calls <c>StopAsync</c> when the runtime has not already stopped.
+    /// What it establishes is that nothing is settled ahead of its handler, so work parked in a lane at
+    /// shutdown comes back rather than vanishing. It does NOT establish crash safety.</para>
+    ///
+    /// <para><b>There is deliberately no hard-kill counterpart, and it is not an oversight.</b> The RabbitMQ
+    /// suite has one -- the broker is asked to drop the node's connection, which invalidates the channel and
+    /// the delivery tag with it -- and that approach was measured against this transport and does not work
+    /// here:
+    /// there is no persistent connection to sever. SQS is HTTP polling against a visibility timeout, so from
+    /// the broker's side "crashed" and "stopped polling" are the same thing -- which is also why the graceful
+    /// case above already exercises the redelivery path a crash would use.</para>
+    ///
+    /// <para>Reaching the crash shape on this transport -- work completed, acknowledgement lost -- needs the
+    /// process killed rather than the connection, which these in-process suites cannot do. Full measurements
+    /// for every transport are recorded on GH-4095.</para>
+    /// </remarks>
     [Fact]
     public async Task nothing_is_settled_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_mode_4051.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_mode_4051.cs
@@ -198,6 +198,26 @@ public class native_ack_mode_4051 : IAsyncLifetime
     /// a node that dies before the handler finishes loses every one of them. Under NativeAck nothing is completed
     /// until the handler succeeds, so the broker's lock expires and it hands them all to the next node.
     /// </summary>
+    /// <remarks>
+    /// <para>GH-4095. This is the GRACEFUL case: <c>host.Dispose()</c> drains, because
+    /// <c>WolverineRuntime.DisposeAsync</c> calls <c>StopAsync</c> when the runtime has not already stopped.
+    /// What it establishes is that nothing is settled ahead of its handler, so work parked in a lane at
+    /// shutdown comes back rather than vanishing. It does NOT establish crash safety.</para>
+    ///
+    /// <para><b>There is deliberately no hard-kill counterpart, and it is not an oversight.</b> The RabbitMQ
+    /// suite has one -- the broker is asked to drop the node's connection, which invalidates the channel and
+    /// the delivery tag with it -- and that approach was measured against this transport and does not work
+    /// here:
+    /// disposing the receiver <i>and</i> the whole <c>ServiceBusClient</c>, then creating a brand new client and
+    /// receiver, still completed the message the dead receiver had locked -- and it was never redelivered. The
+    /// lock token is not bound to the link. Measured against the emulator, which is what CI runs; real Azure
+    /// Service Bus may bind lock tokens to the receiver link, but a test built here behaves the emulator's way
+    /// regardless.</para>
+    ///
+    /// <para>Reaching the crash shape on this transport -- work completed, acknowledgement lost -- needs the
+    /// process killed rather than the connection, which these in-process suites cannot do. Full measurements
+    /// for every transport are recorded on GH-4095.</para>
+    /// </remarks>
     [Fact]
     public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {

--- a/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
+++ b/src/Transports/NATS/Wolverine.Nats.Tests/native_ack_mode.cs
@@ -274,6 +274,25 @@ public class native_ack_mode : IAsyncLifetime
     /// node that dies before the handler finishes loses every one of them. Under NativeAck nothing is acked until
     /// the handler succeeds, so once the dead node stops renewing, JetStream redelivers all of them at AckWait.
     /// </summary>
+    /// <remarks>
+    /// <para>GH-4095. This is the GRACEFUL case: <c>host.Dispose()</c> drains, because
+    /// <c>WolverineRuntime.DisposeAsync</c> calls <c>StopAsync</c> when the runtime has not already stopped.
+    /// What it establishes is that nothing is settled ahead of its handler, so work parked in a lane at
+    /// shutdown comes back rather than vanishing. It does NOT establish crash safety.</para>
+    ///
+    /// <para><b>There is deliberately no hard-kill counterpart, and it is not an oversight.</b> The RabbitMQ
+    /// suite has one -- the broker is asked to drop the node's connection, which invalidates the channel and
+    /// the delivery tag with it -- and that approach was measured against this transport and does not work
+    /// here:
+    /// a JetStream ack is just a publish to the message's reply subject. Capturing that subject, dropping the
+    /// node's connection, and then publishing the ack from a <i>different</i> connection was accepted by the
+    /// server, taking <c>num_ack_pending</c> from 1 to 0. The ack is not bound to the connection that received
+    /// the message, so a reconnecting client heals straight over a severed socket.</para>
+    ///
+    /// <para>Reaching the crash shape on this transport -- work completed, acknowledgement lost -- needs the
+    /// process killed rather than the connection, which these in-process suites cannot do. Full measurements
+    /// for every transport are recorded on GH-4095.</para>
+    /// </remarks>
     [Fact]
     public async Task nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing()
     {


### PR DESCRIPTION
Follow-up to #4103, which added the genuine crash case for RabbitMQ and renamed the misleading "dead node" tests across all six transports.

This puts the reasoning for the remaining three **next to the tests**, so the absence reads as a measured conclusion rather than a gap nobody got to. Comment-only — 57 lines, no behaviour change.

## RabbitMQ is the only transport where a connection kill is a crash

Three different reasons why, each measured with a throwaway probe rather than reasoned about. The Redis attempt in #4103 is why: that test **passed**, and also passed with the kill removed entirely.

| Transport | Why a connection kill isn't a crash |
| --- | --- |
| **Azure Service Bus** | Disposing the receiver **and** the whole `ServiceBusClient`, then creating a brand-new client and receiver, still completed the message the dead receiver had locked — and it was never redelivered. The lock token is not bound to the link. |
| **NATS JetStream** | A JetStream ack is just a publish to the message's reply subject. Capturing it, dropping the node's connection, then publishing the ack from a **different** connection was accepted by the server, taking `num_ack_pending` from 1 to 0. |
| **Amazon SQS** | There is no persistent connection to sever. HTTP polling against a visibility timeout means "crashed" and "stopped polling" are the same thing from the broker's side. |

## Two caveats recorded inline rather than buried

**The ASB measurement is against the emulator**, which is what CI runs. Real Azure Service Bus may bind lock tokens to the receiver link and throw `MessageLockLost` — but a test built here would behave the emulator's way regardless, so the scenario isn't reachable on the PR path either way. That's stated in the remarks block itself.

**The NATS probe had a near-miss.** The first attempt produced `ObjectDisposedException`, which looks like a failed ack but is a client-side object-lifetime artifact from disposing the connection object — not the broker refusing anything. Publishing the ack from a second connection is the question that actually distinguishes the two.

Full measurements for every transport are on [the issue](https://github.com/JasperFx/wolverine/issues/4095#issuecomment-5400391618).

## Verification

`dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)