### PR TITLE
GH-3627: [StreamState] and [StreamEvents] for raw stream reads

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/stream_state_and_events_3627.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/stream_state_and_events_3627.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Alba;
+using JasperFx.Events;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Persistence.EventSourcing;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+/// <summary>
+/// GH-3627. [StreamState] and [StreamEvents] for handlers whose read is the raw stream rather than the
+/// folded aggregate -- timeline and audit shaped endpoints that [ReadAggregate] cannot express, because
+/// folding has already collapsed what they need.
+/// </summary>
+public class stream_state_and_events_3627(AppFixture fixture) : IntegrationContext(fixture)
+{
+    private async Task<Guid> createOrderAsync()
+    {
+        var result = await Host.Scenario(x =>
+        {
+            x.Post.Json(new StartOrder(["Hat", "Shirt"])).ToUrl("/orders/create");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var status = await result.ReadAsJsonAsync<OrderStatus>();
+        return status!.OrderId;
+    }
+
+    [Fact]
+    public async Task both_reads_resolve_against_the_same_stream()
+    {
+        var id = await createOrderAsync();
+
+        var result = await Host.Scenario(x =>
+        {
+            x.Get.Url($"/orders/{id}/timeline");
+            x.StatusCodeShouldBeOk();
+        });
+
+        var timeline = (await result.ReadAsJsonAsync<OrderTimeline>()).ShouldNotBeNull();
+
+        // StreamState carried the version, StreamEvents carried the events themselves
+        timeline.Version.ShouldBe(1);
+
+        // Marten's event ALIAS, not the CLR name -- which is itself the proof that this read went
+        // through Marten's event store rather than anything the test could have fabricated
+        timeline.EventTypes.ShouldContain("order_created");
+    }
+
+    [Fact]
+    public async Task a_missing_stream_is_a_404_when_the_parameter_is_not_nullable()
+    {
+        // [StreamState] StreamState state -- non-nullable, so the standard not-found guard applies,
+        // exactly as [ReadModel] behaves since GH-3929
+        await Host.Scenario(x =>
+        {
+            x.Get.Url($"/orders/{Guid.NewGuid()}/timeline");
+            x.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task a_nullable_parameter_leaves_absence_to_the_handler()
+    {
+        // [StreamState] StreamState? state -- the author said "I will handle absence", so no guard
+        var result = await Host.Scenario(x =>
+        {
+            x.Get.Url($"/orders/{Guid.NewGuid()}/timeline-optional");
+            x.StatusCodeShouldBeOk();
+        });
+
+        (await result.ReadAsJsonAsync<OrderTimeline>())!.Version.ShouldBe(0);
+    }
+
+    [Fact]
+    public void stream_events_deliberately_has_no_required_knob()
+    {
+        // A missing stream yields an EMPTY LIST, not null, so the null-guard model the rest of the
+        // IDataRequirement family is built on has nothing to test. Pinned so nobody "fixes" the
+        // asymmetry by adding one -- pair with [StreamState] for existence guards instead
+        typeof(StreamEventsAttribute).GetProperty("Required").ShouldBeNull();
+        typeof(StreamEventsAttribute).IsAssignableTo(typeof(Wolverine.Persistence.IDataRequirement))
+            .ShouldBeFalse();
+
+        // ...while [StreamState] does have one
+        typeof(StreamStateAttribute).GetProperty("Required").ShouldNotBeNull();
+    }
+}

--- a/src/Http/WolverineWebApi/Marten/Orders.cs
+++ b/src/Http/WolverineWebApi/Marten/Orders.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using JasperFx;
 using JasperFx.Events;
+using Wolverine.Persistence.EventSourcing;
 using Marten;
 using Marten.Events;
 using Marten.Linq;
@@ -323,6 +324,29 @@ public static class MarkItemEndpoint
         );
     }
 
+    #region sample_using_streamstate_and_streamevents_in_http
+
+    // GH-3627. Timeline/audit shaped reads: the handler serves the event history itself, which
+    // [ReadAggregate] cannot express because folding has already collapsed what it needs. Both fetches
+    // batch into one round trip alongside any other batchable load on the same handler.
+    [WolverineGet("/orders/{id}/timeline")]
+    public static OrderTimeline GetTimeline(
+        Guid id,
+        [MartenStreamState] StreamState state,
+        [MartenStreamEvents] IReadOnlyList<IEvent> events)
+    {
+        return new OrderTimeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+
+    #endregion
+
+    // The nullable spelling: no 404 guard, the handler decides what absence means
+    [WolverineGet("/orders/{id}/timeline-optional")]
+    public static OrderTimeline GetTimelineOptional(Guid id, [MartenStreamState] StreamState? state)
+    {
+        return new OrderTimeline(state?.Version ?? 0, []);
+    }
+
     #region sample_using_readaggregate_in_http
     [WolverineGet("/orders/latest/{id}")]
     public static Order GetLatest(Guid id, [ReadAggregate] Order order) => order;
@@ -469,3 +493,5 @@ public static class MarkItemReadyHandler
 }
 
 #endregion
+
+public record OrderTimeline(long Version, string[] EventTypes);

--- a/src/Persistence/Wolverine.Fisher/Codegen/FetchStreamFrames.cs
+++ b/src/Persistence/Wolverine.Fisher/Codegen/FetchStreamFrames.cs
@@ -1,0 +1,76 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using JasperFx.Events;
+using Fisher;
+
+namespace Wolverine.Fisher.Codegen;
+
+// GH-3627. The Fisher spellings of [StreamState] and [StreamEvents], reached through
+// IEventSourcingFrameProvider so core never writes "session.Events.FetchStreamStateAsync(...)" itself.
+//
+// Standalone rather than batched, deliberately: Fisher's own FetchLatestAggregateFrame is a plain
+// AsyncFrame with no IBatchableFrame, so batching these would make the raw stream reads behave
+// differently from the aggregate read right next to them. Marten batches because Marten's fetch-latest
+// already does.
+internal abstract class FetchStreamFrameBase : AsyncFrame
+{
+    protected readonly Variable _identity;
+    protected Variable _session = null!;
+    protected Variable _token = null!;
+
+    protected FetchStreamFrameBase(Variable identity, Type readType)
+    {
+        if (identity.VariableType == typeof(Guid) || identity.VariableType == typeof(string))
+        {
+            _identity = identity;
+        }
+        else
+        {
+            var valueType = ValueTypeInfo.ForType(identity.VariableType);
+            _identity = new MemberAccessVariable(identity, valueType.ValueProperty);
+        }
+
+        Read = new Variable(readType, this);
+    }
+
+    public Variable Read { get; }
+
+    protected abstract string Call { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+
+        _token = chain.FindVariable(typeof(CancellationToken));
+        yield return _token;
+
+        yield return _identity;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"var {Read.Usage} = await {_session.Usage}.Events.{Call}({_identity.Usage}, {_token.Usage});");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+internal class FetchStreamStateFrame : FetchStreamFrameBase
+{
+    public FetchStreamStateFrame(Variable identity) : base(identity, typeof(StreamState))
+    {
+    }
+
+    protected override string Call => nameof(IQueryEventStore.FetchStreamStateAsync);
+}
+
+internal class FetchStreamFrame : FetchStreamFrameBase
+{
+    public FetchStreamFrame(Variable identity) : base(identity, typeof(IReadOnlyList<IEvent>))
+    {
+    }
+
+    protected override string Call => nameof(IQueryEventStore.FetchStreamAsync);
+}

--- a/src/Persistence/Wolverine.Fisher/FisherAncillaryStoreFrameProvider.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherAncillaryStoreFrameProvider.cs
@@ -2,6 +2,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core.Reflection;
 using Fisher;
 using Wolverine.Persistence;
+using Wolverine.Persistence.EventSourcing;
 using Wolverine.Fisher.Codegen;
 
 namespace Wolverine.Fisher;
@@ -15,4 +16,8 @@ internal class FisherAncillaryStoreFrameProvider : IAncillaryStoreFrameProvider
     public bool Matches(Type storeType) => storeType.CanBeCastTo<IDocumentStore>();
 
     public Frame BuildOutboxFactoryFrame(Type storeType) => new AncillaryOutboxFactoryFrame(storeType);
+
+    // GH-3627. Lets [StreamState] / [StreamEvents] find Fisher when a chain has been routed to a Fisher
+    // ancillary store by [Storage(...)] -- those attributes have no aggregate type to resolve through.
+    public IEventSourcingFrameProvider? EventSourcing { get; } = new Persistence.Sagas.FisherPersistenceFrameProvider();
 }

--- a/src/Persistence/Wolverine.Fisher/Persistence/Sagas/FisherEventSourcingFrameProvider.cs
+++ b/src/Persistence/Wolverine.Fisher/Persistence/Sagas/FisherEventSourcingFrameProvider.cs
@@ -31,6 +31,11 @@ internal partial class FisherPersistenceFrameProvider : IEventSourcingFrameProvi
     // AsyncFrame where Marten's also implements IBatchableFrame.
     public Frame BuildLoadAggregateFrame(AggregateLoadRequest request) => new LoadAggregateFrame(request);
 
+    // GH-3627. Fisher's spelling of the raw stream reads.
+    public Frame BuildFetchStreamStateFrame(Variable identity) => new Codegen.FetchStreamStateFrame(identity);
+
+    public Frame BuildFetchStreamFrame(Variable identity) => new Codegen.FetchStreamFrame(identity);
+
     public Frame BuildFetchLatestFrame(Type aggregateType, Variable identity)
         => new FetchLatestAggregateFrame(aggregateType, identity);
 

--- a/src/Persistence/Wolverine.Marten/Codegen/FetchStreamFrames.cs
+++ b/src/Persistence/Wolverine.Marten/Codegen/FetchStreamFrames.cs
@@ -1,0 +1,110 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using JasperFx.Events;
+using Marten;
+using Marten.Services.BatchQuerying;
+
+namespace Wolverine.Marten.Codegen;
+
+// GH-3627. The Marten spellings of [StreamState] and [StreamEvents], reached through
+// IEventSourcingFrameProvider so that core never writes "session.Events.FetchStreamStateAsync(...)"
+// itself -- which is what keeps the batch-query enlistment below on Marten's side of the seam, exactly
+// as FetchLatestAggregateFrame does for [ReadModel].
+internal abstract class FetchStreamFrameBase : AsyncFrame, IBatchableFrame
+{
+    protected readonly Variable _identity;
+    protected Variable _session = null!;
+    protected Variable _token = null!;
+    protected Variable _batchQuery = null!;
+    protected Variable _batchQueryItem = null!;
+
+    protected FetchStreamFrameBase(Variable identity, Type readType)
+    {
+        if (identity.VariableType == typeof(Guid) || identity.VariableType == typeof(string))
+        {
+            _identity = identity;
+        }
+        else
+        {
+            var valueType = ValueTypeInfo.ForType(identity.VariableType);
+            _identity = new MemberAccessVariable(identity, valueType.ValueProperty);
+        }
+
+        Read = new Variable(readType, this);
+    }
+
+    public Variable Read { get; }
+
+    protected abstract string BatchCall { get; }
+
+    protected abstract string StandaloneCall { get; }
+
+    public void WriteCodeToEnlistInBatchQuery(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchQueryItem == null)
+            throw new InvalidOperationException("This frame has not been enlisted in a MartenBatchFrame");
+
+        writer.Write($"var {_batchQueryItem.Usage} = {_batchQuery!.Usage}.Events.{BatchCall}({_identity.Usage});");
+    }
+
+    public void EnlistInBatchQuery(Variable batchQuery)
+    {
+        _batchQueryItem = new Variable(typeof(Task<>).MakeGenericType(Read.VariableType),
+            Read.Usage + "_BatchItem", this);
+        _batchQuery = batchQuery;
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+
+        _token = chain.FindVariable(typeof(CancellationToken));
+        yield return _token;
+
+        if (_batchQuery != null)
+        {
+            yield return _batchQuery;
+        }
+
+        yield return _identity;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (_batchQueryItem == null)
+        {
+            writer.Write($"var {Read.Usage} = await {_session.Usage}.Events.{StandaloneCall}({_identity.Usage}, {_token.Usage});");
+        }
+        else
+        {
+            writer.Write($"var {Read.Usage} = await {_batchQueryItem.Usage}.ConfigureAwait(false);");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+internal class FetchStreamStateFrame : FetchStreamFrameBase
+{
+    public FetchStreamStateFrame(Variable identity) : base(identity, typeof(StreamState))
+    {
+    }
+
+    protected override string BatchCall => nameof(IBatchEvents.FetchStreamState);
+
+    protected override string StandaloneCall => nameof(IQueryEventStore.FetchStreamStateAsync);
+}
+
+internal class FetchStreamFrame : FetchStreamFrameBase
+{
+    public FetchStreamFrame(Variable identity) : base(identity, typeof(IReadOnlyList<IEvent>))
+    {
+    }
+
+    protected override string BatchCall => nameof(IBatchEvents.FetchStream);
+
+    protected override string StandaloneCall => nameof(IQueryEventStore.FetchStreamAsync);
+}

--- a/src/Persistence/Wolverine.Marten/MartenAncillaryStoreFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/MartenAncillaryStoreFrameProvider.cs
@@ -3,6 +3,7 @@ using JasperFx.Core.Reflection;
 using Marten;
 using Wolverine.Marten.Codegen;
 using Wolverine.Persistence;
+using Wolverine.Persistence.EventSourcing;
 
 namespace Wolverine.Marten;
 
@@ -15,4 +16,8 @@ internal class MartenAncillaryStoreFrameProvider : IAncillaryStoreFrameProvider
     public bool Matches(Type storeType) => storeType.CanBeCastTo<IDocumentStore>();
 
     public Frame BuildOutboxFactoryFrame(Type storeType) => new AncillaryOutboxFactoryFrame(storeType);
+
+    // GH-3627. Lets [StreamState] / [StreamEvents] find Marten when a chain has been routed to a Marten
+    // ancillary store by [Storage(...)] -- those attributes have no aggregate type to resolve through.
+    public IEventSourcingFrameProvider? EventSourcing { get; } = new Persistence.Sagas.MartenPersistenceFrameProvider();
 }

--- a/src/Persistence/Wolverine.Marten/MartenStreamAttributes.cs
+++ b/src/Persistence/Wolverine.Marten/MartenStreamAttributes.cs
@@ -1,0 +1,54 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Events;
+using Wolverine.Configuration;
+using Wolverine.Marten.Persistence.Sagas;
+using Wolverine.Persistence.EventSourcing;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+/// The Marten spelling of <see cref="StreamStateAttribute" />: read a stream's <see cref="StreamState" />
+/// through Marten specifically.
+/// </summary>
+/// <remarks>
+/// GH-3627. Prefer <c>[StreamState]</c> in new code — it works against any event store integration. This
+/// exists for the same reason <see cref="ReadAggregateAttribute" /> does: it <b>names</b> its store rather
+/// than resolving one, so it still works in a host that called <c>AddMarten(...)</c> without
+/// <c>IntegrateWithWolverine()</c>, where nothing ever registers a persistence strategy.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class MartenStreamStateAttribute : StreamStateAttribute
+{
+    public MartenStreamStateAttribute()
+    {
+    }
+
+    public MartenStreamStateAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    protected override IEventSourcingFrameProvider ResolveProvider(IChain chain, GenerationRules rules,
+        IServiceContainer container) => new MartenPersistenceFrameProvider();
+}
+
+/// <summary>
+/// The Marten spelling of <see cref="StreamEventsAttribute" />. See
+/// <see cref="MartenStreamStateAttribute" /> for why it exists.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class MartenStreamEventsAttribute : StreamEventsAttribute
+{
+    public MartenStreamEventsAttribute()
+    {
+    }
+
+    public MartenStreamEventsAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    protected override IEventSourcingFrameProvider ResolveProvider(IChain chain, GenerationRules rules,
+        IServiceContainer container) => new MartenPersistenceFrameProvider();
+}

--- a/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenEventSourcingFrameProvider.cs
+++ b/src/Persistence/Wolverine.Marten/Persistence/Sagas/MartenEventSourcingFrameProvider.cs
@@ -31,6 +31,12 @@ internal partial class MartenPersistenceFrameProvider : IEventSourcingFrameProvi
     // Polecat has no equivalent of - entirely on this side of the seam.
     public Frame BuildLoadAggregateFrame(AggregateLoadRequest request) => new LoadAggregateFrame(request);
 
+    // GH-3627. Marten's spelling of the raw stream reads. The batch-query enlistment lives inside these
+    // frames, which is the whole reason the seam hands back a Frame rather than letting core write the call.
+    public Frame BuildFetchStreamStateFrame(Variable identity) => new FetchStreamStateFrame(identity);
+
+    public Frame BuildFetchStreamFrame(Variable identity) => new FetchStreamFrame(identity);
+
     public Frame BuildFetchLatestFrame(Type aggregateType, Variable identity)
         => new FetchLatestAggregateFrame(aggregateType, identity);
 

--- a/src/Persistence/Wolverine.Polecat/Codegen/FetchStreamFrames.cs
+++ b/src/Persistence/Wolverine.Polecat/Codegen/FetchStreamFrames.cs
@@ -1,0 +1,76 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using JasperFx.Events;
+using Polecat;
+
+namespace Wolverine.Polecat.Codegen;
+
+// GH-3627. The Polecat spellings of [StreamState] and [StreamEvents], reached through
+// IEventSourcingFrameProvider so core never writes "session.Events.FetchStreamStateAsync(...)" itself.
+//
+// Standalone rather than batched, deliberately: Polecat's own FetchLatestAggregateFrame is a plain
+// AsyncFrame with no IBatchableFrame, so batching these would make the raw stream reads behave
+// differently from the aggregate read right next to them. Marten batches because Marten's fetch-latest
+// already does.
+internal abstract class FetchStreamFrameBase : AsyncFrame
+{
+    protected readonly Variable _identity;
+    protected Variable _session = null!;
+    protected Variable _token = null!;
+
+    protected FetchStreamFrameBase(Variable identity, Type readType)
+    {
+        if (identity.VariableType == typeof(Guid) || identity.VariableType == typeof(string))
+        {
+            _identity = identity;
+        }
+        else
+        {
+            var valueType = ValueTypeInfo.ForType(identity.VariableType);
+            _identity = new MemberAccessVariable(identity, valueType.ValueProperty);
+        }
+
+        Read = new Variable(readType, this);
+    }
+
+    public Variable Read { get; }
+
+    protected abstract string Call { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IDocumentSession));
+        yield return _session;
+
+        _token = chain.FindVariable(typeof(CancellationToken));
+        yield return _token;
+
+        yield return _identity;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"var {Read.Usage} = await {_session.Usage}.Events.{Call}({_identity.Usage}, {_token.Usage});");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+internal class FetchStreamStateFrame : FetchStreamFrameBase
+{
+    public FetchStreamStateFrame(Variable identity) : base(identity, typeof(StreamState))
+    {
+    }
+
+    protected override string Call => nameof(IQueryEventStore.FetchStreamStateAsync);
+}
+
+internal class FetchStreamFrame : FetchStreamFrameBase
+{
+    public FetchStreamFrame(Variable identity) : base(identity, typeof(IReadOnlyList<IEvent>))
+    {
+    }
+
+    protected override string Call => nameof(IQueryEventStore.FetchStreamAsync);
+}

--- a/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatEventSourcingFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/Persistence/Sagas/PolecatEventSourcingFrameProvider.cs
@@ -31,6 +31,11 @@ internal partial class PolecatPersistenceFrameProvider : IEventSourcingFrameProv
     // AsyncFrame where Marten's also implements IBatchableFrame.
     public Frame BuildLoadAggregateFrame(AggregateLoadRequest request) => new LoadAggregateFrame(request);
 
+    // GH-3627. Polecat's spelling of the raw stream reads.
+    public Frame BuildFetchStreamStateFrame(Variable identity) => new Codegen.FetchStreamStateFrame(identity);
+
+    public Frame BuildFetchStreamFrame(Variable identity) => new Codegen.FetchStreamFrame(identity);
+
     public Frame BuildFetchLatestFrame(Type aggregateType, Variable identity)
         => new FetchLatestAggregateFrame(aggregateType, identity);
 

--- a/src/Persistence/Wolverine.Polecat/PolecatAncillaryStoreFrameProvider.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatAncillaryStoreFrameProvider.cs
@@ -2,6 +2,7 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core.Reflection;
 using Polecat;
 using Wolverine.Persistence;
+using Wolverine.Persistence.EventSourcing;
 using Wolverine.Polecat.Codegen;
 
 namespace Wolverine.Polecat;
@@ -15,4 +16,8 @@ internal class PolecatAncillaryStoreFrameProvider : IAncillaryStoreFrameProvider
     public bool Matches(Type storeType) => storeType.CanBeCastTo<IDocumentStore>();
 
     public Frame BuildOutboxFactoryFrame(Type storeType) => new AncillaryOutboxFactoryFrame(storeType);
+
+    // GH-3627. Lets [StreamState] / [StreamEvents] find Polecat when a chain has been routed to a Polecat
+    // ancillary store by [Storage(...)] -- those attributes have no aggregate type to resolve through.
+    public IEventSourcingFrameProvider? EventSourcing { get; } = new Persistence.Sagas.PolecatPersistenceFrameProvider();
 }

--- a/src/Wolverine/Persistence/EventSourcing/IEventSourcingFrameProvider.cs
+++ b/src/Wolverine/Persistence/EventSourcing/IEventSourcingFrameProvider.cs
@@ -100,6 +100,37 @@ public interface IEventSourcingFrameProvider
             $"{nameof(IEventSourcingFrameProvider)}.{nameof(BuildLoadBoundaryFrame)}.");
 
     /// <summary>
+    /// Build the frame that reads a stream's <see cref="JasperFx.Events.StreamState"/> — the store's
+    /// <c>FetchStreamStateAsync</c> call. Must create exactly one variable of type
+    /// <c>JasperFx.Events.StreamState</c>.
+    /// </summary>
+    /// <remarks>
+    /// GH-3627. Optional, following the <see cref="BuildLoadBoundaryFrame"/> precedent: a store that has
+    /// not implemented it reports that rather than failing at codegen with something obscure. The types
+    /// involved are already store-agnostic -- <c>StreamState</c> and <c>IEvent</c> live in JasperFx.Events,
+    /// and <c>FetchStreamStateAsync</c> is declared on <c>IQueryEventStore</c> -- but the <c>.Events</c>
+    /// accessor that reaches them is not, which is exactly what this seam exists to keep store-side.
+    /// </remarks>
+    Frame BuildFetchStreamStateFrame(Variable identity)
+        => throw new NotSupportedException(
+            $"The {StoreName} integration does not support reading raw stream state. " +
+            $"[{nameof(StreamStateAttribute).Replace("Attribute", "")}] requires " +
+            $"{nameof(IEventSourcingFrameProvider)}.{nameof(BuildFetchStreamStateFrame)}.");
+
+    /// <summary>
+    /// Build the frame that reads a stream's raw events — the store's <c>FetchStreamAsync</c> call. Must
+    /// create exactly one variable of type <c>IReadOnlyList&lt;JasperFx.Events.IEvent&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// GH-3627. Optional, on the same terms as <see cref="BuildFetchStreamStateFrame"/>.
+    /// </remarks>
+    Frame BuildFetchStreamFrame(Variable identity)
+        => throw new NotSupportedException(
+            $"The {StoreName} integration does not support reading raw stream events. " +
+            $"[{nameof(StreamEventsAttribute).Replace("Attribute", "")}] requires " +
+            $"{nameof(IEventSourcingFrameProvider)}.{nameof(BuildFetchStreamFrame)}.");
+
+    /// <summary>
     /// Whether the store identifies streams by <see cref="Guid"/> or by string key. Consulted only to
     /// pick between <c>IEvent.StreamId</c> and <c>IEvent.StreamKey</c> when the handler's input is an
     /// <c>IEvent&lt;T&gt;</c>.

--- a/src/Wolverine/Persistence/EventSourcing/StreamEventsAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/StreamEventsAttribute.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Events;
+using Wolverine.Configuration;
+
+namespace Wolverine.Persistence.EventSourcing;
+
+/// <summary>
+///     Read a stream's raw events as <c>IReadOnlyList&lt;IEvent&gt;</c>. GH-3627.
+/// </summary>
+/// <remarks>
+///     <para>
+///     The companion to <see cref="StreamStateAttribute" /> for timeline and audit shaped handlers.
+///     Batched with any other batchable load on the same handler into a single round trip by the store.
+///     </para>
+///     <para>
+///     <b>There is deliberately no <c>Required</c> here.</b> A missing stream yields an <i>empty list</i>,
+///     not null, so the null-guard model the rest of the <c>IDataRequirement</c> family is built on has
+///     nothing to test — a guard would either never fire or would have to invent a count threshold, and
+///     "zero events" is not the same question as "no such stream". Pair with
+///     <c>[StreamState] StreamState state</c> when the handler needs an existence or aggregate-type guard;
+///     that reads the same stream in the same batch and answers the question precisely.
+///     </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class StreamEventsAttribute : StreamReadAttribute
+{
+    public StreamEventsAttribute()
+    {
+    }
+
+    public StreamEventsAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    protected override Type ReadType => typeof(IReadOnlyList<IEvent>);
+
+    protected override Frame BuildFrame(IEventSourcingFrameProvider provider, Variable identity)
+        => provider.BuildFetchStreamFrame(identity);
+
+    protected override Variable ModifyForRead(IChain chain, ParameterInfo parameter, Frame frame, Variable created,
+        Variable identity)
+    {
+        chain.Middleware.Add(frame);
+        return created;
+    }
+}

--- a/src/Wolverine/Persistence/EventSourcing/StreamReadAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/StreamReadAttribute.cs
@@ -1,0 +1,157 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Sagas;
+using Wolverine.Runtime;
+
+namespace Wolverine.Persistence.EventSourcing;
+
+/// <summary>
+///     Shared base for the raw stream reads — <see cref="StreamStateAttribute" /> and
+///     <see cref="StreamEventsAttribute" />. GH-3627.
+/// </summary>
+/// <remarks>
+///     <para>
+///     Store-agnostic, and unusually so: the parameter types these bind are <b>already</b> shared
+///     vocabulary — <c>JasperFx.Events.StreamState</c> and <c>JasperFx.Events.IEvent</c> — and
+///     <c>FetchStreamStateAsync</c> / <c>FetchStreamAsync</c> are declared on
+///     <c>JasperFx.Events.IQueryEventStore</c>. Only the <c>.Events</c> accessor that reaches them is
+///     store-specific, which is exactly what <see cref="IEventSourcingFrameProvider" /> exists to keep on
+///     the store's side of the seam.
+///     </para>
+///     <para>
+///     That shared vocabulary is also what makes provider resolution different from
+///     <see cref="ReadModelAttribute" />. There is no aggregate type here to ask "who owns this?" about —
+///     the whole point of reading raw stream state is that the aggregate type is a <i>runtime</i> fact —
+///     so resolution goes: an explicit <see cref="AggregateType" />, then the ancillary store a
+///     <see cref="StorageAttribute" /> routed the chain to, then the single registered event sourcing
+///     integration. Ambiguity is an error naming both escape hatches rather than a guess.
+///     </para>
+/// </remarks>
+public abstract class StreamReadAttribute : WolverineParameterAttribute
+{
+    protected StreamReadAttribute()
+    {
+        ValueSource = ValueSource.Anything;
+    }
+
+    protected StreamReadAttribute(string argumentName) : base(argumentName)
+    {
+        ValueSource = ValueSource.Anything;
+    }
+
+    /// <summary>
+    ///     Optionally name the aggregate whose stream this is, purely to identify the owning store in an
+    ///     application with more than one event sourcing integration. It does not change what is read.
+    /// </summary>
+    public Type? AggregateType { get; set; }
+
+    /// <summary>
+    ///     Find the event sourcing integration that should serve this read. See the class remarks for why
+    ///     this cannot simply key off the parameter type the way <see cref="ReadModelAttribute" /> does.
+    /// </summary>
+    protected virtual IEventSourcingFrameProvider ResolveProvider(IChain chain, GenerationRules rules,
+        IServiceContainer container)
+    {
+        // 1. The author named the aggregate, so the question is already answered
+        if (AggregateType != null)
+        {
+            return rules.FindEventSourcingFrameProvider(container, AggregateType);
+        }
+
+        // 2. The chain was routed to an ancillary store by [Storage(typeof(IMyStore))]. Reading the
+        //    primary store's events from a handler explicitly pointed at a secondary one would be wrong
+        //    in a way nothing downstream could detect
+        if (chain.AncillaryStoreType is { } storeType)
+        {
+            var ancillary = container.GetAllInstances<IAncillaryStoreFrameProvider>()
+                .FirstOrDefault(x => x.Matches(storeType));
+
+            if (ancillary?.EventSourcing is { } fromStore)
+            {
+                return fromStore;
+            }
+
+            throw new InvalidOperationException(
+                $"This handler is routed to the ancillary store '{storeType.FullNameInCode()}', but no registered " +
+                $"Wolverine persistence integration owns that store as an event store. [{Label()}] cannot determine " +
+                "which event store to read from.");
+        }
+
+        // 3. One integration registered, so there is nothing to be ambiguous about
+        var providers = rules.OrderedPersistenceProviders()
+            .OfType<IEventSourcingFrameProvider>()
+            .ToArray();
+
+        if (providers.Length == 1)
+        {
+            return providers[0];
+        }
+
+        if (providers.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"[{Label()}] requires an event store integration. Add Wolverine.Marten, Wolverine.Polecat, or " +
+                "another integration that implements IEventSourcingFrameProvider, and register it with " +
+                "IntegrateWithWolverine().");
+        }
+
+        throw new InvalidOperationException(
+            $"[{Label()}] cannot tell which of {providers.Length} registered event store integrations " +
+            $"({providers.Select(x => x.StoreName).Join(", ")}) this stream belongs to, because the parameter type " +
+            "is store-agnostic and carries no aggregate type. Say which one by setting AggregateType — " +
+            $"[{Label()}(AggregateType = typeof(MyAggregate))] — or route the handler to a specific store with " +
+            "[Storage(typeof(IMyStore))].");
+    }
+
+    private string Label() => GetType().Name.Replace("Attribute", "");
+
+    /// <summary>Build the store's frame for this read, and name the variable it creates.</summary>
+    protected abstract Frame BuildFrame(IEventSourcingFrameProvider provider, Variable identity);
+
+    /// <summary>The type the store's frame is required to create exactly one variable of.</summary>
+    protected abstract Type ReadType { get; }
+
+    public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
+        GenerationRules rules)
+    {
+        var provider = ResolveProvider(chain, rules, container);
+
+        // Stream identity is the store's, not an aggregate's: Guid or string, per the integration
+        var idType = provider.DetermineStreamIdentity(container) == JasperFx.Events.StreamIdentity.AsGuid
+            ? typeof(Guid)
+            : typeof(string);
+
+        if (!tryFindIdentityVariable(chain, parameter, idType, out var identity))
+        {
+            throw new InvalidEntityLoadUsageException(this, parameter);
+        }
+
+        var frame = BuildFrame(provider, identity!);
+
+        var created = frame.Creates.FirstOrDefault(x => x.VariableType == ReadType);
+        if (created == null)
+        {
+            throw new InvalidOperationException(
+                $"The {provider.StoreName} integration's {frame.GetType().FullNameInCode()} did not create a variable " +
+                $"of type {ReadType.FullNameInCode()}.");
+        }
+
+        created.OverrideName(parameter.Name!);
+
+        return ModifyForRead(chain, parameter, frame, created, identity!);
+    }
+
+    /// <summary>
+    ///     What each subclass does with the frame once it exists — a null guard for
+    ///     <see cref="StreamStateAttribute" />, nothing for <see cref="StreamEventsAttribute" />.
+    /// </summary>
+    protected abstract Variable ModifyForRead(IChain chain, ParameterInfo parameter, Frame frame, Variable created,
+        Variable identity);
+}

