### PR TITLE
Let AddStopConditionIfNull accept the null identity its signature declares

### DIFF
--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -96,6 +96,19 @@ You can choose a different answer with the `OnMissing` property:
 | `EmptyContentWith204` <Badge type="tip" text="6.28" /> | Log it and stop | Empty **204** |
 | `ThrowException` | Throws `RequiredDataMissingException` | Throws `RequiredDataMissingException` |
 
+`MissingMessage` sets the text of that answer -- the `ProblemDetails` detail, or the
+`RequiredDataMissingException` message. Two placeholders are substituted into it:
+
+| Placeholder | Replaced with |
+|---|---|
+| `{0}` | the identity value, through `string.Format` |
+| `{Id}` | the identity value |
+
+The message is escaped on its way into generated code, so a quote, a backslash or a newline in it is
+safe. Where an entity was not addressed by a single identity value there is nothing to substitute, so
+the message is used exactly as written and the stock message names the entity type rather than an id
+it does not have.
+
 If you need or want any other kind of failure handling on the entity not being found, you'll need to
 use explicit code instead, maybe with a `LoadAsync()` "before" method to still keep your main
 handler or endpoint method a *pure function*.

--- a/src/Http/Wolverine.Http.Tests/Persistence/RequiredTodoEndpoint.cs
+++ b/src/Http/Wolverine.Http.Tests/Persistence/RequiredTodoEndpoint.cs
@@ -36,7 +36,19 @@ public static class RequiredTodoEndpoint
     
     // Should error & custom message
     [WolverineGet("/required/todo7/{id}")]
-    public static Todo2 Get7([Entity(OnMissing = OnMissing.ThrowException, MissingMessage = "Id '{0}' is wrong!")] Todo2 todo) 
+    public static Todo2 Get7([Entity(OnMissing = OnMissing.ThrowException, MissingMessage = "Id '{0}' is wrong!")] Todo2 todo)
         => todo;
 
+    // The message reaches generated code as a string literal, so a quote or a backslash in it has to
+    // be escaped there. Both of these would not compile at all if it were not.
+
+    // Should 400 w/ ProblemDetails on missing & a custom message needing escapes
+    [WolverineGet("/required/todo8/{id}")]
+    public static Todo2 Get8([Entity(OnMissing = OnMissing.ProblemDetailsWith400, MissingMessage = "No \"Todo\" for '{0}' under C:\\todos")] Todo2 todo)
+        => todo;
+
+    // Should error & a custom message needing escapes
+    [WolverineGet("/required/todo9/{id}")]
+    public static Todo2 Get9([Entity(OnMissing = OnMissing.ThrowException, MissingMessage = "No \"Todo\" for '{0}' under C:\\todos")] Todo2 todo)
+        => todo;
 }

--- a/src/Http/Wolverine.Http.Tests/Persistence/reacting_to_entity_attributes.cs
+++ b/src/Http/Wolverine.Http.Tests/Persistence/reacting_to_entity_attributes.cs
@@ -150,5 +150,36 @@ public class reacting_to_entity_attributes : IAsyncLifetime
         text.ShouldContain(typeof(RequiredDataMissingException).FullName!);
         text.ShouldContain("Id 'nonexistent' is wrong!");
     }
-    
+
+    [Fact]
+    public async Task problem_details_400_on_missing_with_a_custom_message_needing_escapes()
+    {
+        var tracked = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/required/todo8/nonexistent");
+            x.StatusCodeShouldBe(400);
+            x.ContentTypeShouldBe("application/problem+json");
+        });
+
+        var details = await tracked.ReadAsJsonAsync<ProblemDetails>();
+        details.Detail.ShouldBe("No \"Todo\" for 'nonexistent' under C:\\todos");
+    }
+
+    [Fact]
+    public async Task throw_exception_on_missing_with_a_custom_message_needing_escapes()
+    {
+        var tracked = await theHost.Scenario(x =>
+        {
+            x.Get.Url("/required/todo9/nonexistent");
+            x.StatusCodeShouldBe(500);
+        });
+
+        // The developer exception page HTML-encodes the quotes, so the assertion sticks to the part
+        // of the message that survives it. Whether the quotes themselves round-trip is settled
+        // exactly by the ProblemDetails test above, whose body is JSON.
+        var text = await tracked.ReadAsTextAsync();
+        text.ShouldContain(typeof(RequiredDataMissingException).FullName!);
+        text.ShouldContain("for 'nonexistent' under C:\\todos");
+    }
+
 }

