### PR TITLE
5.x: fully silence Open Telemetry export and logging for IAgentCommand executions

### DIFF
--- a/src/Testing/CoreTests/Runtime/system_traffic_metrics_silencing.cs
+++ b/src/Testing/CoreTests/Runtime/system_traffic_metrics_silencing.cs
@@ -1,0 +1,259 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using CoreTests.Transports;
+using Wolverine.ErrorHandling;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Transports.Tcp;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+/// <summary>
+/// CritterWatch GH-907: a monitoring tool must not measurably inflate the thing it is monitoring. An idle
+/// Wolverine app reported a steady stream of nothing but its own agent commands and monitoring traffic,
+/// because (a) the meter counters were unconditional, (b) the accumulator guard was a string match that
+/// knew nothing of control endpoints, and (c) only IAgentCommand — not the full system-message surface —
+/// was excluded from the CritterWatch publishing trackers. The fix resolves a metrics-silent tracker ONCE
+/// at each construction site (endpoint agents, pipelines, executors); these tests pin that selection and
+/// the resulting meter silence.
+/// </summary>
+public class system_traffic_metrics_silencing : IAsyncLifetime
+{
+    private const string TheServiceName = "system-traffic-silencing";
+
+    private IHost _host = null!;
+    private WolverineRuntime _runtime = null!;
+    private MeterListener _listener = null!;
+    private readonly ConcurrentDictionary<string, int> _counts = new();
+
+    public async Task InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = TheServiceName;
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<SilencingProbeHandler>();
+            }).StartAsync();
+
+        _runtime = (WolverineRuntime)_host.Services.GetService(typeof(IWolverineRuntime))!;
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "Wolverine:" + TheServiceName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<int>((inst, _, _, _) => record(inst));
+        _listener.SetMeasurementEventCallback<long>((inst, _, _, _) => record(inst));
+        _listener.SetMeasurementEventCallback<double>((inst, _, _, _) => record(inst));
+        _listener.Start();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _listener.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private void record(Instrument instrument)
+    {
+        _counts.AddOrUpdate(instrument.Name, 1, (_, count) => count + 1);
+    }
+
+    private static Endpoint appEndpoint()
+        => new FakeEndpoint("fake://app".ToUri(), EndpointRole.Application);
+
+    private static Endpoint systemEndpoint()
+        => new FakeEndpoint("fake://control".ToUri(), EndpointRole.System);
+
+    private Envelope envelopeFor(object message) => new()
+    {
+        Message = message,
+        Destination = "fake://somewhere".ToUri(),
+        MessageType = message.GetType().FullName
+    };
+
+    /*** TRACKER SELECTION — decided once at construction, never per envelope ***/
+
+    [Fact]
+    public void system_role_endpoints_get_the_metrics_silent_tracker()
+    {
+        _runtime.MessageTrackingFor(systemEndpoint())
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void telemetry_disabled_endpoints_get_the_metrics_silent_tracker()
+    {
+        var endpoint = appEndpoint();
+        endpoint.TelemetryEnabled = false;
+
+        _runtime.MessageTrackingFor(endpoint)
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void application_endpoints_keep_the_standard_tracker()
+    {
+        _runtime.MessageTrackingFor(appEndpoint()).ShouldBeSameAs(_runtime.MessageTracking);
+    }
+
+    [Fact]
+    public void agent_commands_execute_metrics_silent_even_on_an_application_endpoint()
+    {
+        // The message-type half of the gate: an agent command handled on ANY endpoint is system traffic.
+        var executor = ((IExecutorFactory)_runtime).BuildFor(typeof(CheckAgentHealth), appEndpoint());
+
+        executor.ShouldBeOfType<Executor>().Tracker
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void agent_commands_invoked_through_the_runtime_pipeline_are_metrics_silent()
+    {
+        var executor = ((IExecutorFactory)_runtime).BuildFor(typeof(CheckAgentHealth));
+
+        executor.ShouldBeOfType<Executor>().Tracker
+            .ShouldBeOfType<WolverineRuntime.SystemTrafficMessageTracker>();
+    }
+
+    [Fact]
+    public void application_messages_on_application_endpoints_keep_metrics()
+    {
+        var executor = ((IExecutorFactory)_runtime).BuildFor(typeof(SilencingProbeMessage), appEndpoint());
+
+        executor.ShouldBeOfType<Executor>().Tracker.ShouldBeSameAs(_runtime.MessageTracking);
+    }
+
+    [Fact]
+    public void promoting_an_endpoint_to_node_control_duty_marks_it_as_system_and_disables_telemetry()
+    {
+        // UseTcpForControlEndpoint promotes a plain TCP endpoint; before GH-907 it stayed
+        // Application-role and its agent-command traffic was counted as application volume,
+        // and its send/receive/execution OTel spans were still published (GH-1670 follow-up).
+        var options = new WolverineOptions();
+        var endpoint = new TcpEndpoint(577);
+        endpoint.Role.ShouldBe(EndpointRole.Application);
+        endpoint.TelemetryEnabled.ShouldBeTrue();
+
+        options.Transports.NodeControlEndpoint = endpoint;
+
+        endpoint.Role.ShouldBe(EndpointRole.System);
+        endpoint.TelemetryEnabled.ShouldBeFalse();
+    }
+
+    /*** METER BEHAVIOR — the silent tracker records nothing, the standard one records ***/
+
+    [Fact]
+    public void the_silent_tracker_reaches_no_meter_instrument()
+    {
+        _counts.Clear();
+        var tracker = _runtime.MessageTrackingFor(systemEndpoint());
+        var envelope = envelopeFor(new CheckAgentHealth());
+
+        tracker.Sent(envelope);
+        tracker.Received(envelope);
+        tracker.ExecutionStarted(envelope);
+        tracker.ExecutionFinished(envelope);
+        tracker.MessageSucceeded(envelope);
+        tracker.MessageFailed(envelope, new InvalidOperationException("boom"));
+
+        _listener.RecordObservableInstruments();
+        _counts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_standard_tracker_still_records()
+    {
+        _counts.Clear();
+        var envelope = envelopeFor(new SilencingProbeMessage());
+
+        _runtime.MessageTracking.Sent(envelope);
+
+        _counts.ContainsKey(MetricsConstants.MessagesSent).ShouldBeTrue();
+    }
+
+    /*** COMPLETION CONTINUATIONS — the tracker stamped by the executor is honored (#3774) ***/
+
+    private MessageContext contextFor(Envelope envelope)
+    {
+        var context = new MessageContext(_runtime);
+        context.ReadEnvelope(envelope, InvocationCallback.Instance);
+        return context;
+    }
+
+    [Fact]
+    public async Task success_continuation_honors_the_metrics_silent_tracker()
+    {
+        // Pre-#3774, MessageSucceededContinuation reported through runtime.MessageTracking no
+        // matter what the executor resolved, so a system message's completion still recorded
+        // wolverine-messages-succeeded + wolverine-effective-time.
+        _counts.Clear();
+        var envelope = envelopeFor(new CheckAgentHealth());
+        envelope.SentAt = DateTimeOffset.UtcNow;
+
+        var context = contextFor(envelope);
+        context.Tracker = _runtime.MessageTrackingFor(systemEndpoint());
+
+        await MessageSucceededContinuation.Instance.ExecuteAsync(context, _runtime, DateTimeOffset.UtcNow, null);
+
+        _listener.RecordObservableInstruments();
+        _counts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task success_continuation_still_records_for_application_traffic()
+    {
+        // The diversion is only for the metrics-silent tracker — an application message's
+        // completion keeps the historical runtime-global reporting.
+        _counts.Clear();
+        var envelope = envelopeFor(new SilencingProbeMessage());
+        envelope.SentAt = DateTimeOffset.UtcNow;
+
+        var context = contextFor(envelope);
+        context.Tracker = _runtime.MessageTracking;
+
+        await MessageSucceededContinuation.Instance.ExecuteAsync(context, _runtime, DateTimeOffset.UtcNow, null);
+
+        _counts.ContainsKey(MetricsConstants.MessagesSucceeded).ShouldBeTrue();
+        _counts.ContainsKey(MetricsConstants.EffectiveMessageTime).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task no_handler_continuation_honors_the_metrics_silent_tracker()
+    {
+        _counts.Clear();
+        var envelope = envelopeFor(new CheckAgentHealth());
+        envelope.SentAt = DateTimeOffset.UtcNow;
+
+        var context = contextFor(envelope);
+        context.Tracker = _runtime.MessageTrackingFor(systemEndpoint());
+
+        var continuation = new NoHandlerContinuation([], _runtime);
+        await continuation.ExecuteAsync(context, _runtime, DateTimeOffset.UtcNow, null);
+
+        _listener.RecordObservableInstruments();
+        _counts.ShouldBeEmpty();
+    }
+}
+
+public record SilencingProbeMessage;
+
+public class SilencingProbeHandler
+{
+    public void Handle(SilencingProbeMessage _)
+    {
+    }
+}

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -364,17 +364,17 @@ public class EndpointCollection : IEndpointCollection
                     : _runtime.Storage.Outbox;
 
                 return new DurableSendingAgent(sender, _options.Durability,
-                    _runtime.LoggerFactory.CreateLogger<DurableSendingAgent>(), _runtime.MessageTracking,
+                    _runtime.LoggerFactory.CreateLogger<DurableSendingAgent>(), _runtime.MessageTrackingFor(endpoint),
                     outbox, endpoint, _runtime, sendingPolicies);
 
             case EndpointMode.BufferedInMemory:
                 return new BufferedSendingAgent(_runtime.LoggerFactory.CreateLogger<BufferedSendingAgent>(),
-                    _runtime.MessageTracking, sender, _runtime.DurabilitySettings,
+                    _runtime.MessageTrackingFor(endpoint), sender, _runtime.DurabilitySettings,
                     endpoint, _runtime, sendingPolicies);
 
             case EndpointMode.Inline:
                 return new InlineSendingAgent(_runtime.LoggerFactory.CreateLogger<InlineSendingAgent>(), sender,
-                    endpoint, _runtime.MessageTracking,
+                    endpoint, _runtime.MessageTrackingFor(endpoint),
                     _runtime.DurabilitySettings, _runtime, sendingPolicies);
         }
 

--- a/src/Wolverine/ErrorHandling/DiscardEnvelope.cs
+++ b/src/Wolverine/ErrorHandling/DiscardEnvelope.cs
@@ -57,7 +57,7 @@ public sealed class DiscardEnvelope : IContinuation
             // is acceptable noise.
             if (lifecycle.Envelope is { } env)
             {
-                runtime.MessageTracking.DiscardedEnvelope(env);
+                lifecycle.CompletionTrackerFor(runtime).DiscardedEnvelope(env);
             }
         }
     }

--- a/src/Wolverine/ErrorHandling/MoveToErrorQueue.cs
+++ b/src/Wolverine/ErrorHandling/MoveToErrorQueue.cs
@@ -57,8 +57,9 @@ internal class MoveToErrorQueue : IContinuation
 
         activity?.AddEvent(new ActivityEvent(WolverineTracing.MovedToErrorQueue));
 
-        runtime.MessageTracking.MessageFailed(lifecycle.Envelope, Exception);
-        runtime.MessageTracking.MovedToErrorQueue(lifecycle.Envelope, Exception);
+        var tracker = lifecycle.CompletionTrackerFor(runtime);
+        tracker.MessageFailed(lifecycle.Envelope, Exception);
+        tracker.MovedToErrorQueue(lifecycle.Envelope, Exception);
     }
 
     public override string ToString()

--- a/src/Wolverine/ErrorHandling/NoHandlerContinuation.cs
+++ b/src/Wolverine/ErrorHandling/NoHandlerContinuation.cs
@@ -50,8 +50,10 @@ internal class NoHandlerContinuation : IContinuation
         await lifecycle.CompleteAsync();
 
         // These two lines are important to make the message tracking work
-        // if there is no handler
-        runtime.MessageTracking.ExecutionFinished(lifecycle.Envelope);
-        runtime.MessageTracking.MessageSucceeded(lifecycle.Envelope);
+        // if there is no handler. Routed through the executor-resolved tracker so an
+        // unhandled SYSTEM message doesn't record success metrics (GH-907 / #3774).
+        var tracker = lifecycle.CompletionTrackerFor(runtime);
+        tracker.ExecutionFinished(lifecycle.Envelope);
+        tracker.MessageSucceeded(lifecycle.Envelope);
     }
 }

