### PR TITLE
GH-4109: report the top three RSS growths, and stop calling them retainers

### DIFF
--- a/build/SupervisedTests.cs
+++ b/build/SupervisedTests.cs
@@ -291,14 +291,30 @@ partial class Build
             Log.Warning("  [STALLED] {Test} — {Seconds}s in flight on lane {Lane}",
                 stalled.DisplayName, (int)stalled.InFlight.TotalSeconds, stalled.Worker.Lane);
 
+        // GH-4109. Report the top THREE, and do not call them retainers.
+        //
+        // This is a start-to-verdict RSS delta, which is heap EXPANSION, not live bytes: the GC does
+        // not hand memory back to the OS promptly, so whichever test happens to be running when the
+        // heap grows is charged for all of it. Naming a single winner "top retainer" reads as an
+        // accusation against that test, and the very first measurement this ever produced sent us
+        // after CoreTests.Acceptance.wolverine_as_command_bus.use_iasync_enumerable_as_return_value
+        // at +685 MB -- a test that sends three empty records and awaits two 50ms delays.
+        //
+        // Five consecutive runs of the same unchanged suite named five DIFFERENT tests (+535 MB to
+        // +1084 MB) while peak RSS stayed flat at 4956-5468 MB. The leader is noise; the peak is the
+        // signal. Three entries make that visible in the log itself -- a test that really does retain
+        // will hold its place across runs, and a run whose three entries are all strangers is telling
+        // you the ranking means nothing this time.
         var memory = RunResources.For(results);
         if (memory.IsMeasured)
         {
-            Log.Information("  peak worker RSS {Peak}; top retainer: {Retainer}",
+            var growth = memory.TopRetainers(3)
+                .Select(x => $"{RunResources.Delta(x.RetainedBytes!.Value)} {x.DisplayName}")
+                .ToArray();
+
+            Log.Information("  peak worker RSS {Peak}; largest RSS growth during: {Growth}",
                 RunResources.Humanize(memory.PeakBytes!.Value),
-                memory.TopRetainers(1) is [{ } top]
-                    ? $"{RunResources.Delta(top.RetainedBytes!.Value)} {top.DisplayName}"
-                    : "(none attributed)");
+                growth.Length > 0 ? string.Join(", ", growth) : "(none attributed)");
         }
 
         foreach (var test in results.Indeterminate)


### PR DESCRIPTION
Closes #4109. Third of the **CI Improvements** milestone.

## The measurement the issue asked for — and it exonerates the test

`use_iasync_enumerable_as_return_value` is not a memory problem.

**Solo, in a fresh process:** it peaks at **397 MB**, against a **162 MB** floor for a trivial host-building test in the same suite. The test sends three empty records and awaits two 50ms delays.

**In-suite, across five consecutive runs of the same unchanged suite**, the top entry was a *different test every time*:

| run | top entry | delta | peak worker RSS |
|---|---|---|---|
| issue's | `wolverine_as_command_bus.use_iasync_enumerable_as_return_value` | +685 MB | 5047 MB |
| 2 | `compound_handlers.can_send_messages_from_before_methods_…` | +770 MB | 5315 MB |
| 3 | `async_method_name_saga.complete_and_delete_with_HandleAsync` | +535 MB | 4956 MB |
| 4 | `Bug_42_concurrent_creation_of_command_handlers.try_to_break` | +1084 MB | 5468 MB |
| 5 | `async_method_name_saga.ConsumeAsync_is_an_ExistingCall` | +692 MB | 5290 MB |

Five runs, five names. Peak RSS flat at 4956–5468 MB (±5%). **The issue's third hypothesis was the right one** — its counter-argument ("Against this reading: no other test in the suite came close") was true of a single run.

## So the number is real, but the attribution is not

A start-to-verdict RSS delta is heap **expansion**, not live bytes. The GC does not return memory to the OS promptly, so whichever test is running when the heap grows is charged for all of it. Naming one winner **"top retainer"** reads as an accusation against that test — and the very first measurement it ever produced cost a full investigation of an innocent one.

## The change

Report the **top three**, labelled **"largest RSS growth during"**. That makes the shape visible in the log itself: a test that genuinely retains will hold its place across runs, and a run whose three entries are all strangers is telling you the ranking means nothing this time.

The first run under the new format already earns it:

```
peak worker RSS 4536 MB; largest RSS growth during:
  +1171 MB CoreTests.Bugs.Bug_42_concurrent_creation_of_command_handlers.try_to_break,
   +569 MB CoreTests.Persistence.using_storage_return_types_and_entity_attributes.do_not_execute_the_handler_if_the_entity_is_not_found,
   +559 MB CoreTests.Persistence.using_storage_return_types_and_entity_attributes.use_generic_action_as_update
```

`Bug_42_concurrent_creation_of_command_handlers.try_to_break` is the **only name so far to repeat** (it also led run 4 at +1084 MB) — and "concurrent creation of command handlers" is a plausible genuine allocator. That is what a real signal looks like through this lens, versus the one-run appearance that started this issue.

## What this does not settle

**CoreTests' worker peaks near 5 GB on every run.** That number is stable where the per-test ranking is not, so it is the real question — and #4109 as filed was chasing the unstable half of it. Happy to open a separate issue for the aggregate if you want it tracked; I have not filed one, since the point of this pass is to burn the count down rather than grow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3