### PR TITLE
GH-4166: AutoCreate.None no longer pays for a full schema diff at startup

### DIFF
--- a/src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs
+++ b/src/Persistence/PostgresqlTests/explicit_resource_setup_with_auto_create_none.cs
@@ -70,6 +70,19 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
         await conn.CloseAsync();
     }
 
+    /// <summary>
+    ///     Schema drift that leaves every table in place: an extra column Wolverine never built. Weasel's
+    ///     diff reports this as a difference; the cheap startup probe deliberately does not care.
+    /// </summary>
+    private static async Task addUnexpectedColumnAsync(string tableName)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand($"alter table {SchemaName}.{tableName} add column gh4166_drift varchar(25) null")
+            .ExecuteNonQueryAsync();
+        await conn.CloseAsync();
+    }
+
     private static async Task<bool> envelopeTablesExist()
     {
         await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
@@ -190,21 +203,19 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
     }
 
     /// <summary>
-    ///     The GH-3130 compatibility path. Storage that is merely <em>out of date</em> rather than absent is
-    ///     the case this matters for: the assert is strict about any difference, but a host whose code never
-    ///     touches the drifted object used to start perfectly well - so a deployment that provisions after
-    ///     its replicas has to be able to keep that behaviour.
+    ///     The GH-3130 compatibility path. A host whose code never touches the missing object used to start
+    ///     perfectly well, so a deployment that provisions after its replicas has to keep that behaviour.
     /// </summary>
     [Fact]
-    public async Task continue_on_failures_starts_the_host_when_the_storage_is_out_of_date()
+    public async Task continue_on_failures_starts_the_host_when_a_table_is_missing()
     {
         using (var provisioned = configureHost().Build())
         {
             await provisioned.SetupResources(cancellation: TestContext.Current.CancellationToken);
         }
 
-        // Nothing in the startup path reads the dead letter table, so this is drift the host can tolerate -
-        // and the assert still has to see it, or the test proves nothing.
+        // Nothing in the startup path reads the dead letter table, so this is a gap the host can tolerate -
+        // and the check still has to see it, or the test proves nothing.
         await dropAsync(DatabaseConstants.DeadLetterTable);
 
         using var host = configureHost(ResourceMigrationFailureMode.ContinueOnFailures).Build();
@@ -214,7 +225,7 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
     }
 
     [Fact]
-    public async Task fail_fast_stops_the_host_when_the_storage_is_out_of_date()
+    public async Task fail_fast_stops_the_host_when_a_table_is_missing()
     {
         using (var provisioned = configureHost().Build())
         {
@@ -229,6 +240,30 @@ public class explicit_resource_setup_with_auto_create_none : PostgresqlContext, 
             () => host.StartAsync(TestContext.Current.CancellationToken));
 
         exception.ToString().ShouldContain("resources setup");
+    }
+
+    /// <summary>
+    ///     GH-4166. AutoCreate.None is a claim that something ELSE owns this schema, so startup must not
+    ///     fail over a schema that merely differs from what this Wolverine version would have built. 6.30.0
+    ///     ran the full Weasel diff here and threw on any difference, which broke controlled-migration and
+    ///     rolling-deploy setups that had been starting fine. Every table is present here; only its shape
+    ///     differs, and that is the migration path's business, not startup's.
+    /// </summary>
+    [Fact]
+    public async Task drift_that_leaves_the_tables_in_place_does_not_stop_startup()
+    {
+        using (var provisioned = configureHost().Build())
+        {
+            await provisioned.SetupResources(cancellation: TestContext.Current.CancellationToken);
+        }
+
+        await addUnexpectedColumnAsync(DatabaseConstants.IncomingTable);
+
+        // Fail-fast mode deliberately, so this cannot pass merely because failures are being swallowed
+        using var host = configureHost().Build();
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        await host.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -211,6 +211,56 @@ public abstract partial class MessageDatabase<T>
         }
     }
 