--- a/src/Wolverine/Runtime/CompletionTrackerExtensions.cs
+++ b/src/Wolverine/Runtime/CompletionTrackerExtensions.cs
@@ -1,0 +1,31 @@
+using Wolverine.Logging;
+
+namespace Wolverine.Runtime;
+
+/// <summary>
+///     CritterWatch GH-907 / wolverine#3774. Completion continuations (success, no-handler,
+///     error-queue, discard) historically reported through the runtime's global tracker, which
+///     bypassed the metrics-silent tracker the executor resolved for system traffic — so a
+///     system message's completion still recorded wolverine-messages-succeeded and
+///     wolverine-effective-time (and, in the publishing modes, still fed the CritterWatch
+///     accumulator's effective-time rollup: the CritterWatch#880 producer).
+///
+///     <para>The diversion is deliberately narrow: ONLY the metrics-silent tracker is honored
+///     here. Every other resolved tracker (Direct/Hybrid publishing) keeps the historical
+///     runtime-global reporting, because those trackers' completion methods post to their own
+///     accumulator sink AND delegate to the runtime — routing completions through them would
+///     double-count application traffic. The single type test below is on the completion path,
+///     not the per-envelope hot path.</para>
+/// </summary>
+internal static class CompletionTrackerExtensions
+{
+    internal static IMessageTracker CompletionTrackerFor(this IEnvelopeLifecycle lifecycle, IWolverineRuntime runtime)
+    {
+        if (lifecycle is MessageContext { Tracker: WolverineRuntime.SystemTrafficMessageTracker silent })
+        {
+            return silent;
+        }
+
+        return runtime.MessageTracking;
+    }
+}

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -44,7 +44,9 @@ public class HandlerPipeline : IHandlerPipeline
         _contextPool = runtime.ExecutionPool;
         _cancellation = runtime.Cancellation;
 