--- a/src/Wolverine/Persistence/EventSourcing/StreamStateAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/StreamStateAttribute.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Events;
+using Wolverine.Configuration;
+
+namespace Wolverine.Persistence.EventSourcing;
+
+/// <summary>
+///     Read a stream's <see cref="StreamState" /> — version, aggregate type, created/updated timestamps —
+///     without folding it into an aggregate. GH-3627.
+/// </summary>
+/// <remarks>
+///     For handlers that serve the event history itself, where <see cref="ReadModelAttribute" /> cannot
+///     express the read because state has already collapsed what they need. Batched with any other
+///     batchable load on the same handler into a single round trip by the store, exactly as
+///     <c>[ReadModel]</c> is.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class StreamStateAttribute : StreamReadAttribute, IDataRequirement
+{
+    private OnMissing? _onMissing;
+    private bool? _required;
+
+    public StreamStateAttribute()
+    {
+    }
+
+    public StreamStateAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    /// <summary>
+    ///     Should Wolverine stop the handler when the stream does not exist? Defaults to the opposite of the
+    ///     parameter's nullable annotation, matching <see cref="ReadModelAttribute" />: <c>StreamState state</c>
+    ///     is required, <c>StreamState? state</c> is not.
+    /// </summary>
+    public bool Required
+    {
+        get => _required ?? true;
+        set => _required = value;
+    }
+
+    public OnMissing OnMissing
+    {
+        get => _onMissing ?? OnMissing.Simple404;
+        set => _onMissing = value;
+    }
+
+    public string MissingMessage { get; set; } = null!;
+
+    protected override Type ReadType => typeof(StreamState);
+
+    protected override Frame BuildFrame(IEventSourcingFrameProvider provider, Variable identity)
+        => provider.BuildFetchStreamStateFrame(identity);
+
+    protected override Variable ModifyForRead(IChain chain, ParameterInfo parameter, Frame frame, Variable created,
+        Variable identity)
+    {
+        // Nullable annotation decides the default, same as [ReadModel] since GH-3929
+        _required ??= !ParameterNullability.IsNullableAnnotated(parameter);
+
+        if (chain.IsDataRequired(this))
+        {
+            var otherFrames = chain.AddStopConditionIfNull(created, identity, this);
+            var block = new LoadEntityFrameBlock(created, otherFrames);
+            chain.Middleware.Add(block);
+
+            return block.Mirror;
+        }
+
+        chain.Middleware.Add(frame);
+        return created;
+    }
+}

