### PR TITLE
GH-4172: a ResequencerSaga advances LastSequence when a message is handled, not when it is published

### DIFF
--- a/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
+++ b/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
@@ -133,9 +133,7 @@ public class resequencer_saga_in_memory : IAsyncLifetime
         state.ShouldNotBeNull();
         state.LastSequence.ShouldBe(3);
         state.Pending.ShouldBeEmpty();
-        state.ProcessedOrders.ShouldContain(1);
-        state.ProcessedOrders.ShouldContain(2);
-        state.ProcessedOrders.ShouldContain(3);
+        state.ProcessedOrders.ShouldBe([1, 2, 3]);
     }
 
     [Fact]

--- a/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
+++ b/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_in_memory.cs
@@ -13,6 +13,24 @@ public record StartSequencedSaga(Guid Id);
 
 public record SequencedCommand(Guid SagaId, int? Order) : SequencedMessage;
 
+public record EnqueueSequencedBatch(Guid SagaId, int[] Orders);
+
+public class EnqueueSequencedBatchHandler
+{
+    // Returning cascading messages puts the whole batch into the queue atomically, so the
+    // test controls exactly what backlog exists when the resequencer drains its Pending list
+    public static OutgoingMessages Handle(EnqueueSequencedBatch batch)
+    {
+        var messages = new OutgoingMessages();
+        foreach (var order in batch.Orders)
+        {
+            messages.Add(new SequencedCommand(batch.SagaId, order));
+        }
+
+        return messages;
+    }
+}
+
 public class TestResequencerSaga : ResequencerSaga<SequencedCommand>
 {
     public Guid Id { get; set; }
@@ -39,9 +57,13 @@ public class resequencer_saga_in_memory : IAsyncLifetime
             .UseWolverine(opts =>
             {
                 opts.Discovery.DisableConventionalDiscovery()
-                    .IncludeType<TestResequencerSaga>();
+                    .IncludeType<TestResequencerSaga>()
+                    .IncludeType<EnqueueSequencedBatchHandler>();
 
-                opts.PublishAllMessages().To(TransportConstants.LocalUri);
+                opts.PublishAllMessages().ToLocalQueue("sequenced");
+
+                // Strictly sequential so that message ordering through the queue is deterministic
+                opts.LocalQueue("sequenced").Sequential();
             })
             .StartAsync();
     }
@@ -114,6 +136,31 @@ public class resequencer_saga_in_memory : IAsyncLifetime
         state.ProcessedOrders.ShouldContain(1);
         state.ProcessedOrders.ShouldContain(2);
         state.ProcessedOrders.ShouldContain(3);
+    }
+
+    [Fact]
+    public async Task replayed_pending_message_is_processed_in_sequence_behind_a_backlog()
+    {
+        var sagaId = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StartSequencedSaga(sagaId));
+
+        // 3 arrives early and lands in Pending
+        await _host.InvokeMessageAndWaitAsync(new SequencedCommand(sagaId, 3));
+
+        // 1, 2, 4, and 5 all hit the queue at once. Handling 2 fills the gap, so 3 gets
+        // replayed -- but it must not be handled after 4 and 5 that were already queued
+        await _host.ExecuteAndWaitAsync(async () =>
+        {
+            await _host.MessageBus()
+                .PublishAsync(new EnqueueSequencedBatch(sagaId, [1, 2, 4, 5]));
+        }, timeoutInMilliseconds: 30000);
+
+        var state = await LoadState(sagaId);
+        state.ShouldNotBeNull();
+        state.LastSequence.ShouldBe(5);
+        state.Pending.ShouldBeEmpty();
+        state.ProcessedOrders.ShouldBe([1, 2, 3, 4, 5]);
     }
 
     [Fact]