+    /// <summary>
+    /// GH-4166. The cheap startup counterpart to <see cref="AssertStorageExistsAsync"/>: one trivially
+    /// planned probe per core table rather than a full schema diff of every object. `select 1 ... where
+    /// 1 = 0` returns no rows and reads no data on every engine we support -- it fails only when the
+    /// table itself is not there, which is the condition worth catching when AutoCreate is None.
+    /// </summary>
+    public async Task AssertStorageProvisionedAsync(CancellationToken token)
+    {
+        // Envelope storage first, then the node tables, which only the Main store owns. Deliberately not
+        // the stored procedures or indexes -- their absence is drift for the migration path to report,
+        // not the "nothing was ever provisioned" case this exists to name.
+        var tables = new List<string>
+        {
+            DatabaseConstants.IncomingTable,
+            DatabaseConstants.OutgoingTable,
+            DatabaseConstants.DeadLetterTable
+        };
+
+        if (Role == MessageStoreRole.Main)
+        {
+            tables.Add(DatabaseConstants.NodeTableName);
+        }
+
+        await using var conn = await DataSource.OpenConnectionAsync(token);
+        try
+        {
+            foreach (var table in tables)
+            {
+                var name = QuotedTableNameFor(table);
+
+                try
+                {
+                    await using var command = conn.CreateCommand();
+                    command.CommandText = $"select 1 from {name} where 1 = 0";
+                    await command.ExecuteNonQueryAsync(token);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException(
+                        $"The Wolverine message storage for database '{Name}' is missing (could not read '{name}'). Run 'resources setup' / IHost.SetupResources(), or enable auto-provisioning with AutoBuildMessageStorageOnStartup.",
+                        e);
+                }
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+    }
+
     private Task migrateAsync(DbConnection conn)
     {
         return migrateAsync(conn, _settings.AutoCreate);

--- a/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStoreAdmin.cs
@@ -69,6 +69,28 @@ public interface IMessageStoreAdmin
     Task AssertStorageExistsAsync(CancellationToken token) => Task.CompletedTask;
 
     /// <summary>
+    ///     Verify that the durable envelope storage has been provisioned at all, throwing when it has not.
+    ///     Deliberately weaker AND far cheaper than <see cref="AssertStorageExistsAsync" />: it asks only
+    ///     whether the storage exists, not whether it matches the configured schema exactly.
+    /// </summary>
+    /// <remarks>
+    ///     This is the startup-path check for <c>AutoBuildMessageStorageOnStartup = AutoCreate.None</c>
+    ///     (GH-4166). Startup used to call <see cref="AssertStorageExistsAsync" />, whose RDBMS
+    ///     implementation runs the same full Weasel schema diff as the migration itself -- 14 schema
+    ///     objects including five stored procedures on SQL Server, measured at ~80ms against a warm local
+    ///     database and enough to blow the 30s command timeout on a small Azure SQL tier. That is exactly
+    ///     the work <c>None</c> is set to avoid.
+    ///
+    ///     It is also deliberately tolerant of drift. <c>None</c> is a claim that something else owns the
+    ///     schema, so failing startup because a column differs from what this Wolverine version would have
+    ///     built punishes the controlled-migration and rolling-deploy cases that set it. Absent storage is
+    ///     the failure worth catching early, and it is the one this catches.
+    ///
+    ///     The default is a no-op for stores that cannot introspect their own storage.
+    /// </remarks>
+    Task AssertStorageProvisionedAsync(CancellationToken token) => Task.CompletedTask;
+
+    /// <summary>
     ///     Apply any necessary database migrations to bring the underlying envelope
     ///     storage to the configured requirements of the Wolverine system
     /// </summary>

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -479,6 +479,11 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         return executeOnAllAsync(d => d.Admin.AssertStorageExistsAsync(token));
     }
 
+    Task IMessageStoreAdmin.AssertStorageProvisionedAsync(CancellationToken token)
+    {
+        return executeOnAllAsync(d => d.Admin.AssertStorageProvisionedAsync(token));
+    }
+
     Task IMessageStoreAdmin.MigrateAsync()
     {
         return migrateAsync(null);

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -314,13 +314,18 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
     }
 
     /// <summary>
-    ///     Verify that every store's durable objects exist and match configuration, throwing when they do
+    ///     Verify that every store's durable storage has actually been provisioned, throwing when it has
     ///     not. The counterpart to <see cref="MigrateAsync" /> for a system that provisions its storage ahead
     ///     of startup instead of building it there, and it has to cover the same set of stores: an ancillary
     ///     store whose schema was never provisioned fails whenever something first uses it, which can be a
     ///     long way from startup.
     /// </summary>
-    public async Task AssertStorageExistsAsync(CancellationToken token)
+    /// <remarks>
+    ///     GH-4166: this asks each store's cheap <see cref="IMessageStoreAdmin.AssertStorageProvisionedAsync" />,
+    ///     NOT the full schema diff behind <see cref="IMessageStoreAdmin.AssertStorageExistsAsync" />. Startup
+    ///     under AutoCreate.None must not pay for the introspection that setting exists to avoid.
+    /// </remarks>
+    public async Task AssertStorageProvisionedAsync(CancellationToken token)
     {
         var stores = await FindAllAsync();
         var exceptions = new List<Exception>();
@@ -329,7 +334,7 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         {
             try
             {
-                await store.Admin.AssertStorageExistsAsync(token);
+                await store.Admin.AssertStorageProvisionedAsync(token);
             }
             catch (Exception e)
             {

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -309,12 +309,17 @@ public partial class WolverineRuntime
             // deploy that deliberately tolerates a replica starting ahead of its provisioning step still
             // can. Stores that cannot introspect their own schema no-op this (IMessageStoreAdmin default).
             //
+            // GH-4166: this asks only whether the storage EXISTS. It deliberately does not run the full
+            // Weasel schema diff -- that is the very work AutoCreate.None is set to avoid, and doing it
+            // here timed out startup on small Azure SQL tiers in 6.30.0/6.30.1. Drift is likewise not a
+            // startup failure: None means something else owns this schema.
+            //
             // The whole collection rather than Storage alone, so that it covers what MigrateAsync above
             // covers: an ancillary store whose schema was never provisioned would otherwise go unchecked and
             // fail whenever something first used it.
             try
             {
-                await _stores.Value.AssertStorageExistsAsync(Cancellation);
+                await _stores.Value.AssertStorageProvisionedAsync(Cancellation);
             }
             catch (Exception e) when (Options.ResourceMigrationFailureMode ==
                                       ResourceMigrationFailureMode.ContinueOnFailures)


### PR DESCRIPTION
Fixes #4166 — a 6.30.0 regression. The reporter's host stops starting when `AutoBuildMessageStorageOnStartup = AutoCreate.None`, and rolling back to 6.29.2 fixes it.

## Diagnosis

`388c3f75a` (6.30.0) added a verification step to the `AutoCreate.None` startup path so a wrong "something else provisioned this" claim fails fast instead of surfacing later as a bare `relation does not exist`. The intent is right. But it calls `AssertStorageExistsAsync`, whose RDBMS implementation runs `SchemaMigration.DetermineAsync` — **the same full Weasel schema diff the migration itself runs**.

So `None` stopped skipping the expensive introspection and started only skipping the part that *applies* it — precisely the work that setting exists to avoid. The reporter's own comment says as much: *"THE MIGRATION IS DDL HEAVY AND REQUIRES UPGRADING AZURE SQL ON THE SMALLER ENVIRONMENTS"*.

Measured against a warm local SQL Server:

| | median |
|---|---|
| `AssertStorageExistsAsync` — **14 schema objects** | **80 ms** |
| existence probe of the core tables | **1 ms** |

The 14 are four tables plus their indexes, a table type, **five stored procedures**, and five node/control tables. On a small Azure SQL tier — low DTU, cold plan cache, network latency — that is enough to exceed the 30 s default command timeout. Which is exactly what the log shows: 30 seconds between `Skipping automatic message storage migration` and `Failed to start the Wolverine messaging … Execution Timeout Expired`.

## Fix

- New `IMessageStoreAdmin.AssertStorageProvisionedAsync`, default no-op so non-RDBMS stores are unaffected.
- RDBMS implementation probes the core tables with `select 1 … where 1 = 0` — no catalog scan, no plan cost.
- Startup calls it; **`resources check` is untouched** and keeps the full diff, which is the right semantic there because an operator asked for it explicitly.

### Deliberate semantic change: drift no longer blocks startup

Failing startup because a column differs from what this Wolverine version would have built punishes the controlled-migration and rolling-deploy setups that are the entire reason to set `None` — and it is the wrong semantic for a method asking whether storage *exists*. Absent storage still fails fast and still names `resources setup`.

The two existing tests drop a whole table, so they cover **absence** rather than drift; renamed to say so. A new test covers real drift — an extra column, every table present — and asserts the host starts in fail-fast mode.

## Verification

- The new drift test **fails against the 6.30.0/6.30.1 behaviour** and passes with the fix, so it is not vacuous.
- `PostgresqlTests` 500/501 (the one failure is a RabbitMQ test with the broker stopped; passes with it running).
- `wolverine.slnx` clean under `-c Release -f net9.0`.

## On the two SqlServerTests failures seen earlier — resolved

An earlier full `SqlServerTests` run with this change showed 2 failures (`clear_all_async_alone_leaves_the_queue_tables_alone`, `hammer_it_with_lots_of_messages_global_partitioned`) that a baseline run on `main` did not. **They were flakes**, confirmed two independent ways rather than assumed: a clean repeat run of the full suite with this change (405 total, **0 failed**, matching the baseline exactly) and **`CISqlServer` passing** here. Recorded because the PR previously carried a hold on this, not because anything is outstanding.

## API note

`MessageStoreCollection.AssertStorageExistsAsync` is renamed to `AssertStorageProvisionedAsync`. It is public, but was introduced by that same 6.30.0 commit for exactly this internal call and has no other caller in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
