### PR TITLE
Feed Supervisor.KnownTestDurations from the previous main run's ledger data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,11 @@ jobs:
   test:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # For fetch-duration-baseline.sh: downloading the previous main run's artifact crosses
+      # runs, which the default token cannot do.
+      actions: read
     # The 20 minute cap is deliberately a REAL signal: a job that needs longer than this is a job that
     # needs to be split, not a job that needs a bigger number. The two suites that used to blow through it
     # (CIAWS and CIPolecat) are now sharded across parallel jobs instead. See #3350.
@@ -111,6 +116,16 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # Best-effort: feeds Supervisor.KnownTestDurations so lanes balance by measured duration
+      # instead of test count (build/TestDurations.cs). Lands OUTSIDE artifacts/ because the
+      # build's Clean wipes artifacts/ on every invocation. Nothing downstream fails when this
+      # finds nothing — the run balances by count exactly as before.
+      - name: Fetch duration baseline
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./build/fetch-duration-baseline.sh previous-durations
+
       - name: Run Tests
         env:
           # Names this job in the retry ledger (build/RetryLedger.cs). GITHUB_JOB is the matrix's
@@ -187,6 +202,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-ledger-run
-          path: rollup/aggregate.json
+          # Both under rollup/, so aggregate.json stays at the artifact root — the shape the
+          # baseline walk in flakiness-report.sh and fetch-duration-baseline.sh both read.
+          path: |
+            rollup/aggregate.json
+            rollup/durations/
           if-no-files-found: warn
           retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,9 @@ FakesAssemblies/
 *.opt
 
 artifacts
+# The previous main run's published test durations, fetched by CI (or by hand) for
+# Supervisor.KnownTestDurations — see build/TestDurations.cs.
+previous-durations/
 src/CommonAssemblyInfo.cs
 paket.lock
 

--- a/build/RetryLedger.cs
+++ b/build/RetryLedger.cs
@@ -84,6 +84,7 @@ partial class Build
         writeLedgerFile(entry);
         appendStepSummary(entry);
         annotate(entry);
+        recordDurations(projectName, framework, results);
     }
 
     /// <summary>

--- a/build/SupervisedTests.cs
+++ b/build/SupervisedTests.cs
@@ -174,7 +174,13 @@ partial class Build
             //   which tests grew it).
             StallThreshold = TimeSpan.FromMinutes(5),
             HeartbeatInterval = TimeSpan.FromSeconds(30),
-            ResourceSampleInterval = TimeSpan.FromSeconds(15)
+            ResourceSampleInterval = TimeSpan.FromSeconds(15),
+
+            // The previous main run's per-test durations, when a CI step (or a developer) has
+            // fetched them into previous-durations/ — longest-processing-time lane balancing
+            // instead of count balancing. Null degrades to exactly today's behavior. See
+            // build/TestDurations.cs for the whole loop.
+            KnownTestDurations = knownDurationsFor(projectName, framework)
         };
 
         if (!DisableTestRetry) supervisor.AddFailurePolicy(new RetryFailuresInFreshProcess());

