### PR TITLE
GH-4167: one BatchingProcessor per batched message type, not one per racing caller

### DIFF
--- a/src/Testing/CoreTests/Acceptance/batching_processor_build_race.cs
+++ b/src/Testing/CoreTests/Acceptance/batching_processor_build_race.cs
@@ -1,0 +1,104 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Batching;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+/// GH-4167. BatchingOptions.BuildHandler is lazy init on the message-handling path, reached through
+/// HandlerPipeline's LightweightCache&lt;Type, IExecutor&gt; whose indexer does not lock — two concurrent
+/// misses each invoke the factory and each returns its own instance.
+///
+/// A duplicate stateless executor is harmless. A duplicate BatchingProcessor is not: each owns a
+/// separate BatchingChannel buffer, its own flush Timer, and two Blocks with live worker tasks. Two
+/// instances means the batch silently splits, and the loser is never returned to anyone so it is
+/// never disposed — its timer and worker tasks leak for the life of the process.
+/// </summary>
+public class batching_processor_build_race
+{
+    private static Task<IHost> hostAsync(TimeSpan triggerTime, string queueName)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.BatchMessagesOf<ExpiryItem>(batching =>
+                {
+                    batching.TriggerTime = triggerTime;
+                    batching.LocalExecutionQueueName = queueName;
+                });
+            }).StartAsync();
+    }
+
+    /// <summary>
+    /// The direct expression of the race, and the one that fails without the fix regardless of which
+    /// JasperFx version is referenced. The end-to-end test below can only fail once Block stops running
+    /// continuations inline on the publisher (jasperfx#714), because that inline execution serializes
+    /// the first messages onto one thread and closes the window.
+    /// </summary>
+    [Fact]
+    public async Task concurrent_BuildHandler_yields_one_shared_processor()
+    {
+        using var host = await hostAsync(1.Seconds(), "race_direct");
+
+        var runtime = (WolverineRuntime)host.Services.GetRequiredService<IWolverineRuntime>();
+        var options = runtime.Options.BatchDefinitions.Single(x => x.ElementType == typeof(ExpiryItem));
+
+        const int racers = 8;
+        var gate = new Barrier(racers);
+
+        var handlers = await Task.WhenAll(Enumerable.Range(0, racers).Select(_ => Task.Run(() =>
+        {
+            gate.SignalAndWait();
+            return options.BuildHandler(runtime);
+        })));
+
+        // Reference equality: every racer must have been handed the SAME processor. Without the fix
+        // each concurrent miss builds and returns its own, each with its own buffer and flush timer.
+        handlers.Distinct().Count().ShouldBe(1,
+            $"BuildHandler produced {handlers.Distinct().Count()} distinct BatchingProcessor instances " +
+            "across concurrent callers; every extra one owns an orphaned Timer and worker tasks.");
+    }
+
+    /// <summary>
+    /// End-to-end consequence: the two members of a concurrent first wave must land in one batch.
+    /// NOTE: this passes against JasperFx 2.56.0 even without the fix, because Block's inline
+    /// continuations serialize the first two messages. It becomes a real guard once jasperfx#714 ships.
+    /// </summary>
+    [Fact]
+    public async Task concurrent_first_messages_still_assemble_a_single_batch()
+    {
+        ExpiryItemHandler.Clear();
+
+        using var host = await hostAsync(500.Milliseconds(), "race_items");
+
+        var session = await host.TrackActivity()
+            .Timeout(30.Seconds())
+            .WaitForMessageToBeReceivedAt<ExpiryItem[]>(host)
+            .ExecuteAndWaitAsync((Func<IMessageContext, Task>)(async c =>
+            {
+                var gate = new Barrier(2);
+
+                await Task.WhenAll(
+                    Task.Run(async () =>
+                    {
+                        gate.SignalAndWait();
+                        await c.PublishAsync(new ExpiryItem("one"));
+                    }),
+                    Task.Run(async () =>
+                    {
+                        gate.SignalAndWait();
+                        await c.PublishAsync(new ExpiryItem("two"));
+                    }));
+            }));
+
+        var batches = session.Executed.MessagesOf<ExpiryItem[]>().ToArray();
+
+        batches.Length.ShouldBe(1,
+            "The two members were split across separate BatchingProcessor instances: " +
+            string.Join(" | ", batches.Select(b => "[" + string.Join(",", b.Select(x => x.Name)) + "]")));
+    }
+}

--- a/src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs
@@ -75,9 +75,18 @@ public class Bug_3399_batched_message_separated_handler_codegen
                 opts.BatchMessagesOf<ItemDeleted3399>();
             }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
 
+        // GH-4167: wait for EXECUTION, not receipt. A WaitFor* condition REPLACES quiescence rather
+        // than adding to it, so WaitForMessageToBeReceivedAt released this session the moment the batch
+        // envelope arrived -- before any handler ran -- and the assertion below raced it. That passed
+        // only because JasperFx ran Block continuations inline on the publisher, which made receive and
+        // execute effectively atomic; it failed on every run once that was fixed (jasperfx#714).
+        //
+        // The count is 2 because that is the whole point of this fixture: under Separated behavior the
+        // batched array has TWO chains (TelemetryHandler3399 and OtherDeletedHandler3399). Waiting on
+        // one execution just swaps a receive/execute race for a which-chain-won race.
         await host.TrackActivity()
             .Timeout(30.Seconds())