--- a/src/Http/Wolverine.Http.Tests/Persistence/stop_condition_with_no_identity.cs
+++ b/src/Http/Wolverine.Http.Tests/Persistence/stop_condition_with_no_identity.cs
@@ -1,0 +1,90 @@
+using JasperFx.CodeGeneration.Model;
+using Shouldly;
+using Wolverine.Http.Policies;
+using Wolverine.Persistence;
+using Xunit;
+
+namespace Wolverine.Http.Tests.Persistence;
+
+/// <summary>
+/// The HTTP half of <c>CoreTests.Persistence.stop_condition_with_no_identity</c>.
+/// <see cref="HttpChain.AddStopConditionIfNull(Variable, Variable?, IDataRequirement)" /> declares the
+/// identity nullable and then dereferenced it as <c>identity!</c> into
+/// <see cref="WriteProblemDetailsIfNull" />, so passing null crashed code generation.
+/// </summary>
+public class stop_condition_with_no_identity
+{
+    private static readonly Variable theEntity = new(typeof(Invoice), "invoice");
+
+    // Any endpoint will do -- these tests are about the frames AddStopConditionIfNull hands back, not
+    // about the endpoint. It has to be one with no attributed parameters, though: ChainFor builds its
+    // chain with no parent HttpGraph, so parameter matching has no WolverineOptions to resolve.
+    private static HttpChain aChain() =>
+        HttpChain.ChainFor<StopConditionEndpoint>(x => x.Get());
+
+    [Theory]
+    [InlineData(OnMissing.ProblemDetailsWith400, 400)]
+    [InlineData(OnMissing.ProblemDetailsWith404, 404)]
+    public void problem_details_without_an_identity(OnMissing onMissing, int statusCode)
+    {
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute { OnMissing = onMissing });
+
+        var frame = frames.ShouldHaveSingleItem().ShouldBeOfType<WriteProblemDetailsIfNull>();
+
+        frame.Identity.ShouldBeNull();
+        frame.StatusCode.ShouldBe(statusCode);
+
+        // WriteProblems already accepted an object? identity, so "null" is a legal argument -- but the
+        // stock message must not ask for an id that will never arrive
+        frame.Message.ShouldBe("Required Invoice was not found");
+    }
+
+    [Fact]
+    public void a_supplied_missing_message_is_used_verbatim()
+    {
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute
+            {
+                OnMissing = OnMissing.ProblemDetailsWith404,
+                MissingMessage = "That invoice has not been written yet"
+            });
+
+        frames.ShouldHaveSingleItem().ShouldBeOfType<WriteProblemDetailsIfNull>()
+            .Message.ShouldBe("That invoice has not been written yet");
+    }
+
+    [Fact]
+    public void throw_exception_without_an_identity()
+    {
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute { OnMissing = OnMissing.ThrowException });
+
+        var frame = frames.ShouldHaveSingleItem().ShouldBeOfType<ThrowRequiredDataMissingExceptionFrame>();
+
+        frame.Identity.ShouldBeNull();
+        frame.Message.ShouldBe("Required Invoice was not found");
+    }
+
+    [Fact]
+    public void an_identity_is_still_carried_through_when_there_is_one()
+    {
+        var identity = new Variable(typeof(string), "number");
+
+        var frames = aChain().AddStopConditionIfNull(theEntity, identity,
+            new EntityAttribute { OnMissing = OnMissing.ProblemDetailsWith400 });
+
+        frames.ShouldHaveSingleItem().ShouldBeOfType<WriteProblemDetailsIfNull>()
+            .Identity.ShouldBeSameAs(identity);
+    }
+}
+
+// Top level rather than nested, because NameInCode() renders a nested type as
+// "stop_condition_with_no_identity.Invoice" and these assertions are about the message a user reads.
+public record Invoice(string Number);
+
+internal class StopConditionEndpoint
+{
+    [WolverineGet("/stop-condition")]
+    public string Get() => "ok";
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -474,7 +474,11 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
 
     public override Frame[] AddStopConditionIfNull(Variable data, Variable? identity, IDataRequirement requirement)
     {
-        var message = requirement.MissingMessage ?? $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}";
+        // AddStopConditionIfNull declares the identity nullable, so an entity addressed by
+        // something other than a single identity variable has none for the stock message to name.
+        var message = requirement.MissingMessage ?? (identity == null
+            ? $"Required {data.VariableType.NameInCode()} was not found"
+            : $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}");
         
         switch (requirement.OnMissing)
         {
@@ -484,17 +488,17 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
                 
             case OnMissing.ProblemDetailsWith400:
                 Metadata.Produces(400, contentType: "application/problem+json");
-                return [new WriteProblemDetailsIfNull(data, identity!, message, 400)];
+                return [new WriteProblemDetailsIfNull(data, identity, message, 400)];
             case OnMissing.ProblemDetailsWith404:
                 Metadata.Produces(404, contentType: "application/problem+json");
-                return [new WriteProblemDetailsIfNull(data, identity!, message, 404)];
+                return [new WriteProblemDetailsIfNull(data, identity, message, 404)];
 
             case OnMissing.EmptyContentWith204:
                 Metadata.Produces(204);
                 return [new SetStatusCodeAndReturnIfEntityIsNullFrame(data, 204)];
 
             default:
-                return [new ThrowRequiredDataMissingExceptionFrame(data, identity!, message)];
+                return [new ThrowRequiredDataMissingExceptionFrame(data, identity, message)];
         }
     }
 