--- a/build/TestDurations.cs
+++ b/build/TestDurations.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Bobcat.Supervisor;
+using Nuke.Common.IO;
+using Serilog;
+
+// Per-test durations fed back into Supervisor.KnownTestDurations — the follow-up the ledger work
+// left queued (BOBCAT-CI-OPTIMIZATION-HANDOFF, "Timing data worth keeping between runs").
+//
+// Why: Bobcat balances lanes longest-processing-time-first, but a run with no duration data falls
+// back to test COUNT — measured on PersistenceTests as lanes finishing at 101.5s and 11.4s, a
+// quarter of the fleet idle. The durations exist on every run's SupervisorResults and were being
+// thrown away.
+//
+// The loop: every supervised run writes {Job}.{Project}.{Framework}.durations.json beside its
+// ledger (so the existing per-job artifact upload carries it); the flakiness roll-up folds every
+// job's durations into the run-level `test-ledger-run` artifact it already publishes from main;
+// the next run's test jobs download that artifact into previous-durations/ (repo root — anything
+// under artifacts/ is wiped by Clean at the start of every build) before ./build.sh runs, and
+// runSupervised feeds the matching file into KnownTestDurations. Every hop is best-effort: no
+// baseline, a stale baseline, or a renamed test all degrade to exactly today's behavior — count
+// balancing, with unknown tests charged the median of what is known.
+//
+// Honest scope note: lane balancing only bites where MaxParallelWorkers > 1 — today CISqlServer
+// (workers: 4) and local --test-workers runs. Everything else gets the data recorded for free,
+// which is also the groundwork for duration trend reporting (Bobcat #56 layer 3).
+partial class Build
+{
+    /// <summary>
+    /// Where a CI step (or a curious developer) drops the previous main run's published
+    /// durations. Repo root, NOT under artifacts/: Clean wipes artifacts/ on every invocation,
+    /// and this file must survive into the test target.
+    /// </summary>
+    static AbsolutePath PreviousDurationsDirectory => RootDirectory / "previous-durations";
+
+    static string durationsFileName(string projectName, string framework)
+        => fileNameSafe($"{ledgerJobName}.{projectName}.{framework}.durations.json");
+
+    /// <summary>
+    /// Writes this run's per-test durations beside the ledger. First-attempt durations, because
+    /// lane balancing wants the typical cost of running the test once — a retry-amplified total
+    /// would overweight exactly the flaky tests. A test with no reported duration is omitted,
+    /// never zero-filled: Bobcat charges absent tests the median of what is known, and a zero
+    /// would instead read as "free".
+    /// </summary>
+    static void recordDurations(string projectName, string framework, SupervisorResults results)
+    {
+        try
+        {
+            var durations = new SortedDictionary<string, long>(StringComparer.Ordinal);
+            foreach (var test in results.Tests)
+            {
+                var measured = test.Attempts
+                    .OrderBy(a => a.AttemptNumber)
+                    .Select(a => a.Outcome.Duration)
+                    .FirstOrDefault(d => d is not null);
+
+                if (measured is { } duration) durations[test.Uid] = (long)duration.TotalMilliseconds;
+            }
+
+            if (durations.Count == 0) return;
+
+            LedgerDirectory.CreateDirectory();
+            File.WriteAllText(
+                LedgerDirectory / durationsFileName(projectName, framework),
+                JsonSerializer.Serialize(durations, LedgerJson));
+        }
+        catch (Exception e)
+        {
+            // Same rule as the ledger: reporting about the tests must never fail the tests.
+            Log.Warning(e, "Could not write test durations for {Project}", projectName);
+        }
+    }
+
+    /// <summary>
+    /// The previous main run's durations for this job+project+framework, or null when there are
+    /// none — which is not an error, it is the first run, a new shard, or a build outside CI.
+    /// Searched recursively because the artifact download may or may not preserve its
+    /// durations/ subdirectory depending on how it was fetched.
+    /// </summary>
+    static IReadOnlyDictionary<string, TimeSpan> knownDurationsFor(string projectName, string framework)
+    {
+        try
+        {
+            if (!Directory.Exists(PreviousDurationsDirectory)) return null;
+
+            var wanted = durationsFileName(projectName, framework);
+            var file = Directory
+                .EnumerateFiles(PreviousDurationsDirectory, wanted, SearchOption.AllDirectories)
+                .FirstOrDefault();
+            if (file is null) return null;
+
+            var raw = JsonSerializer.Deserialize<Dictionary<string, long>>(File.ReadAllText(file));
+            if (raw is null || raw.Count == 0) return null;
+
+            Log.Information("  balancing lanes with {Count} test duration(s) from the previous main run",
+                raw.Count);
+
+            return raw.ToDictionary(
+                pair => pair.Key,
+                pair => TimeSpan.FromMilliseconds(pair.Value),
+                StringComparer.Ordinal);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Could not read previous test durations for {Project} — balancing by count", projectName);
+            return null;
+        }
+    }
+}

--- a/build/fetch-duration-baseline.sh
+++ b/build/fetch-duration-baseline.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Downloads the last completed main run's published `test-ledger-run` artifact (aggregate.json +
+# durations/) into the given directory, so runSupervised can feed Supervisor.KnownTestDurations —
+# see build/TestDurations.cs for the whole loop. Best-effort by design: every failure path exits 0
+# with nothing downloaded, and the build then balances lanes by test count exactly as before.
+# Walks a few runs back rather than taking the immediately previous one, same as the flakiness
+# baseline: a cancelled run publishes nothing, and a slightly older baseline beats none.
+#
+# Usage: fetch-duration-baseline.sh <dest-dir>
+# Expects: GH_TOKEN (or a gh auth login), GITHUB_REPOSITORY; GITHUB_RUN_ID excluded when set.
+
+set -uo pipefail
+
+dest="${1:?usage: fetch-duration-baseline.sh <dest-dir>}"
+repo="${GITHUB_REPOSITORY:-JasperFx/wolverine}"
+
+candidates=$(gh api "repos/${repo}/actions/workflows/tests.yml/runs?branch=main&status=completed&per_page=10" \
+  --jq '.workflow_runs[].id' 2>/dev/null | grep -v "^${GITHUB_RUN_ID:-none}$" | head -n 6)
+
+for candidate in ${candidates}; do
+  rm -rf "${dest}"
+  if gh run download "${candidate}" --repo "${repo}" -n test-ledger-run -D "${dest}" >/dev/null 2>&1 \
+     && find "${dest}" -name '*.durations.json' -type f 2>/dev/null | head -1 | grep -q .; then
+    echo "duration baseline: run ${candidate}, $(find "${dest}" -name '*.durations.json' | wc -l | tr -d ' ') job file(s)"
+    exit 0
+  fi
+done
+
+rm -rf "${dest}"
+echo "duration baseline: none found in the last few completed main runs — lanes will balance by count"
+exit 0