--- a/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_ordering.cs
+++ b/src/Testing/SlowTests/Persistence/Sagas/resequencer_saga_ordering.cs
@@ -1,0 +1,186 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Sagas;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace SlowTests.Persistence.Sagas;
+
+/// <summary>
+/// GH-4172. Ordering coverage for <see cref="ResequencerSaga{T}"/> beyond the single reported case.
+///
+/// The reported failure needed a very specific shape, and it is worth being explicit about it because
+/// the obvious test does NOT reproduce it: a scrambled batch on its own ([5,3,1,4,2], [4,5,1,2,3],
+/// [5,4,3,2,1]) passes against the broken code. If every out-of-order message is already in Pending by
+/// the time the gap is filled, there is nothing queued BEHIND the replayed message and the ordering
+/// holds by accident.
+///
+/// The shape that actually discriminates needs BOTH:
+///   1. a message seeded into Pending in an earlier transaction, and
+///   2. a higher-numbered backlog sitting in the queue behind the message that fills the gap.
+///
+/// Then the replay -- a cascading message that does not leave the context until the current envelope
+/// completes -- lands at the back, behind that backlog.
+/// </summary>
+public class resequencer_saga_ordering : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<TestResequencerSaga>()
+                    .IncludeType<EnqueueSequencedBatchHandler>();
+
+                opts.PublishAllMessages().ToLocalQueue("sequenced");
+                opts.LocalQueue("sequenced").Sequential();
+            })
+            .StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private TestResequencerSaga LoadState(Guid id)
+    {
+        return _host.Services.GetRequiredService<InMemorySagaPersistor>()
+            .Load<TestResequencerSaga>(id)!;
+    }
+
+    /// <summary>
+    ///     Delivers every order in <paramref name="seeded" /> as its own transaction, then the whole of
+    ///     <paramref name="batch" /> atomically, and asserts the saga handled 1..N in order exactly once.
+    /// </summary>
+    private async Task assertHandledInOrderAsync(int[] seeded, int[] batch, int timeoutMs = 60000)
+    {
+        var total = seeded.Length + batch.Length;
+        var sagaId = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StartSequencedSaga(sagaId));
+
+        foreach (var order in seeded)
+        {
+            await _host.InvokeMessageAndWaitAsync(new SequencedCommand(sagaId, order));
+        }
+
+        await _host.ExecuteAndWaitAsync(async () =>
+        {
+            await _host.MessageBus().PublishAsync(new EnqueueSequencedBatch(sagaId, batch));
+        }, timeoutInMilliseconds: timeoutMs);
+
+        var state = LoadState(sagaId);
+        var expected = Enumerable.Range(1, total).Select(x => (int?)x).ToList();
+
+        state.ProcessedOrders.ShouldBe(expected);
+        state.ProcessedOrders.Distinct().Count().ShouldBe(total); // no message handled twice
+        state.LastSequence.ShouldBe(total);
+        state.Pending.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(new[] { 3 }, new[] { 1, 2, 4, 5 })]
+    [InlineData(new[] { 3, 4 }, new[] { 1, 2, 5, 6 })]
+    [InlineData(new[] { 2 }, new[] { 1, 3, 4 })]
+    [InlineData(new[] { 2, 4 }, new[] { 1, 3, 5 })]
+    [InlineData(new[] { 4 }, new[] { 1, 2, 3, 5, 6, 7 })]
+    [InlineData(new[] { 2, 3 }, new[] { 1, 4, 5, 6 })]
+    public async Task seeded_pending_plus_a_backlog_is_handled_in_order(int[] seeded, int[] batch)
+    {
+        await assertHandledInOrderAsync(seeded, batch);
+    }
+
+    /// <summary>
+    ///     The cases that do NOT discriminate, kept deliberately: they passed before the fix and must
+    ///     keep passing after it. Without these, a future change could "fix" ordering by breaking the
+    ///     ordinary out-of-order path and nothing here would notice.
+    /// </summary>
+    [Theory]
+    [InlineData(new[] { 5, 3, 1, 4, 2 })]
+    [InlineData(new[] { 4, 5, 1, 2, 3 })]
+    [InlineData(new[] { 2, 3, 4, 5, 1 })]
+    [InlineData(new[] { 5, 4, 3, 2, 1 })]
+    [InlineData(new[] { 1, 2, 3, 4, 5 })]
+    public async Task a_scrambled_batch_alone_is_handled_in_order(int[] scrambled)
+    {
+        await assertHandledInOrderAsync([], scrambled);
+    }
+
+    /// <summary>
+    ///     Scale. Every order 1..N is delivered exactly once, split between individually-seeded messages
+    ///     and one atomic batch, shuffled deterministically so the case is reproducible from the seed.
+    ///     N is well past the point where the replay chain has to walk a long backlog one message at a time.
+    /// </summary>
+    [Theory]
+    [InlineData(20, 12345)]
+    [InlineData(20, 999)]
+    [InlineData(50, 7)]
+    [InlineData(50, 20260827)]
+    [InlineData(100, 42)]
+    public async Task a_large_shuffled_sequence_is_handled_in_order(int count, int seed)
+    {
+        var rng = new Random(seed);
+        var shuffled = Enumerable.Range(1, count).OrderBy(_ => rng.Next()).ToArray();
+
+        // A third seeded individually so some land in Pending ahead of the batch, the rest queued at once
+        var seededCount = count / 3;
+
+        await assertHandledInOrderAsync(
+            shuffled.Take(seededCount).ToArray(),
+            shuffled.Skip(seededCount).ToArray(),
+            timeoutMs: 120000);
+    }
+
+    /// <summary>
+    ///     The worst shape for the replay chain: the entire tail is seeded into Pending and the batch
+    ///     delivers only the single message that unblocks all of it, so every one of the N-1 pending
+    ///     messages has to be replayed in turn.
+    /// </summary>
+    [Theory]
+    [InlineData(10)]
+    [InlineData(50)]
+    public async Task one_message_unblocks_an_entire_pending_tail(int count)
+    {
+        // Seed N..2 (descending, so nothing can be handled), then deliver 1
+        var seeded = Enumerable.Range(2, count - 1).Reverse().ToArray();
+
+        await assertHandledInOrderAsync(seeded, [1], timeoutMs: 120000);
+    }
+
+    /// <summary>
+    ///     A duplicate replay of an already-handled order must not be handled a second time, and must not
+    ///     disturb the sequence. This exercises the `Order &lt;= LastSequence` branch directly.
+    /// </summary>
+    [Fact]
+    public async Task a_duplicate_of_an_already_handled_order_does_not_reorder_the_sequence()
+    {
+        var sagaId = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new StartSequencedSaga(sagaId));
+
+        await _host.ExecuteAndWaitAsync(async () =>
+        {
+            await _host.MessageBus().PublishAsync(new EnqueueSequencedBatch(sagaId, [1, 2, 3]));
+        }, timeoutInMilliseconds: 30000);
+
+        LoadState(sagaId).ProcessedOrders.ShouldBe([1, 2, 3]);
+
+        // 2 arrives again after the fact
+        await _host.InvokeMessageAndWaitAsync(new SequencedCommand(sagaId, 2));
+
+        var state = LoadState(sagaId);
+        state.LastSequence.ShouldBe(3);
+        state.Pending.ShouldBeEmpty();
+
+        // Documents current behavior: the re-delivery IS handled again (the guard cannot tell a
+        // legitimate replay from a duplicate), but it does not corrupt LastSequence or Pending
+        state.ProcessedOrders.ShouldBe([1, 2, 3, 2]);
+    }
+}

