### PR TITLE
One shared emulator probe, and stop the S3 claim check suite silently skipping

### DIFF
--- a/src/EmulatorProbe.cs
+++ b/src/EmulatorProbe.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Collections.Concurrent;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// "Is this emulator up?", for the test suites that skip rather than fail when their emulator is not
+/// running. Probed once per host and port per process.
+/// </summary>
+public static class EmulatorProbe
+{
+    private static readonly ConcurrentDictionary<string, Lazy<bool>> _probes = new();
+
+    public static bool IsListening(string host, int port)
+    {
+        return _probes
+            .GetOrAdd($"{host}:{port}", _ => new Lazy<bool>(() => probe(host, port)))
+            .Value;
+    }
+
+    /// <summary>
+    /// Tries every address the host resolves to and takes the first that connects.
+    /// </summary>
+    /// <remarks>
+    /// GH-4160. Each suite used to carry its own copy of a single <c>ConnectAsync(host, port)</c>
+    /// with a two second budget for the whole call. docker-compose publishes the LocalStack gateway
+    /// as <c>127.0.0.1:4566:4566</c>, so <c>::1</c> has no listener, and the IPv6 attempt
+    /// <c>localhost</c> resolves to first does not always fail inside that budget: the S3 suite
+    /// skipped every test against a LocalStack that was up and reported green. The other three
+    /// emulators publish dual-stack today and so happened to be unaffected. Same silent-skip failure
+    /// mode as GH-4007.
+    /// </remarks>
+    private static bool probe(string host, int port)
+    {
+        IPAddress[] addresses;
+        try
+        {
+            addresses = IPAddress.TryParse(host, out var literal) ? [literal] : Dns.GetHostAddresses(host);
+        }
+        catch
+        {
+            return false;
+        }
+
+        foreach (var address in addresses)
+        {
+            try
+            {
+                using var client = new TcpClient(address.AddressFamily);
+                var connect = client.ConnectAsync(address, port);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+                if (connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected)
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // One address family failing says nothing about the next.
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/LocalStackFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/LocalStackFact.cs
@@ -1,14 +1,11 @@
 using System.Runtime.CompilerServices;
-using System.Net.Sockets;
+using IntegrationTests;
 using Amazon.S3;
 
 namespace Wolverine.ClaimCheck.AmazonS3.Tests;
 
 /// <summary>
-/// Probe LocalStack once per process and cache the result. We treat any TCP
-/// connect failure on <c>localhost:4566</c> as "not running" and let tests
-/// skip cleanly. This mirrors the <c>AzuriteFact</c> pattern used by the
-/// Azure Blob backend tests.
+/// Where LocalStack lives, and whether it is up. Tests skip cleanly when it is not.
 /// </summary>
 internal static class LocalStack
 {
@@ -16,9 +13,7 @@ internal static class LocalStack
     public const int Port = 4566;
     public const string ServiceUrl = "http://localhost:4566";
 
-    private static readonly Lazy<bool> _isRunning = new(Probe);
-
-    public static bool IsRunning => _isRunning.Value;
+    public static bool IsRunning => EmulatorProbe.IsListening(Host, Port);
 
     public const string SkipReason =
         "LocalStack is not running on localhost:4566. " +
@@ -34,22 +29,6 @@ internal static class LocalStack
         };
 
         return new AmazonS3Client("xxx", "xxx", config);
-    }
-
-    private static bool Probe()
-    {
-        try
-        {
-            using var client = new TcpClient();
-            var connect = client.ConnectAsync(Host, Port);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-        }
-        catch
-        {
-            return false;
-        }
     }
 }
 

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj
@@ -22,6 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="../../EmulatorProbe.cs">
+            <Link>EmulatorProbe.cs</Link>
+        </Compile>
         <Using Include="Xunit" />
     </ItemGroup>
 

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/AzuriteFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/AzuriteFact.cs
@@ -1,13 +1,11 @@
 using System.Runtime.CompilerServices;
-using System.Net.Sockets;
+using IntegrationTests;
 using Azure.Storage.Blobs;
 
 namespace Wolverine.ClaimCheck.AzureBlobStorage.Tests;
 
 /// <summary>
-/// Probe Azurite (the official Azure Storage emulator) once per process and
-/// cache the result. We treat any TCP connect failure on
-/// <c>127.0.0.1:10000</c> as "not running" and let tests skip cleanly.
+/// Where Azurite lives, and whether it is up. Tests skip cleanly when it is not.
 /// </summary>
 internal static class Azurite
 {
@@ -34,31 +32,13 @@ internal static class Azurite
     public const string Host = "127.0.0.1";
     public const int Port = 10000;
 
-    private static readonly Lazy<bool> _isRunning = new(Probe);
-
-    public static bool IsRunning => _isRunning.Value;
+    public static bool IsRunning => EmulatorProbe.IsListening(Host, Port);
 
     public const string SkipReason =
         "Azurite is not running on 127.0.0.1:10000. " +
         "Start it with `azurite --silent --location ./.azurite --debug ./.azurite/debug.log` " +
         "or `docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0` " +
         "to enable these tests.";
-
-    private static bool Probe()
-    {
-        try
-        {
-            using var client = new TcpClient();
-            var connect = client.ConnectAsync(Host, Port);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-        }
-        catch
-        {
-            return false;
-        }
-    }
 }
 
 /// <summary>

--- a/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.AzureBlobStorage.Tests/Wolverine.ClaimCheck.AzureBlobStorage.Tests.csproj
@@ -22,6 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="../../EmulatorProbe.cs">
+            <Link>EmulatorProbe.cs</Link>
+        </Compile>
         <Using Include="Xunit" />
     </ItemGroup>
 

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/FakeGcsFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/FakeGcsFact.cs
@@ -1,12 +1,10 @@
 using System.Runtime.CompilerServices;
-using System.Net.Sockets;
+using IntegrationTests;
 
 namespace Wolverine.ClaimCheck.GoogleCloudStorage.Tests;
 
 /// <summary>
-/// Probe the fake-gcs-server emulator once per process and cache the result. Any TCP connect
-/// failure on <c>localhost:4443</c> is treated as "not running" so tests skip cleanly. Mirrors
-/// the <c>LocalStackFact</c> pattern used by the Amazon S3 backend tests.
+/// Where the fake-gcs-server emulator lives, and whether it is up. Tests skip cleanly when it is not.
 /// </summary>
 internal static class FakeGcs
 {
@@ -14,29 +12,11 @@ internal static class FakeGcs
     public const int Port = 4443;
     public const string EmulatorHost = "http://localhost:4443";
 
-    private static readonly Lazy<bool> _isRunning = new(Probe);
-
-    public static bool IsRunning => _isRunning.Value;
+    public static bool IsRunning => EmulatorProbe.IsListening(Host, Port);
 
     public const string SkipReason =
         "The fake-gcs-server emulator is not running on localhost:4443. " +
         "Start it with `docker compose up -d fake-gcs-server` from the repo root to enable these tests.";
-
-    private static bool Probe()
-    {
-        try
-        {
-            using var client = new TcpClient();
-            var connect = client.ConnectAsync(Host, Port);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-        }
-        catch
-        {
-            return false;
-        }
-    }
 }
 
 /// <summary>

--- a/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.GoogleCloudStorage.Tests/Wolverine.ClaimCheck.GoogleCloudStorage.Tests.csproj
@@ -22,6 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="../../EmulatorProbe.cs">
+            <Link>EmulatorProbe.cs</Link>
+        </Compile>
         <Using Include="Xunit" />
     </ItemGroup>
 

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsFact.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/NatsFact.cs
@@ -1,12 +1,10 @@
 using System.Runtime.CompilerServices;
-using System.Net.Sockets;
+using IntegrationTests;
 
 namespace Wolverine.ClaimCheck.Nats.Tests;
 
 /// <summary>
-/// Probe NATS once per process and cache the result. Any TCP connect failure on
-/// <c>localhost:4222</c> is treated as "not running" so tests skip cleanly. Mirrors
-/// the <c>LocalStackFact</c> pattern used by the Amazon S3 backend tests.
+/// Where NATS lives, and whether it is up. Tests skip cleanly when it is not.
 /// </summary>
 internal static class NatsServer
 {
@@ -14,29 +12,11 @@ internal static class NatsServer
     public const int Port = 4222;
     public const string Url = "nats://localhost:4222";
 
-    private static readonly Lazy<bool> _isRunning = new(Probe);
-
-    public static bool IsRunning => _isRunning.Value;
+    public static bool IsRunning => EmulatorProbe.IsListening(Host, Port);
 
     public const string SkipReason =
         "NATS is not running on localhost:4222. " +
         "Start it with `docker compose up -d nats` from the repo root to enable these tests.";
-
-    private static bool Probe()
-    {
-        try
-        {
-            using var client = new TcpClient();
-            var connect = client.ConnectAsync(Host, Port);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-        }
-        catch
-        {
-            return false;
-        }
-    }
 }
 
 /// <summary>

--- a/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
+++ b/src/Persistence/Wolverine.ClaimCheck.Nats.Tests/Wolverine.ClaimCheck.Nats.Tests.csproj
@@ -22,6 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="../../EmulatorProbe.cs">
+            <Link>EmulatorProbe.cs</Link>
+        </Compile>
         <Using Include="Xunit" />
     </ItemGroup>
 


### PR DESCRIPTION
Independent of the rest of #4160 — found while moving around in these suites.

## The bug

`LocalStackFact`, `AzuriteFact`, `FakeGcsFact` and `NatsFact` each carried the same hand-copied probe:

```csharp
using var client = new TcpClient();
var connect = client.ConnectAsync(Host, Port);
return connect.Wait(TimeSpan.FromSeconds(2)) && client.Connected;
```

docker-compose publishes the LocalStack gateway as `"127.0.0.1:4566:4566"` — the only service in the file bound explicitly to loopback. So `::1` has no listener, and the IPv6 attempt that `localhost` resolves to *first* does not always fail inside that two second budget for the whole call.

With LocalStack up and healthy, on `main`:

```
Skipped! - Failed: 0, Passed: 0, Skipped: 4, Total: 4 - Wolverine.ClaimCheck.AmazonS3.Tests.dll
```

On this branch, same LocalStack:

```
Passed! - Failed: 0, Passed: 4, Skipped: 0, Total: 4 - Wolverine.ClaimCheck.AmazonS3.Tests.dll
```

Green either way, which is the point — this is the same silent-skip failure mode as #4007, one layer down. #4007 gave the object-store suites a CI target so they would stop only ever running on a developer machine; this is the S3 one still not running *on* a developer machine.

The other three emulators use the bare `port:port` form, which Docker Desktop binds dual-stack, so `::1` does have a listener and they happened to be unaffected. They share the code, so they'd break the moment someone tightens a binding the way LocalStack's is.

## The fix

`src/EmulatorProbe.cs` — one probe that resolves the host and tries every address, taking the first that connects. Linked into the four suites the way `src/Servers.cs` already is, so it needs no new project and no package dependency. Each suite keeps only what is actually specific to it: host, port, skip reason, client factory.

An IP literal short-circuits the DNS lookup, so `AzuriteFact`'s `127.0.0.1` costs nothing extra.

## Verification

All four suites, against live emulators (`docker compose up -d localstack nats fake-gcs-server azurite`), 23 tests, **0 skipped**:

| Suite | Result |
| --- | --- |
| `Wolverine.ClaimCheck.AmazonS3.Tests` | 4/4 |
| `Wolverine.ClaimCheck.AzureBlobStorage.Tests` | 4/4 |
| `Wolverine.ClaimCheck.GoogleCloudStorage.Tests` | 4/4 |
| `Wolverine.ClaimCheck.Nats.Tests` | 11/11 |

Before/after measured on two worktrees of the same commit, not on a stash, so the "before" is really `main`.