### PR TITLE
GH-4012 item 3: terminal-failure classification for Azure Service Bus and SQS

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/terminal_ack_classification_4012.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/terminal_ack_classification_4012.cs
@@ -1,0 +1,85 @@
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests.Internal;
+
+/// <summary>
+/// GH-4012 item 3. Before this, SQS treated every delete failure as transient, so a permanent one burned
+/// the whole retry budget before being dropped. SQS classifies better than either sibling transport: it
+/// raises distinct typed exceptions, so the terminal set is named rather than inferred from broker text
+/// (RabbitMQ) or a boolean (Azure Service Bus).
+/// </summary>
+public class terminal_ack_classification_4012
+{
+    private static IAmazonSQS clientThatThrows(Exception exception)
+    {
+        var client = Substitute.For<IAmazonSQS>();
+        client.DeleteMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<DeleteMessageResponse>>(_ => throw exception);
+        return client;
+    }
+
+    private static Task deleteAsync(IAmazonSQS client)
+    {
+        return SqsSettlement.DeleteAsync(client, "https://sqs.test/q", "receipt-handle",
+            NullLogger.Instance, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task terminal_failures_are_swallowed_so_the_retry_block_stops()
+    {
+        Exception[] terminals =
+        [
+            new ReceiptHandleIsInvalidException("handle is not valid"),
+            new MessageNotInflightException("visibility already lapsed"),
+            new QueueDoesNotExistException("queue is gone")
+        ];
+
+        foreach (var terminal in terminals)
+        {
+            SqsSettlement.IsTerminal(terminal).ShouldBeTrue($"{terminal.GetType().Name} should be terminal");
+
+            // Swallowing is what stops the RetryBlock. The message is simply not deleted; SQS makes it
+            // visible again on its own clock and redelivers it
+            await deleteAsync(clientThatThrows(terminal));
+        }
+    }
+
+    [Fact]
+    public async Task transient_failures_still_propagate_so_the_retry_block_retries()
+    {
+        Exception[] transients =
+        [
+            new RequestThrottledException("slow down"),
+            new OverLimitException("too many inflight"),
+            new AmazonSQSException("some other service fault")
+        ];
+
+        foreach (var transient in transients)
+        {
+            SqsSettlement.IsTerminal(transient).ShouldBeFalse($"{transient.GetType().Name} should NOT be terminal");
+
+            // These are exactly the failures the retry budget exists for. Swallowing them would turn a
+            // recoverable blip into a message that silently never gets deleted
+            await Should.ThrowAsync<Exception>(() => deleteAsync(clientThatThrows(transient)));
+        }
+    }
+
+    [Fact]
+    public async Task a_successful_delete_is_left_alone()
+    {
+        var client = Substitute.For<IAmazonSQS>();
+        client.DeleteMessageAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DeleteMessageResponse());
+
+        await deleteAsync(client);
+
+        await client.Received(1).DeleteMessageAsync("https://sqs.test/q", "receipt-handle",
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -89,8 +89,10 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
 
         _reassembler = new SqsFragmentReassembler(queue.FragmentReassemblyTimeout, logger);
 
+        // GH-4012 item 3: a delete that can never succeed must not burn the retry budget
         _singleDeleteBlock = new RetryBlock<Message>(
-            (message, token) => _transport.Client!.DeleteMessageAsync(_queue.QueueUrl, message.ReceiptHandle, token),
+            (message, token) => SqsSettlement.DeleteAsync(_transport.Client!, _queue.QueueUrl!,
+                message.ReceiptHandle, logger, token),
             logger, runtime.Cancellation);
 
         if (_queue.DeleteMessageBatchSize > 1)

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSettlement.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSettlement.cs
@@ -1,0 +1,56 @@
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.AmazonSqs.Internal;
+
+/// <summary>
+/// GH-4012 item 3. Terminal-failure classification for the SQS delete -- the settle on this transport.
+/// </summary>
+/// <remarks>
+/// <para>Without it a permanent failure burns the whole retry budget before being dropped. The same
+/// reasoning as <c>sendOrDiscardAsync</c> (GH-3926) applies in the other direction: a <see cref="RetryBlock{T}" />
+/// retries until it succeeds, so an operation that can never succeed spins the block for nothing.</para>
+///
+/// <para>SQS classifies better than either sibling. RabbitMQ has to match broker text -- and that needle
+/// was silently wrong for a long time -- while Azure Service Bus offers a boolean; SQS raises distinct
+/// typed exceptions, so the terminal set is named rather than inferred:</para>
+/// <list type="bullet">
+/// <item><see cref="ReceiptHandleIsInvalidException"/> -- the handle is not valid, and no later attempt
+/// makes it valid.</item>
+/// <item><see cref="MessageNotInflightException"/> -- the visibility window already lapsed, so the
+/// message is back on the queue and this delete is addressing something nobody holds.</item>
+/// <item><see cref="QueueDoesNotExistException"/> -- the queue is gone; retrying cannot bring it back.</item>
+/// </list>
+///
+/// <para>Deliberately NOT swallowing <see cref="RequestThrottledException"/> or <see cref="OverLimitException"/>:
+/// those are exactly the transient failures the retry budget exists for.</para>
+///
+/// <para>Note there is no ack budget here, unlike the Azure Service Bus path. The SQS delete block is keyed
+/// on <see cref="Message"/> rather than on the envelope, so <c>Envelope.AckAttempts</c> is not reachable --
+/// carrying it would mean rekeying the block, which is GH-4012 item 1's territory rather than item 3's.</para>
+/// </remarks>
+internal static class SqsSettlement
+{
+    internal static async Task DeleteAsync(IAmazonSQS client, string queueUrl, string receiptHandle,
+        ILogger logger, CancellationToken token)
+    {
+        try
+        {
+            await client.DeleteMessageAsync(queueUrl, receiptHandle, token);
+        }
+        catch (Exception e) when (IsTerminal(e))
+        {
+            // Swallowing is what stops the RetryBlock. The delivery is simply not deleted; SQS makes it
+            // visible again on its own clock and redelivers it.
+            logger.LogInformation(
+                "Discarding a terminal SQS delete failure ({Failure}) on {QueueUrl}; the message will be redelivered when its visibility window lapses",
+                e.GetType().Name, queueUrl);
+        }
+    }
+
+    internal static bool IsTerminal(Exception e)
+    {
+        return e is ReceiptHandleIsInvalidException or MessageNotInflightException or QueueDoesNotExistException;
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Internal/terminal_ack_classification_4012.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Internal/terminal_ack_classification_4012.cs
@@ -1,0 +1,78 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests.Internal;
+
+/// <summary>
+/// GH-4012 item 3. Before this, Azure Service Bus treated every settle failure as transient, so a
+/// permanent one burned the whole retry budget before being dropped. Azure Service Bus makes the
+/// distinction first class -- <c>ServiceBusException.IsTransient</c> -- so unlike RabbitMQ there is no
+/// broker text to string-match, which is worth having: the Rabbit needle was silently wrong for a long
+/// time precisely because it was a string.
+/// </summary>
+public class terminal_ack_classification_4012
+{
+    private static AzureServiceBusEnvelope envelopeFor(ServiceBusReceiver receiver)
+    {
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            lockTokenGuid: Guid.NewGuid());
+
+        return new AzureServiceBusEnvelope(message, receiver);
+    }
+
+    [Fact]
+    public async Task a_terminal_failure_is_swallowed_so_the_retry_block_stops()
+    {
+        var receiver = Substitute.For<ServiceBusReceiver>();
+        receiver.CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw new ServiceBusException("lock is gone", ServiceBusFailureReason.MessageLockLost));
+
+        var envelope = envelopeFor(receiver);
+
+        // Swallowing is what stops the RetryBlock. The delivery is left unsettled, its lock lapses,
+        // and the broker redelivers -- the same recovery Rabbit's unknown-delivery-tag branch relies on
+        await AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task a_transient_failure_still_propagates_so_the_retry_block_retries()
+    {
+        var receiver = Substitute.For<ServiceBusReceiver>();
+        receiver.CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw new ServiceBusException("busy", ServiceBusFailureReason.ServiceBusy));
+
+        var envelope = envelopeFor(receiver);
+
+        // The whole point of classifying: a transient failure must NOT be swallowed, or the retry
+        // budget this change exists to protect would never be spent on the cases that deserve it
+        await Should.ThrowAsync<ServiceBusException>(() =>
+            AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task the_ack_budget_is_shared_across_posts_and_stops_the_broker_round_trips()
+    {
+        var receiver = Substitute.For<ServiceBusReceiver>();
+        receiver.CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw new ServiceBusException("busy", ServiceBusFailureReason.ServiceBusy));
+
+        var envelope = envelopeFor(receiver);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await Should.ThrowAsync<ServiceBusException>(() =>
+                AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None));
+        }
+
+        // Budget spent. This call must not reach the broker at all -- that is the difference between
+        // three round trips and the nine that stacked RetryBlocks used to produce
+        await AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None);
+
+        await receiver.Received(3)
+            .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_lease_renewal_4051.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/native_ack_lease_renewal_4051.cs
@@ -130,7 +130,7 @@ public class native_ack_lease_renewal_4051
 
         await using var listener = new BatchedAzureServiceBusListener(queue,
             NullLogger<BatchedAzureServiceBusListener>.Instance, Substitute.For<IReceiver>(), receiver,
-            Substitute.For<IAzureServiceBusEnvelopeMapper>(), Substitute.For<ISender>());
+            Substitute.For<IAzureServiceBusEnvelopeMapper>(), Substitute.For<ISender>(), 3);
 
         var dead = new AzureServiceBusEnvelope(deadMessage, receiver);
         var live = new AzureServiceBusEnvelope(liveMessage, receiver);
@@ -192,7 +192,7 @@ public class native_ack_lease_renewal_4051
         var client = new ServiceBusClient(Servers.AzureServiceBusConnectionString);
         return new BatchedAzureServiceBusListener(endpoint, NullLogger<BatchedAzureServiceBusListener>.Instance,
             Substitute.For<IReceiver>(), client.CreateReceiver("never-used"),
-            Substitute.For<IAzureServiceBusEnvelopeMapper>(), Substitute.For<ISender>());
+            Substitute.For<IAzureServiceBusEnvelopeMapper>(), Substitute.For<ISender>(), 3);
     }
 }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.Listening.cs