-            .WaitForMessageToBeReceivedAt<ItemDeleted3399[]>(host)
+            .WaitForExecutionOf<ItemDeleted3399[]>(2)
             .SendMessageAndWaitAsync(new ItemDeleted3399(Guid.NewGuid()));
 
         TelemetryHandler3399.Batched.ShouldBeGreaterThan(0);

--- a/src/Wolverine/Runtime/Batching/BatchingOptions.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingOptions.cs
@@ -9,7 +9,11 @@ namespace Wolverine.Runtime.Batching;
 
 public class BatchingOptions : IAsyncDisposable
 {
-    private IMessageHandler _handler = null!;
+    private volatile IMessageHandler _handler = null!;
+
+    // GH-4167. BuildHandler runs on the message-handling path, not at bootstrap, so it has to be
+    // safe for concurrent first-touch. See the note there for why a duplicate is not benign.
+    private readonly object _handlerLock = new();
 
     // CloseAndBuildAs over DefaultMessageBatcher<elementType> and
     // ProcessorBuilder<ElementType> closes a generic over the user-supplied
@@ -179,8 +183,25 @@ public class BatchingOptions : IAsyncDisposable
     {
         if (_handler != null) return _handler;
 
-        var builder = typeof(ProcessorBuilder<>).CloseAndBuildAs<IProcessorBuilder>(ElementType);
-        _handler = builder.Build(runtime, Batcher, this);
+        // GH-4167. This is lazy init on the message-handling path, and the caller reaches it through
+        // HandlerPipeline's LightweightCache<Type, IExecutor>, whose indexer does NOT lock: two
+        // concurrent misses each invoke the factory AND each returns its own instance. A duplicate
+        // stateless executor is harmless, which is why that cache is fine everywhere else. A duplicate
+        // BatchingProcessor is not -- each one owns a separate BatchingChannel buffer, its own flush
+        // Timer, and two Blocks with live worker tasks. Two instances means the batch silently splits
+        // across them, and the loser is never handed back to anyone, so it is never disposed: its timer
+        // and worker tasks leak for the life of the process.
+        //
+        // Reproduced deterministically once JasperFx stopped running Block continuations inline on the
+        // publisher (jasperfx#714) -- that inline execution had been serializing the first messages onto
+        // one thread and hiding this. The race was always reachable under genuinely concurrent traffic.
+        lock (_handlerLock)
+        {
+            if (_handler != null) return _handler;
+
+            var builder = typeof(ProcessorBuilder<>).CloseAndBuildAs<IProcessorBuilder>(ElementType);
+            _handler = builder.Build(runtime, Batcher, this);
+        }
 
         return _handler;
     }


### PR DESCRIPTION
Found while verifying the JasperFx fix for #4167 (JasperFx/jasperfx#714). **This is a live bug on `main` today** — it does not depend on that fix.

## The bug

`BatchingOptions.BuildHandler` is an unguarded lazy init, and it runs on the **message-handling path**, not at bootstrap:

```csharp
if (_handler != null) return _handler;
_handler = builder.Build(runtime, Batcher, this);
```

Callers reach it through `HandlerPipeline`'s `LightweightCache<Type, IExecutor>`, whose indexer does not lock — two concurrent misses each invoke the factory **and each returns its own instance**.

For a stateless executor that is harmless, which is why the cache is fine everywhere else. A `BatchingProcessor` is not stateless: each instance owns a separate `BatchingChannel` buffer, its own flush `Timer`, and two `Block`s with live worker tasks.

Instrumented — two instances on two threads, and a two-member batch arrives as two batches:

```
BuildHandler BUILT instance 11865849 for ExpiryItem on tid=24
BuildHandler BUILT instance 34717384 for ExpiryItem on tid=19
TriggerBatch count=1 tid=21
TriggerBatch count=1 tid=6
→ 2 batch(es): [one] | [two]
```

Two consequences:

1. **Batches silently fragment** — members of one logical batch are split across buffers and flushed separately.
2. **The loser leaks.** It is never handed back to any caller, so nothing disposes it; its `Timer` and worker tasks live for the process lifetime.

## The fix

Double-checked lock, with `_handler` made `volatile` for the unlocked read.

## Tests

`concurrent_BuildHandler_yields_one_shared_processor` races 8 callers into `BuildHandler` and asserts reference equality. It **fails on every run without the fix, against the currently referenced JasperFx 2.56.0** — deliberately written to exercise the race directly rather than through message publishing, so it does not depend on the JasperFx release to be meaningful.

The end-to-end companion (`concurrent_first_messages_still_assemble_a_single_batch`) still passes on 2.56.0 even unfixed, because inline `Block` continuations serialize the first messages. It becomes a real guard after the JasperFx bump; the comment says so.

## Also: `Bug_3399`'s wait condition

A latent test race the same inline execution was hiding. A `WaitFor*` condition **replaces** quiescence rather than adding to it, so `WaitForMessageToBeReceivedAt` released the session at receipt, before any handler ran, and the assertion raced it. Probed: `Batched=0` immediately, `Batched=1` after 1s — the handler runs, the test just asked the wrong question.

Now waits for execution, of **both** separated chains for the batched array; waiting on one only trades a receive/execute race for a which-chain-won race.

## Verification

- `CoreTests` **2664 passed / 2 skipped / 0 failed** against a locally built JasperFx carrying jasperfx#714
- `CoreTests` green on stock JasperFx 2.56.0
- `wolverine.slnx` clean under `-c Release -f net9.0`

## Follow-up

The GH-4167 local-queue reproduction test is **not** in this PR — it asserts the publisher thread never runs the handler, which cannot pass until JasperFx ships jasperfx#714. It should land with the JasperFx version bump, as that bump's acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)