### PR TITLE
GH-3519: isolate agent start failures so one wedged agent doesn't skip its siblings (5.x backport)

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/agent_start_isolation.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/agent_start_isolation.cs
@@ -1,0 +1,127 @@
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// Regression coverage for GH-3519. When a single agent cannot start during a Solo-mode
+/// assignment reevaluation (e.g. an event-subscription shard that loses a first-assignment
+/// startup race with high-water detection), that one failure must not skip the remaining,
+/// healthy sibling agents in the same family. Before the fix the family loop bailed on the
+/// first throw, so every agent after the wedged one stayed unstarted — reproduced in the wild
+/// as "two of three projection shards dead on that boot; only one ran."
+/// </summary>
+public class agent_start_isolation
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly CancellationTokenSource _cancellation = new();
+
+    public agent_start_isolation()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false; // skip MessageStoreCollection wiring
+        // Keep the recurring loop out of the way; the assertion is on the single startup pass.
+        _options.Durability.CheckAssignmentPeriod = 1.Hours();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+    }
+
+    [Fact]
+    public async Task one_failing_agent_does_not_prevent_its_siblings_from_starting()
+    {
+        var healthyBefore = new Uri("test-family://a");
+        var wedged = new Uri("test-family://b");
+        var healthyAfter = new Uri("test-family://c");
+
+        var family = new FakeAgentFamily("test-family");
+        family.Add(new FakeAgent(healthyBefore));
+        family.Add(new FakeAgent(wedged) { ThrowOnStart = true });
+        family.Add(new FakeAgent(healthyAfter));
+
+        var controller = new NodeAgentController(
+            _runtime,
+            Substitute.For<INodeAgentPersistence>(),
+            [family],
+            NullLogger<NodeAgentController>.Instance,
+            _cancellation.Token);
+
+        await controller.StartSoloModeAsync();
+        await _cancellation.CancelAsync();
+
+        // The agent listed before the wedged one starts (it always did), but critically the
+        // sibling listed AFTER the wedged one must also be started now.
+        controller.Agents.ContainsKey(healthyBefore).ShouldBeTrue();
+        controller.Agents.ContainsKey(healthyAfter).ShouldBeTrue(
+            "a sibling agent after the failing one must still be started (GH-3519)");
+
+        // The agent that could not start is not recorded as running, so it is retried next tick.
+        controller.Agents.ContainsKey(wedged).ShouldBeFalse();
+    }
+
+    private class FakeAgentFamily : IAgentFamily
+    {
+        private readonly Dictionary<Uri, FakeAgent> _agents = new();
+
+        public FakeAgentFamily(string scheme)
+        {
+            Scheme = scheme;
+        }
+
+        public void Add(FakeAgent agent) => _agents[agent.Uri] = agent;
+
+        public string Scheme { get; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => ValueTask.FromResult<IAgent>(_agents[uri]);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    private class FakeAgent : IAgent
+    {
+        public FakeAgent(Uri uri) => Uri = uri;
+
+        public bool ThrowOnStart { get; init; }
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (ThrowOnStart)
+            {
+                throw new Exception("Unable to start a subscription agent for " + Uri);
+            }
+
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Status = AgentStatus.Stopped;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.StartLocally.cs
@@ -70,19 +70,35 @@ public partial class NodeAgentController
     {
         foreach (var controller in _agentFamilies.Values)
         {
+            IReadOnlyList<Uri> allAgents;
             try
             {
-                var allAgents = await controller.AllKnownAgentsAsync();
-                foreach (var uri in allAgents)
-                {
-                    // This is idempotent, so call away!
-                    await StartAgentAsync(uri);
-                }
+                allAgents = await controller.AllKnownAgentsAsync();
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error trying to reevaluate agent assignments for '{Scheme}' agents",
                     controller.Scheme);
+                continue;
+            }
+
+            foreach (var uri in allAgents)
+            {
+                try
+                {
+                    // This is idempotent, so call away!
+                    await StartAgentAsync(uri);
+                }
+                catch (Exception e)
+                {
+                    // GH-3519: isolate each agent's start so a single agent that cannot start --
+                    // e.g. an event-subscription shard that loses a first-assignment startup race
+                    // with high-water detection -- does not skip the remaining, healthy sibling
+                    // agents in the same family for this reevaluation tick. The wedged agent is
+                    // still retried on the next tick; it just no longer takes its siblings down
+                    // with it.
+                    _logger.LogError(e, "Error trying to start agent {AgentUri}", uri);
+                }
             }
         }
     }


### PR DESCRIPTION
Backport of main's `cb72ca0ea` (#3535) to the 5.x maintenance line, following #4123.

## The bug

In `DurabilityMode.Solo`, `startAllAgentsAsync` iterated each family's agents and awaited `StartAgentAsync` per agent inside a **single per-family try/catch**. When one agent threw, the throw broke out of the family loop, so **every sibling listed after the wedged one was never started that tick** — and it repeated on every reevaluation. In the wild this showed up as "two of three projection shards dead on that boot; only one ran."

## The fix

Each agent's `StartAgentAsync` gets its own try/catch (log + continue), so one failing agent only blocks itself. The family-level catch is retained around `AllKnownAgentsAsync` itself, which now `continue`s to the next family. The wedged agent is still retried next tick.

## Why GH-3519's second commit is NOT here — please read

GH-3519 spans **two** commits on main, and only the first is safe to backport:

| commit | scope | portable to 5.x? |
|---|---|---|
| `cb72ca0ea` (#3535) | start-failure isolation — **this PR** | yes, applies cleanly |
| `e08abdeb3` (#3550) | restart a registered-but-stopped agent | **no — see below** |

`e08abdeb3` has two halves. The first changes `EventSubscriptionAgent.Status` to delegate to the live inner daemon agent; that type **does not exist on 5.x** (it arrived with the 6.x event-subscription agent family), so there is nothing to patch.

The second half replaces `StartAgentAsync`'s bare `Agents.ContainsKey` short-circuit with "restart it if its status is `Stopped`". That half *would* compile on 5.x — 5.x has the identical `ContainsKey` short-circuit — but it would be **actively harmful** here, because 5.x still carries the GH-3604 defect that main fixed in #3728:

```csharp
// 5.0 — ExclusiveListenerFamily.cs
public Task StartAsync(CancellationToken cancellationToken)
{
    return _runtime.Endpoints.StartListenerAsync(_endpoint, cancellationToken);
    // NOTE: Status is never reset to Running
}

public async Task StopAsync(CancellationToken cancellationToken)
{
    await _runtime.Endpoints.StopListenerAsync(_endpoint, cancellationToken);
    Status = AgentStatus.Stopped;
}
```

These families hand out **one cached agent instance per URI for the life of the runtime**, so any exclusive listener that has ever failed away from a node and come back is running normally while permanently reporting `Stopped`. A restart-if-`Stopped` rule would classify those healthy listeners as wedged and evict + stop + restart them **on every Solo reevaluation tick** — trading a rare wedge for continuous listener churn.

So `e08abdeb3` should only be considered for 5.x *after* GH-3604/#3728 is backported, if at all. Happy to do that pair as a follow-up if you want it.

## Testing

- New `agent_start_isolation` (ported unchanged from main — 5.x's `IAgent`/`IAgentFamily` signatures are identical). **Red baseline verified**: with the fix reverted it fails on `a sibling agent after the failing one must still be started (GH-3519)`, and passes once restored.
- Full CoreTests: **1692 passed, 0 failed** on net9.0.
- Full `wolverine.slnx` builds clean pinned to net9.0 (Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)