### PR TITLE
GH-4052: NativeAck endpoint mode for GCP Pub/Sub

### DIFF
--- a/src/Transports/GCP/Wolverine.Pubsub.Tests/native_ack_mode_4052.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub.Tests/native_ack_mode_4052.cs
@@ -1,0 +1,169 @@
+using Google.Api.Gax;
+using Google.Cloud.PubSub.V1;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Pubsub.Internal;
+using Xunit;
+
+namespace Wolverine.Pubsub.Tests;
+
+/// <summary>
+/// GH-4052. Pub/Sub opts into <see cref="EndpointMode.NativeAck" /> by <b>holding the subscriber callback
+/// open</b> until every envelope a delivery carried reaches a terminal.
+/// </summary>
+/// <remarks>
+/// This transport is unlike the others in the wave: it has no per-message settle API at all.
+/// <c>PubsubListener.CompleteAsync</c> is a no-op and always was, because acknowledgement happens entirely
+/// through the value the subscriber callback returns. So "do not settle on receipt" can only mean "do not
+/// return yet", which is why the settlement bookkeeping below is keyed by delivery rather than envelope.
+/// </remarks>
+public class native_ack_mode_4052
+{
+    private static PubsubEndpoint endpointFor()
+    {
+        var transport = new PubsubTransport
+        {
+            ProjectId = "wolverine",
+            PublisherApiClient = Substitute.For<PublisherServiceApiClient>(),
+            SubscriberApiClient = Substitute.For<SubscriberServiceApiClient>(),
+            EmulatorDetection = EmulatorDetection.EmulatorOnly
+        };
+
+        return new PubsubEndpoint("one", transport);
+    }
+
+    [Fact]
+    public void the_endpoint_now_opts_into_native_ack()
+    {
+        var endpoint = endpointFor();
+
+        // The mode gate is default-closed across the whole wave, so this override IS the opt-in
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        endpoint.Mode.ShouldBe(EndpointMode.NativeAck);
+    }
+
+    [Fact]
+    public void supported_modes_are_an_explicit_allow_list_not_a_blanket_true()
+    {
+        var endpoint = endpointFor();
+
+        // GH-4011's hazard, and the spike called Pub/Sub its worst case: a bare `true` silently claims
+        // every FUTURE mode the moment it is added to the enum. Pinning the four it actually supports is
+        // what makes the next enum member a compile-time conversation instead of a silent data loss bug
+        foreach (var mode in Enum.GetValues<EndpointMode>())
+        {
+            endpoint.Mode = mode;
+            endpoint.Mode.ShouldBe(mode);
+        }
+    }
+
+    [Fact]
+    public async Task a_single_envelope_delivery_acks_when_its_envelope_succeeds()
+    {
+        var deliveries = new PubsubHeldDeliveries();
+        var delivery = deliveries.Hold("m1", 1);
+
+        delivery.Succeeded().ShouldBeTrue();
+
+        (await delivery.Reply).ShouldBe(SubscriberClient.Reply.Ack);
+    }
+
+    [Fact]
+    public async Task a_batched_delivery_waits_for_every_envelope_before_settling()
+    {
+        // One Pub/Sub message can carry many envelopes, and a single Ack settles the lot -- so settling on
+        // the first terminal would ack work that is still running
+        var deliveries = new PubsubHeldDeliveries();
+        var delivery = deliveries.Hold("m1", 3);
+
+        delivery.Succeeded().ShouldBeFalse();
+        delivery.Succeeded().ShouldBeFalse();
+        delivery.Reply.IsCompleted.ShouldBeFalse();
+
+        delivery.Succeeded().ShouldBeTrue();
+        (await delivery.Reply).ShouldBe(SubscriberClient.Reply.Ack);
+    }
+
+    [Fact]
+    public async Task one_failure_makes_the_whole_batched_delivery_a_nack()
+    {
+        // A single Ack/Nack covers the batch, so any failure has to nack all of it. Pub/Sub redelivers and
+        // the inbox or the in-memory idempotency guard deduplicates the ones that already succeeded
+        var deliveries = new PubsubHeldDeliveries();
+        var delivery = deliveries.Hold("m1", 3);
+
+        delivery.Succeeded();
+        delivery.Failed();
+        delivery.Succeeded().ShouldBeTrue();
+
+        (await delivery.Reply).ShouldBe(SubscriberClient.Reply.Nack);
+    }
+
+    [Fact]
+    public async Task a_failure_still_waits_for_its_siblings()
+    {
+        // Doomed to nack, but a batch must not be settled while part of it is still executing
+        var deliveries = new PubsubHeldDeliveries();
+        var delivery = deliveries.Hold("m1", 2);
+
+        delivery.Failed().ShouldBeFalse();
+        delivery.Reply.IsCompleted.ShouldBeFalse();
+
+        delivery.Succeeded().ShouldBeTrue();
+        (await delivery.Reply).ShouldBe(SubscriberClient.Reply.Nack);
+    }
+
+    [Fact]
+    public async Task shutdown_nacks_everything_still_held()
+    {
+        // Spike section 4c: a held callback that never returns wedges SubscriberClient.StopAsync forever.
+        // Anything still held is unsettled by definition, so Nack is both correct and the only answer that
+        // lets shutdown finish
+        var deliveries = new PubsubHeldDeliveries();
+        var first = deliveries.Hold("m1", 5);
+        var second = deliveries.Hold("m2", 2);
+
+        deliveries.NackAll();
+
+        (await first.Reply).ShouldBe(SubscriberClient.Reply.Nack);
+        (await second.Reply).ShouldBe(SubscriberClient.Reply.Nack);
+    }
+
+    [Fact]
+    public void an_envelope_finds_its_delivery_by_the_stamped_key()
+    {
+        var deliveries = new PubsubHeldDeliveries();
+        deliveries.Hold("m1", 1);
+
+        var envelope = new Envelope();
+        envelope.Headers[PubsubHeldDeliveries.DeliveryKeyHeader] = "m1";
+
+        deliveries.TryFind(envelope, out var found).ShouldBeTrue();
+        found.Key.ShouldBe("m1");
+    }
+
+    [Fact]
+    public void an_unstamped_envelope_finds_nothing_rather_than_throwing()
+    {
+        // Every settle path checks this before acting, so an envelope from another mode -- or a released
+        // delivery -- has to be a quiet miss rather than an exception on the settle path
+        var deliveries = new PubsubHeldDeliveries();
+
+        deliveries.TryFind(new Envelope(), out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_released_delivery_is_no_longer_found()
+    {
+        var deliveries = new PubsubHeldDeliveries();
+        deliveries.Hold("m1", 1);
+        deliveries.Release("m1");
+
+        var envelope = new Envelope();
+        envelope.Headers[PubsubHeldDeliveries.DeliveryKeyHeader] = "m1";
+
+        deliveries.TryFind(envelope, out _).ShouldBeFalse();
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubHeldDelivery.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubHeldDelivery.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+using Google.Cloud.PubSub.V1;
+
+namespace Wolverine.Pubsub.Internal;
+
+/// <summary>
+/// GH-4052. One Pub/Sub delivery whose subscriber callback is being <b>held open</b> until every envelope
+/// it carried reaches a terminal.
+/// </summary>
+/// <remarks>
+/// <para>Pub/Sub has no per-message settle API — <c>PubsubListener.CompleteAsync</c> is a no-op, and always
+/// was. Acknowledgement happens entirely through the value the subscriber callback returns, so the only way
+/// to not settle on receipt is to not return yet. The spike (GH-4052) measured that
+/// <c>SubscriberClient</c> dispatches callbacks concurrently while others are held — 1000 of 1200 held
+/// simultaneously — so holding is a live design rather than a serialisation trap.</para>
+///
+/// <para>Keyed by the <b>delivery</b>, not the envelope: one Pub/Sub message can carry many envelopes when
+/// Wolverine batched them on the send side, and a single Ack/Nack settles the lot. So the reply is decided
+/// by counting envelopes down, and any single failure makes the whole delivery a Nack — the batch is
+/// redelivered and the durable inbox or the in-memory idempotency guard deduplicates the ones that already
+/// succeeded.</para>
+/// </remarks>
+internal sealed class PubsubHeldDelivery
+{
+    private readonly TaskCompletionSource<SubscriberClient.Reply> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private int _outstanding;
+    private int _failed;
+
+    public PubsubHeldDelivery(string key, int envelopeCount)
+    {
+        Key = key;
+        _outstanding = envelopeCount;
+    }
+
+    public string Key { get; }
+
+    public Task<SubscriberClient.Reply> Reply => _completion.Task;
+
+    /// <summary>One envelope reached a successful terminal. Settles the delivery when it was the last.</summary>
+    public bool Succeeded()
+    {
+        return countDown();
+    }
+
+    /// <summary>
+    /// One envelope reached a failing terminal. The delivery is doomed to Nack, but still waits for its
+    /// siblings so a batch is not settled while some of it is still running.
+    /// </summary>
+    public bool Failed()
+    {
+        Interlocked.Exchange(ref _failed, 1);
+        return countDown();
+    }
+
+    /// <summary>
+    /// Settle immediately regardless of outstanding envelopes. Used on shutdown, where the alternative is
+    /// a callback that never returns and a <c>StopAsync</c> that never completes (spike section 4c).
+    /// </summary>
+    public bool NackNow()
+    {
+        return _completion.TrySetResult(SubscriberClient.Reply.Nack);
+    }
+
+    private bool countDown()
+    {
+        if (Interlocked.Decrement(ref _outstanding) > 0) return false;
+
+        return _completion.TrySetResult(Volatile.Read(ref _failed) == 1
+            ? SubscriberClient.Reply.Nack
+            : SubscriberClient.Reply.Ack);
+    }
+}
+
+/// <summary>
+/// GH-4052. The deliveries a listener is currently holding, and the envelope-to-delivery lookup that lets a
+/// settle call find its delivery.
+/// </summary>
+internal sealed class PubsubHeldDeliveries
+{
+    public const string DeliveryKeyHeader = "wolverine-pubsub-delivery";
+
+    private readonly ConcurrentDictionary<string, PubsubHeldDelivery> _held = new();
+
+    public PubsubHeldDelivery Hold(string key, int envelopeCount)
+    {
+        var delivery = new PubsubHeldDelivery(key, envelopeCount);
+        _held[key] = delivery;
+        return delivery;
+    }
+
+    public void Release(string key) => _held.TryRemove(key, out _);
+
+    public bool TryFind(Envelope envelope, out PubsubHeldDelivery delivery)
+    {
+        delivery = null!;
+
+        if (!envelope.Headers.TryGetValue(DeliveryKeyHeader, out var key) || key is null) return false;
+
+        return _held.TryGetValue(key, out delivery!);
+    }
+
+    /// <summary>Nack everything still held. Idempotent, and safe to call from a cancellation callback.</summary>
+    public void NackAll()
+    {
+        foreach (var delivery in _held.Values)
+        {
+            delivery.NackNow();
+        }
+    }
+}

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubListener.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubListener.cs
@@ -5,6 +5,7 @@ using Grpc.Core;
 using JasperFx.Blocks;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
+using Wolverine.Configuration;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Serialization;
 using Wolverine.Transports;
@@ -36,6 +37,11 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
     /// The connection (default or per-tenant) this listener consumes and, for requeue/dead-letter, re-publishes over.
     /// </summary>
     protected readonly PubsubClientSet _clients;
+
+    /// <summary>GH-4052. Only populated when the endpoint is in EndpointMode.NativeAck.</summary>
+    private readonly PubsubHeldDeliveries _held = new();
+
+    private bool holdsUntilSettled => _endpoint.Mode == EndpointMode.NativeAck;
     private readonly IPubsubEnvelopeMapper _mapper;
 
     /// <summary>
@@ -102,16 +108,39 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
 
     public ValueTask CompleteAsync(Envelope envelope)
     {
+        // GH-4052. Pub/Sub has no per-message settle API, so under NativeAck the "ack" is the subscriber
+        // callback finally being allowed to return Ack. Outside NativeAck this stays the no-op it always
+        // was: the callback already returned Ack the moment the envelope was handed to the receiver.
+        if (holdsUntilSettled && _held.TryFind(envelope, out var delivery))
+        {
+            delivery.Succeeded();
+        }
+
         return ValueTask.CompletedTask;
     }
 
     public async ValueTask DeferAsync(Envelope envelope)
     {
+        // GH-4052. Under NativeAck a Nack IS the requeue -- the spike measured redelivery in ~10ms -- and it
+        // is the correct one: the delivery was never settled, so republishing a copy would put a SECOND
+        // message on the subscription on top of the redelivery Pub/Sub is about to perform anyway.
+        if (holdsUntilSettled && _held.TryFind(envelope, out var delivery))
+        {
+            delivery.Failed();
+            return;
+        }
+
         await _requeue.PostAsync(envelope);
     }
 
     public async Task<bool> TryRequeueAsync(Envelope envelope)
     {
+        if (holdsUntilSettled && _held.TryFind(envelope, out var delivery))
+        {
+            delivery.Failed();
+            return true;
+        }
+
         await _requeue.PostAsync(envelope);
 
         return true;
@@ -119,6 +148,11 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
 
     public async ValueTask StopAsync()
     {
+        // GH-4052 (spike section 4c). A held callback that never returns wedges SubscriberClient.StopAsync
+        // forever. Everything still held is unsettled by definition, so Nack is both correct and the only
+        // answer that lets shutdown finish -- Pub/Sub redelivers it to whoever is still running.
+        _held.NackAll();
+
         await _cancellation.CancelAsync();
     }
 
@@ -282,6 +316,15 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
         {
             await subscriber.StartAsync(async (PubsubMessage message, CancellationToken cancel) =>
             {
+                // GH-4052. Under NativeAck the callback is held open until every envelope this delivery
+                // carried reaches a terminal, because the callback's return value IS the settlement -- Pub/Sub
+                // exposes no per-message ack. Every other mode returns as soon as the envelopes are handed
+                // over, exactly as before.
+                if (holdsUntilSettled)
+                {
+                    return await handleMessageHeldAsync(message);
+                }
+
                 var success = await handleMessageAsync(message);
                 return success ? SubscriberClient.Reply.Ack : SubscriberClient.Reply.Nack;
             });
@@ -375,6 +418,83 @@ public abstract class PubsubListener : IListener, ISupportDeadLetterQueue, IRepo
         {
             _ackExtensionWatchdog.Release(ticket);
         }
+    }
+
+    /// <summary>
+    /// GH-4052. The NativeAck path: map the delivery's envelopes, stamp them with the delivery key, hand them
+    /// to the receiver, and then <b>wait</b> for the settle calls that the handler pipeline will make.
+    /// </summary>
+    private async Task<SubscriberClient.Reply> handleMessageHeldAsync(PubsubMessage message)
+    {
+        // Same watchdog as every other mode. It matters MORE here: the hold now spans lane queue time plus
+        // handler time, and outliving the ack extension budget means Pub/Sub silently starts a concurrent
+        // second execution rather than reporting anything (GH-4066, spike section 3).
+        var ticket = _ackExtensionWatchdog.Track(message.MessageId);
+
+        Envelope[] envelopes;
+
+        try
+        {
+            envelopes = readEnvelopes(message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "{Uri}: Error while mapping Google Cloud Platform Pub/Sub message {MessageId}.",
+                _endpoint.Uri, message.MessageId);
+
+            _ackExtensionWatchdog.Release(ticket);
+            return SubscriberClient.Reply.Nack;
+        }
+
+        if (envelopes.Length == 0)
+        {
+            // Nothing to wait on. Ack rather than Nack: an empty delivery is not a failure, and nacking it
+            // would have Pub/Sub redeliver something nobody will ever process
+            _ackExtensionWatchdog.Release(ticket);
+            return SubscriberClient.Reply.Ack;
+        }
+
+        var key = message.MessageId.IsNotEmpty() ? message.MessageId : Guid.NewGuid().ToString();
+        var delivery = _held.Hold(key, envelopes.Length);
+
+        foreach (var envelope in envelopes)
+        {
+            envelope.Headers[PubsubHeldDeliveries.DeliveryKeyHeader] = key;
+        }
+
+        try
+        {
+            await _receiver.ReceivedAsync(this, envelopes);
+
+            return await delivery.Reply;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{Uri}: Error while handing Pub/Sub message {MessageId} to the receiver.",
+                _endpoint.Uri, message.MessageId);
+
+            delivery.NackNow();
+            return SubscriberClient.Reply.Nack;
+        }
+        finally
+        {
+            _held.Release(key);
+            _ackExtensionWatchdog.Release(ticket);
+        }
+    }
+
+    /// <summary>The envelopes one Pub/Sub delivery carries -- many when the sender batched them.</summary>
+    private Envelope[] readEnvelopes(PubsubMessage message)
+    {
+        if (message.Attributes.Keys.Contains("batched"))
+        {
+            return EnvelopeSerializer.ReadMany(message.Data.ToByteArray()).ToArray();
+        }
+
+        var envelope = new Envelope();
+        _mapper.MapIncomingToEnvelope(envelope, message);
+        return [envelope];
     }
 
     private async Task<bool> processMessageAsync(PubsubMessage message)

--- a/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/PubsubEndpoint.cs
@@ -527,8 +527,25 @@ public class PubsubEndpoint : Endpoint<IPubsubEnvelopeMapper, PubsubEnvelopeMapp
         );
     }
 
+    // GH-4052. An explicit allow-list rather than a bare `true`. The spike called this out as the worst
+    // case of the "supportsMode overrides leak a new enum member" hazard (GH-4011): a blanket true means
+    // every future mode is silently claimed the moment it is added to the enum, and for Pub/Sub that would
+    // mean acking on receipt in a mode built on NOT doing that.
     protected override bool supportsMode(EndpointMode mode)
     {
-        return true;
+        return mode is EndpointMode.Inline or EndpointMode.BufferedInMemory or EndpointMode.Durable
+            or EndpointMode.NativeAck;
     }
+
+    /// <summary>
+    /// GH-4052. Pub/Sub settles by holding the subscriber callback open until the envelopes it carried
+    /// terminate -- it exposes no per-message ack, so the callback's return value is the settlement.
+    /// </summary>
+    /// <remarks>
+    /// The spike measured the load-bearing assumption rather than assuming it: SubscriberClient dispatches
+    /// callbacks concurrently while others are held (1000 of 1200 held simultaneously), so holding does not
+    /// serialise the subscription. Concurrency is bounded by FlowControlSettings.MaxOutstandingElementCount,
+    /// surfaced as PubsubClientOptions.MaxOutstandingMessages, which must be at least lanes x per-lane depth.
+    /// </remarks>
+    protected override bool supportsNativeAck => true;
 }


### PR DESCRIPTION
Closes #4052. The last transport in the NativeAck wave.

## Why the spike's "defer" no longer applies

`PUBSUB-NATIVEACK-SPIKE.md` recommended deferring, and its **entire stated reason** was sequencing:

> `EndpointMode.NativeAck` does not exist. There is no enum member, no `NativeAckReceiver`, and no compliance suite to run against… **the transport work is genuinely small once the mode lands; the sequencing is what argues for waiting, not the difficulty.**

The mode shipped, `NativeAckReceiver` exists, five transports have adopted it. The spike went on to say that when it did land, *"Pub/Sub should be an early adopter rather than a late one"*. Its two "land now regardless" items were both done in the wave (#4011, #4086).

## The design — spike §6

Pub/Sub is unlike every other transport here: it has **no per-message settle API**. `PubsubListener.CompleteAsync` is a no-op and always was, because acknowledgement happens entirely through the value the subscriber callback returns. So *"don't settle on receipt"* can only mean *"don't return yet"*.

The load-bearing assumption was measured, not assumed — `SubscriberClient` dispatches callbacks concurrently while others are held (1000 of 1200 held simultaneously), so holding does not serialise the subscription.

**Settlement is keyed by delivery, not envelope.** One Pub/Sub message can carry many envelopes when the sender batched them, and a single Ack/Nack settles the lot. So `PubsubHeldDelivery` counts envelopes down; any single failure nacks the whole batch, and a failing envelope **still waits for its siblings** so a batch is never settled while part of it is still running.

**Defer and requeue resolve to Nack rather than republishing.** The delivery was never settled, so republishing a copy would put a *second* message on the subscription on top of the redelivery Pub/Sub is about to perform anyway. The spike measured nack-redelivery at ~10 ms.

**`StopAsync` nacks everything held before cancelling** — fixing spike §4c, where a held callback that never returns makes `SubscriberClient.StopAsync` hang forever.

**`supportsMode` is now an explicit allow-list**, not a bare `true` — the spike called Pub/Sub the worst case of GH-4011's "overrides leak a new enum member" hazard.

## One thing worth recording

The spike warned that the bare `supportsMode` true would mean **silent data loss** the moment `NativeAck` was added to the enum. Checked rather than assumed: it wouldn't have. `Endpoint.Mode`'s setter guards on `supportsNativeAck`, which is default-closed and which Pub/Sub had not overridden — so a user asking for NativeAck got a clear exception, not silent acking-on-receipt. The hazard was **latent, not live**. Still worth replacing the blanket `true`, which is what this does.

## On ordering keys

The handoff listed "ordering-keys vs partition-lanes" as an open design decision. Spike §4b already answered it by measurement: with `EnableMessageOrdering` the SDK gives per-key serialisation — the same invariant Wolverine's group-partitioned block provides — and **when the callback is held, the SDK's is the binding one**. They agree rather than compete. The consequence is a sizing fact, not a design fork: effective concurrency is `min(MaxOutstandingElementCount, distinct in-flight ordering keys)`.

## Verification

| Leg | Result |
| --- | --- |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean, 0 warnings |
| `Wolverine.Pubsub.Tests` | **217 / 0** |

Ten new tests over the settlement bookkeeping. **Red baseline**: removing the opt-in fails two of them with a clean build.

## Not covered — both need a live GCP project, not the emulator

- the real-service long-hold ceiling
- the `DeadLetterPolicy.MaxDeliveryAttempts` interaction

Both are named in spike §5 as open questions requiring a real project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)