--- a/src/Http/Wolverine.Http/Policies/WriteProblemDetailsIfNull.cs
+++ b/src/Http/Wolverine.Http/Policies/WriteProblemDetailsIfNull.cs
@@ -2,6 +2,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Microsoft.AspNetCore.Http;
+using Wolverine.Util;
 
 namespace Wolverine.Http.Policies;
 
@@ -9,7 +10,7 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
 {
     private Variable? _httpContext;
 
-    public WriteProblemDetailsIfNull(Variable entity, Variable identity, string message, int statusCode = 400)
+    public WriteProblemDetailsIfNull(Variable entity, Variable? identity, string message, int statusCode = 400)
     {
         Entity = entity;
         Identity = identity;
@@ -17,11 +18,20 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
         StatusCode = statusCode;
         
         uses.Add(Entity);
-        uses.Add(Identity);
+        if (Identity != null)
+        {
+            uses.Add(Identity);
+        }
     }
 
     public Variable Entity { get; }
-    public Variable Identity { get; }
+
+    /// <summary>
+    /// Null when the entity was not addressed by a single identity value, which
+    /// <c>AddStopConditionIfNull</c> allows for. <c>WriteProblems</c> already accepts a null
+    /// identity.
+    /// </summary>
+    public Variable? Identity { get; }
     public string Message { get; }
     public int StatusCode { get; }
 
@@ -30,14 +40,19 @@ internal class WriteProblemDetailsIfNull : AsyncFrame
         writer.WriteComment("Write ProblemDetails if this required object is null");
         writer.Write($"BLOCK:if ({Entity.Usage} == null)");
 
-        if (Message.Contains("{0}"))
+        var identity = Identity?.Usage ?? "null";
+
+        // The message can come straight from an [Entity(MissingMessage = "...")], so it is only ever
+        // emitted as an escaped literal — see ToStringLiteral for why Constant.For will not do.
+        var literal = Message.ToStringLiteral();
+
+        if (Identity != null && Message.Contains("{0}"))
         {
-            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, string.Format(\"{Message}\", {Identity.Usage}), {_httpContext!.Usage}, {Identity.Usage});");
+            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, string.Format({literal}, {identity}), {_httpContext!.Usage}, {identity});");
         }
         else
         {
-            var constant = Constant.For(Message);
-            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, {constant.Usage}, {_httpContext!.Usage}, {Identity.Usage});");
+            writer.Write($"await {nameof(HttpHandler.WriteProblems)}({StatusCode}, {literal}, {_httpContext!.Usage}, {identity});");
         }
 
         writer.Write("return;");

