### PR TITLE
GH-3399: wait on the fact the test asserts, not on a count of envelopes

### DIFF
--- a/src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_3399_batched_message_separated_handler_codegen.cs
@@ -75,18 +75,25 @@ public class Bug_3399_batched_message_separated_handler_codegen
                 opts.BatchMessagesOf<ItemDeleted3399>();
             }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        // GH-4167: wait for EXECUTION, not receipt. A WaitFor* condition REPLACES quiescence rather
-        // than adding to it, so WaitForMessageToBeReceivedAt released this session the moment the batch
-        // envelope arrived -- before any handler ran -- and the assertion below raced it. That passed
-        // only because JasperFx ran Block continuations inline on the publisher, which made receive and
-        // execute effectively atomic; it failed on every run once that was fixed (jasperfx#714).
+        // Wait for the exact fact this test asserts, and nothing else.
         //
-        // The count is 2 because that is the whole point of this fixture: under Separated behavior the
-        // batched array has TWO chains (TelemetryHandler3399 and OtherDeletedHandler3399). Waiting on
-        // one execution just swaps a receive/execute race for a which-chain-won race.
+        // Two earlier attempts both raced. WaitForMessageToBeReceivedAt released at receipt, before any
+        // handler ran (GH-4167). Its replacement, WaitForExecutionOf<ItemDeleted3399[]>(2), counted
+        // ENVELOPES of that type -- and under Separated behavior there are THREE, not two: the batch
+        // lands on its own execution queue and is then relayed to each sticky handler queue. Measured:
+        //
+        //   ExecutionFinished env=...5310 dest=local://coretests.bugs.itemdeleted3399/          <- relay source
+        //   ExecutionFinished env=...b332 dest=local://coretests.bugs.otherdeletedhandler3399/  <- sibling
+        //   Received         env=...a676 dest=local://coretests.bugs.telemetryhandler3399/      <- never ran
+        //
+        // Those first two satisfy a count of 2 on their own, so the session was released while the
+        // handler under assertion had only been received. It runs a moment later -- probed
+        // immediate=0, eventual=1 -- so nothing was ever lost; the test was simply reading the counter
+        // too early. Counting envelopes can never express "TelemetryHandler3399 ran", so don't: gate on
+        // the counter itself.
         await host.TrackActivity()
             .Timeout(30.Seconds())
-            .WaitForExecutionOf<ItemDeleted3399[]>(2)
+            .WaitForCondition(new TelemetryBatchHandled())
             .SendMessageAndWaitAsync(new ItemDeleted3399(Guid.NewGuid()));
 
         TelemetryHandler3399.Batched.ShouldBeGreaterThan(0);
@@ -111,6 +118,24 @@ public record ItemCreated3399(Guid Id);
 // TelemetryHandler3399's calls get a sticky chain -- and sticky chains are named off the HANDLER type
 // (HandlerChain.cs:85). The two sticky chains therefore share a TypeName, which drives HandlerGraph's
 // duplicate disambiguation to rebuild the name off the message type: "ItemDeleted3399[]<hash>_...".
+/// <summary>
+/// Completes the tracked session once <see cref="TelemetryHandler3399"/> has actually handled a batch.
+/// Conditions are re-evaluated as envelope records arrive, and the handler increments before its own
+/// ExecutionFinished record is written, so this is satisfied no later than that record.
+/// </summary>
+internal class TelemetryBatchHandled : ITrackedCondition
+{
+    public void Record(EnvelopeRecord record)
+    {
+        // Nothing to accumulate -- the handler's own static counter is the observable.
+    }
+
+    public bool IsCompleted()
+    {
+        return TelemetryHandler3399.Batched > 0;
+    }
+}
+
 [WolverineIgnore]
 public class TelemetryHandler3399
 {


### PR DESCRIPTION
Test-only. No product change.

## Symptom

`CoreTests.Bugs.Bug_3399_batched_message_separated_handler_codegen.batched_handler_actually_executes` failed in **full-suite** runs — 2/3, and 3/3 in some configurations — while passing **5/5 in isolation**. That combination is why CI stayed green.

## Nothing was broken

Probed at the moment the tracked session completes, then polled: **`immediate=0 eventual=1`**. The batched handler runs; the test was reading its static counter too early. Generated code for all four Bug_3399 chains is byte-identical across the builds involved.

## The wait was counting the wrong thing

`WaitForExecutionOf<T>(count)` counts **envelopes** of a type, deduped by envelope id. Under `MultipleHandlerBehavior.Separated` a single batch produces **three** `ItemDeleted3399[]` envelopes, not two — the batch lands on its own execution queue and is then relayed to each sticky handler queue. Measured from `session.AllRecordsInOrder()`:

```
ExecutionFinished env=...5310 dest=local://coretests.bugs.itemdeleted3399/          <- relay source
ExecutionFinished env=...b332 dest=local://coretests.bugs.otherdeletedhandler3399/  <- sibling chain
Received          env=...a676 dest=local://coretests.bugs.telemetryhandler3399/     <- never executed
```

The first two satisfy a count of 2 between them, so the session was released while the handler the assertion depends on had only been *received*.

## The fix

Stop counting. Gate on the observable being asserted, via an `ITrackedCondition` on `TelemetryHandler3399.Batched > 0`.

This is the **second** time this test has been fixed by tightening its wait, and the second time the wait still did not name what it asserts — GH-4167 replaced `WaitForMessageToBeReceivedAt` (released at receipt) with the execution count. A count of executions cannot express "TelemetryHandler3399 ran", so the test no longer tries to express it that way. The comment now records the measured envelope trace so the next person doesn't have to rediscover it.

## Why it surfaced now

JasperFx 2.57.1 shifted timing, exactly as jasperfx#714 did for GH-4167. Both times a JasperFx change **stopped masking** this race rather than causing it — see the `Block` `AllowSynchronousContinuations` history on GH-4167, where this same test was one of three that surfaced.

Confirmed by holding the JasperFx pin as the only variable, three full runs per configuration:

| Wolverine | JasperFx | result |
|---|---|---|
| pre-#4178 | 2.57.0 | 3/3 pass |
| pre-#4178 | **2.57.1** | 2/3 fail |
| #4178 | 2.57.1 | 3/3 fail |

**JasperFx 2.57.1 and Wolverine 6.30.3 are both clean.** An initial bisect that varied the priming change and the JasperFx pin together pointed at #4178; isolating the pin corrected that.

## Verification

Full CoreTests **3/3 green at 2666** (previously 0/3 or 1/3), Wolverine.Http.Tests **997**. Three runs rather than one, because a ⅔ failure rate is precisely what a single green run fails to detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