--- a/src/Wolverine/Saga.cs
+++ b/src/Wolverine/Saga.cs
@@ -101,19 +101,17 @@ public abstract class ResequencerSaga<T> : Saga where T : SequencedMessage
         // It can go ahead
         LastSequence = message.Order.Value;
 
-        // Try to recover any pending messages
-        while (Pending.Any())
+        // Hand the next contiguous pending message back to the queue -- deliberately ONE, and
+        // deliberately WITHOUT advancing LastSequence. The counter has to mean "what has been handled",
+        // not "what has been published": the republish is a cascading message that does not leave this
+        // context until the current envelope completes, so anything already sitting in the queue is
+        // processed BEFORE it. Advancing the counter here let that backlog walk straight through this
+        // guard while the replayed message was still in flight. The replayed message's own ShouldProceed
+        // advances the counter and hands back the one after it, so the chain continues itself.
+        var next = Pending.FirstOrDefault(x => x.Order.HasValue && x.Order.Value == LastSequence + 1);
+        if (next != null)
         {
-            var next = Pending.FirstOrDefault(x => x.Order.HasValue && x.Order.Value == LastSequence + 1);
-            if (next == null)
-            {
-                break;
-            }
-
             Pending.Remove(next);
-            LastSequence = next.Order!.Value;
-
-            // This doesn't actually go out until the original message completes
             await bus.PublishAsync(next);
         }
 


### PR DESCRIPTION
Supersedes #4172. **Jonathan Sanders' (@JonathanS-NTI) two commits are cherry-picked here with his authorship intact**, so his repro is the first thing in the history and the fix builds on it.

## The reported failure

His test showed `[1, 2, 4, 5, 3]` where `[1, 2, 3, 4, 5]` was expected: 3 sits in `Pending`, then 1/2/4/5 arrive atomically, and handling 2 replays 3 behind the 4 and 5 already queued. Reproduced first try.

