### PR TITLE
GH-4135: report Received exactly once per receipt

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/duplicate_received_with_partitioning_4135.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/duplicate_received_with_partitioning_4135.cs
@@ -60,8 +60,13 @@ public class duplicate_received_with_partitioning_4135 : IAsyncLifetime
             .Where(x => x.Envelope?.Message is DupProbe)
             .ToArray();
 
-        records.Count(x => x.MessageEventType == MessageEventType.ExecutionStarted).ShouldBe(1);
-        records.Count(x => x.MessageEventType == MessageEventType.Received).ShouldBe(1);
+        var dump = string.Join("\n  ", records.Select(x =>
+            $"{x.MessageEventType} seq={x.Sequence} svc={x.ServiceName} node={x.UniqueNodeId} env={x.Envelope?.Id} attempts={x.AttemptNumber}"));
+
+        records.Count(x => x.MessageEventType == MessageEventType.ExecutionStarted)
+            .ShouldBe(1, "records were:\n  " + dump);
+        records.Count(x => x.MessageEventType == MessageEventType.Received)
+            .ShouldBe(1, "records were:\n  " + dump);
 
         session.Received.SingleMessage<DupProbe>().Name.ShouldBe("only-once");
     }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/duplicate_received_with_partitioning_4135.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/duplicate_received_with_partitioning_4135.cs
@@ -1,0 +1,77 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+// GH-4135. A listener with PartitionProcessingByGroupId recorded TWO Received events for one
+// envelope while executing it exactly once, because ShardedExecutionBlock pre-deserializes through
+// HandlerPipeline.TryDeserializeEnvelope -- whose finally block records Received -- and the envelope
+// then reaches executeAsync already carrying a Message, taking the branch that records Received
+// again. Beyond turning Received.SingleMessage<T>() red against correct behaviour, that
+// double-counted the received metric and double-logged every receipt on any partitioned listener.
+public class duplicate_received_with_partitioning_4135 : IAsyncLifetime
+{
+    private IHost _sender = null!;
+    private IHost _receiver = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _receiver = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Receiver";
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+                opts.ListenToRabbitQueue("dup_received_4135")
+                    .BufferedInMemory()
+                    .PartitionProcessingByGroupId(PartitionSlots.Five);
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(DupProbeHandler));
+            }).StartAsync();
+
+        _sender = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Sender";
+                opts.UseRabbitMq().AutoProvision();
+                opts.PublishAllMessages().ToRabbitQueue("dup_received_4135");
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _sender.StopAsync();
+        await _receiver.StopAsync();
+    }
+
+    [Fact]
+    public async Task records_exactly_one_received_per_envelope()
+    {
+        var session = await _sender.TrackActivity()
+            .AlsoTrack(_receiver)
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(new DupProbe("only-once"));
+
+        var records = session.AllRecordsInOrder()
+            .Where(x => x.Envelope?.Message is DupProbe)
+            .ToArray();
+
+        records.Count(x => x.MessageEventType == MessageEventType.ExecutionStarted).ShouldBe(1);
+        records.Count(x => x.MessageEventType == MessageEventType.Received).ShouldBe(1);
+
+        session.Received.SingleMessage<DupProbe>().Name.ShouldBe("only-once");
+    }
+}
+
+public record DupProbe(string Name);
+
+public static class DupProbeHandler
+{
+    public static void Handle(DupProbe message)
+    {
+    }
+}

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -55,6 +55,18 @@ public partial class Envelope
     [JsonIgnore]
     public bool WasPersistedInInbox { get; set; }
 
+    /// <summary>
+    /// GH-4135. Guards against reporting IMessageTracker.Received more than once for a single
+    /// receipt. Partitioned processing deserializes an envelope up front -- through
+    /// HandlerPipeline.TryDeserializeEnvelope, so it can read the group id off the message -- and the
+    /// envelope then arrives at the pipeline already carrying a Message, which is the other branch
+    /// that reports Received. Two reports per delivery double-counted the received metric, double-fed
+    /// the CritterWatch accumulator, logged each receipt twice, and put two Received records in a
+    /// tracked session so Received.SingleMessage&lt;T&gt;() failed against correct behaviour.
+    /// </summary>
+    [JsonIgnore]
+    internal bool WasTrackedAsReceived { get; set; }
+
     [JsonIgnore]
     public IMessageSerializer? Serializer { get; set; }
 
