### PR TITLE
GH-4130: OutboxedSessionFactory resolves the Main message store lazily

### DIFF
--- a/src/Persistence/MartenTests/outboxed_session_factory_resolves_main_store_lazily.cs
+++ b/src/Persistence/MartenTests/outboxed_session_factory_resolves_main_store_lazily.cs
@@ -1,0 +1,105 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Marten.Publishing;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+
+namespace MartenTests;
+
+/// <summary>
+/// GH-4130. <c>OutboxedSessionFactory</c> used to capture <c>MessageStore = runtime.Storage</c> in its
+/// constructor. <c>IWolverineRuntime.Storage</c> is <c>Stores.Main</c>, which is the placeholder
+/// <see cref="NullMessageStore"/> until <c>MessageStoreCollection.InitializeAsync()</c> assigns the real
+/// one — and that assignment is deferred whenever more than one store claims
+/// <see cref="MessageStoreRole.Main"/> and <c>ResolveMainStoreOnConflict</c> (GH-3226) has to reconcile
+/// them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The shape that hits it is ordinary: an event-store-integrated Main plus a database-backed queue
+/// transport, which also claims Main. The factory kept the placeholder for the life of the process while
+/// <c>Stores.Main</c> read perfectly correct afterwards — so the host booted and listened cleanly, then
+/// failed every message and HTTP request with "This Wolverine application is not using Postgresql +
+/// Marten as the backing message persistence" (Polecat's twin says "requires a SQL Server-backed message
+/// store … was NullMessageStore").
+/// </para>
+/// <para>
+/// ⚠️ <b>Assert by opening a session, not by inspecting store roles.</b> The roles are correct — the
+/// reconciler does exactly what it is supposed to. A test that checks <c>Stores.Main</c>, or counts Main
+/// stores, passes on a host that fails 100% of its work.
+/// </para>
+/// </remarks>
+public class outboxed_session_factory_resolves_main_store_lazily : PostgresqlContext
+{
+    [Fact]
+    public async Task opens_a_session_when_main_was_settled_by_reconciliation()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                // Registered BEFORE Wolverine's own hosted service, so it runs before
+                // MessageStoreCollection.InitializeAsync(). This is not contrived: an integration that
+                // wires hosted services through opts.Services (CritterWatch does, and so does anything
+                // provisioning resources at startup) lands them ahead of Wolverine's in the collection.
+                services.AddHostedService<ResolvesTheSessionFactoryAtStartup>();
+            })
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Claimant one: the Postgres queue transport's own persistence, on its own schema.
+                opts.UsePostgresqlPersistenceAndTransport(
+                        Servers.PostgresConnectionString, "lazymain_q", "lazymain_q_queues")
+                    .AutoProvision();
+
+                // Claimant two: Marten's integrated store, on another.
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "lazymain";
+                    })
+                    .IntegrateWithWolverine(w => w.MessageStorageSchemaName = "lazymain_wolverine");
+
+                // Two Mains, so Wolverine defers the Main assignment to InitializeAsync and reconciles
+                // there. Without a resolver it simply throws, and the deferral never happens.
+                opts.Durability.ResolveMainStoreOnConflict = mains =>
+                    mains.FirstOrDefault(s => s.Uri.AbsolutePath.EndsWith("lazymain_q"));
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        // Reconciliation worked — this was never the broken part.
+        runtime.Stores.Main.ShouldNotBeOfType<NullMessageStore>();
+
+        // ...and the factory sees the same store, rather than the placeholder it was built alongside.
+        var factory = host.Services.GetRequiredService<OutboxedSessionFactory>();
+        using var session = factory.OpenSession(new MessageContext(runtime));
+
+        session.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// Forces the singleton <see cref="OutboxedSessionFactory"/> to be constructed while
+    /// <c>Stores.Main</c> is still the placeholder. Without this the factory is first resolved after
+    /// startup, when <c>runtime.Storage</c> already reads correctly — which is why the defect looked
+    /// intermittent and why store-role assertions never saw it.
+    /// </summary>
+    private sealed class ResolvesTheSessionFactoryAtStartup(IServiceProvider services) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            services.GetRequiredService<OutboxedSessionFactory>();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Persistence/PolecatTests/outboxed_session_factory_resolves_main_store_lazily.cs
+++ b/src/Persistence/PolecatTests/outboxed_session_factory_resolves_main_store_lazily.cs
@@ -1,0 +1,86 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Polecat;
+using Wolverine.Polecat.Publishing;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Xunit;
+
+namespace PolecatTests;
+
+/// <summary>
+/// GH-4130. The Polecat twin of <c>MartenTests.outboxed_session_factory_resolves_main_store_lazily</c> — see that
+/// test for the full rationale. <c>OutboxedSessionFactory</c> captured
+/// <c>MessageStore = runtime.Storage</c> in its constructor, and <c>runtime.Storage</c> is the
+/// placeholder <see cref="NullMessageStore"/> until <c>MessageStoreCollection.InitializeAsync()</c> runs
+/// — which is deferred whenever <c>ResolveMainStoreOnConflict</c> (GH-3226) has to reconcile competing
+/// Main claims, as it does for an event-store-integrated Main plus a database-backed queue transport.
+/// </summary>
+/// <remarks>
+/// Both providers carry the identical capture and the identical fix; both need the test, because the
+/// failure surfaces in provider-specific code (<c>resolveSqlServerMessageStore</c> here,
+/// <c>MartenEnvelopeTransaction</c>'s constructor there) and a shared assertion would not have caught a
+/// one-sided regression.
+/// </remarks>
+public class outboxed_session_factory_resolves_main_store_lazily
+{
+    [Fact]
+    public async Task opens_a_session_when_main_was_settled_by_reconciliation()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                // Registered BEFORE Wolverine's own hosted service, so it runs before
+                // MessageStoreCollection.InitializeAsync(). Not contrived: an integration that wires
+                // hosted services through opts.Services lands them ahead of Wolverine's.
+                services.AddHostedService<ResolvesTheSessionFactoryAtStartup>();
+            })
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Claimant one: the SQL Server queue transport's own persistence.
+                opts.UseSqlServerPersistenceAndTransport(
+                        Servers.SqlServerConnectionString, "lazymain_q", "lazymain_q_queues")
+                    .AutoProvision();
+
+                // Claimant two: Polecat's integrated store.
+                opts.Services.AddPolecat(m =>
+                    {
+                        m.ConnectionString = Servers.SqlServerConnectionString;
+                        m.DatabaseSchemaName = "lazymain";
+                    })
+                    .IntegrateWithWolverine(w => w.MessageStorageSchemaName = "lazymain_wolverine");
+
+                opts.Durability.ResolveMainStoreOnConflict = mains =>
+                    mains.FirstOrDefault(s => s.Uri.AbsolutePath.EndsWith("lazymain_q"));
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        runtime.Stores.Main.ShouldNotBeOfType<NullMessageStore>();
+
+        var factory = host.Services.GetRequiredService<OutboxedSessionFactory>();
+        await using var session = factory.OpenSession(new MessageContext(runtime));
+
+        session.ShouldNotBeNull();
+    }
+
+    private sealed class ResolvesTheSessionFactoryAtStartup(IServiceProvider services) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            services.GetRequiredService<OutboxedSessionFactory>();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/Publishing/OutboxedSessionFactory.cs
+++ b/src/Persistence/Wolverine.Marten/Publishing/OutboxedSessionFactory.cs
@@ -44,6 +44,8 @@ public class OutboxedSessionFactory
     private readonly IDocumentStore _store;
     private readonly bool _shouldPublishEvents;
     private readonly bool _shouldTrackAppends;