@@ -96,7 +96,7 @@ public partial class AzureServiceBusTransport
             var inlineListener = new InlineAzureServiceBusListener(queue,
                 runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusListener>(), messageProcessor, receiver,
                 mapper,
-                requeue);
+                requeue, runtime.DurabilitySettings.MaximumAckAttempts);
 
             await inlineListener.StartAsync();
 
@@ -105,7 +105,8 @@ public partial class AzureServiceBusTransport
 
         var messageReceiver = BusClient.CreateReceiver(queue.QueueName, BuildReceiverOptions(queue));
         var logger = runtime.LoggerFactory.CreateLogger<BatchedAzureServiceBusListener>();
-        var listener = new BatchedAzureServiceBusListener(queue, logger, receiver, messageReceiver, mapper, requeue);
+        var listener = new BatchedAzureServiceBusListener(queue, logger, receiver, messageReceiver, mapper, requeue,
+            runtime.DurabilitySettings.MaximumAckAttempts);
 
         return listener;
     }
@@ -168,7 +169,8 @@ public partial class AzureServiceBusTransport
         {
             var messageProcessor = BusClient.CreateProcessor(subscription.Topic.TopicName, subscription.SubscriptionName, BuildProcessorOptions(subscription));
             var inlineListener = new InlineAzureServiceBusListener(subscription,
-                runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusListener>(), messageProcessor, receiver, mapper,  requeue
+                runtime.LoggerFactory.CreateLogger<InlineAzureServiceBusListener>(), messageProcessor, receiver, mapper,  requeue,
+                runtime.DurabilitySettings.MaximumAckAttempts
             );
 
             await inlineListener.StartAsync();
@@ -179,7 +181,9 @@ public partial class AzureServiceBusTransport
         var messageReceiver = BusClient.CreateReceiver(subscription.Topic.TopicName, subscription.SubscriptionName,
             BuildReceiverOptions(subscription));
 
-        var listener = new BatchedAzureServiceBusListener(subscription, runtime.LoggerFactory.CreateLogger<BatchedAzureServiceBusListener>(), receiver, messageReceiver, mapper, requeue);
+        var listener = new BatchedAzureServiceBusListener(subscription,
+            runtime.LoggerFactory.CreateLogger<BatchedAzureServiceBusListener>(), receiver, messageReceiver, mapper,
+            requeue, runtime.DurabilitySettings.MaximumAckAttempts);
 
         return listener;
     }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSettlement.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSettlement.cs