--- a/src/Testing/CoreTests/Persistence/stop_condition_with_no_identity.cs
+++ b/src/Testing/CoreTests/Persistence/stop_condition_with_no_identity.cs
@@ -1,0 +1,108 @@
+using JasperFx.CodeGeneration.Model;
+using Shouldly;
+using Wolverine.Middleware;
+using Wolverine.Persistence;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+/// <summary>
+/// <c>IChain.AddStopConditionIfNull(Variable, Variable?, IDataRequirement)</c> declares its identity
+/// parameter nullable, but both implementations dereferenced it as <c>identity!</c> straight into the
+/// guard frames. Passing the null the signature invites therefore crashed code generation instead of
+/// producing a guard. These tests pin the seam.
+/// </summary>
+public class stop_condition_with_no_identity
+{
+    private static readonly Variable theEntity = new(typeof(Invoice), "invoice");
+
+    private static HandlerChain aChain() =>
+        HandlerChain.For<StopConditionHandler>(x => x.Handle(null!), null!);
+
+    [Fact]
+    public void the_stock_message_names_the_entity_type_rather_than_an_id_it_does_not_have()
+    {
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute { OnMissing = OnMissing.ThrowException });
+
+        var frame = frames.ShouldHaveSingleItem().ShouldBeOfType<ThrowRequiredDataMissingExceptionFrame>();
+
+        frame.Identity.ShouldBeNull();
+
+        // Deliberately not "Unknown Invoice with identity {Id}" -- there is no id to substitute, so
+        // the message must not ask for one
+        frame.Message.ShouldBe("Required Invoice was not found");
+    }
+
+    [Fact]
+    public void a_supplied_missing_message_is_used_verbatim()
+    {
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute
+            {
+                OnMissing = OnMissing.ThrowException,
+                MissingMessage = "That invoice has not been written yet"
+            });
+
+        frames.ShouldHaveSingleItem().ShouldBeOfType<ThrowRequiredDataMissingExceptionFrame>()
+            .Message.ShouldBe("That invoice has not been written yet");
+    }
+
+    [Fact]
+    public void an_id_placeholder_in_a_supplied_message_is_left_alone_when_there_is_no_id()
+    {
+        // Nothing to substitute, and silently deleting the placeholder would hide the mistake. The
+        // frame emits the message as it stands.
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute
+            {
+                OnMissing = OnMissing.ThrowException,
+                MissingMessage = "No invoice {Id}"
+            });
+
+        frames.ShouldHaveSingleItem().ShouldBeOfType<ThrowRequiredDataMissingExceptionFrame>()
+            .Message.ShouldBe("No invoice {Id}");
+    }
+
+    [Fact]
+    public void an_identity_is_still_carried_through_when_there_is_one()
+    {
+        var identity = new Variable(typeof(string), "number");
+
+        var frames = aChain().AddStopConditionIfNull(theEntity, identity,
+            new EntityAttribute { OnMissing = OnMissing.ThrowException });
+
+        var frame = frames.ShouldHaveSingleItem().ShouldBeOfType<ThrowRequiredDataMissingExceptionFrame>();
+
+        frame.Identity.ShouldBeSameAs(identity);
+        frame.Message.ShouldBe("Unknown Invoice with identity {Id}");
+    }
+
+    [Theory]
+    [InlineData(OnMissing.Simple404)]
+    [InlineData(OnMissing.ProblemDetailsWith400)]
+    [InlineData(OnMissing.ProblemDetailsWith404)]
+    [InlineData(OnMissing.EmptyContentWith204)]
+    public void the_log_and_stop_conditions_never_needed_an_identity(OnMissing onMissing)
+    {
+        var frames = aChain().AddStopConditionIfNull(theEntity, null,
+            new EntityAttribute { OnMissing = onMissing });
+
+        frames.Length.ShouldBe(2);
+        frames[1].ShouldBeOfType<HandlerContinuationFrame>();
+    }
+}
+
+// Top level rather than nested, because NameInCode() renders a nested type as
+// "stop_condition_with_no_identity.Invoice" and these assertions are about the message a user reads.
+public record Invoice(string Number);
+
+public record StopConditionMessage(string Number);
+
+public class StopConditionHandler
+{
+    public void Handle(StopConditionMessage message)
+    {
+    }
+}

--- a/src/Testing/CoreTests/Util/SourceCodeExtensionsTests.cs
+++ b/src/Testing/CoreTests/Util/SourceCodeExtensionsTests.cs
@@ -1,0 +1,28 @@
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Util;
+
+public class SourceCodeExtensionsTests
+{
+    [Theory]
+    [InlineData("plain text", "\"plain text\"")]
+    [InlineData("", "\"\"")]
+    [InlineData("says \"hello\"", "\"says \\\"hello\\\"\"")]
+    [InlineData("C:\\temp\\file", "\"C:\\\\temp\\\\file\"")]
+    [InlineData("first\nsecond", "\"first\\nsecond\"")]
+    [InlineData("first\r\nsecond", "\"first\\r\\nsecond\"")]
+    [InlineData("before\tafter", "\"before\\tafter\"")]
+    [InlineData("bell\a", "\"bell\\a\"")]
+    [InlineData("null\0char", "\"null\\0char\"")]
+    [InlineData("ctrl\u0001", "\"ctrl\\u0001\"")]
+    [InlineData("next\u0085line", "\"next\\u0085line\"")]
+    [InlineData("line\u2028separator", "\"line\\u2028separator\"")]
+    // Neither a brace nor a non-ASCII character needs anything doing to it.
+    [InlineData("still {0} a format string", "\"still {0} a format string\"")]
+    [InlineData("em dash \u2014 stays", "\"em dash \u2014 stays\"")]
+    public void escape_for_a_csharp_literal(string value, string expected)
+    {
+        value.ToStringLiteral().ShouldBe(expected);
+    }
+}

