### PR TITLE
GH-4053: correct the NATS native-ack badge to 6.30

### DIFF
--- a/docs/guide/messaging/transports/nats.md
+++ b/docs/guide/messaging/transports/nats.md
@@ -292,7 +292,7 @@ opts.ListenToNatsSubject("orders.received")
     .UseJetStream("ORDERS", "my-consumer");
 ```
 
-### Native Acks with Parallel Processing <Badge type="tip" text="6.31" />
+### Native Acks with Parallel Processing <Badge type="tip" text="6.30" />
 
 JetStream listeners support `EndpointMode.NativeAck` (see [GH-3708](https://github.com/JasperFx/wolverine/issues/3708)),
 which combines `BufferedInMemory`'s parallelism and group partitioning with `ProcessInline()`'s no-loss behavior, and


### PR DESCRIPTION
`docs/guide/messaging/transports/nats.md:295` badged **Native Acks with Parallel Processing** as `6.31`, but the feature shipped in **6.30**.

Verification:

```
$ git tag --contains 2795b2796   # "GH-4053: NativeAck endpoint mode for NATS JetStream"
V6.30.0
```

The commit is also reachable through `#4093` (`nativeack/transport-adoptions`), which merged ahead of the `Release 6.30.0` commit `3ffe17089`.

This was the only `6.31` badge anywhere under `docs/guide` — every sibling transport that adopted the mode in the same wave (RabbitMQ, SQS, ASB, Redis, Pulsar, Pub/Sub) is badged `6.30`, so NATS was the odd one out rather than the rule.

Docs-only, one character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)