### PR TITLE
Resequence draining using PublishAsync appears problematic

### DIFF
--- a/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
+++ b/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
@@ -133,9 +133,7 @@ public class resequencer_saga_in_memory : IAsyncLifetime
         state.ShouldNotBeNull();
         state.LastSequence.ShouldBe(3);
         state.Pending.ShouldBeEmpty();
-        state.ProcessedOrders.ShouldContain(1);
-        state.ProcessedOrders.ShouldContain(2);
-        state.ProcessedOrders.ShouldContain(3);
+        state.ProcessedOrders.ShouldBe([1, 2, 3]);
     }
 
     [Fact]

--- a/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
+++ b/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
@@ -13,6 +13,24 @@ public record StartSequencedSaga(Guid Id);
 
 public record SequencedCommand(Guid SagaId, int? Order) : SequencedMessage;
 
+public record EnqueueSequencedBatch(Guid SagaId, int[] Orders);
+
+public class EnqueueSequencedBatchHandler
+{
+    // Returning cascading messages puts the whole batch into the queue atomically, so the
+    // test controls exactly what backlog exists when the resequencer drains its Pending list
+    public static OutgoingMessages Handle(EnqueueSequencedBatch batch)
+    {
+        var messages = new OutgoingMessages();
+        foreach (var order in batch.Orders)
+        {
+            messages.Add(new SequencedCommand(batch.SagaId, order));
+        }
+
+        return messages;
+    }
+}
+
 public class TestResequencerSaga : ResequencerSaga<SequencedCommand>
 {
     public Guid Id { get; set; }
@@ -39,9 +57,13 @@ public class resequencer_saga_in_memory : IAsyncLifetime
             .UseWolverine(opts =>
             {
                 opts.Discovery.DisableConventionalDiscovery()
-                    .IncludeType<TestResequencerSaga>();
+                    .IncludeType<TestResequencerSaga>()
+                    .IncludeType<EnqueueSequencedBatchHandler>();
 
-                opts.PublishAllMessages().To(TransportConstants.LocalUri);
+                opts.PublishAllMessages().ToLocalQueue("sequenced");
+
+                // Strictly sequential so that message ordering through the queue is deterministic
+                opts.LocalQueue("sequenced").Sequential();
             })
             .StartAsync();
     }
@@ -114,6 +136,31 @@ public class resequencer_saga_in_memory : IAsyncLifetime
         state.ProcessedOrders.ShouldContain(1);
         state.ProcessedOrders.ShouldContain(2);
         state.ProcessedOrders.ShouldContain(3);
+    }
+
+    [Fact]
+    public async Task replayed_pending_message_is_processed_in_sequence_behind_a_backlog()
+    {
+        var sagaId = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StartSequencedSaga(sagaId));
+
+        // 3 arrives early and lands in Pending
+        await _host.InvokeMessageAndWaitAsync(new SequencedCommand(sagaId, 3));
+
+        // 1, 2, 4, and 5 all hit the queue at once. Handling 2 fills the gap, so 3 gets
+        // replayed -- but it must not be handled after 4 and 5 that were already queued
+        await _host.ExecuteAndWaitAsync(async () =>
+        {
+            await _host.MessageBus()
+                .PublishAsync(new EnqueueSequencedBatch(sagaId, [1, 2, 4, 5]));
+        }, timeoutInMilliseconds: 30000);
+
+        var state = await LoadState(sagaId);
+        state.ShouldNotBeNull();
+        state.LastSequence.ShouldBe(5);
+        state.Pending.ShouldBeEmpty();
+        state.ProcessedOrders.ShouldBe([1, 2, 3, 4, 5]);
     }
 
     [Fact]


### PR DESCRIPTION
I am seeing an issue with the ResequencerSaga in certain scenarios.  I tried to create somewhat representative test but am not sure on the appropriate fix.

The test queues sequence 3 in Pending, then atomically publishes [1, 2, 4, 5] to a sequential local queue. When processing 2, ShouldProceed republishes 3, but that message is appended behind the existing 4 and 5. The observed result is: [1, 2, 4, 5, 3]

instead of: [1, 2, 3, 4, 5]

The root cause is that `ShouldProceed` drains `Pending` via `bus.PublishAsync(next)`, and `bus` there is the current `MessageContext` (wired in by ShouldProceedGuardFrame.cs), so the drained message is a _cascading_ message that doesn't flush until the current envelope finishes — landing at the **back** of the queue, behind messages already sitting there.

**The key to a deterministic repro:** you must get a backlog into the queue atomically. Publishing 1, 2, 4, 5 in a loop from the test races against the listener. Instead, return them all as an OutgoingMessages collection from a single handler — Wolverine flushes those as one batch, guaranteeing the queue holds [1,2,4,5] before any is processed.