-        Logger = runtime.MessageTracking;
+        // CritterWatch GH-907: a system endpoint's received traffic never reaches the meters or the
+        // CritterWatch accumulator. Resolved once here, not per envelope.
+        Logger = runtime.MessageTrackingFor(endpoint);
 
         _executors = new LightweightCache<Type, IExecutor>(type => executorFactory.BuildFor(type, endpoint));
     }

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -58,6 +58,12 @@ internal class Executor : IExecutor
     private readonly IWolverineRuntime? _runtime;
 
     /// <summary>
+    ///     The tracker this executor reports to. Exposed for tests asserting which traffic is
+    ///     metrics-silent (CritterWatch GH-907).
+    /// </summary>
+    internal IMessageTracker Tracker => _tracker;
+
+    /// <summary>
     /// When <see langword="true"/>, the executor publishes the in-flight <see cref="MessageContext"/>
     /// through <see cref="MessageContext.Current"/> for the duration of each invocation, so
     /// service-located <see cref="IMessageContext"/> / <see cref="IMessageBus"/> see the same
@@ -181,6 +187,10 @@ internal class Executor : IExecutor
 
     public async Task<IContinuation> ExecuteAsync(MessageContext context, CancellationToken cancellation)
     {
+        // Completion continuations report through the tracker this executor resolved — see
+        // CompletionTrackerExtensions (CritterWatch GH-907 / wolverine#3774).
+        context.Tracker = _tracker;
+
         var envelope = context.Envelope;
         _tracker.ExecutionStarted(envelope!);
         _executionStarted(_logger, envelope!.CorrelationId!, _messageTypeName, envelope.Id, null);

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -6,6 +6,7 @@ using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
 using JasperFx;
 using JasperFx.MultiTenancy;
+using Wolverine.Logging;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.RemoteInvocation;
@@ -60,6 +61,15 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         get => _current.Value;
         internal set => _current.Value = value;
     }
