### PR TITLE
GH-3627: document [StreamState] and [StreamEvents]

### DIFF
--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -18,6 +18,8 @@ These all speak one vocabulary, and none of it names your database:
 | An event sourced model's current state, read only | `[ReadModel]` |
 | The whole method to be an event sourced command handler | `[DeciderFunction]` |
 | An event sourced model spanning several streams, matched by tag | `[DcbModel]` |
+| A stream's metadata — version, type, timestamps — **unfolded** | [`[StreamState]`](#raw-stream-reads) |
+| A stream's raw events, **unfolded** | [`[StreamEvents]`](#raw-stream-reads) |
 | To write a document back | `Storage.Store` / `Insert` / `Update` / `Delete` / `Nothing<T>` |
 | To append events to a stream | [`Storage.AppendEvents` / `Storage.StartStream`](/guide/handlers/side-effects#event-side-effects) |
 | Every document of a type | [`[All]`](#reading-every-document-of-a-type) |
@@ -407,7 +409,7 @@ public static class ShipOrderHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L29-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_write_model_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L30-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_write_model_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `[DeciderFunction]` for the same workflow at the method or class level, where the model's
@@ -431,7 +433,7 @@ public static class MarkItemReadyHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L44-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_decider_function_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L45-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_decider_function_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Use `[ReadModel]` when the handler only needs to *look at* the model. It resolves the current state
@@ -450,7 +452,7 @@ public static class ReadOrderStatusHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L60-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_read_model_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L61-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_read_model_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 By default `[WriteModel]` and `[DeciderFunction]` use an optimistic concurrency check at the point
@@ -468,8 +470,132 @@ public static class ShipOrderExclusivelyHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L74-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_write_model_with_exclusive_locking' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L75-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_write_model_with_exclusive_locking' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+### Raw Stream Reads <Badge type="tip" text="6.30" />
+
+`[ReadModel]` gives you a model *folded* from a stream's events. Sometimes folding is exactly the wrong
+thing: a timeline endpoint, an audit view, or a "what happened to this order?" screen needs the history
+itself, and the fold has already collapsed it. `[StreamState]` and `[StreamEvents]` are the raw reads for
+those handlers.
+
+`[StreamState]` resolves the stream's metadata — version, aggregate type, created and updated timestamps —
+and `[StreamEvents]` resolves its events as `IReadOnlyList<IEvent>`. Neither one folds anything. Both are
+store-agnostic in the same way the rest of this vocabulary is, and the store batches them with any other
+batchable load on the same handler into a single round trip:
+
+<!-- snippet: sample_using_stream_state_and_events -->
+<a id='snippet-sample_using_stream_state_and_events'></a>
+```cs
+public static class OrderTimelineHandler
+{
+    // [StreamState] gives you the stream's metadata -- version, aggregate type, created/updated
+    // timestamps -- and [StreamEvents] gives you the raw events, WITHOUT folding either into an
+    // aggregate. This is the read [ReadModel] cannot express, because folding has already thrown
+    // away the history this handler exists to serve. Both fetches batch into one round trip.
+    public static OrderTimeline Handle(
+        OrderTimelineQuery query,
+        [StreamState] StreamState state,
+        [StreamEvents] IReadOnlyList<IEvent> events)
+    {
+        return new OrderTimeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L130-L147' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stream_state_and_events' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Like `[ReadModel]`, `[StreamState]` takes its required-ness from the parameter's nullable annotation:
+`StreamState state` stops the handler when the stream does not exist, and `StreamState? state` leaves
+absence to you.
+
+<!-- snippet: sample_stream_state_optional -->
+<a id='snippet-sample_stream_state_optional'></a>
+```cs
+public static class OptionalOrderTimelineHandler
+{
+    // Nullable annotation decides the default, exactly as it does for [ReadModel]:
+    // "StreamState state" is required and stops the handler when the stream does not exist,
+    // "StreamState? state" leaves absence to you
+    public static OrderTimeline Handle(OrderTimelineQuery query, [StreamState] StreamState? state)
+    {
+        return new OrderTimeline(state?.Version ?? 0, []);
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L168-L181' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_stream_state_optional' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning The identity convention is not the one `[Entity]` uses
+This is the easiest thing here to get wrong. `[Entity] Order order` can infer an identity member named
+`OrderId`, because the parameter's own type names your entity. The parameter type here is `StreamState` —
+the *store's* vocabulary, not your aggregate — so there is no aggregate name to infer from, and the
+convention degrades to a member literally named `Id`.
+
+For anything else, name the member explicitly:
+
+<!-- snippet: sample_stream_state_with_named_identity -->
+<a id='snippet-sample_stream_state_with_named_identity'></a>
+```cs
+public static class OrderAuditHandler
+{
+    // The identity convention here is NOT the one [Entity] and [ReadModel] use. Those infer
+    // "OrderId" from the parameter's own type; the parameter type here is StreamState, which
+    // names the store's vocabulary rather than your aggregate. So a bare [StreamState] resolves
+    // only a member literally named "Id" -- name the member explicitly for anything else.
+    public static OrderTimeline Handle(
+        OrderAuditQuery query,
+        [StreamState("OrderId")] StreamState state,
+        [StreamEvents("OrderId")] IReadOnlyList<IEvent> events)
+    {
+        return new OrderTimeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L149-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_stream_state_with_named_identity' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A miss is not silent. Wolverine throws `InvalidEntityLoadUsageException` when the chain is compiled — at
+startup, not at the first request.
+:::
+
+#### There is deliberately no `Required` on `[StreamEvents]`
+
+`[StreamState]` has a `Required` property; `[StreamEvents]` does not, and that asymmetry is intentional
+rather than an oversight. A missing stream yields an **empty list**, not null, so the null-guard model the
+rest of the `[Entity]` family is built on has nothing to test — a guard would either never fire, or would
+have to invent a count threshold. And "zero events" is a genuinely different question from "no such
+stream."
+
+When a handler needs an existence guard, pair the two. `[StreamState]` reads the same stream in the same
+batch and answers the question precisely:
+
+```csharp
+public static OrderTimeline Handle(
+    OrderTimelineQuery query,
+    [StreamState] StreamState state,           // non-nullable, so this is the not-found guard
+    [StreamEvents] IReadOnlyList<IEvent> events)
+```
+
+#### Choosing a store
+
+Because these parameter types are store vocabulary rather than your own types, Wolverine cannot ask "who
+owns this?" the way it can for `[ReadModel] Order`. Resolution goes, in order:
+
+1. An explicit `AggregateType` — `[StreamState(AggregateType = typeof(Order))]` — which identifies the
+   owning store and nothing else. It does not change what is read.
+2. The ancillary store the chain was routed to by `[Storage(typeof(IMyStore))]`.
+3. The single registered event store integration, when there is only one.
+
+With more than one integration registered and no other signal, Wolverine throws at compile time with a
+message naming both escape hatches rather than guessing.
+
+There are also Marten-specific spellings, `[MartenStreamState]` and `[MartenStreamEvents]`, which exist
+for the same reason [`[ReadAggregate]`](/guide/durability/marten/event-sourcing) does: they **name** their
+store instead of resolving one, so they still work in a host that called `AddMarten(...)` without
+`IntegrateWithWolverine()`, where nothing ever registers a persistence strategy. Prefer the store-agnostic
+`[StreamState]` and `[StreamEvents]` in new code.
 
 ### Dynamic Consistency Boundaries <Badge type="tip" text="6.27" />
 
@@ -507,7 +633,7 @@ public static class ReserveSeatHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L97-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_dcb_model_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs#L98-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_dcb_model_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Mark the parameter as `IEventBoundary<T>` instead of `T` if you want the boundary handle itself —

--- a/docs/guide/http/marten.md
+++ b/docs/guide/http/marten.md
@@ -152,7 +152,7 @@ public static OrderShipped Ship(ShipOrder2 command, [Aggregate] Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L146-L160' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L149-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Using this version of the "aggregate workflow", you no longer have to supply a command in the request body, so you could
@@ -171,7 +171,7 @@ public static OrderShipped Ship3([Aggregate] Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L162-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L165-L176' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_aggregate_attribute_2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A couple other notes: 
@@ -264,7 +264,7 @@ public class Order
     public bool IsShipped() => Shipped.HasValue;
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L18-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_aggregate_for_http' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L21-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_aggregate_for_http' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To append a single event to an event stream from an HTTP endpoint, you can use a return value like so:
@@ -283,7 +283,7 @@ public static OrderShipped Ship(ShipOrder command, Order order)
     return new OrderShipped();
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L122-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_emptyresponse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L125-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_emptyresponse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or potentially append multiple events using the `Events` type as a return value like this sample:
@@ -319,7 +319,7 @@ public static (OrderStatus, Events) Post(MarkItemReady command, Order order)
     return (new OrderStatus(order.Id, order.IsReadyToShip()), events);
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L236-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_multiple_events_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L239-L268' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_multiple_events_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Responding with the Updated Aggregate
@@ -345,7 +345,7 @@ public static (UpdatedAggregate, Events) ConfirmDifferent(ConfirmOrder command, 
     );
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L293-L306' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_updated_aggregate_as_response_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L300-L313' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_returning_updated_aggregate_as_response_from_http_endpoint' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you should happen to have a message handler or HTTP endpoint signature that uses multiple event streams,
@@ -519,7 +519,7 @@ an HTTP endpoint method, use the `[ReadAggregate]` attribute like this:
 [WolverineGet("/orders/latest/{id}")]
 public static Order GetLatest(Guid id, [ReadAggregate] Order order) => order;
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L320-L324' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_http' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L350-L354' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_readaggregate_in_http' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If the aggregate doesn't exist, the HTTP request will stop with a 404 status code. 
@@ -528,6 +528,45 @@ The aggregate/stream identity is found with the same rules as the `[Entity]` or 
 1. You can specify a particular request body property name or route argument
 2. Look for a request body property or route argument named "EntityTypeId"
 3. Look for a request body property or route argument named "Id" or "id"
+
+## Reading a Stream Without Folding It <Badge type="tip" text="6.30" />
+
+`[ReadAggregate]` gives you the *folded* aggregate. When an endpoint's whole job is to serve the history —
+a timeline view, an audit trail — folding has already thrown away what it needs. `[StreamState]` and
+`[StreamEvents]` are the raw reads for those endpoints:
+
+<!-- snippet: sample_using_streamstate_and_streamevents_in_http -->
+<a id='snippet-sample_using_streamstate_and_streamevents_in_http'></a>
+```cs
+// GH-3627. Timeline/audit shaped reads: the handler serves the event history itself, which
+// [ReadAggregate] cannot express because folding has already collapsed what it needs. Both fetches
+// batch into one round trip alongside any other batchable load on the same handler.
+[WolverineGet("/orders/{id}/timeline")]
+public static OrderTimeline GetTimeline(
+    Guid id,
+    [MartenStreamState] StreamState state,
+    [MartenStreamEvents] IReadOnlyList<IEvent> events)
+{
+    return new OrderTimeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Orders.cs#L327-L341' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_streamstate_and_streamevents_in_http' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`[StreamState]` follows the same not-found rules as `[ReadAggregate]`: a non-nullable `StreamState`
+parameter stops the request with a 404, and `StreamState?` leaves absence to the endpoint.
+
+The identity rules are **not** quite the same, though, and it is worth reading the
+[full treatment in the persistence helpers guide](/guide/handlers/persistence.html#raw-stream-reads)
+before you use them. `[ReadAggregate] Order order` can find a route argument named `OrderId` because the
+parameter type names your aggregate; the parameter type here is `StreamState`, so only a route argument or
+body property named `Id` resolves without help. Name it explicitly for anything else —
+`[StreamState("orderId")]`.
+
+The `[MartenStreamState]` and `[MartenStreamEvents]` spellings used above name Marten directly, in the
+same way `[ReadAggregate]` does. The store-agnostic `[StreamState]` and `[StreamEvents]` work identically
+in any host that registered an event store integration with `IntegrateWithWolverine()`, and are the better
+default in new code.
 
 ### Compiled Query Resource Writer Policy
 
@@ -539,7 +578,7 @@ Register it in `WolverineHttpOptions` like this:
 ```cs
 opts.UseMartenCompiledQueryResultPolicy();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L343-L346' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_marten_compiled_query_policy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Program.cs#L347-L350' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_marten_compiled_query_policy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you now return a compiled query from an Endpoint the result will get directly streamed to the client as JSON. Short circuiting JSON deserialization.
@@ -566,7 +605,7 @@ public class ApprovedInvoicedCompiledQuery : ICompiledListQuery<Invoice>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L106-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Http/WolverineWebApi/Marten/Documents.cs#L117-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiled_query_return_query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Streaming JSON Responses <Badge type="tip" text="5.32" />

--- a/src/Persistence/MartenTests/stream_state_and_events_handlers_3627.cs
+++ b/src/Persistence/MartenTests/stream_state_and_events_handlers_3627.cs
@@ -1,0 +1,112 @@
+using IntegrationTests;
+using JasperFx.Events;
+using JasperFx.Resources;
+using Marten;
+using MartenTests.AggregateHandlerWorkflow;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence.EventSourcing;
+
+namespace MartenTests;
+
+public record FindTimeline(Guid Id);
+
+public record FindTimelineByAggregateId(Guid AggregateId);
+
+public record Timeline(long Version, string[] EventTypes);
+
+public static class FindTimelineHandler
+{
+    public static Timeline Handle(
+        FindTimeline query,
+        [StreamState] StreamState state,
+        [StreamEvents] IReadOnlyList<IEvent> events)
+    {
+        return new Timeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+
+    public static Timeline Handle(
+        FindTimelineByAggregateId query,
+        [StreamState("AggregateId")] StreamState state,
+        [StreamEvents("AggregateId")] IReadOnlyList<IEvent> events)
+    {
+        return new Timeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+}
+
+/// <summary>
+/// GH-3627. The message handler side of [StreamState] / [StreamEvents]. The HTTP side is covered by
+/// Wolverine.Http.Tests, but the handler path had no coverage, and its identity resolution differs in
+/// a way that is easy to get wrong: the parameter type is StreamState, not your aggregate, so the
+/// "&lt;ParameterType&gt;Id" convention looks for "StreamStateId". Only a member named "Id" or the
+/// explicit named-argument form resolves. A miss is an InvalidEntityLoadUsageException at bootstrap.
+/// </summary>
+public class stream_state_and_events_handlers_3627 : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(FindTimelineHandler));
+
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private async Task<Guid> startStreamAsync()
+    {
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<LetterAggregate>(streamId, new AEvent(), new AEvent(), new CEvent());
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return streamId;
+    }
+
+    [Fact]
+    public async Task the_Id_convention_resolves_the_stream()
+    {
+        var streamId = await startStreamAsync();
+
+        var timeline = await theHost.MessageBus()
+            .InvokeAsync<Timeline>(new FindTimeline(streamId), TestContext.Current.CancellationToken);
+
+        timeline.Version.ShouldBe(3);
+        timeline.EventTypes.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task the_named_argument_form_resolves_a_differently_named_property()
+    {
+        var streamId = await startStreamAsync();
+
+        var timeline = await theHost.MessageBus()
+            .InvokeAsync<Timeline>(new FindTimelineByAggregateId(streamId), TestContext.Current.CancellationToken);
+
+        timeline.Version.ShouldBe(3);
+        timeline.EventTypes.Length.ShouldBe(3);
+    }
+}

--- a/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs
+++ b/src/Samples/DocumentationSamples/EventSourcedModelSamples.cs
@@ -1,3 +1,4 @@
+using JasperFx.Events;
 using JasperFx.Events.Tags;
 using Wolverine.Persistence;
 using Wolverine.Persistence.EventSourcing;
@@ -115,6 +116,65 @@ public static class ReserveSeatHandler
         }
 
         return new SeatReserved(command.ScreeningId, command.CustomerId);
+    }
+}
+
+#endregion
+
+public record OrderTimelineQuery(Guid Id);
+
+public record OrderAuditQuery(Guid OrderId);
+
+public record OrderTimeline(long Version, string[] EventTypes);
+
+#region sample_using_stream_state_and_events
+
+public static class OrderTimelineHandler
+{
+    // [StreamState] gives you the stream's metadata -- version, aggregate type, created/updated
+    // timestamps -- and [StreamEvents] gives you the raw events, WITHOUT folding either into an
+    // aggregate. This is the read [ReadModel] cannot express, because folding has already thrown
+    // away the history this handler exists to serve. Both fetches batch into one round trip.
+    public static OrderTimeline Handle(
+        OrderTimelineQuery query,
+        [StreamState] StreamState state,
+        [StreamEvents] IReadOnlyList<IEvent> events)
+    {
+        return new OrderTimeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+}
+
+#endregion
+
+#region sample_stream_state_with_named_identity
+
+public static class OrderAuditHandler
+{
+    // The identity convention here is NOT the one [Entity] and [ReadModel] use. Those infer
+    // "OrderId" from the parameter's own type; the parameter type here is StreamState, which
+    // names the store's vocabulary rather than your aggregate. So a bare [StreamState] resolves
+    // only a member literally named "Id" -- name the member explicitly for anything else.
+    public static OrderTimeline Handle(
+        OrderAuditQuery query,
+        [StreamState("OrderId")] StreamState state,
+        [StreamEvents("OrderId")] IReadOnlyList<IEvent> events)
+    {
+        return new OrderTimeline(state.Version, events.Select(x => x.EventTypeName).ToArray());
+    }
+}
+
+#endregion
+
+#region sample_stream_state_optional
+
+public static class OptionalOrderTimelineHandler
+{
+    // Nullable annotation decides the default, exactly as it does for [ReadModel]:
+    // "StreamState state" is required and stops the handler when the stream does not exist,
+    // "StreamState? state" leaves absence to you
+    public static OrderTimeline Handle(OrderTimelineQuery query, [StreamState] StreamState? state)
+    {
+        return new OrderTimeline(state?.Version ?? 0, []);
     }
 }
 


### PR DESCRIPTION
`[StreamState]` and `[StreamEvents]` shipped in 6.30 with **no documentation anywhere** — nothing under `docs/guide` mentioned them. This fills that in.

## What's added

- **`docs/guide/handlers/persistence.md`** — a `### Raw Stream Reads` section under Event Sourced Models, which is where the store-agnostic vocabulary lives. Two new rows in the vocabulary table at the top.
- **`docs/guide/http/marten.md`** — a section next to `[ReadAggregate]`, reusing the `sample_using_streamstate_and_streamevents_in_http` region that already existed in `Orders.cs`.
- **`EventSourcedModelSamples.cs`** — three new worked samples.
- **`MartenTests/stream_state_and_events_handlers_3627.cs`** — message-handler coverage this path never had.

## The identity convention gets a callout

This is the part worth reviewing. `[Entity] Order order` can infer an identity member named `OrderId`, because the parameter's own type names your entity. The parameter type for these attributes is `StreamState` — the *store's* vocabulary, not your aggregate — so `tryFindIdentityVariable` looks for `"StreamStateId"`, and in practice only a member literally named `Id` resolves without help.

Verified rather than reasoned about. A handler taking `ProbeFindByOrderId(Guid OrderId)` with a bare `[StreamState]` fails at bootstrap:

```
Wolverine.Persistence.InvalidEntityLoadUsageException :: Unable to determine a value
variable named '' and source Anything to load an entity of type
JasperFx.Events.StreamState for parameter state
```

Fails fast rather than silently, which is the important part. (Minor observation, not addressed here: the message renders the variable name as empty quotes, so it does not name the member it looked for.)

## Why a test came with the docs

Only the HTTP path had coverage (`Wolverine.Http.Tests/Marten/stream_state_and_events_3627.cs`), and its endpoints use a `{id}` route argument — which happens to be exactly the case the convention handles. The handler path, where the convention bites, had none. The new test pins both the `Id` convention and the explicit `[StreamState("AggregateId")]` form.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings
- New MartenTests class — 2/2 passing
- `mdsnippets` run; unrelated pre-existing snippet drift in 84 other files was reverted rather than swept into this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)