+    private readonly IWolverineRuntime _runtime;
+    private IMessageStore? _messageStore;
 
     private readonly Func<MessageContext, IDocumentSession> _builder;
 
@@ -55,7 +57,7 @@ public class OutboxedSessionFactory
         _shouldPublishEvents = runtime.TryFindExtension<MartenIntegration>()?.UseFastEventForwarding ?? false;
         _shouldTrackAppends = runtime.Options.Tracking.EnableEventAppendTracking;
 
-        MessageStore = runtime.Storage;
+        _runtime = runtime;
         
         if (factory is SessionFactoryBase factoryBase)
         {
@@ -83,7 +85,29 @@ public class OutboxedSessionFactory
         }
     }
     
-    internal IMessageStore MessageStore { get; set; }
+    /// <summary>
+    /// The message store this factory enlists sessions in. Defaults to the runtime's <b>Main</b> store,
+    /// resolved on every read rather than captured in the constructor; an ancillary-store subclass
+    /// (<c>OutboxedSessionFactory&lt;T&gt;</c>) assigns a fixed store and that assignment wins.
+    /// </summary>
+    /// <remarks>
+    /// ⚠️ <b>GH-4130. Do not go back to <c>MessageStore = runtime.Storage</c> in the constructor.</b>
+    /// <c>IWolverineRuntime.Storage</c> is <c>Stores.Main</c>, which is the placeholder
+    /// <see cref="NullMessageStore"/> until <c>MessageStoreCollection.InitializeAsync()</c> assigns the
+    /// real one — and that assignment is deferred whenever more than one store claims
+    /// <see cref="MessageStoreRole.Main"/> and <c>DurabilitySettings.ResolveMainStoreOnConflict</c> has to
+    /// reconcile them (GH-3226). A database-backed queue transport alongside an event-store-integrated
+    /// Main is exactly that shape. Capturing early left this factory holding the placeholder for the life
+    /// of the process while <c>Stores.Main</c> read perfectly correct afterwards, so the host booted and
+    /// listened cleanly and then failed EVERY message and HTTP request with "requires a SQL Server-backed
+    /// message store / is not using Postgresql + Marten as the backing message persistence". Nothing
+    /// pointed at the store roles, which were right the whole time.
+    /// </remarks>
+    internal IMessageStore MessageStore
+    {
+        get => _messageStore ?? _runtime.Storage;
+        set => _messageStore = value;
+    }
 
     /// <summary>Build new instances of IQuerySession on demand</summary>
     /// <returns></returns>

