### PR TITLE
GH-4098: keep the evidence when a job is cancelled at its cap

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,6 +41,36 @@ jobs:
           CI_JOB_NAME: dotnet-ci
         run: ./build/run-with-cancellation-relay.sh ci
 
+      # GH-4098. This job wedged once and was cancelled at its cap, and every piece of evidence went
+      # with it: a cancelled job's logs are not truncated, they are DISCARDED (BlobNotFound), leaving
+      # only per-step timestamps in the API. The supervisor already writes a partial ledger inside the
+      # runner's grace window when it is cancelled (build/SupervisedTests.cs registerCancellationCapture,
+      # build/StallCapture.cs) -- naming the tests that were still in flight -- but this workflow never
+      # uploaded it, so the one artifact that survives a discarded log was being thrown away with the
+      # runner. tests.yml has had this since GH-3787; dotnet.yml is the workflow that actually wedged.
+      #
+      # `always()` and not `failure()`: a cancelled job is neither success nor failure, and cancellation
+      # is precisely the case this exists for.
+      - name: Upload retry ledger
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-ledger-dotnet-ci
+          path: artifacts/test-ledger/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      # Only reachable when the runner itself survived. If the OOM killer took a *test* process rather
+      # than the runner service, the kill is recorded here and nowhere else. Same `always()` reasoning
+      # as the upload above.
+      - name: Kernel OOM report
+        if: always()
+        run: |
+          echo "::group::dmesg (OOM / kill events)"
+          sudo dmesg | grep -iE "out of memory|oom-kill|killed process" || echo "no OOM events in dmesg"
+          echo "::endgroup::"
+          free -m
+
       # The CI target now also runs MessageRoutingTests, which boots a real
       # RabbitMQ broker (started inline by the build target via docker compose).
       # Tear it down on exit so the runner is clean for downstream steps and

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,8 +138,12 @@ jobs:
 
       # Only reachable when the runner itself survived. If the OOM killer took a *test* process
       # rather than the runner service, the kill is recorded here and nowhere else.
+      #
+      # GH-4098: `always()`, not `failure()`. A job cancelled at the 20-minute cap is neither success
+      # nor failure, so `failure()` skipped this step on exactly the wedges it was written for --
+      # #4083's CIMarten cancellations among them.
       - name: Kernel OOM report
-        if: failure()
+        if: always()
         run: |
           echo "::group::dmesg (OOM / kill events)"
           sudo dmesg | grep -iE "out of memory|oom-kill|killed process" || echo "no OOM events in dmesg"


### PR DESCRIPTION
Closes #4098. First of the **CI Improvements** milestone.

## What was actually missing

`dotnet.yml`'s `build` job wedged, ran to its 20-minute cap plus the full 5-minute grace window, and was cancelled — and every piece of evidence went with it. A cancelled job's logs are not truncated, they are **discarded** (`BlobNotFound`); only per-step timestamps survive in the API.

**The supervisor side of this is already built.** Bobcat 0.8.0 moved the old external watchdog inside the supervisor, and `build/SupervisedTests.cs` registers a cancellation capture (`registerCancellationCapture`, `build/StallCapture.cs`) that snapshots the run, writes a partial ledger, and names the tests still in flight inside the grace window. The ledger carries precisely what the issue says is missing:

```json
{ "Job": "dotnet-ci", "AbortReason": null, "IsPartial": false,
  "Stalled": 0, "StalledTests": [], "PeakWorkerRssMb": 5315, ... }
```

**`dotnet.yml` just never uploaded it.** `tests.yml` has had that step since #3787; `dotnet.yml` — the workflow that actually wedged — threw away the one artifact that survives a discarded log.

I verified the fix isn't inert rather than assuming the path was right: running the CI path with `CI_JOB_NAME=dotnet-ci` writes `artifacts/test-ledger/dotnet-ci.CoreTests.net9.0.json` (output above is from that run).

## Second blind spot, same class

`tests.yml`'s **Kernel OOM report was gated on `failure()`**. A job cancelled at the cap is neither success nor failure, so the step was skipped on exactly the wedges it was written for — including #4083's CIMarten cancellations. Both evidence steps now use `always()`.

## On the issue's suggested fix

The issue proposes wiring `build/ci-memory-sampler.sh` into this workflow. **That is stale** — the script was retired the same day the issue was filed, when Bobcat 0.8.0 subsumed it, and `dotnet.yml`'s `CI` target already runs through the supervisor via `RunTestProject`, so it has the per-test RSS attribution and stall detection the sampler used to *infer* from outside the process. Nothing to re-add.

## What this does not fix

Two things in the issue are outside our control and stay true:
- Re-running a cancelled attempt overwrites the run's conclusion, so history scans for `conclusion == "cancelled"` still miss it.
- `gh pr checks` still renders a cancelled job as `fail`. Confirm with `gh api repos/JasperFx/wolverine/actions/jobs/<id> --jq '"\(.status) \(.conclusion)"'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3