@@ -1,0 +1,49 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.AzureServiceBus.Internal;
+
+/// <summary>
+/// GH-4012 item 3. The settle path shared by both Azure Service Bus listeners, carrying the two
+/// protections RabbitMQ already had and Azure Service Bus did not: the envelope's ack budget, and
+/// terminal-failure classification.
+/// </summary>
+/// <remarks>
+/// <para>Without classification a permanent failure burns the whole retry budget before being
+/// dropped. Azure Service Bus makes the distinction first class -- <see cref="ServiceBusException.IsTransient"/>
+/// -- so unlike RabbitMQ there is no broker text to string-match. That matters: the Rabbit needle was
+/// wrong for a long time precisely because it was a string, and nothing failed loudly when it stopped
+/// matching.</para>
+///
+/// <para>Both give-up paths deliberately swallow rather than rethrow. Swallowing is what stops the
+/// <c>RetryBlock</c>; the delivery is simply left unsettled, its lock lapses, and the broker
+/// redelivers -- the same recovery the RabbitMQ unknown-delivery-tag branch relies on.</para>
+/// </remarks>
+internal static class AzureServiceBusSettlement
+{
+    internal static async Task CompleteAsync(AzureServiceBusEnvelope envelope, int maximumAckAttempts,
+        ILogger logger, CancellationToken token)
+    {
+        if (!envelope.TryRecordAckAttempt(maximumAckAttempts))
+        {
+            logger.LogWarning(
+                "Giving up on completing Azure Service Bus message for envelope {EnvelopeId} after {AckAttempts} attempts; leaving it for broker redelivery",
+                envelope.Id, envelope.AckAttempts);
+            return;
+        }
+
+        try
+        {
+            await envelope.CompleteAsync(token);
+        }
+        catch (ServiceBusException e) when (!e.IsTransient)
+        {
+            // Terminal. MessageLockLost is the common one: the lock is gone, so no later attempt on
+            // any receiver can settle this delivery. Retrying only delays the redelivery that is
+            // already coming.
+            logger.LogInformation(
+                "Discarding a terminal Azure Service Bus settle failure ({Reason}) for envelope {EnvelopeId}; the broker will redeliver it",
+                e.Reason, envelope.Id);
+        }
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -31,7 +31,7 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
 
     public BatchedAzureServiceBusListener(AzureServiceBusEndpoint endpoint, ILogger logger,
         IReceiver wolverineReceiver, ServiceBusReceiver receiver, IIncomingMapper<ServiceBusReceivedMessage> mapper,
-        ISender requeue)
+        ISender requeue, int maximumAckAttempts)
     {
         _endpoint = endpoint;
         _logger = logger;
@@ -42,7 +42,9 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
 
         _task = Task.Run(listenForMessages, _cancellation.Token);
 
-        _complete = new RetryBlock<AzureServiceBusEnvelope>((e, _) => { return e.CompleteAsync(_cancellation.Token); },
+        // GH-4012 item 3: ack budget + terminal-failure classification, shared with the inline listener
+        _complete = new RetryBlock<AzureServiceBusEnvelope>(
+            (e, _) => AzureServiceBusSettlement.CompleteAsync(e, maximumAckAttempts, _logger, _cancellation.Token),
             _logger, _cancellation.Token);
 
         _defer = new RetryBlock<Envelope>(async (envelope, _) =>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
@@ -31,7 +31,7 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
         ILogger logger,
         ServiceBusProcessor processor, IReceiver receiver,
         IIncomingMapper<ServiceBusReceivedMessage> mapper,
-        ISender requeue)
+        ISender requeue, int maximumAckAttempts)
     {
         _endpoint = endpoint;
         _logger = logger;
@@ -40,7 +40,9 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
         _mapper = mapper;
         _requeue = requeue;
 
-        _complete = new RetryBlock<AzureServiceBusEnvelope>((e, _) => { return e.CompleteAsync(_cancellation.Token); },
+        // GH-4012 item 3: ack budget + terminal-failure classification, shared with the batched listener
+        _complete = new RetryBlock<AzureServiceBusEnvelope>(
+            (e, _) => AzureServiceBusSettlement.CompleteAsync(e, maximumAckAttempts, _logger, _cancellation.Token),
             _logger, _cancellation.Token);
 
         _defer = new RetryBlock<AzureServiceBusEnvelope>(async (envelope, _) =>


### PR DESCRIPTION
Item 3 of #4012. Items 1–2 shipped in #4014; item 3 unblocked when #4093 merged.

Only RabbitMQ distinguished a terminal settle failure from a transient one. Everywhere else a permanent failure burned the **full retry budget** before being dropped — and under `EndpointMode.NativeAck` there is no inbox row, so a settle that silently exhausts its budget is a redelivery and a duplicate execution rather than a no-op.

## Both new transports classify better than the precedent

Worth stating, because this issue's own history is the argument: the Rabbit needle was silently wrong for a long time **precisely because it was a string match**, and nothing failed loudly when it stopped matching.

| Transport | Signal | Quality |
| --- | --- | --- |
| RabbitMQ (existing) | broker text match | fragile — the failure mode this issue documents |
| **Azure Service Bus** | `ServiceBusException.IsTransient` | first-class boolean |
| **Amazon SQS** | distinct typed exceptions | terminal set is **named**, not inferred |

SQS terminal set: `ReceiptHandleIsInvalidException`, `MessageNotInflightException`, `QueueDoesNotExistException`. `RequestThrottledException` and `OverLimitException` are deliberately left transient — those are exactly what the budget exists for.

## Also

**ASB picks up the shared ack budget** (item 1's `TryRecordAckAttempt`), which it did not have. Both ASB listeners carried **byte-identical** `_complete` blocks, so this removes the duplication as well: `AzureServiceBusSettlement` is now the one settle path, with `MaximumAckAttempts` plumbed from `DurabilitySettings` at all four construction sites.

**SQS gets classification but not the budget**, and that asymmetry is documented in the helper rather than left silent. Its delete block is keyed on `Message` rather than the envelope, so `Envelope.AckAttempts` is not reachable without rekeying the block — that is item 1's territory, not item 3's.

Both give-up paths **swallow rather than rethrow**. Swallowing is what stops the `RetryBlock`; the delivery is left unsettled and the broker redelivers it on its own clock — the same recovery Rabbit's unknown-delivery-tag branch relies on.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| ASB `terminal_ack_classification_4012` | 3 / 3 |
| SQS `terminal_ack_classification_4012` | 3 / 3 |

**Red baselines** — both re-done, because the first attempt **failed to compile** (`CS8360`) and, run with `--no-build`, silently re-executed a stale binary that reported all green:

- ASB: 2 of 3 fail without the change
- SQS: the terminal test fails when `IsTerminal` returns false

In both suites the transient test passes either way — that is the control proving the change does not simply swallow everything.

## Still open on #4012

Item 4 (broker-side redelivery-count bounding across Rabbit `x-death` / SQS `ApproximateReceiveCount` / ASB `DeliveryCount`) is cross-transport and deserves its own PR. Item 5 is cross-repo into JasperFx and explicitly gated on 1–4 proving the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)