--- a/src/Persistence/Wolverine.Polecat/Publishing/OutboxedSessionFactory.cs
+++ b/src/Persistence/Wolverine.Polecat/Publishing/OutboxedSessionFactory.cs
@@ -14,6 +14,8 @@ public class OutboxedSessionFactory
     private readonly IDocumentStore _store;
     private readonly bool _shouldPublishEvents;
     private readonly bool _shouldTrackAppends;
+    private readonly IWolverineRuntime _runtime;
+    private IMessageStore? _messageStore;
 
     public OutboxedSessionFactory(ISessionFactory factory, IWolverineRuntime runtime, IDocumentStore store)
     {
@@ -23,10 +25,32 @@ public class OutboxedSessionFactory
         _shouldPublishEvents = runtime.TryFindExtension<PolecatIntegration>()?.UseFastEventForwarding ?? false;
         _shouldTrackAppends = runtime.Options.Tracking.EnableEventAppendTracking;
 
-        MessageStore = runtime.Storage;
+        _runtime = runtime;
     }
 
-    internal IMessageStore MessageStore { get; set; }
+    /// <summary>
+    /// The message store this factory enlists sessions in. Defaults to the runtime's <b>Main</b> store,
+    /// resolved on every read rather than captured in the constructor; an ancillary-store subclass
+    /// (<c>OutboxedSessionFactory&lt;T&gt;</c>) assigns a fixed store and that assignment wins.
+    /// </summary>
+    /// <remarks>
+    /// ⚠️ <b>GH-4130. Do not go back to <c>MessageStore = runtime.Storage</c> in the constructor.</b>
+    /// <c>IWolverineRuntime.Storage</c> is <c>Stores.Main</c>, which is the placeholder
+    /// <see cref="NullMessageStore"/> until <c>MessageStoreCollection.InitializeAsync()</c> assigns the
+    /// real one — and that assignment is deferred whenever more than one store claims
+    /// <see cref="MessageStoreRole.Main"/> and <c>DurabilitySettings.ResolveMainStoreOnConflict</c> has to
+    /// reconcile them (GH-3226). A database-backed queue transport alongside an event-store-integrated
+    /// Main is exactly that shape. Capturing early left this factory holding the placeholder for the life
+    /// of the process while <c>Stores.Main</c> read perfectly correct afterwards, so the host booted and
+    /// listened cleanly and then failed EVERY message and HTTP request with "requires a SQL Server-backed
+    /// message store / is not using Postgresql + Marten as the backing message persistence". Nothing
+    /// pointed at the store roles, which were right the whole time.
+    /// </remarks>
+    internal IMessageStore MessageStore
+    {
+        get => _messageStore ?? _runtime.Storage;
+        set => _messageStore = value;
+    }
 
     /// <summary>Build new instances of IQuerySession on demand</summary>
     public IQuerySession QuerySession(MessageContext context)


