### PR TITLE
Adopt Weasel 9.27.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,13 +137,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.26.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.26.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.26.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.26.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.26.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.26.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.26.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.27.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.27.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.27.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.27.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.27.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.27.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.


### PR DESCRIPTION
Last dependency bump before the 6.30 release.

## What changed

`Weasel.*` 9.26.0 → **9.27.0** across all seven packages (Core, Postgresql, SqlServer, MySql, Oracle, Sqlite, EntityFrameworkCore).

**JasperFx is already on 2.56.0**, which is the current release — it was bumped in #4153 yesterday, so there is nothing to move there.

## Why

Weasel 9.27.0 is nine fixes, every one a case where Weasel read a schema back as something other than what the database actually held. Three of them never converged — the patch is applied, the read-back is still different, and the next run produces the identical patch forever:

- A **named foreign key on SQLite** rebuilt the table (and copied every row) on every run — `pragma_foreign_key_list` has no name column, so the read invented one.
- A **partition-aligned index on SQL Server** was dropped and recreated on every run — the implicit `sys.index_columns` row for the partitioning column was read as a declared key column, so the index compared unequal to itself.
- A **concurrent index on a manager-owned partitioned table** stayed permanently invalid — `ListPartitioning.PartitionTableNames` ignored the partition manager and returned an empty sequence, so only the metadata-only first step of the three-step sequence rendered.

No DDL changes for a schema Weasel was already reading correctly, and no configuration changes.

## Compatibility

Marten 9.23.0, Polecat 5.19.1 and Fisher 1.0.2 all carry `Weasel.*` as a version *floor* (9.24.0 / 9.24.0 / 9.25.1), so 9.27.0 resolves cleanly under all three. Weasel 9.27.0's own JasperFx floor is 2.46.0, well under our pinned 2.56.0.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — **0 errors, 0 warnings** (this is the CI gate; `.nuke/parameters.json` pins the framework)
- `dotnet build wolverine.slnx -c Release` (unpinned, multi-target) — **0 errors, 0 warnings**
- `PostgresqlTests` on net9.0 — **498 passed, 0 failed, 1 skipped**. This is the Weasel-heaviest suite reachable locally: schema migration, DDL diffing, and durability-table management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3