--- a/src/Wolverine/Persistence/IAncillaryStoreFrameProvider.cs
+++ b/src/Wolverine/Persistence/IAncillaryStoreFrameProvider.cs
@@ -26,4 +26,16 @@ public interface IAncillaryStoreFrameProvider
     /// handler opens and commits through that store rather than the primary store.
     /// </summary>
     Frame BuildOutboxFactoryFrame(Type storeType);
+
+    /// <summary>
+    /// This integration's event sourcing seam, when it has one. Lets a parameter attribute that has no
+    /// aggregate type to resolve through -- <c>[StreamState]</c> / <c>[StreamEvents]</c>, GH-3627 -- find
+    /// the right store when a chain has been routed to an ancillary one by <see cref="StorageAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Optional and defaulted to null, on the same terms as the optional members of
+    /// <see cref="EventSourcing.IEventSourcingFrameProvider"/>: an integration with no event sourcing
+    /// (EF Core) inherits the default and the caller reports that rather than failing obscurely.
+    /// </remarks>
+    EventSourcing.IEventSourcingFrameProvider? EventSourcing => null;
 }


### PR DESCRIPTION
Closes #3627.

Timeline and audit shaped handlers serve the event history *itself*, which `[ReadModel]` cannot express because folding has already collapsed what they need. Today such handlers take `IQuerySession` imperatively — sequential round trips, impure handler — or hand-roll query plan adapters.