+
+    /// <summary>
+    ///     The metrics tracker the executing handler resolved for this envelope — stamped by the
+    ///     executor at execution time so completion continuations (success, no-handler, error-queue,
+    ///     discard) can honor the metrics-silent selection for system traffic instead of reporting
+    ///     through the runtime's global tracker. Null outside an execution. CritterWatch GH-907 /
+    ///     wolverine#3774.
+    /// </summary>
+    internal IMessageTracker? Tracker { get; set; }
 
     private IChannelCallback? _channel;
 
@@ -768,6 +778,7 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
         Envelope = null;
         Transaction = null;
         _sagaId = null;
+        Tracker = null;
     }
 
     public void SetSagaId(object sagaId) => _sagaId = sagaId;

--- a/src/Wolverine/Runtime/MessageSucceededContinuation.cs
+++ b/src/Wolverine/Runtime/MessageSucceededContinuation.cs
@@ -23,14 +23,14 @@ public class MessageSucceededContinuation : IContinuation
 
             await lifecycle.CompleteAsync();
 
-            runtime.MessageTracking.MessageSucceeded(lifecycle.Envelope!);
+            lifecycle.CompletionTrackerFor(runtime).MessageSucceeded(lifecycle.Envelope!);
         }
         catch (Exception ex)
         {
             await lifecycle.SendFailureAcknowledgementAsync("Sending cascading message failed: " + ex.Message);
 
             runtime.Logger.LogError(ex, "Failure while post-processing a successful envelope");
-            runtime.MessageTracking.MessageFailed(lifecycle.Envelope!, ex);
+            lifecycle.CompletionTrackerFor(runtime).MessageFailed(lifecycle.Envelope!, ex);
 
             await new MoveToErrorQueue(ex).ExecuteAsync(lifecycle, runtime, now, activity);
         }