@@ -567,6 +579,7 @@ public partial class Envelope
 
         // Public / internal settable properties — runtime-only (Envelope.Internals.cs)
         WasPersistedInInbox = false;
+        WasTrackedAsReceived = false;
         Serializer = null;
         ResponseType = null;
         Response = null;

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -268,8 +268,27 @@ public class HandlerPipeline : IHandlerPipeline
         }
         finally
         {
-            Logger.Received(envelope);
+            recordReceivedOnce(envelope);
         }
+    }
+
+    /// <summary>
+    /// GH-4135: report Received exactly once per receipt. Both the deserialization path and the
+    /// already-deserialized path report it, and partitioned processing goes through BOTH -- it
+    /// deserializes up front so it can read the group id, then hands the pipeline an envelope that
+    /// already carries a Message. Reporting twice double-counted the received metric, double-fed the
+    /// CritterWatch accumulator, logged each receipt twice, and left two Received records in a tracked
+    /// session, which is what made Received.SingleMessage&lt;T&gt;() fail on correct behaviour.
+    /// </summary>
+    private void recordReceivedOnce(Envelope envelope)
+    {
+        if (envelope.WasTrackedAsReceived)
+        {
+            return;
+        }
+
+        envelope.WasTrackedAsReceived = true;
+        Logger.Received(envelope);
     }
 
     // Resolve the serializer for an envelope whose runtime-only Serializer reference
@@ -339,7 +358,7 @@ public class HandlerPipeline : IHandlerPipeline
         }
         else
         {
-            Logger.Received(envelope);
+            recordReceivedOnce(envelope);
         }
 
         if (envelope.IsResponse)


### PR DESCRIPTION
Closes #4135.

## The bug

A listener with `PartitionProcessingByGroupId` recorded **two** `Received` events for one envelope while executing it exactly once. Reproduced verbatim from the issue's repro.

Two branches of `HandlerPipeline` report `Received`, and they are meant to be mutually exclusive:

- `TryDeserializeEnvelope` reports it from a `finally` block
- `executeAsync` reports it directly when the envelope already carries a `Message`

**Partitioned processing goes through both.** `ShardedExecutionBlock.DeserializeFirst` deserializes up front — it has to, because receiver-side grouping rules (`ByMessage`, `ByPropertyNamed`, inferred grouping) resolve the group id off the *deserialized* message — and the envelope then reaches `executeAsync` already carrying a `Message`, taking the second branch. That matches the reporter's guess exactly.

## It is bigger than the reported symptom

The issue reports that `Received.SingleMessage<T>()` fails against a system behaving correctly, with a message that reads as duplicate delivery and sends you hunting a routing bug that is not there — it cost the reporter a full bisect.

But `IMessageTracker.Received` is not only tracking. The same call:

- increments `_receivedCounter`
- posts `RecordReceived` to the CritterWatch accumulator
- logs the receipt

So **every partitioned listener has been double-counting received messages in production metrics and logging each receipt twice.** The red test was the visible half.

## The fix

A `WasTrackedAsReceived` guard on the envelope, rather than removing either call site — both are correct for the path they serve, and the deserialization one has to stay in its `finally` so a malformed payload is still reported as received before it is moved to the error queue. `GlobalPartitionedInterceptor` takes the same pre-deserialize route and is fixed by the same guard.

## Verification

- New `duplicate_received_with_partitioning_4135` reproduces the issue's repro against a real broker. Confirmed **red before, green after**.
- CoreTests 2648 passed / 0 failed.
- Full RabbitMQ suite 514/515 — the one failure (`drain_wait_for_prefetch`) passes 2/2 in isolation on this branch *and* 2/2 on `origin/main`, and every full-suite run tonight produced exactly one, always different, failure under local load. Re-running the full suite to confirm non-reproduction.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3