### PR TITLE
GH-4139: OnException return values no longer collide with the message body variable (CS0136)

### DIFF
--- a/src/Testing/CoreTests/Acceptance/on_exception_cascade_name_collision.cs
+++ b/src/Testing/CoreTests/Acceptance/on_exception_cascade_name_collision.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+// The catch block an OnException middleware generates is emitted *inside* the scope that already
+// declares the chain's message body variable, and both names are derived from their type. So when an
+// OnException returns the same type a chain handles, the generated handler declared
+//
+//     var collidingCascade = (CollidingCascade)context.Envelope.Message;
+//     try { ... }
+//     catch (CollisionException e) { var collidingCascade = middleware.OnException(e); ... }
+//
+// and failed to compile with CS0136. The handler for that message type then never ran at all.
+//
+// This was silent because the cascading message is still *sent* -- only its execution is missing --
+// so the existing coverage, which asserts on session.Sent, stayed green. This test asserts the
+// cascaded message is actually HANDLED.
+public class on_exception_cascade_name_collision
+{
+    [Fact]
+    public async Task cascaded_message_of_the_same_type_as_a_chain_is_handled()
+    {
+        var recorder = new CollisionRecorder();
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton(recorder);
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(CollisionTriggerHandler))
+                    .IncludeType(typeof(CollidingCascadeHandler));
+                opts.Policies.AddMiddleware(typeof(CollidingCascadeMiddleware));
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new CollisionTrigger("go"));
+
+        // Before the fix the CollidingCascade chain failed to compile at runtime, so this never ran
+        recorder.Handled.ShouldContain("cascaded:go");
+    }
+}
+
+public class CollisionRecorder
+{
+    public List<string> Handled { get; } = new();
+}
+
+public class CollisionException : Exception
+{
+    public CollisionException(string message) : base(message)
+    {
+    }
+}
+
+public record CollisionTrigger(string Text);
+
+public record CollidingCascade(string Text);
+
+public static class CollisionTriggerHandler
+{
+    public static void Handle(CollisionTrigger message)
+    {
+        throw new CollisionException(message.Text);
+    }
+}
+
+public static class CollidingCascadeHandler
+{
+    public static void Handle(CollidingCascade message, CollisionRecorder recorder)
+    {
+        recorder.Handled.Add(message.Text);
+    }
+}
+
+public static class CollidingCascadeMiddleware
+{
+    // Returns the very type CollidingCascadeHandler handles -- that is the collision
+    public static CollidingCascade OnException(CollisionException ex)
+    {
+        return new CollidingCascade($"cascaded:{ex.Message}");
+    }
+}

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -398,6 +398,7 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
                 var exceptionType = parameters[0].ParameterType;
                 var call = new MethodCall(handlerType, onException);
                 ApplyParameterMatching(call);
+                MiddlewarePolicy.DisambiguateOnExceptionReturnValue(call);
 
                 var frames = new List<Frame> { call };
 

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -111,6 +111,32 @@ public class MiddlewarePolicy : IChainPolicy
         ApplyExceptionHandling(applications, rules, chain);
     }
 
+    /// <summary>
+    /// Give an OnException method's return value a name that cannot collide with the enclosing scope.
+    /// The catch block is emitted *inside* the scope that already declares the chain's message body
+    /// variable, and both names are derived from their type -- so an OnException that returns the same
+    /// type the chain handles produced two locals called e.g. "cascadedFromOnException" nested one
+    /// inside the other, and the generated handler failed to compile with CS0136. The handler then
+    /// never ran, which is silent: the cascading message is still *sent*, so anything asserting on
+    /// sent messages rather than executed ones stayed green.
+    /// </summary>
+    internal static void DisambiguateOnExceptionReturnValue(MethodCall call)
+    {
+        var returnVariable = call.ReturnVariable;
+        if (returnVariable == null)
+        {
+            return;
+        }
+
+        var usage = returnVariable.Usage;
+        if (usage.IsEmpty())
+        {
+            return;
+        }
+
+        returnVariable.OverrideName($"onException{char.ToUpperInvariant(usage[0])}{usage[1..]}");
+    }
+
     internal static void ApplyExceptionHandling(List<Application> applications, GenerationRules rules, IChain chain)
     {
         var exceptionHandlers = applications
@@ -427,6 +453,7 @@ public class MiddlewarePolicy : IChainPolicy
                 var exceptionType = parameters[0].ParameterType;
                 var call = new MethodCall(MiddlewareType, method);
                 chain.ApplyParameterMatching(call);
+                DisambiguateOnExceptionReturnValue(call);
                 yield return (exceptionType, call);
             }
         }


### PR DESCRIPTION
Closes #4139. Independent of the other two PRs from this thread (#4137, #4138) — targets `main` directly.

## The bug

An `OnException` method's return value takes its default variable name from its type, and so does a chain's message body variable. The catch block is emitted *inside* the scope that declares the body variable, so an `OnException` returning the same type a chain handles generates:

```csharp
var collidingCascade = (CollidingCascade)context.Envelope.Message;
try { ... }
catch (CollisionException e)
{
    var collidingCascade = middleware.OnException(e);   // CS0136
    await context.EnqueueCascadingAsync(collidingCascade);
}
```

That chain's handler fails to compile at runtime, so **it never runs at all**.

## Why nobody noticed

Silent from two directions:

1. The cascading message is still **sent** — only its execution is missing. `CoreTests.Acceptance.on_exception_convention` covers exactly this feature and was green because both tests assert on `session.Sent.SingleEnvelope<CascadedFromOnException>()` and on the *first* handler's recorder. Neither requires `CascadedFromOnExceptionHandler` to run.
2. Both tests also use `DoNotAssertOnExceptionsDetected()`, which until #4125 suppressed the session timeout that would otherwise have exposed it.

## The fix

`MiddlewarePolicy.DisambiguateOnExceptionReturnValue` renames the return variable to `onException` + its default name, applied at both construction sites — `Application.BuildOnExceptionCalls` for middleware types and the handler-type `OnException` loop in `Chain.cs`.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings.
- New `on_exception_cascade_name_collision` asserts the cascaded message is actually **handled**, not merely sent. Confirmed **red on `main`** (test fails) and green with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3