### PR TITLE
GH-4012 item 4: bound the redeliver → dedupe → re-ack loop with the broker's own count

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/broker_redelivery_bounding_4012.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/broker_redelivery_bounding_4012.cs
@@ -1,0 +1,159 @@
+using JasperFx.Core;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Wolverine.Persistence.Durability;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4012 item 4. The redeliver -> dedupe -> re-ack loop: a delivery that can never be settled, an inbox
+/// that deduplicates it on arrival, a settle that fails again, and a broker that delivers it once more.
+/// </summary>
+/// <remarks>
+/// Envelope.AckAttempts (item 1) cannot bound this and never could -- every redelivery arrives as a brand
+/// new envelope with a fresh counter. Only the broker's own count survives that boundary, which is the
+/// entire reason Envelope.BrokerDeliveryCount exists.
+/// </remarks>
+public class broker_redelivery_bounding_4012
+{
+    private class UnsettleableListener : IListener, ISupportDeadLetterQueue
+    {
+        public int CompleteCallCount { get; private set; }
+        public int DeadLetterCallCount { get; private set; }
+
+        public bool NativeDeadLetterQueueEnabled => true;
+
+        public IHandlerPipeline? Pipeline => null;
+
+        public ValueTask CompleteAsync(Envelope envelope)
+        {
+            CompleteCallCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        public Task MoveToErrorsAsync(Envelope envelope, Exception exception)
+        {
+            DeadLetterCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public Uri Address { get; } = new("stub://redelivery");
+        public ValueTask StopAsync() => ValueTask.CompletedTask;
+    }
+
+    private static DurableReceiver receiverFor(int limit)
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.DurabilitySettings.MaximumBrokerRedeliveries = limit;
+
+        return new DurableReceiver(new StubEndpoint("one", new StubTransport()), runtime,
+            Substitute.For<IHandlerPipeline>());
+    }
+
+    private static Envelope envelopeWith(int? brokerDeliveryCount)
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.BrokerDeliveryCount = brokerDeliveryCount;
+        return envelope;
+    }
+
+    [Fact]
+    public void a_delivery_count_past_the_limit_is_exhausted()
+    {
+        receiverFor(3).HasExhaustedBrokerRedeliveries(envelopeWith(4)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_limit_itself_is_not_past_it()
+    {
+        // Off-by-one matters: a message delivered exactly the permitted number of times still gets to run
+        receiverFor(3).HasExhaustedBrokerRedeliveries(envelopeWith(3)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_bound_is_off_by_default()
+    {
+        // Zero leaves the broker's own limit in charge and changes nothing, which is what makes this
+        // additive for every existing application
+        receiverFor(0).HasExhaustedBrokerRedeliveries(envelopeWith(500)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_transport_with_no_delivery_count_is_unaffected()
+    {
+        // RabbitMQ on plain nack-requeue, core NATS, Redis Streams -- nothing to bound, so nothing happens.
+        // Guessing a count here is exactly what the RabbitMQ mapper deliberately refuses to do
+        receiverFor(3).HasExhaustedBrokerRedeliveries(envelopeWith(null)).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// The behaviour, not just the predicate. This is the loop actually turning: the inbox rejects the
+    /// envelope as a duplicate, and instead of settling it again -- the settle that keeps failing, which is
+    /// what keeps the broker redelivering -- it goes to the dead letter queue.
+    /// </summary>
+    [Fact]
+    public async Task an_over_delivered_duplicate_is_dead_lettered_instead_of_re_acked()
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.DurabilitySettings.MaximumBrokerRedeliveries = 3;
+
+        var receiver = new DurableReceiver(new StubEndpoint("one", new StubTransport()), runtime,
+            Substitute.For<IHandlerPipeline>());
+
+        var envelope = envelopeWith(4);
+        var listener = new UnsettleableListener();
+
+        runtime.Storage.Inbox.StoreIncomingAsync(envelope)
+            .Throws(new DuplicateIncomingEnvelopeException(envelope));
+
+        await receiver.ReceivedAsync(listener, envelope);
+        await receiver.DrainAsync();
+
+        listener.DeadLetterCallCount.ShouldBe(1);
+        listener.CompleteCallCount.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// The control. Same path, same duplicate, a delivery count inside the limit -- and the existing
+    /// settle-the-duplicate behaviour is untouched. Without this the test above would pass just as well
+    /// if the bound fired on every duplicate.
+    /// </summary>
+    [Fact]
+    public async Task a_duplicate_within_the_limit_is_still_settled_the_old_way()
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.DurabilitySettings.MaximumBrokerRedeliveries = 3;
+
+        var receiver = new DurableReceiver(new StubEndpoint("one", new StubTransport()), runtime,
+            Substitute.For<IHandlerPipeline>());
+
+        var envelope = envelopeWith(2);
+        var listener = new UnsettleableListener();
+
+        runtime.Storage.Inbox.StoreIncomingAsync(envelope)
+            .Throws(new DuplicateIncomingEnvelopeException(envelope));
+
+        await receiver.ReceivedAsync(listener, envelope);
+        await receiver.DrainAsync();
+
+        listener.CompleteCallCount.ShouldBe(1);
+        listener.DeadLetterCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void the_default_setting_is_off()
+    {
+        new DurabilitySettings().MaximumBrokerRedeliveries.ShouldBe(0);
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsQueue.cs
@@ -952,9 +952,18 @@ public class AmazonSqsQueue : Endpoint, IBrokerQueue, IMassTransitInteropEndpoin
         request.VisibilityTimeout = VisibilityTimeout;
 
         request.MessageAttributeNames = _receivedAttributeNames ??= resolveAttributeNames();
+
+        // GH-4012 item 4. ApproximateReceiveCount is a SYSTEM attribute, and SQS returns only what a
+        // receive names -- so without asking, message.Attributes comes back empty and the broker's own
+        // delivery count is invisible. It is the one counter that survives envelope reconstruction, which
+        // is what lets DurabilitySettings.MaximumBrokerRedeliveries bound a redeliver -> dedupe -> re-ack
+        // loop that Envelope.AckAttempts cannot see.
+        request.MessageSystemAttributeNames = _receivedSystemAttributeNames;
     }
 
     private List<string>? _receivedAttributeNames;
+
+    private static readonly List<string> _receivedSystemAttributeNames = ["ApproximateReceiveCount"];
 
     /// <summary>
     ///     Whatever the endpoint asked for, plus Wolverine's own fragment framing (GH-3926). SQS returns

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -451,6 +451,22 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
     }
 
     /// <summary>
+    /// GH-4012 item 4. SQS's own delivery count, requested as a system attribute in
+    /// <c>AmazonSqsQueue.ConfigureRequest</c>. Null when absent -- an older queue, a custom receive, or a
+    /// broker emulator that does not populate it -- which leaves the redelivery bound simply inactive
+    /// rather than guessing.
+    /// </summary>
+    private static int? readApproximateReceiveCount(Message message)
+    {
+        if (message.Attributes == null) return null;
+
+        return message.Attributes.TryGetValue("ApproximateReceiveCount", out var raw)
+               && int.TryParse(raw, out var count)
+            ? count
+            : null;
+    }
+
+    /// <summary>
     /// Build one envelope from the message(s) that carried it. A fragmented message hands over every
     /// SQS message in the set plus the reassembled body; everything else is a set of one.
     /// </summary>
@@ -464,6 +480,11 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         // Guarantee a non-null dictionary so ISqsEnvelopeMapper implementations can read freely.
         var attributes = messages[0].MessageAttributes ?? new Dictionary<string, MessageAttributeValue>();
         _mapper.ReadEnvelopeData(envelope, body, attributes);
+
+        // GH-4012 item 4. Read AFTER the mapper, so a custom ISqsEnvelopeMapper cannot accidentally clear
+        // it -- this is Wolverine's own bookkeeping rather than user-mapped data. A fragmented message is
+        // one logical delivery, so the first fragment's count speaks for the set.
+        envelope.BrokerDeliveryCount = readApproximateReceiveCount(messages[0]);
 
         // CritterWatch#942 — the Body string (base64, UTF-16, ~2.7× the wire payload size) is fully
         // mapped into the envelope now, and every later use of SqsMessage — single delete, batched

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
@@ -58,6 +58,12 @@ public class AzureServiceBusEnvelopeMapper : EnvelopeMapper<ServiceBusReceivedMe
 
     protected override void writeIncomingHeaders(ServiceBusReceivedMessage incoming, Envelope envelope)
     {
+        // GH-4012 item 4. Azure Service Bus counts deliveries itself and the count survives the envelope
+        // being reconstructed on every redelivery, which is what makes it the only thing able to bound a
+        // redeliver -> dedupe -> re-ack loop. First delivery is 1, so it is a delivery count rather than a
+        // redelivery count -- Envelope.BrokerDeliveryCount is documented in those terms.
+        envelope.BrokerDeliveryCount = incoming.DeliveryCount;
+
         if (incoming.ApplicationProperties == null) return;
 
         foreach (var pair in incoming.ApplicationProperties) envelope.Headers[pair.Key] = pair.Value?.ToString();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -167,6 +167,10 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
         {
             envelope.Data = body.ToArray();
             _mapper.MapIncomingToEnvelope(envelope, properties);
+
+            // GH-4012 item 4. Read AFTER the mapper so a custom envelope mapper cannot clear it -- this is
+            // Wolverine's own bookkeeping, not user-mapped data.
+            envelope.BrokerDeliveryCount = readDeathCount(properties.Headers);
         }
         catch (Exception e)
         {
@@ -259,5 +263,27 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
                 _logger.LogError(ex, "Failure trying to Nack a previously failed message {Id}", envelope.Id);
             }
         }
+    }
+
+    /// <summary>
+    /// GH-4012 item 4. RabbitMQ's own delivery count, when it has one.
+    /// </summary>
+    /// <remarks>
+    /// Weaker than the Azure Service Bus and SQS signals, and deliberately not faked up to match them.
+    /// The <c>redelivered</c> flag is a BOOLEAN -- it says "not the first delivery" and nothing more --
+    /// so the only real count RabbitMQ carries is <c>x-death</c>, which the broker adds when a message
+    /// has been dead-lettered and routed back. That makes the redelivery bound effective on the
+    /// dead-letter-and-retry topologies where a loop actually accumulates, and inactive on plain
+    /// nack-requeue, where the broker simply does not count. Returning a made up 2 for "redelivered"
+    /// would bound the wrong thing on the first requeue.
+    /// </remarks>
+    private static int? readDeathCount(IDictionary<string, object?>? headers)
+    {
+        if (headers == null) return null;
+        if (!headers.TryGetValue("x-death", out var raw)) return null;
+        if (raw is not IList<object> deaths || deaths.Count == 0) return null;
+        if (deaths[0] is not IDictionary<string, object> latest) return null;
+
+        return latest.TryGetValue("count", out var c) && c is long count ? (int)count : null;
     }
 }

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -132,6 +132,24 @@ public class DurabilitySettings : IDescribeMyself
     public int MaximumAckAttempts { get; set; } = 3;
 
     /// <summary>
+    /// GH-4012 item 4. The most times a broker may redeliver one message before Wolverine stops trying to
+    /// process it and moves it to the dead letter queue instead. Zero — the default — leaves the broker's
+    /// own limit in charge and changes nothing.
+    /// </summary>
+    /// <remarks>
+    /// This is the counterpart to <see cref="MaximumAckAttempts" /> for the failure that one cannot reach.
+    /// An in-process budget restarts at zero on every redelivery because each one constructs a brand new
+    /// envelope; the broker's count does not, so it is the only thing that can bound a
+    /// redeliver → dedupe → re-ack loop — the shape where a delivery can never be settled, the inbox
+    /// deduplicates it on arrival, the settle fails again, and the broker delivers it once more.
+    ///
+    /// Read from whichever native signal the transport carries: RabbitMQ's <c>x-death</c> count, Amazon
+    /// SQS's <c>ApproximateReceiveCount</c>, Azure Service Bus's <c>DeliveryCount</c>. A transport with no
+    /// such signal leaves <c>Envelope.BrokerDeliveryCount</c> null and is unaffected.
+    /// </remarks>
+    public int MaximumBrokerRedeliveries { get; set; }
+
+    /// <summary>
     /// GH-3711. The most successful handler completions a durable endpoint coalesces into one batched
     /// mark-as-handled <c>UPDATE</c> against the inbox. One flush is in flight at a time and every
     /// completion that arrives while it runs joins the next flush, so batches form from concurrency

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -245,6 +245,20 @@ public partial class Envelope : IHasTenantId
     /// </summary>
     public int SendAttempts { get; set; }
 
+    /// <summary>
+    ///     The <b>broker's</b> own count of how many times it has delivered this message, when the
+    ///     transport reports one — RabbitMQ's <c>x-death</c> count, Amazon SQS's
+    ///     <c>ApproximateReceiveCount</c>, Azure Service Bus's <c>DeliveryCount</c>. Null on a transport
+    ///     that has no such concept, and on the first delivery of transports that only count redeliveries.
+    /// </summary>
+    /// <remarks>
+    ///     GH-4012 item 4. This is the one delivery counter that <b>survives envelope reconstruction</b>:
+    ///     every redelivery builds a brand new <c>RabbitMqEnvelope</c> / <c>AzureServiceBusEnvelope</c>, so
+    ///     <see cref="Attempts" /> and <c>AckAttempts</c> both restart at zero and neither can bound a
+    ///     redeliver → dedupe → re-ack loop. Only the broker remembers across those boundaries.
+    /// </remarks>
+    public int? BrokerDeliveryCount { get; set; }
+
     public DateTimeOffset SentAt { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -727,18 +727,55 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     {
         _logger.LogError(e, "Duplicate incoming envelope detected");
 
-        if (envelope.Listener != null)
+        if (envelope.Listener == null) return;
+
+        // GH-4012 item 4. THIS is where the redeliver -> dedupe -> re-ack loop turns: the settle below
+        // cannot succeed, so the broker redelivers, the inbox deduplicates it again, and around it goes.
+        // Envelope.AckAttempts cannot bound that -- every redelivery arrives as a brand new envelope with
+        // a fresh counter -- but the broker's own delivery count survives, which is the whole reason it
+        // exists. Past the limit, hand the delivery to the dead letter queue instead of settling it again.
+        if (HasExhaustedBrokerRedeliveries(envelope) &&
+            envelope.Listener is ISupportDeadLetterQueue { NativeDeadLetterQueueEnabled: true } deadLetters)
         {
             try
             {
-                await envelope.Listener.CompleteAsync(envelope).ConfigureAwait(false);
+                await deadLetters.MoveToErrorsAsync(envelope, e).ConfigureAwait(false);
+
+                _logger.LogWarning(
+                    "Moved envelope {Id} from {Uri} to the dead letter queue after the broker delivered it {DeliveryCount} times; it is a duplicate that cannot be settled",
+                    envelope.Id, Uri, envelope.BrokerDeliveryCount);
+
+                return;
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, "Error trying to complete duplicated message {Id} from {Uri}",
+                // Fall through to the ordinary settle -- a dead letter move that fails is no worse than
+                // the loop we were already in
+                _logger.LogError(exception, "Error trying to dead letter over-delivered message {Id} from {Uri}",
                     envelope.Id, Uri);
             }
         }
+
+        try
+        {
+            await envelope.Listener.CompleteAsync(envelope).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Error trying to complete duplicated message {Id} from {Uri}",
+                envelope.Id, Uri);
+        }
+    }
+
+    /// <summary>
+    /// GH-4012 item 4. Has the broker delivered this message more times than
+    /// <see cref="DurabilitySettings.MaximumBrokerRedeliveries" /> allows? False when the limit is off
+    /// (the default) or the transport reports no delivery count.
+    /// </summary>
+    internal bool HasExhaustedBrokerRedeliveries(Envelope envelope)
+    {
+        var limit = _settings.MaximumBrokerRedeliveries;
+        return limit > 0 && envelope.BrokerDeliveryCount is { } count && count > limit;
     }
 
     /// <summary>


### PR DESCRIPTION
Item 4 of #4012. Items 1–2 shipped in #4014, item 3 in #4106.

This is the lever none of those could be. Item 1's `Envelope.AckAttempts` **explicitly cannot bound this loop** — every redelivery arrives as a brand new `RabbitMqEnvelope` / `AzureServiceBusEnvelope` with a fresh counter. Only the broker remembers across that boundary. The issue and the existing `MaximumAckAttempts` docstring both say so.

## The loop

From the original field report: a delivery that can never be settled (a channel-scoped tag whose channel is gone), an inbox that deduplicates it on arrival, a settle that fails again, and a broker that delivers it once more. Sustained indefinitely by a steady arrival of fresh envelopes rather than one immortal one.

## The fix

`Envelope.BrokerDeliveryCount` (nullable) + `DurabilitySettings.MaximumBrokerRedeliveries`, defaulting to **0 = off** so this is additive for every existing application.

Enforcement sits in `DurableReceiver.handleDuplicateIncomingEnvelope` — exactly where the loop turns. Past the limit the delivery goes to the dead letter queue instead of being settled again, falling back to the ordinary settle if the dead-letter move itself fails.

## Population, and one deliberate asymmetry

| Transport | Signal | |
| --- | --- | --- |
| **Azure Service Bus** | `DeliveryCount` | Direct property, always present |
| **Amazon SQS** | `ApproximateReceiveCount` | Needed `MessageSystemAttributeNames` on the receive request — SQS returns only the attributes a receive *names*, so this was invisible before regardless of anyone wanting it |
| **RabbitMQ** | `x-death` count, and only that | See below |

RabbitMQ's `redelivered` flag is a **boolean** — "not the first delivery" and nothing more. So `x-death` is the only real count it carries, present on dead-letter-and-retry topologies where a loop actually accumulates. Left **null** on plain nack-requeue rather than fabricating a `2`, which would bound the wrong thing on the very first requeue. The reasoning is in the code so the gap doesn't read as an oversight.

SQS and RabbitMQ both read the count **after** the envelope mapper runs, so a custom user mapper can't clear Wolverine's own bookkeeping.

## Tests — 7, including a real control

Four cover the predicate: the off-by-one (the limit itself is *not* past it), default-off, and the null case for transports with no signal.

Two drive the actual duplicate path through a stubbed inbox:
- an over-delivered duplicate is **dead lettered and not re-acked**
- **the control** — same path, same duplicate, count *within* the limit — asserts the old settle behaviour is untouched

Without that control the first test would pass just as well if the bound fired on every duplicate.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| CoreTests | **2644 / 0** — the 2637 baseline plus these seven |

## Remaining on #4012

Item 5 (`RetryBlock.ShouldRetry` in JasperFx) — cross-repo, and the issue gates it on 1–4 proving the shape, which this completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)