--- a/src/Wolverine/Runtime/Wolverine.ExecutorFactory.cs
+++ b/src/Wolverine/Runtime/Wolverine.ExecutorFactory.cs
@@ -1,5 +1,6 @@
 ﻿using JasperFx.Core.Reflection;
 using Wolverine.Configuration;
+using Wolverine.Configuration.Capabilities;
 using Wolverine.Logging;
 using Wolverine.Runtime.Agents;
 using Wolverine.Runtime.Handlers;
@@ -12,6 +13,18 @@ public partial class WolverineRuntime : IExecutorFactory
 {
     IExecutor IExecutorFactory.BuildFor(Type messageType)
     {
+        // CritterWatch GH-907: system message types (agent commands, acknowledgements, CritterWatch
+        // monitoring traffic) invoked through the runtime-level pipeline must not record execution
+        // metrics. Decided here, once per message type, never per envelope.
+        if (messageType.IsSystemMessageType())
+        {
+            var handler = Handlers.HandlerFor(messageType);
+            if (handler != null)
+            {
+                return Executor.Build(this, ExecutionPool, Handlers, handler, SystemTraffic);
+            }
+        }
+
         var executor = Executor.Build(this, ExecutionPool, Handlers, messageType);
 
         return executor;
@@ -27,7 +40,7 @@ public partial class WolverineRuntime : IExecutorFactory
                 handler = new PartitionedMessageReRouter(topology, messageType);
             }
         }
-        
+
         handler ??= (IMessageHandler?)Handlers.HandlerFor(messageType, endpoint);
         if (handler == null )
         {
@@ -38,22 +51,41 @@ public partial class WolverineRuntime : IExecutorFactory
             }
         }
 
-        IMessageTracker tracker = this;
-        if (!messageType.CanBeCastTo<IAgentCommand>() && Options.Metrics.Mode == WolverineMetricsMode.CritterWatch)
-        {
-            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
-            tracker = new DirectMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
-        }
-        else if (!messageType.CanBeCastTo<IAgentCommand>() && Options.Metrics.Mode == WolverineMetricsMode.Hybrid)
-        {
-            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
-            tracker = new HybridMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
-        }
-        
+        var tracker = trackerFor(messageType, endpoint);
+
         var executor = handler == null
             ? new NoHandlerExecutor(messageType, this)
             : Executor.Build(this, ExecutionPool, Handlers, handler, tracker);
 
         return executor;
+    }
+
+    // CritterWatch GH-907: pick each executor's tracker ONCE at construction. System traffic — a system
+    // message type (agent commands, acks, CritterWatch monitoring messages), a system-role endpoint (node
+    // control queues, internal local queues), or an endpoint with telemetry deliberately switched off —
+    // gets the metrics-silent tracker, in EVERY metrics mode. This used to exclude only IAgentCommand and
+    // only from the two CritterWatch-publishing modes, so agent commands still hit the OTel meters in the
+    // default mode and CritterWatch's own monitoring messages were counted (and re-published) as
+    // application volume — the feedback loop behind an idle app reporting hundreds of messages a minute.
+    private IMessageTracker trackerFor(Type messageType, Endpoint endpoint)
+    {
+        if (messageType.IsSystemMessageType() || endpoint.Role == EndpointRole.System || !endpoint.TelemetryEnabled)
+        {
+            return SystemTraffic;
+        }
+
+        if (Options.Metrics.Mode == WolverineMetricsMode.CritterWatch)
+        {
+            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
+            return new DirectMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
+        }
+
+        if (Options.Metrics.Mode == WolverineMetricsMode.Hybrid)
+        {
+            var accumulator = MetricsAccumulator.FindAccumulator(messageType.ToMessageTypeName(), endpoint);
+            return new HybridMetricsPublishingMessageTracker(this, accumulator.EntryPoint);
+        }
+
+        return this;
     }
 }