### PR DESCRIPTION
Fixes #4130.

`OutboxedSessionFactory` — in both `Wolverine.Marten` and `Wolverine.Polecat` — captured the Main message store in its constructor:

```csharp
MessageStore = runtime.Storage;
```

`IWolverineRuntime.Storage` is `Stores.Main`, which is the placeholder `NullMessageStore` until `MessageStoreCollection.InitializeAsync()` assigns the real one — and that assignment is **deferred whenever more than one store claims `MessageStoreRole.Main`** and `ResolveMainStoreOnConflict` (GH-3226) has to reconcile them.

So a factory constructed during startup kept the placeholder for the life of the process, while `Stores.Main` read perfectly correct afterwards. The host booted and listened cleanly, then failed **every** message and HTTP request:

```
System.InvalidOperationException: Wolverine.Polecat requires a SQL Server-backed message store.
The configured store was Wolverine.Persistence.Durability.NullMessageStore.
```

The reproducing shape is ordinary — an event-store-integrated Main plus a **database-backed queue transport**, which also claims Main. That is the whole broker-less deployment mode. Found in [CritterWatch#1130](https://github.com/JasperFx/CritterWatch/issues/1130), where it broke it on both store flavours.

## The change

`MessageStore` now defaults to a lazy read of `runtime.Storage`, keeping the setter so `OutboxedSessionFactory<T>`'s ancillary assignment (`runtime.FindAncillaryStoreForMarkerType`) still wins:

```csharp
internal IMessageStore MessageStore
{
    get => _messageStore ?? _runtime.Storage;
    set => _messageStore = value;
}
```

## Tests

One in each of `MartenTests` and `PolecatTests`. Two things about them worth reviewing:

**They assert by opening a session, not by inspecting store roles.** The roles are *correct* — the reconciler does exactly what it should. Every existing test in this area checks `Stores.Main` or counts Mains, and those assertions pass on a host that fails 100% of its work. That is why this reached a release.

**They force the factory to be constructed during startup**, via a hosted service registered ahead of Wolverine's. Without that the test passes even with the bug restored, because a factory first resolved after `StartAsync` reads a `runtime.Storage` that is already correct — which is also why the defect looked environment-dependent. Not contrived: an integration that wires hosted services through `opts.Services` lands them ahead of Wolverine's in the collection.

Both A/B-verified red-then-green. Full `PolecatTests` (289 passed) and full `MartenTests` (620 passed) clean with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mpctjngqnraWVnDaqWtYf