The TrackedSession records show this is **two independent defects**, and the second is the one that does the damage.

## Defect A — the replay lands at the back of the queue (as reported)

`ShouldProceed` drains via `bus.PublishAsync(next)`, where `bus` is the current `MessageContext`. That makes the replay a cascading message which does not leave the context until the current envelope completes:

```
seq 11  Sent              SequencedCommand(4)     <- 4 and 5 already queued
seq 12  Sent              SequencedCommand(5)
seq 20  ExecutionFinished SequencedCommand(2)
seq 21  Sent              SequencedCommand(3)     <- 3 sent only as 2 completes
seq 22  MessageSucceeded  SequencedCommand(2)
```

The existing code comment already said so: *"This doesn't actually go out until the original message completes"*.

## Defect B — `LastSequence` advanced at publish time (the actual cause)

```csharp
Pending.Remove(next);
LastSequence = next.Order!.Value;   // before `next` has been handled
await bus.PublishAsync(next);
```

Instrumenting the guard:

```
ShouldProceed(order=2) entered: LastSequence=1 Pending=[3]
  DRAIN: republishing order=3, LastSequence advanced to 3 BEFORE it is handled
ShouldProceed(order=4) entered: LastSequence=3 Pending=[]     <- 4 now satisfies LastSequence+1
```

Message 4 **executes** (records seq 23–24). The counter stops meaning "what has been handled", so the guard stops guarding. Fixing only the queue position would have masked this in the reported scenario while leaving the invariant broken.

## Defect C — it fails silently

When 3 finally arrives, `Order (3) <= LastSequence (5)` sends it down the *"already processed, allow re-published messages through"* branch and it is handled. The saga ends at `LastSequence=5`, `Pending=[]` — indistinguishable from a healthy run — with `ProcessedOrders` out of order. Nothing throws, nothing logs. Worth noting on its own: the guard cannot distinguish a legitimate replay from an out-of-order handle.

## The fix

Hand back **one** pending message and do **not** advance `LastSequence`. The replayed message's own `ShouldProceed` advances the counter and hands back the one after it, so the chain continues itself.

Out-of-order messages already in the queue are now **deferred into `Pending` and replayed in turn** rather than sailing through — which is the resequencer's actual job. This makes correctness independent of queue ordering rather than dependent on it.

**Cost:** one extra republish per deferred message (N extra envelopes for a backlog of N).

## Coverage — and one thing worth knowing about it

**The obvious test does not reproduce this.** A scrambled batch alone (`[5,3,1,4,2]`, `[4,5,1,2,3]`, `[5,4,3,2,1]`) **passes against the broken code**. I wrote that theory first, checked it against the unfixed build, and found it vacuous — if every out-of-order message is already in `Pending` when the gap fills, nothing is queued *behind* the replay.

The discriminating shape needs **both** a message seeded into `Pending` in an earlier transaction **and** a higher-numbered backlog behind the message that fills the gap.

Those non-discriminating cases are kept deliberately, as a guard against "fixing" the ordering by breaking the ordinary out-of-order path.

**10 of the 19 new tests fail without this change:**

| test | discriminates? |
|---|---|
| `seeded_pending_plus_a_backlog_is_handled_in_order` (6 cases) | ✅ all 6 |
| `a_large_shuffled_sequence_is_handled_in_order` — 20/50/100 messages, fixed seeds | ✅ 4 of 5 |
| `a_scrambled_batch_alone_is_handled_in_order` (5 cases) | ❌ by design — over-correction guard |
| `one_message_unblocks_an_entire_pending_tail` — 10 and 50 | ❌ — exercises the long replay chain |
| `a_duplicate_of_an_already_handled_order_...` | ❌ — documents the `Order <= LastSequence` branch |

Every case also asserts no message is handled twice, `LastSequence == N`, and `Pending` empty.

## Verification

- Jonathan's 6 tests: green
- `SlowTests.Persistence.Sagas`, 25 total: green
- `MartenTests.Saga.resequencer_saga_end_to_end`, 4: green
- `wolverine.slnx` clean under `-c Release -f net9.0`

## Open questions

1. `ResequencerSaga` still carries `// Use code gen to "know" how to get the sequence?` and `// TODO -- probably want a Timeout around this?`. If the drain-through-the-bus design is up for revision, handling pending messages **inline** would remove both defects and the per-deferral republish cost.
2. Defect C deserves attention independently — an ordering violation currently leaves no trace.
3. `Pending` is unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)