--- a/src/Wolverine/Runtime/WolverineRuntime.SystemTraffic.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.SystemTraffic.cs
@@ -1,0 +1,150 @@
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Tracking;
+
+namespace Wolverine.Runtime;
+
+public partial class WolverineRuntime
+{
+    /// <summary>
+    ///     The single metrics-silent tracker instance handed to every construction site that carries
+    ///     system traffic. See <see cref="SystemTrafficMessageTracker" />.
+    /// </summary>
+    internal IMessageTracker SystemTraffic => _systemTraffic ??= new SystemTrafficMessageTracker(this);
+
+    private SystemTrafficMessageTracker? _systemTraffic;
+
+    /// <summary>
+    ///     The message tracker a sending agent, local queue, or listening pipeline for this endpoint
+    ///     should use — resolved ONCE at construction, never per envelope. System endpoints (node control
+    ///     queues, reply queues, the internal local queues) and endpoints whose telemetry is deliberately
+    ///     switched off get the metrics-silent tracker, so their traffic never reaches the meters or the
+    ///     CritterWatch accumulator. CritterWatch GH-907: a monitoring tool must not measurably inflate
+    ///     the thing it is monitoring, and an idle app was reporting hundreds of messages a minute of
+    ///     nothing but its own control-queue and monitoring traffic.
+    /// </summary>
+    internal IMessageTracker MessageTrackingFor(Endpoint endpoint)
+    {
+        return endpoint.Role == EndpointRole.System || !endpoint.TelemetryEnabled
+            ? SystemTraffic
+            : MessageTracking;
+    }
+
+    /// <summary>
+    ///     CritterWatch GH-907. An <see cref="IMessageTracker" /> for Wolverine's own internal traffic —
+    ///     agent commands on the node control queues, acknowledgements, CritterWatch monitoring messages —
+    ///     that keeps the debug logging, tracked-session bookkeeping, and wire taps of the standard
+    ///     tracker while emitting <b>no metrics</b>: no meter counters or histograms, and nothing into the
+    ///     CritterWatch accumulator (which would otherwise publish the system's own noise back to the
+    ///     console as apparent application volume — a feedback loop, since those publishes are themselves
+    ///     messages that get counted).
+    ///
+    ///     <para>Deliberately a separate tracker resolved once at construction time (per endpoint, per
+    ///     executor) rather than an if-test inside the counting methods: Wolverine keeps per-envelope
+    ///     branching out of the hot path, the same way <c>InlineSendingAgent</c> picks
+    ///     <c>sendWithTracing</c> vs <c>sendWithOutTracing</c> up front.</para>
+    /// </summary>
+    internal class SystemTrafficMessageTracker : IMessageTracker
+    {
+        private readonly WolverineRuntime _runtime;
+
+        public SystemTrafficMessageTracker(WolverineRuntime runtime)
+        {
+            _runtime = runtime;
+        }
+
+        public void Sent(Envelope envelope)
+        {
+            _runtime.ActiveSession?.MaybeRecord(MessageEventType.Sent, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+            _sent(_runtime.Logger, envelope.CorrelationId!, envelope.GetMessageTypeName(), envelope.Id,
+                envelope.Destination?.ToString() ?? string.Empty, null);
+
+            _runtime.fireWireTapSuccess(envelope);
+        }
+
+        public void Received(Envelope envelope)
+        {
+            _runtime.ActiveSession?.Record(MessageEventType.Received, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+            _received(_runtime.Logger, envelope.CorrelationId!, envelope.GetMessageTypeName(), envelope.Id,
+                envelope.Destination?.ToString() ?? string.Empty,
+                envelope.ReplyUri?.ToString() ?? string.Empty, null);
+        }
+
+        public void ExecutionStarted(Envelope envelope)
+        {
+            _runtime.ExecutionStarted(envelope);
+        }
+
+        public void ExecutionFinished(Envelope envelope)
+        {
+            // Still stop the timing so the envelope's state stays symmetric with ExecutionStarted;
+            // the measurement is simply not recorded anywhere.
+            envelope.StopTiming();
+            _runtime.ActiveSession?.Record(MessageEventType.ExecutionFinished, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+        }
+
+        public void ExecutionFinished(Envelope envelope, Exception exception)
+        {
+            ExecutionFinished(envelope);
+        }
+
+        public void MessageSucceeded(Envelope envelope)
+        {
+            _runtime.ActiveSession?.Record(MessageEventType.MessageSucceeded, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+
+            _runtime.fireWireTapSuccess(envelope);
+        }
+
+        public void MessageFailed(Envelope envelope, Exception ex)
+        {
+            // The base tracker records this with MessageEventType.Sent as well — see
+            // WolverineRuntime.MessageFailed
+            _runtime.ActiveSession?.Record(MessageEventType.Sent, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId, ex);
+
+            _runtime.fireWireTapFailure(envelope, ex);
+        }
+
+        public void NoHandlerFor(Envelope envelope)
+        {
+            _runtime.NoHandlerFor(envelope);
+        }
+
+        public void NoRoutesFor(Envelope envelope)
+        {
+            _runtime.NoRoutesFor(envelope);
+        }
+
+        public void MovedToErrorQueue(Envelope envelope, Exception ex)
+        {
+            _runtime.ActiveSession?.Record(MessageEventType.MovedToErrorQueue, envelope, _runtime._serviceName,
+                _runtime._uniqueNodeId);
+            _movedToErrorQueue(_runtime.Logger, envelope, ex);
+        }
+
+        public void DiscardedEnvelope(Envelope envelope)
+        {
+            _runtime.DiscardedEnvelope(envelope);
+        }
+
+        public void Requeued(Envelope envelope)
+        {
+            _runtime.Requeued(envelope);
+        }
+
+        public void LogException(Exception ex, object? correlationId = null,
+            string message = "Exception detected:")
+        {
+            _runtime.LogException(ex, correlationId, message);
+        }
+
+        public void LogStatus(string message)
+        {
+            _runtime.ActiveSession?.LogStatus(message);
+        }
+    }
+}

--- a/src/Wolverine/TransportCollection.cs
+++ b/src/Wolverine/TransportCollection.cs
@@ -32,6 +32,20 @@ public class TransportCollection : IEnumerable<ITransport>, IAsyncDisposable
             if (value != null)
             {
                 value.IsListener = true;
+
+                // CritterWatch GH-907: whatever endpoint carries node control traffic is system
+                // traffic by definition. The database and shared-memory control endpoints are born
+                // with the System role, but a generic endpoint promoted to control duty (e.g.
+                // UseTcpForControlEndpoint or broker control queues) was not — leaving its
+                // agent-command traffic visible to metrics as apparent application volume.
+                value.Role = EndpointRole.System;
+
+                // GH-1670 follow-up: node control traffic is nothing but IAgentCommand executions
+                // and their replies. Switching telemetry off here suppresses the send, receive,
+                // and execution Open Telemetry spans that were still being published for agent
+                // commands whenever the control endpoint was a broker queue or TCP endpoint
+                // (the database control endpoint was already born with TelemetryEnabled = false).
+                value.TelemetryEnabled = false;
             }
 
             _nodeControlEndpoint = value;

--- a/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
@@ -14,7 +14,7 @@ internal class BufferedLocalQueue : BufferedReceiver, ISendingAgent, IListenerCi
 
     public BufferedLocalQueue(Endpoint endpoint, IWolverineRuntime runtime) : base(endpoint, runtime, new HandlerPipeline((WolverineRuntime)runtime, (IExecutorFactory)runtime, endpoint))
     {
-        _messageTracker = runtime.MessageTracking;
+        _messageTracker = ((WolverineRuntime)runtime).MessageTrackingFor(endpoint);
         _runtime = runtime;
         Destination = endpoint.Uri;
         Endpoint = endpoint;

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -38,7 +38,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
             ? new DelegatingMessageInbox(runtime.Storage.Inbox, runtime.Stores)
             : runtime.Storage.Inbox;
 
-        _messageLogger = runtime.MessageTracking;
+        _messageLogger = runtime.MessageTrackingFor(endpoint);
         _serializer = endpoint.DefaultSerializer ??
                       throw new ArgumentOutOfRangeException(nameof(endpoint),
                           "No default serializer for this Endpoint");


### PR DESCRIPTION
## What this does

A client reported that the latest 5.x still publishes Open Telemetry data for `IAgentCommand` executions, despite the earlier noise-reduction work (GH-1670: the agent-command chain already runs with `ProcessingLogLevel`/`SuccessLogLevel = LogLevel.None` and `TelemetryEnabled = false` on this branch). This PR brings the 5.x line up to what `main` already does for agent-command observability, and closes the one remaining span hole.

### 1. Backport of CritterWatch GH-907 (`main` commit 2c0aea2d9)

On 5.x, the executor factory excluded `IAgentCommand` from metrics **only** in the two CritterWatch publishing modes — so in the **default** metrics mode every agent command execution still recorded `wolverine-messages-sent`, `wolverine-messages-received`, `wolverine-execution-time`, and `wolverine-messages-succeeded` on the OTel meters. That is the "OTel export for agent commands" a collector still sees.

Now, exactly as on `main`:

- New metrics-silent `WolverineRuntime.SystemTrafficMessageTracker` — keeps the Debug-level logging, tracked-session bookkeeping, and wire taps, but records **no** meter measurements.
- Sending agents, local queues, and listening pipelines resolve their tracker once at construction via `MessageTrackingFor(endpoint)`: a System-role endpoint or one with `TelemetryEnabled = false` gets the silent tracker.
- The executor factory's `trackerFor` excludes the full system-message surface (`IsSystemMessageType()`: `IInternalMessage`, `IAgentCommand`, `INotToBeRouted`, opted-out assemblies) in **every** metrics mode, and consults the endpoint's role — including the runtime-level `BuildFor(Type)` used by local invocation.
- The `NodeControlEndpoint` setter stamps `EndpointRole.System` on any endpoint promoted to node control duty (`UseTcpForControlEndpoint`, broker control queues), which the database and shared-memory control endpoints already had from birth.

### 2. Backport of wolverine#3774

Completion continuations (success, no-handler, error-queue, discard) reported through the runtime's **global** tracker regardless of what the executor resolved, so a successful agent command still recorded `wolverine-messages-succeeded` + `wolverine-effective-time`. The executor now stamps its resolved tracker on the `MessageContext`, and the continuations honor the metrics-silent selection through `CompletionTrackerFor` (narrow diversion: only the silent tracker is diverted; Direct/Hybrid publishing trackers keep the historical runtime-global reporting to avoid double-counting).

### 3. No more spans for agent commands over control transports

Execution spans were already suppressed by the chain gate, and the local agent queue + database control endpoint were already born with `TelemetryEnabled = false` — but a control endpoint that is a broker queue (e.g. RabbitMQ `EnableWolverineControlQueues`) or a TCP endpoint kept the default `TelemetryEnabled = true`, so every agent command over it still published **send**, **receive**, and pipeline-level **execution** spans. The `NodeControlEndpoint` setter now switches `TelemetryEnabled` off along with the System-role promotion. Node control traffic is nothing but agent commands and their replies, so nothing user-visible is lost.

This last piece goes one step past `main` (which stamps only the role); `main` should probably pick it up as a follow-up.

### Out of scope, deliberately

- The `wolverine_node_assignments` health-check traces stay governed by `Durability.NodeAssignmentHealthCheckTracingEnabled` / `NodeAssignmentHealthCheckTraceSamplingPeriod` (default enabled), matching `main`. A client who wants those gone can set the flag to `false`.
- The agent lifecycle `LogInformation` lines ("Successfully started agent …") match `main` and are untouched.

## Testing

- New `CoreTests.Runtime.system_traffic_metrics_silencing` (12 tests, adapted from the `main` suite for xUnit v2 and this branch's surface) pins the tracker selection per endpoint role/telemetry flag/message type, meter silence via a `MeterListener`, the control-endpoint promotion, and the continuation diversion.
- Full CoreTests: **1689 passed, 0 failed** on net9.0.
- Full `wolverine.slnx` builds clean pinned to net9.0 (Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)