### PR TITLE
GH-4100: guard that no tracked-session budget outlives the CI job cap

### DIFF
--- a/build/TrackedSessionTimeouts.cs
+++ b/build/TrackedSessionTimeouts.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Serilog;
+
+// GH-4100. A guard that no tracked-session budget can outlive the CI job cap.
+//
+// PulsarNativeReliabilityTests.run_setup_with_simulated_exception_in_handler asked for
+// TrackActivity(TimeSpan.FromSeconds(1000)). 1000s is 16m40s against a 20 minute cap, and the suite
+// spends six-plus minutes building and standing up Pulsar before its first test runs -- so the
+// session's own timeout could never fire. When DotPulsar wedged, the job hit the cap first and was
+// CANCELLED, and a cancelled job's logs are discarded outright (#4098). A budget longer than the cap
+// converts every hang under it from a readable test failure with a tracking dump into an unreadable
+// job cancellation with nothing at all.
+//
+// Two deliberate design choices, both from what VerifyCITargetCoverage learned (GH-3816):
+//
+//   * LITERALS ONLY. TrackActivity(Fixture.DefaultTimeout) and .Timeout(timeout) cannot be evaluated
+//     from source text, and guessing at them is how a guard starts crying wolf. They are skipped
+//     silently -- this checks what it can actually read.
+//   * FINDING NOTHING IS NOT THE SAME AS NOTHING BEING WRONG. If the scan matches no budgets at all
+//     the patterns have rotted or the tree moved, and that is reported as a broken guard rather than
+//     as a clean build.
+partial class Build
+{
+    /// <summary>
+    /// The ceiling for any literal tracked-session budget.
+    ///
+    /// Derived rather than picked: the job cap is 20 minutes (timeout-minutes in tests.yml and
+    /// dotnet.yml), and a test's budget has to fit in what is LEFT of that after restore, build,
+    /// container startup and every test that ran before it -- which for the broker suites is six
+    /// minutes and up. Five minutes leaves fifteen for all of that.
+    ///
+    /// It is also exactly the largest budget in the tree today (.Timeout(5.Minutes())), so this
+    /// admits every existing test and rejects only new outliers. Raising it means arguing that a
+    /// suite can hang for longer than that and still leave the job able to report.
+    /// </summary>
+    static readonly TimeSpan MaximumTrackedSessionBudget = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// TrackActivity(...) and .Timeout(...) taking a TimeSpan, plus the millisecond overloads on
+    /// SendMessageAndWaitAsync / PublishMessageAndWaitAsync. Each captures the number and its unit.
+    /// </summary>
+    static readonly Regex[] BudgetPatterns =
+    [
+        new(@"\b(?:TrackActivity|Timeout)\(\s*TimeSpan\.From(?<unit>Milliseconds|Seconds|Minutes|Hours)\(\s*(?<value>\d+(?:\.\d+)?)\s*\)",
+            RegexOptions.Compiled),
+        new(@"\b(?:TrackActivity|Timeout)\(\s*(?<value>\d+(?:\.\d+)?)\s*\.(?<unit>Milliseconds|Seconds|Minutes|Hours)\(\s*\)",
+            RegexOptions.Compiled),
+        new(@"\btimeoutInMilliseconds\s*:\s*(?<value>\d+)(?<unit>)", RegexOptions.Compiled)
+    ];
+
+    Target VerifyTrackedSessionTimeouts => _ => _
+        .Description(
+            "Fails when a literal tracked-session budget exceeds what the CI job cap can report on. GH-4100.")
+        .Executes(() =>
+        {
+            var offenders = new List<string>();
+            var examined = 0;
+
+            foreach (var file in sourceFilesToScan())
+            {
+                var lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    foreach (var pattern in BudgetPatterns)
+                    {
+                        foreach (Match match in pattern.Matches(lines[i]))
+                        {
+                            var budget = budgetFrom(match);
+                            if (budget is null) continue;
+
+                            examined++;
+                            if (budget <= MaximumTrackedSessionBudget) continue;
+
+                            var relative = Path.GetRelativePath(RootDirectory, file);
+                            offenders.Add($"  {relative}:{i + 1}  {budget.Value.TotalSeconds:0}s  {match.Value.Trim()}");
+                        }
+                    }
+                }
+            }
+
+            if (examined == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Found no tracked-session budgets at all under {RootDirectory / "src"}. The patterns have " +
+                    "rotted or the tree moved -- that is a broken guard, not a clean build.");
+            }
+
+            if (offenders.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{offenders.Count} tracked-session budget(s) exceed {MaximumTrackedSessionBudget.TotalMinutes:0} minutes, " +
+                    "so a hang under them cancels the CI job instead of failing the test -- and a cancelled job's logs " +
+                    $"are discarded (GH-4098). See GH-4100.{Environment.NewLine}{string.Join(Environment.NewLine, offenders)}");
+            }
+
+            Log.Information("Tracked-session timeouts: {Examined} literal budgets, all within {Max} minutes",
+                examined, MaximumTrackedSessionBudget.TotalMinutes);
+        });
+
+    static IEnumerable<string> sourceFilesToScan()
+    {
+        return Directory
+            .EnumerateFiles(RootDirectory / "src", "*.cs", SearchOption.AllDirectories)
+            .Where(x => !x.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            .Where(x => !x.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"));
+    }
+
+    static TimeSpan? budgetFrom(Match match)
+    {
+        if (!double.TryParse(match.Groups["value"].Value,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var value))
+        {
+            return null;
+        }
+
+        // The timeoutInMilliseconds pattern has no unit to capture
+        return match.Groups["unit"].Value switch
+        {
+            "Hours" => TimeSpan.FromHours(value),
+            "Minutes" => TimeSpan.FromMinutes(value),
+            "Seconds" => TimeSpan.FromSeconds(value),
+            "Milliseconds" or "" => TimeSpan.FromMilliseconds(value),
+            _ => null
+        };
+    }
+}

--- a/build/build.cs
+++ b/build/build.cs
@@ -61,8 +61,12 @@ partial class Build : NukeBuild
     // VerifyCITargetCoverage is here rather than in tests.yml on purpose: it costs under a second, and
     // dotnet.yml's `./build.sh ci` runs on every push and PR, so a target that runs nowhere is reported
     // on the cheap workflow instead of behind the 20 minute matrix. GH-3816.
+    //
+    // VerifyTrackedSessionTimeouts rides along for the same reason and at the same cost (~1s for 345
+    // budgets): a tracked-session budget longer than the job cap turns every hang under it into a job
+    // cancellation with discarded logs instead of a test failure with a tracking dump. GH-4100.
     Target CI => _ => _
-        .DependsOn(VerifyCITargetCoverage, CoreTests, CIMessageRouting);
+        .DependsOn(VerifyCITargetCoverage, VerifyTrackedSessionTimeouts, CoreTests, CIMessageRouting);
 
     Target Test => _ => _
         .DependsOn(CoreTests, TestExtensions, Commands, PolicyTests, HttpTests);


### PR DESCRIPTION
Addresses the general rule from #4100. **Does not close it** — see "What is still open" below.

## Where the issue already stands

Part 1 of the issue — dropping `PulsarNativeReliabilityTests`' `TrackActivity(TimeSpan.FromSeconds(1000))` to `100` — **already landed** in 5bea2a920. This is the rule the issue asked for separately, so the next 1000 cannot be introduced silently.

## Why a guard rather than tidiness

1000s is **16m40s against a 20 minute job cap**, and the Pulsar suite spends six-plus minutes building and standing up the broker before its first test runs. That session's own timeout could **never fire in CI**. So when DotPulsar wedged, the job hit the cap first and was **cancelled** — and a cancelled job's logs are discarded outright (#4098).

A budget longer than what the cap can report on converts every hang under it from a readable test failure *with a tracking dump* into an unreadable job cancellation with *nothing at all*. That is the whole failure mode, and it is silent until it bites.

## The ceiling is derived, not picked

The cap is 20 minutes, and a budget has to fit in what is **left** after restore, build, container startup, and every test that ran before it. Five minutes leaves fifteen for all of that — and is also exactly the largest budget in the tree today (`.Timeout(5.Minutes())`).

So this admits **every existing test** and rejects only new outliers. Current scan: **345 literal budgets, all within 5 minutes, in ~1 second.**

## Two choices carried over from GH-3816

`VerifyCITargetCoverage`'s write-up makes the point that "a guard that cries wolf immediately is how a signal channel gets ignored." Both lessons are applied:

- **Literals only.** `TrackActivity(Fixture.DefaultTimeout)` and `.Timeout(timeout)` cannot be evaluated from source text, and guessing is how the crying-wolf starts. Skipped silently.
- **Finding nothing ≠ nothing wrong.** If the scan matches no budgets at all, the patterns have rotted or the tree moved — reported as a *broken guard*, not a clean build.

## Verified it catches the actual defect

Reintroducing the 1000s budget fails the target and names every offender:

```
System.InvalidOperationException: 4 tracked-session budget(s) exceed 5 minutes, so a hang under them
cancels the CI job instead of failing the test -- and a cancelled job's logs are discarded (GH-4098).
  src/Transports/Pulsar/Wolverine.Pulsar.Tests/PulsarNativeReliabilityTests.cs:72  1000s  TrackActivity(TimeSpan.FromSeconds(1000)
  ...
```

Rides on the `CI` target beside `VerifyCITargetCoverage`, for the same reason and at the same cost: `dotnet.yml` runs it on every push and PR, so it reports on the cheap workflow rather than behind the 20-minute matrix. `VerifyCITargetCoverage` still passes with the new target in the graph.

## What is still open

**The other half of #4100 — why DotPulsar producers and consumers stall in `Setup`.** The captured `dumpasync` shows seven producers and three consumers parked in `Producer.Setup` → `Executor.Execute` → `Monitor` → `StateChangedTo`, on a live connection to the broker. That is an upstream DotPulsar question, it is intermittent (a re-run went green), and I have no way to reproduce it on demand. What this PR changes is that the *next* occurrence fails as a test with a tracking dump instead of vanishing into a cancelled job.

I'd suggest leaving #4100 open, retitled to the stall alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3