--- a/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
+++ b/src/Wolverine/Persistence/ThrowRequiredDataMissingExceptionFrame.cs
@@ -2,23 +2,34 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
+using Wolverine.Util;
 
 namespace Wolverine.Persistence;
 
 internal class ThrowRequiredDataMissingExceptionFrame : SyncFrame
 {
     public Variable Entity { get; }
-    public Variable Identity { get; }
+
+    /// <summary>
+    /// Null when the entity was not addressed by a single identity value, which
+    /// <c>AddStopConditionIfNull</c> allows for. The message is then used as it stands instead of
+    /// being substituted into.
+    /// </summary>
+    public Variable? Identity { get; }
+
     public string Message { get; }
     
-    public ThrowRequiredDataMissingExceptionFrame(Variable entity, Variable identity, string message)
+    public ThrowRequiredDataMissingExceptionFrame(Variable entity, Variable? identity, string message)
     {
         Entity = entity;
         Identity = identity;
         Message = message;
         
         uses.Add(Entity);
-        uses.Add(Identity);
+        if (Identity != null)
+        {
+            uses.Add(Identity);
+        }
     }
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
@@ -26,22 +37,28 @@ internal class ThrowRequiredDataMissingExceptionFrame : SyncFrame
         writer.WriteComment("Write ProblemDetails if this required object is null");
         writer.Write($"BLOCK:if ({Entity.Usage} == null)");
 
-        if (Message.Contains("{0}"))
+        // The message can come straight from an [Entity(MissingMessage = "...")], so it is only ever
+        // emitted as an escaped literal — see ToStringLiteral for why Constant.For will not do.
+        var literal = Message.ToStringLiteral();
+        var exceptionType = typeof(RequiredDataMissingException).FullNameInCode();
+
+        if (Identity != null && Message.Contains("{0}"))
         {
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(string.Format(\"{Message}\", {Identity.Usage}));");
+            writer.Write($"throw new {exceptionType}(string.Format({literal}, {Identity.Usage}));");
         }
-        else if (Message.Contains("{Id}"))
+        else if (Identity != null && Message.Contains("{Id}"))
         {
             var toStringExpression = Identity.VariableType.IsValueType
                 ? $"{Identity.Usage}.ToString()"
                 : $"{Identity.Usage}?.ToString() ?? \"\"";
 
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}(\"{Message}\".Replace(\"{{Id}}\", {toStringExpression}));");
+            writer.Write($"throw new {exceptionType}({literal}.Replace(\"{{Id}}\", {toStringExpression}));");
         }
         else
         {
-            var constant = Constant.For(Message);
-            writer.Write($"throw new {typeof(RequiredDataMissingException).FullNameInCode()}({constant.Usage});");
+            // Either there is no identity to substitute, or the message never asked for one, so it
+            // goes out as it stands.
+            writer.Write($"throw new {exceptionType}({literal});");
         }
 
         writer.FinishBlock();

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -519,8 +519,12 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
                 return [frame, new HandlerContinuationFrame(frame)];
                 
             default:
-                var message = requirement.MissingMessage ?? $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}";
-                return [new ThrowRequiredDataMissingExceptionFrame(data, identity!, message)];
+                // AddStopConditionIfNull declares the identity nullable, so an entity addressed by
+                // something other than a single identity variable has none for the stock message to name.
+                var message = requirement.MissingMessage ?? (identity == null
+                    ? $"Required {data.VariableType.NameInCode()} was not found"
+                    : $"Unknown {data.VariableType.NameInCode()} with identity {{Id}}");
+                return [new ThrowRequiredDataMissingExceptionFrame(data, identity, message)];
         }
     }
 

