### PR TITLE
GH-4132/4128/4129/4127: describe-routing NRE, duplicated EF Core eager check, and two docs scoping fixes

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -192,13 +192,20 @@ Two things follow, and both matter more than the headline percentage:
   already running, so nothing runs twice. The prefetch window is still redelivered — it simply had not been
   executed yet, so those are first executions.
 * **A hard kill costs about one duplicate per busy lane, not one per unacked message.** Only handlers that
-  were *mid-flight* when the connection died can run twice, and that population is the partition slot count,
-  not the prefetch depth. In the runs above that was three or four per killed node against an unacked window
-  of 180 — a factor of roughly 45, and it barely moved between runs.
+  were *mid-flight* when the connection died can run twice, and that population is the number of lanes the
+  endpoint runs, not the prefetch depth. On the group-partitioned endpoint measured here that is the partition
+  slot count: three or four duplicates per killed node against an unacked window of 180 — a factor of roughly
+  45, and it barely moved between runs. On an **unpartitioned** `NativeAck` endpoint there are no slots, and
+  the ceiling is `MaximumParallelMessages()` instead.
 
-None of this weakens the guarantee. Every duplicate still enters its group's sequential lane, so a duplicate
-never runs concurrently with the original, and the intra-group concurrency invariant held across every kill
-and every handoff in all of the runs above. Handlers must still be idempotent — at-least-once is the contract,
+On a **group-partitioned** endpoint, none of this weakens the guarantee: every duplicate re-enters its group's
+sequential lane, so a duplicate never runs concurrently with the original, and the intra-group concurrency
+invariant held across every kill and every handoff in all of the runs above. That is a property of group
+partitioning rather than of `NativeAck` itself — an **unpartitioned** `NativeAck` endpoint has no such lanes,
+and a redelivery can and will run alongside the original. Group partitioning is opt-in via
+[`PartitionProcessingByGroupId()`](/guide/messaging/partitioning); it is never on by default.
+
+Handlers must still be idempotent either way — at-least-once is the contract,
 and 0.1% of a flood is not a small number of messages — but size that work against in-flight lanes rather than
 against prefetch. The [in-memory idempotency guard](#in-memory-idempotency-guard) below removes the remainder
 within a *running* process; it cannot help across a node's death, because the guard dies with it.

--- a/docs/tutorials/idempotency.md
+++ b/docs/tutorials/idempotency.md
@@ -92,14 +92,16 @@ Idempotency checking within message handlers executing within `Buffered` or more
 you to "opt in." First though, the idempotency check in this case can be done in one of two modes:
 
 1. `Eager` -- just means that Wolverine will apply some middleware around the handler such that it will make an early database call to try to insert a skeleton placeholder in the transactional inbox storage
-2. `Optmistic` -- Wolverine will try to insert the skeleton message information as part of the message handling transaction to try to avoid extra database round trips
+2. `Optimistic` -- Wolverine would try to insert the skeleton message information as part of the message handling transaction to try to avoid extra database round trips
 
-To be honest, the EF Core integration will always use the `Eager` approach no matter what. Marten supports both modes, and the `Optimistic`
-approach may be valuable if all the activity of your message handler is in changes to that same database so everything can still be 
-rolled back by the idempotency check failing. 
+`Optimistic` was the more optimal of the two on paper, but as the warning above says, it is **not currently reachable**. Every
+provider -- EF Core, Marten, Polecat, and Fisher alike -- emits the `Eager` check for any handler configured with either style,
+so `IdempotencyStyle.Optimistic` behaves exactly like `IdempotencyStyle.Eager` at runtime. Treat the two as one option until
+that changes; nothing in your code has to change if it does.
 
-For another example, if your message handler involves a web service call to an external system or really any kind of action
-that potentially makes state changes outside of the current transaction, you have to use the `Eager` mode.
+`Eager` is also the mode you actually want in most cases: if your message handler involves a web service call to an external
+system or really any kind of action that potentially makes state changes outside of the current transaction, the check has to
+happen before the handler runs.
 
 With all of that being said, you can either opt into the idempotency checks one at a time with an overload of the `[Transactional]`
 attribute like this:

--- a/src/Persistence/EfCoreTests/eager_idempotency_emitted_once_4128.cs
+++ b/src/Persistence/EfCoreTests/eager_idempotency_emitted_once_4128.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Persistence;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace EfCoreTests;
+
+// GH-4128: StartDatabaseTransactionForDbContext -- the multi-tenanted counterpart to
+// EnrollDbContextInTransaction -- emitted the eager idempotency check twice under identical
+// guards, once above and once below the BeginTransactionAsync block. On the paths where
+// AssertEagerIdempotencyAsync falls through to Runtime.Storage.Inbox.ExistsAsync (which does not
+// set Envelope.WasPersistedInInbox), that meant two identical inbox existence queries per message.
+public class eager_idempotency_emitted_once_4128
+{
+    [Theory]
+    [InlineData(IdempotencyStyle.Eager)]
+    [InlineData(IdempotencyStyle.Optimistic)]
+    public void emits_the_eager_check_exactly_once_and_after_the_transaction_starts(IdempotencyStyle style)
+    {
+        var code = generate(style);
+
+        countOf(code, nameof(MessageContext.AssertEagerIdempotencyAsync)).ShouldBe(1);
+
+        // ...and it lands after BeginTransactionAsync, matching EnrollDbContextInTransaction
+        code.IndexOf(nameof(MessageContext.AssertEagerIdempotencyAsync), StringComparison.Ordinal)
+            .ShouldBeGreaterThan(code.IndexOf("BeginTransactionAsync", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void emits_no_check_at_all_for_none()
+    {
+        generate(IdempotencyStyle.None)
+            .ShouldNotContain(nameof(MessageContext.AssertEagerIdempotencyAsync));
+    }
+
+    private static string generate(IdempotencyStyle style)
+    {
+        var frame = new StartDatabaseTransactionForDbContext(typeof(LookupDbContext), style);
+
+        var variables = new StubMethodVariables();
+        variables.Store(new Variable(typeof(MessageContext), "context"));
+        variables.Store(new Variable(typeof(LookupDbContext), "dbContext"));
+        variables.Store(new Variable(typeof(CancellationToken), "cancellation"));
+
+        frame.FindVariables(variables).ToList();
+
+        using var writer = new SourceWriter();
+        frame.GenerateCode(null!, writer);
+        return writer.Code();
+    }
+
+    private static int countOf(string code, string token)
+    {
+        var count = 0;
+        var index = code.IndexOf(token, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = code.IndexOf(token, index + token.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+
+    private sealed class StubMethodVariables : IMethodVariables
+    {
+        private readonly Dictionary<Type, Variable> _byType = new();
+
+        public Variable FindVariable(Type type) => _byType[type];
+
+        public Variable FindVariable(ParameterInfo parameter) => FindVariable(parameter.ParameterType);
+
+        public Variable FindVariableByName(Type dependency, string name)
+        {
+            if (TryFindVariableByName(dependency, name, out var v)) return v;
+            throw new InvalidOperationException($"No known variable for {dependency} named {name}");
+        }
+
+        public bool TryFindVariableByName(Type dependency, string name, out Variable variable)
+        {
+            variable = _byType.Values.FirstOrDefault(x => x.Usage == name && x.VariableType == dependency)!;
+            return variable != null;
+        }
+
+        public Variable? TryFindVariable(Type type, VariableSource source)
+            => _byType.TryGetValue(type, out var v) ? v : null;
+
+        public void Store(Variable variable) => _byType[variable.VariableType] = variable;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/StartDatabaseTransactionForDbContext.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/StartDatabaseTransactionForDbContext.cs
@@ -33,17 +33,15 @@ internal class StartDatabaseTransactionForDbContext : AsyncFrame
     {
         writer.Write("BLOCK:try");
 
-        // EF Core can only do eager idempotent checks
-        if (_idempotencyStyle == IdempotencyStyle.Eager || _idempotencyStyle == IdempotencyStyle.Optimistic)
-        {
-            writer.Write($"await {_context!.Usage}.{nameof(MessageContext.AssertEagerIdempotencyAsync)}({_cancellation.Usage}).ConfigureAwait(false);");
-        }
-
         writer.Write($"BLOCK:if ({_dbContext.Usage}.Database.CurrentTransaction == null)");
         writer.Write($"await {_dbContext.Usage}.Database.BeginTransactionAsync({_cancellation.Usage}).ConfigureAwait(false);");
         writer.FinishBlock();
 
-        // EF Core can only do eager idempotent checks
+        // EF Core can only do eager idempotent checks. GH-4128: this is emitted exactly once, and
+        // after the transaction is opened, matching the single-DbContext sibling
+        // EnrollDbContextInTransaction. A second copy above the BeginTransactionAsync block used to
+        // run the same inbox existence query twice per message on the paths where
+        // AssertEagerIdempotencyAsync does not set Envelope.WasPersistedInInbox.
         if (_idempotencyStyle == IdempotencyStyle.Eager || _idempotencyStyle == IdempotencyStyle.Optimistic)
         {
             writer.Write($"await {_context!.Usage}.{nameof(MessageContext.AssertEagerIdempotencyAsync)}({_cancellation.Usage}).ConfigureAwait(false);");

--- a/src/Testing/CoreTests/Runtime/Routing/describing_a_route_without_a_serializer_4132.cs
+++ b/src/Testing/CoreTests/Runtime/Routing/describing_a_route_without_a_serializer_4132.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.ComplianceTests.Compliance;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Runtime.Routing;
+using Wolverine.Tracking;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace CoreTests.Runtime.Routing;
+
+// GH-4132. Endpoint.Compile() is what assigns DefaultSerializer, and the MessageRoute constructor
+// only demands a serializer when it is *not* running under WolverineSystemPart.WithinDescription --
+// the description path deliberately takes the null-forgiving branch so that diagnostics can describe
+// a topology without forcing sending agents into existence. That leaves Serializer null on any route
+// built during description against an endpoint the runtime never compiled, and Describe() then blew
+// up with a NullReferenceException -- taking out `describe-routing` for the whole application, not
+// just the offending route. WolverineDiagnosticsCommand already null-guards route.Serializer when it
+// reads content types directly; Describe() now agrees with it.
+public class describing_a_route_without_a_serializer_4132
+{
+    [Fact]
+    public async Task describe_falls_back_to_the_default_content_type()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.GetRuntime();
+
+        // Never handed to a transport, so Compile() never ran and DefaultSerializer is null
+        var uncompiled = new LocalQueue("never-compiled-4132");
+        uncompiled.DefaultSerializer.ShouldBeNull();
+
+        WolverineSystemPart.WithinDescription = true;
+        try
+        {
+            var route = MessageRoute.For(typeof(Message1), uncompiled, runtime);
+            route.Serializer.ShouldBeNull();
+
+            var descriptor = route.Describe();
+
+            descriptor.Endpoint.ShouldBe(uncompiled.Uri);
+            descriptor.ContentType.ShouldBe("application/json");
+        }
+        finally
+        {
+            WolverineSystemPart.WithinDescription = false;
+        }
+    }
+
+    [Fact]
+    public async Task a_globally_partitioned_route_describes_all_of_its_slots()
+    {
+        // The reported stack came through GlobalPartitionedRoute.Describe(), which maps over every
+        // slot route -- so one uncompiled slot took down the whole topology's description.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.GetRuntime();
+
+        WolverineSystemPart.WithinDescription = true;
+        try
+        {
+            var slots = new IMessageRoute[]
+            {
+                MessageRoute.For(typeof(Message1), new LocalQueue("slot-one-4132"), runtime),
+                MessageRoute.For(typeof(Message1), new LocalQueue("slot-two-4132"), runtime)
+            };
+
+            var route = new GlobalPartitionedRoute(new Uri("shard://local/slots-4132"),
+                runtime.Options.MessagePartitioning, slots, [], [], nativeAcks: true);
+
+            var descriptor = route.Describe();
+
+            descriptor.Description.ShouldBe("Global Partitioned");
+            descriptor.Partitions.Length.ShouldBe(2);
+            descriptor.Partitions.All(x => x.ContentType == "application/json").ShouldBeTrue();
+        }
+        finally
+        {
+            WolverineSystemPart.WithinDescription = false;
+        }
+    }
+}

--- a/src/Wolverine/Persistence/IdempotencyStyle.cs
+++ b/src/Wolverine/Persistence/IdempotencyStyle.cs
@@ -9,11 +9,15 @@ public enum IdempotencyStyle
     None,
     
     /// <summary>
-    /// Message idempotency will be checked at the time the current transaction
+    /// Message idempotency would be checked at the time the current transaction
     /// is being committed. This mode is a little more optimal as it allows for more database command batching,
     /// but should not be used if the message handling involves any actions not part of the current transaction
     /// like calls to external web services
-    /// 
+    ///
+    /// NOT CURRENTLY REACHABLE. As of 5.4.1 every persistence provider -- EF Core, Marten, Polecat and Fisher --
+    /// emits the <see cref="Eager" /> check for this style as well, so choosing Optimistic behaves exactly like
+    /// choosing Eager at runtime. Reserved rather than removed so that existing configuration keeps compiling.
+    ///
     /// Only applies to messages received at "Inline" or "Buffered" endpoints
     /// </summary>
     Optimistic,

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -204,7 +204,12 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
     {
         return new MessageSubscriptionDescriptor
         {
-            ContentType = Serializer.ContentType,
+            // GH-4132: Serializer is only guaranteed non-null when this route was built outside of
+            // description mode -- the constructor's WithinDescription branch deliberately accepts a
+            // null DefaultSerializer from an endpoint the runtime never compiled. Describing a
+            // topology must not be the thing that throws, so fall back the same way
+            // WolverineDiagnosticsCommand does when it reads Serializer directly.
+            ContentType = Serializer?.ContentType ?? _endpoint.DefaultSerializer?.ContentType ?? "application/json",
             Endpoint = _endpoint.Uri
         };
     }


### PR DESCRIPTION
Four small, independent items off the recent issue queue.

## GH-4132 — `describe-routing` throws a NullReferenceException

`Endpoint.Compile()` is what assigns `DefaultSerializer`, and the `MessageRoute` constructor's `WolverineSystemPart.WithinDescription` branch deliberately takes the null-forgiving path rather than forcing sending agents into existence. So a route built during description against an endpoint the runtime never compiled has a genuinely-null `Serializer`, and `MessageRoute.Describe()` dereferenced it.

Because `GlobalPartitionedRoute.Describe()` maps over every slot, one such route took out `wolverine-diagnostics describe-routing` for the entire application — the diagnostic you reach for *because* the topology is hard to reason about.

`WolverineDiagnosticsCommand` already null-guards `route.Serializer` where it reads the content type directly (`WolverineDiagnosticsCommand.cs:567`); `Describe()` now agrees with it, falling back to the endpoint's default serializer and then to `application/json`.

**Note on the issue's stated cause:** the issue attributes this to a second `MessageRoute` constructor that leaves `Serializer` unset. There is only one constructor on `main`, and the reporter's exact topology (`ProcessInParallelWithNativeAcks()` + `UseShardedRabbitQueues`, against a live broker) does **not** reproduce — those slot endpoints are registered in the transport's queue collection and do get compiled. The NRE is real and reproduces deterministically against any uncompiled endpoint in description mode, which is what the regression test pins; whatever produces an uncompiled endpoint in the reporter's app is still unidentified.

## GH-4128 — EF Core multi-tenanted middleware emits the eager check twice

`StartDatabaseTransactionForDbContext` emitted `AssertEagerIdempotencyAsync` twice under identical guards, once above and once below the `BeginTransactionAsync` block. Where `AssertEagerIdempotencyAsync` falls through to `Runtime.Storage.Inbox.ExistsAsync` — which does not set `Envelope.WasPersistedInInbox` — that is two identical inbox existence queries per message.

The surviving call is the one *after* the transaction opens, matching the single-DbContext sibling `EnrollDbContextInTransaction`. The regression test was confirmed red against the pre-fix frame (counted 2) and green after.

## GH-4129 — `tutorials/idempotency.md` contradicted itself on `Optimistic`

The warning box said every explicit idempotency usage outside a durable listener falls back to `Eager`; the prose a few lines below said "Marten supports both modes" and recommended tuning toward `Optimistic`.

The warning is the accurate one. Marten, Polecat and Fisher all gate on `_chain.Idempotency != IdempotencyStyle.None` and emit the eager check; EF Core gates on `Eager || Optimistic` and does the same. `Optimistic` is unreachable in every provider. Stated once in the prose and mirrored onto the `IdempotencyStyle.Optimistic` XML doc, which still described a live choice.

The enum member is documented as reserved rather than marked `[Obsolete]` — that is a public-API call worth making deliberately, so it is left out of this PR.

## GH-4127 — the NativeAck duplicate-concurrency guarantee was stated unconditionally

`listeners.md` presented "a duplicate never runs concurrently with the original" as a property of `EndpointMode.NativeAck`. It is a property of **group partitioning**, which is opt-in via `PartitionProcessingByGroupId()` and never on by default. An unpartitioned `NativeAck` endpoint has no group lanes; a redelivery can run alongside the original, bounded by `MaximumParallelMessages()`.

Scoped both the guarantee and the #3713 measurements that inherit it (the harness was group-partitioned across five slots, which is *why* the hard-kill bound is 3–4 rather than the prefetch depth). The same edit is made to the 6.30 release blog draft locally, but that file is untracked on `main` so it is not part of this commit.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings.
- `CoreTests.Runtime.Routing` + `CoreTests.Runtime.Partitioning` — 146 passed.
- New `eager_idempotency_emitted_once_4128` — 3 passed; verified red against the pre-fix frame.

Closes #4132
Closes #4128
Closes #4129
Closes #4127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3