--- a/build/flakiness-report.sh
+++ b/build/flakiness-report.sh
@@ -33,7 +33,9 @@ mkdir -p "${output_dir}"
 
 # One object per project run. Several projects can report under one job (CIAWS, CIMQTT), so the job
 # rows are a group-by rather than a rename.
-ledger_files=$(find "${ledger_dir}" -name '*.json' -type f 2>/dev/null | sort)
+# *.durations.json files ride the same per-job artifacts but are Supervisor.KnownTestDurations
+# feed, not ledger entries — folding one in here would trip the Job/RetriesPerformed assert below.
+ledger_files=$(find "${ledger_dir}" -name '*.json' -not -name '*.durations.json' -type f 2>/dev/null | sort)
 if [ -n "${ledger_files}" ]; then
   # Ledger file names are composed from job/project/framework — no spaces to quote around.
   # shellcheck disable=SC2086
@@ -70,6 +72,12 @@ jq '[group_by(.Job)[] | {
       partial:       (map(.IsPartial // false) | any)
     }] | sort_by(-.retries, .job)' \
   "${output_dir}/entries.json" > "${output_dir}/aggregate.json"
+
+# Fold every job's per-test durations into the published baseline, so the next run's test jobs
+# can feed Supervisor.KnownTestDurations (build/TestDurations.cs, build/fetch-duration-baseline.sh).
+# Copied verbatim, not aggregated: the consumer wants exactly the per-job files back.
+mkdir -p "${output_dir}/durations"
+find "${ledger_dir}" -name '*.durations.json' -type f -exec cp {} "${output_dir}/durations/" \; 2>/dev/null
 
 total_retries=$(jq '[.[] | .retries] | add // 0' "${output_dir}/aggregate.json")
 # GH-3855. A readiness gate that restarted a wedged container and then succeeded makes the job PASS,


### PR DESCRIPTION
The follow-up queued since the supervised-CI work landed: Bobcat balances lanes longest-processing-time-first, but with no duration data it falls back to test **count** — measured on PersistenceTests as lanes finishing at 101.5s vs 11.4s, a quarter of the fleet idle. Every run's `SupervisorResults` already carried per-test durations; they were being thrown away.

## The loop

1. **Write** (`build/TestDurations.cs`): every supervised run writes `{Job}.{Project}.{Framework}.durations.json` beside its ledger — first-attempt milliseconds per uid (a retry-amplified total would overweight exactly the flaky tests), unmeasured tests omitted rather than zero-filled. Rides the existing per-job `test-ledger-*` artifact upload untouched.
2. **Publish**: the flakiness roll-up copies every job's durations files verbatim into the `test-ledger-run` baseline artifact it already publishes from `main` (and excludes `*.durations.json` from its ledger-entry fold, which would otherwise trip its field assert). `aggregate.json` stays at the artifact root, so the existing baseline walk is unchanged.
3. **Fetch** (`build/fetch-duration-baseline.sh`): each test job downloads the last completed main run's baseline into `previous-durations/` **before** `./build.sh` runs — repo root, not `artifacts/`, because `Clean` wipes `artifacts/` on every invocation. Same walk-a-few-runs-back logic as the flakiness baseline. The test job gains an explicit `permissions: actions: read` block because the download crosses runs.
4. **Read**: `runSupervised` feeds the matching file into `Supervisor.KnownTestDurations`.

Every hop is best-effort by design: no baseline (including the very first run after this merges), a stale one, or a renamed test degrades to exactly today's count balancing, with unknown tests charged the median of what is known — Bobcat's own rule.

## Verified

- Run 1 (CoreTests, 2633 tests) wrote 2633 durations; seeded back into `previous-durations/`, run 2 logged `balancing lanes with 2633 test duration(s) from the previous main run` and passed 2633/2633.
- **Uid stability across runs: 2633/2633 identical keys** — xUnit v3's hashed uids are deterministic, so LPT balancing genuinely matches tests to their measured cost instead of silently falling through to medians.
- The roll-up exercised synthetically: durations excluded from `entries.json` (no assert trip), copied into the published `durations/` directory.

## Honest scope

Lane balancing only bites where `MaxParallelWorkers > 1` — today that is `CISqlServer` (workers: 4) and local `--test-workers` runs. Everything else records the data for free, which is also the groundwork for duration trend reporting (Bobcat #56's committed-ledger layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)