## Store-agnostic, and unusually cheaply so

The issue frames these as "Marten-only attributes". They needn't be. The parameter types are **already shared vocabulary**:

- `JasperFx.Events.StreamState` and `JasperFx.Events.IEvent` live in JasperFx.Events, not Marten
- `FetchStreamStateAsync` / `FetchStreamAsync` are declared on `JasperFx.Events.IQueryEventStore`

Only the `.Events` accessor that reaches them is store-specific — which is exactly what `IEventSourcingFrameProvider` exists to keep on the store's side of the seam.

So the attributes live **once in Wolverine core**, alongside `ReadModelAttribute`. Worth being explicit about why that isn't the obvious reading: `ReadAggregateAttribute` exists three times, which looks like a triplication precedent, but its own docstring says it is the *legacy Marten spelling* of core's `[ReadModel]` — "prefer `[ReadModel]` in new code". The pattern is core-plus-seam, not per-store copies.

**No JasperFx.Events change required**, so this is 6.30 work rather than 6.31.

## Provider resolution had to differ from `[ReadModel]`

`[ReadModel]` resolves its store by asking which provider can persist *this aggregate type*. There is no aggregate type here — the whole point of reading raw stream state is that the aggregate type is a **runtime** fact (the issue's own example writes `state?.AggregateType == typeof(Journey)`).

So resolution is layered:

1. an explicit `AggregateType` on the attribute
2. the ancillary store a `[Storage(typeof(IMyStore))]` routed the chain to
3. the single registered event sourcing integration

Ambiguity is an **error naming both escape hatches**, not a guess.

## Interface changes — three members, all optional, none breaking

Following the `BuildLoadBoundaryFrame` precedent (default implementation throwing an actionable `NotSupportedException`):

- `IEventSourcingFrameProvider.BuildFetchStreamStateFrame` / `BuildFetchStreamFrame`
- `IAncillaryStoreFrameProvider.EventSourcing` — links a store type to its event sourcing seam, which is what makes resolution step 2 possible

## All three stores implemented

**Marten batches**, enlisting in `MartenBatchFrame` exactly as `FetchLatestAggregateFrame` does — that is where the issue's measured **−38% latency / +27% throughput** comes from.

**Polecat and Fisher are standalone, deliberately.** Their own `FetchLatestAggregateFrame` is a plain `AsyncFrame` with no `IBatchableFrame`, so batching the raw reads would make them behave differently from the aggregate read sitting right next to them. Both were checked against the shipped packages for `FetchStreamStateAsync`/`FetchStreamAsync` rather than assumed.

## No `Required` on `[StreamEvents]`

The issue's first open design question, resolved as it proposed. A missing stream yields an **empty list, not null**, so the null-guard model the rest of the `IDataRequirement` family is built on has nothing to test — a guard would either never fire or would have to invent a count threshold, and "zero events" is not the same question as "no such stream". Pair with `[StreamState]` for existence and aggregate-type guards; it reads the same stream in the same batch.

A test pins the **absence** of the knob, so nobody closes the asymmetry later without reading why.

## `[MartenStreamState]` / `[MartenStreamEvents]`

Not cosmetic. A store-agnostic attribute cannot survive endpoint **discovery** in a host that registered no event store — and the shared `WolverineWebApi` is scanned by tests that build Marten-less hosts. The first full-suite run went **9 tests red** for exactly that reason, while the four targeted tests passed throughout. These name their store rather than resolving one, mirroring `ReadAggregateAttribute`, which is what that "AddMarten without IntegrateWithWolverine is supported" note in its docstring has always been about.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| CoreTests | **2637 / 0** |
| `Wolverine.Http.Tests` | **1000 / 0** — the 996 baseline plus these four |

The event-read test asserts on `"order_created"` — Marten's event **alias**, not the CLR name. That is deliberate: an alias can only come from Marten's event store, so it proves the read genuinely went through the store rather than anything the test could fabricate.

## Not in this PR

Docs, and a test proving both fetches share one round trip (the batching is exercised, but the round-trip count is not asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)