--- a/src/Wolverine/Util/SourceCodeExtensions.cs
+++ b/src/Wolverine/Util/SourceCodeExtensions.cs
@@ -1,0 +1,77 @@
+using System.Text;
+
+namespace Wolverine.Util;
+
+internal static class SourceCodeExtensions
+{
+    /// <summary>
+    /// This string as a C# string literal, quotes and escapes included, for embedding a value in
+    /// generated code.
+    /// <para>
+    /// JasperFx's <c>Constant.For(string)</c> and <c>Constant.ForString(string)</c> only wrap the
+    /// value in quotes, so any string reaching generated code from application configuration — an
+    /// <c>[Entity(MissingMessage = "...")]</c>, say — has to come through here instead. A quote, a
+    /// backslash or a newline in such a value would otherwise emit source that does not compile.
+    /// </para>
+    /// </summary>
+    public static string ToStringLiteral(this string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('"');
+
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\0':
+                    builder.Append("\\0");
+                    break;
+                case '\a':
+                    builder.Append("\\a");
+                    break;
+                case '\b':
+                    builder.Append("\\b");
+                    break;
+                case '\f':
+                    builder.Append("\\f");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                case '\v':
+                    builder.Append("\\v");
+                    break;
+                default:
+                    // Anything else the C# lexer will not take verbatim inside a literal: other
+                    // control characters, plus NEL, LINE SEPARATOR and PARAGRAPH SEPARATOR, which it
+                    // also treats as line breaks. Compared by code point so this line needs no
+                    // escapes of its own.
+                    if (char.IsControl(c) || c == 0x0085 || c == 0x2028 || c == 0x2029)
+                    {
+                        builder.Append("\\u").Append(((int)c).ToString("x4"));
+                    }
+                    else
+                    {
+                        builder.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        builder.Append('"');
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
First in the stack for #4160. Independent of the rest of it — this is two latent defects in the missing-data guard frames, both found while writing #4082.

## 1. The nullable identity was dereferenced anyway

```csharp
Frame[] AddStopConditionIfNull(Variable data, Variable? identity, IDataRequirement requirement);
```

Both implementations dereferenced it as `identity!` straight into the guard frames — `HandlerChain.cs`, `HttpChain.cs`. Passing the null the signature invites therefore crashed code generation instead of producing a guard, so the nullability on the parameter was decorative.

`ThrowRequiredDataMissingExceptionFrame` and `WriteProblemDetailsIfNull` now take a `Variable?`. With no identity they emit the message as it stands instead of substituting into it, and the stock message becomes `Required {Type} was not found` rather than `Unknown {Type} with identity {Id}` — there is no id, so the message must not ask for one. A supplied `MissingMessage` is used verbatim either way, `{Id}` placeholder included: nothing to substitute, and silently deleting the placeholder would hide the mistake.

`HttpHandler.WriteProblems` already took an `object? identity`, so the HTTP side needed no change beyond passing `null`.

## 2. The missing-data message was interpolated into generated source raw

```csharp
writer.Write($"throw new {...}(\"{Message}\".Replace(...));");
```

`Message` can come straight from `[Entity(MissingMessage = "...")]`, so a quote, a backslash or a newline in it emitted source that does not compile — from a string an application author is invited to write. Both frames now escape it through a new `string.ToStringLiteral()`.

That extension exists rather than reusing JasperFx's `Constant.For(string)` / `Constant.ForString(string)`, which only wrap the value in quotes. Anything reaching generated code from application configuration has to be escaped properly, and it handles quotes, backslashes, the C# escape characters, other control characters, and NEL / LINE SEPARATOR / PARAGRAPH SEPARATOR — which the C# lexer also treats as line breaks.

## Verification

- `CoreTests.Util.SourceCodeExtensionsTests` — 13 cases over `ToStringLiteral`, including that braces and non-ASCII characters are deliberately left alone.
- `CoreTests.Persistence.stop_condition_with_no_identity` and `Wolverine.Http.Tests.Persistence.stop_condition_with_no_identity` — 12 tests pinning the seam in both chain implementations: the stock message with and without an identity, a verbatim `MissingMessage`, a `{Id}` placeholder with no id to put in it, and that an identity is still carried through when there is one.
- `Wolverine.Http.Tests.Persistence.reacting_to_entity_attributes` gains two end-to-end cases on endpoints whose `MissingMessage` contains `"` and `\`, through `ProblemDetails` (JSON, so the quotes are visible in the assertion) and through `ThrowException`. Before the escaping fix these two endpoints do not compile at all.
- Regression: `CoreTests.Persistence.*` 249/249, `Wolverine.Http.Tests.Persistence.*` 36/36.
- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 errors, 0 code warnings.

Nothing in the tree passes a null identity today, so part 1 removes a latent crash rather than fixing a visible one; the tests pin the contract at the seam instead of through a caller. The escaping half is reachable now, from any `MissingMessage` containing a quote.