### PR TITLE
GH-4180: logical message deduplication, opt-in, on its own table

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -289,6 +289,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Validation', link: '/guide/http/validation'},
                         {text: 'Fluent Validation', link: '/guide/http/fluentvalidation'},
                         {text: 'Problem Details', link: '/guide/http/problemdetails'},
+                        {text: 'Idempotency Keys', link: '/guide/http/deduplication'},
                         {text: 'Caching', link: '/guide/http/caching'},
                         {text: 'Output Caching', link: '/guide/http/output-caching'},
                         {text: 'Rate Limiting', link: '/guide/http/rate-limiting'},

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -300,6 +300,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                                 {text: 'How gRPC Handlers Work', link: '/guide/grpc/handlers'},
                                 {text: 'Code-First and Proto-First Contracts', link: '/guide/grpc/contracts'},
                                 {text: 'Error Handling', link: '/guide/grpc/errors'},
+                        {text: 'Idempotency Keys', link: '/guide/grpc/deduplication'},
                                 {text: 'Streaming', link: '/guide/grpc/streaming'},
                                 {text: 'Typed gRPC Clients', link: '/guide/grpc/client'},
                                 {text: 'Multi-Tenancy', link: '/guide/grpc/multi-tenancy'},

--- a/docs/guide/durability/idempotency.md
+++ b/docs/guide/durability/idempotency.md
@@ -27,3 +27,146 @@ using var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L188-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_keepaftermessagehandling' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Logical Message Deduplication <Badge type="tip" text="6.31" />
+
+::: warning
+This is opt-in, and turning it on provisions a new `wolverine_deduplication` table. Leaving it off
+means no schema change at all on upgrade.
+:::
+
+Everything above keys on `Envelope.Id`, which identifies **one delivery**. That is the right identity
+for "the broker handed me this same message twice", and it is the wrong identity for a different
+question:
+
+> The operator clicked *Rebuild* twice. The console republished the command after a timeout. A
+> scheduling agent pre-published tonight's 03:00 occurrence yesterday, and the scheduler published it
+> again on the night. Should the projection rebuild four times?
+
+Each of those is a *different* delivery of the *same intent*, so each carries a different
+`Envelope.Id` and every one of them gets through. What is needed is an identity for the intent, and
+that is what `DeduplicationId` is.
+
+`Envelope.DeduplicationId` is a `string`, it is set by your application, and it already round-trips on
+every transport Wolverine supports — it is written to and read from the `deduplication-id` wire header
+by Wolverine's own serialization, so it survives Rabbit MQ, Kafka, Azure Service Bus, SQS, and the
+rest without any transport-specific configuration. (Two transports also consume it natively: SQS/SNS
+FIFO queues and topics, and GCP Pub/Sub.)
+
+### Turning it on
+
+<!-- snippet: sample_enabling_message_deduplication -->
+<!-- endSnippet -->
+
+### Deduplicating a message handler
+
+<!-- snippet: sample_deduplicated_message_handler -->
+<!-- endSnippet -->
+
+and on the publishing side:
+
+<!-- snippet: sample_publishing_with_a_deduplication_id -->
+<!-- endSnippet -->
+
+A logical id is a `string` rather than a `Guid` on purpose: it is meant to be legible in the database
+when someone is working out why a job did not fire.
+
+The second message with that id never reaches your handler. It is discarded, acknowledged to the
+broker, and logged at `Information` — a duplicate that vanished without a trace would be
+indistinguishable from a message that was lost.
+
+### Where the id comes from
+
+By default a message handler reads `Envelope.DeduplicationId`. You can point at a member of the
+message itself instead, so publishers do not have to set `DeliveryOptions`:
+
+<!-- snippet: sample_deduplicated_from_the_message_body -->
+<!-- endSnippet -->
+
+`ValueSource.Header` reads an envelope header, and `ValueSource.Anything` uses the chain type's
+natural default.
+
+### Required or optional?
+
+`Required` defaults to `true`, and a message that arrives at a `[Deduplicated]` handler with no
+logical id is dead-lettered with a `MissingDeduplicationIdException`.
+
+That default is deliberately the strict one. The lenient reading is the dangerous one: a handler that
+asked for deduplication and then quietly processed every unkeyed message would report itself as
+protected while providing nothing, and the failure is invisible — the traffic succeeds, the
+duplicates run, and no log line distinguishes it from a working configuration.
+
+Set `Required = false` when a mixed stream is genuinely expected:
+
+<!-- snippet: sample_deduplication_with_optional_id -->
+<!-- endSnippet -->
+
+Unkeyed messages on such a handler pay no database round trip at all.
+
+### Applying it across many handlers
+
+<!-- snippet: sample_requiring_deduplication_ids_by_policy -->
+<!-- endSnippet -->
+
+The filter is required rather than optional. Applying logical deduplication to *every* handler would
+demand an id on traffic that has no business carrying one, and with `Required` defaulting to `true`
+that turns into a dead-lettered message per unkeyed send.
+
+### The deduplication window
+
+`DeduplicationWindow` defaults to 24 hours, and it is the whole guarantee: past that window the same
+logical id is accepted again.
+
+It is deliberately **not** `KeepAfterMessageHandling`. That setting exists to absorb a broker
+redelivery and defaults to five minutes, which would turn "idempotent" into "idempotent for a while" —
+worse than no guarantee, because it holds in testing and fails in production. Size the window against
+how long a duplicate could plausibly arrive: an operator double-click is seconds, a console republish
+is minutes, an agent pre-publishing tomorrow's occurrences is a day.
+
+A background reaper deletes expired claims on its own timer
+(`Durability.DeduplicationCleanupPollingTime`, default 5 minutes), in bounded batches, in its own
+transaction. It logs how many claims it removed each cycle — a count that keeps climbing is the signal
+that the window is too long, the cadence too slow, or the volume higher than the settings assume.
+
+### Failed handlers do not poison the id
+
+If your handler throws, the claim is released and a retry gets through. Where the handler is
+transactional the claim was written inside that transaction and the rollback removes it; where it is
+not, Wolverine issues a compensating release.
+
+This matters more than it sounds. Without it, the first failed attempt would permanently claim that
+logical id, every retry would be discarded as a duplicate of its own failed attempt, and the work
+would silently never happen while the logs reported successful deduplication.
+
+### Why a separate table
+
+The claims live in `wolverine_deduplication` rather than as a column on
+`wolverine_incoming_envelopes`, for three reasons:
+
+1. **Partitioning.** With `EnableInboxPartitioning` the inbox is `PARTITION BY LIST (status)`, and
+   PostgreSQL will not create a unique index on a partitioned table unless the index carries the
+   partition key. Marking an envelope handled updates `status`, which moves the row between
+   partitions — so a `(deduplication_id, status)` index would let the same logical id exist once as
+   `Incoming` and once as `Handled`, silently, and only for users who enabled partitioning.
+2. **Retention.** A deduplication marker has to outlive the inbox row it came from, and the inbox is
+   reaped on a five-minute default.
+3. **Migration cost.** `wolverine_incoming_envelopes` is small, hot, and written by every running
+   node. Adding a column is a migration; changing one later needs an `ACCESS EXCLUSIVE` lock that
+   queues behind in-flight inbox writes. Its own table means the inbox schema never moves for this
+   feature at all.
+
+### Scope and limitations
+
+- **Supported on:** message handlers and [Wolverine.HTTP endpoints](/guide/http/deduplication).
+  Wolverine's gRPC services are not supported yet, and a `[Deduplicated]` gRPC method fails at
+  bootstrap with a clear message rather than silently doing nothing.
+- **Storage:** the RDBMS message stores — PostgreSQL, SQL Server, MySQL and SQLite (and therefore
+  Marten-backed applications). Other stores report themselves as unsupported and fail loudly rather
+  than passing every duplicate through.
+- **Scope:** logical ids are unique per message store, not per tenant. In a database-per-tenant
+  setup each tenant database has its own table and is therefore naturally isolated; under conjoined
+  (single-database) tenancy the id is global.
+- **Fire-and-forget only.** Replaying the *original response* of a deduplicated `InvokeAsync<T>` is
+  Stripe-style idempotency-key machinery — storing and returning the prior result — and is not part
+  of this feature. HTTP endpoints get a useful answer regardless, because a status code is a
+  response; see below.

--- a/docs/guide/durability/idempotency.md
+++ b/docs/guide/durability/idempotency.md
@@ -58,6 +58,19 @@ FIFO queues and topics, and GCP Pub/Sub.)
 <!-- snippet: sample_enabling_message_deduplication -->
 <!-- endSnippet -->
 
+::: warning
+If a handler asks for deduplication and `EnableMessageDeduplication` is left off, Wolverine logs a
+warning at startup and that handler **throws on its first message**. It is deliberately a warning
+rather than a startup failure: `[Deduplicated]` lives on a handler type, and handler types are
+discovered by every host that scans their assembly. In a modular monolith where one module wants
+deduplication and a sibling host does not, a hard failure would stop the sibling from starting
+through no fault of its own configuration.
+
+What is *not* softened is the guarantee itself. A store that cannot enforce deduplication throws
+rather than answering "yes, that's new" to every id, so a misconfigured host can never quietly
+process a duplicate.
+:::
+
 ### Deduplicating a message handler
 
 <!-- snippet: sample_deduplicated_message_handler -->
@@ -157,9 +170,8 @@ The claims live in `wolverine_deduplication` rather than as a column on
 
 ### Scope and limitations
 
-- **Supported on:** message handlers and [Wolverine.HTTP endpoints](/guide/http/deduplication).
-  Wolverine's gRPC services are not supported yet, and a `[Deduplicated]` gRPC method fails at
-  bootstrap with a clear message rather than silently doing nothing.
+- **Supported on:** message handlers, [Wolverine.HTTP endpoints](/guide/http/deduplication), and
+  [Wolverine gRPC services](/guide/grpc/deduplication).
 - **Storage:** the RDBMS message stores — PostgreSQL, SQL Server, MySQL and SQLite (and therefore
   Marten-backed applications). Other stores report themselves as unsupported and fail loudly rather
   than passing every duplicate through.

--- a/docs/guide/grpc/deduplication.md
+++ b/docs/guide/grpc/deduplication.md
@@ -1,0 +1,100 @@
+# Idempotency Keys
+
+<Badge type="tip" text="6.31" />
+
+::: tip
+This is the gRPC half of Wolverine's [logical message
+deduplication](/guide/durability/idempotency#logical-message-deduplication). Read that page first
+for the storage, the retention window, and why this is opt-in.
+:::
+
+A unary RPC that creates something has the same at-most-once problem as an HTTP `POST`: the client
+retries after a deadline it cannot distinguish from a failure, an operator triggers the call twice,
+a queued call replays when connectivity returns.
+
+Wolverine reads the logical id from the call's **request metadata**, under the conventional
+`idempotency-key` key.
+
+## Deduplicating an RPC
+
+`[Deduplicated]` goes on the individual RPC method, on any of the three service flavours — proto-first
+stubs, code-first contracts, and hand-written service classes:
+
+```csharp
+[ServiceContract]
+[WolverineGrpcService]
+public interface IOrderService
+{
+    [Deduplicated]
+    Task<OrderReply> CreateOrder(CreateOrder request, CallContext context = default);
+
+    // Untouched — the requirement is resolved per RPC, not per service
+    Task<OrderReply> GetOrder(GetOrder request, CallContext context = default);
+}
+```
+
+Putting it on the service type instead applies it to every RPC on that service; a method-level
+attribute always wins over the type-level one.
+
+With `Durability.EnableMessageDeduplication` turned on, `CreateOrder` now:
+
+- runs normally for the first call carrying a given `idempotency-key`
+- throws `RpcException` with **`StatusCode.AlreadyExists`** for any later call carrying the same key
+  within the [deduplication window](/guide/durability/idempotency#the-deduplication-window)
+- throws `RpcException` with **`StatusCode.InvalidArgument`** for a call carrying no key at all
+
+Both codes come from [AIP-193](https://google.aip.dev/193) — the same table
+[`WolverineGrpcExceptionInterceptor`](/guide/grpc/errors) already maps ordinary .NET exceptions
+through, so a client sees deduplication refusals in the shape it already handles every other refusal
+in.
+
+Throwing rather than returning is not a stylistic choice. A unary RPC has to produce a response
+message, and there is no honest response body for "this was already done" — the status is the answer.
+
+## Sending the key
+
+```csharp
+var headers = new Metadata { { "idempotency-key", $"{scheduleId}|{occurrence:O}" } };
+var reply = await client.CreateOrder(request, new CallContext(new CallOptions(headers)));
+```
+
+::: warning
+gRPC metadata keys are lower-case. `Grpc.Core.Metadata` rejects a key containing upper-case
+characters outright, so `Idempotency-Key` will not compile into a working call. Wolverine lower-cases
+the configured header name on the server side for exactly this reason, so `[Deduplicated]` and
+`[Deduplicated("Idempotency-Key")]` both match a client sending `idempotency-key`.
+:::
+
+## Which RPC shapes are supported
+
+The logical id lives in request metadata, which every call shape carries — but the generated method
+has to be able to *await* the claim before doing any work, and it needs a route to the
+`ServerCallContext`.
+
+| Flavour | Supported shapes |
+|---|---|
+| Proto-first | all four (unary, server-streaming, client-streaming, bidirectional) |
+| Code-first | unary and client-streaming, with a `CallContext` parameter |
+| Hand-written | unary, with a `CallContext` parameter |
+
+The code-first and hand-written limits are the same ones [tenant
+detection](/guide/grpc/multi-tenancy) already has: a server-streaming method returns
+`IAsyncEnumerable<T>` directly, so its body cannot await, and without a `CallContext` parameter there
+is no route to the request metadata at all.
+
+Asking for deduplication on a shape that cannot support it is a **bootstrap failure** naming the
+method, not a silently unprotected RPC. Add a `CallContext` parameter, or drop the attribute.
+
+## Other key sources
+
+Unlike message handlers and HTTP endpoints, gRPC services can only source the id from request
+metadata. `ValueSource.InputMember` and friends are rejected at bootstrap: the generated wrapper
+forwards the request to the message bus rather than binding its members, so there is no place to
+read one from.
+
+## Failed calls do not poison the key
+
+A gRPC service method is never enrolled in a Wolverine transaction of its own — it forwards to the
+bus, and any transaction belongs to the handler on the other side. So the claim is always already
+committed by the time the forward runs, and Wolverine always issues a compensating release when the
+call throws. A retry with the same key gets through.

--- a/docs/guide/http/deduplication.md
+++ b/docs/guide/http/deduplication.md
@@ -1,0 +1,103 @@
+# Idempotency Keys
+
+<Badge type="tip" text="6.31" />
+
+::: tip
+This is the HTTP half of Wolverine's [logical message
+deduplication](/guide/durability/idempotency#logical-message-deduplication). Read that page first
+for the storage, the retention window, and why this is opt-in — everything here builds on it.
+:::
+
+A `POST` that creates something is the classic at-most-once problem. The user double-clicks; the
+client retries after a timeout it could not distinguish from a failure; a mobile app replays a queued
+request when connectivity returns. Each is a separate HTTP request that means the same thing, and
+without an identity for that *meaning*, all of them create a record.
+
+Wolverine's answer is the conventional `Idempotency-Key` request header — the same header Stripe,
+Adyen, and the
+[IETF draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) already
+use, so a client that already sends one gets this for free.
+
+## Deduplicating an endpoint
+
+```csharp
+[Deduplicated]
+[WolverinePost("/orders")]
+public static async Task<OrderCreated> Post(CreateOrder command, IDocumentSession session)
+{
+    // create the order...
+}
+```
+
+With `Durability.EnableMessageDeduplication` turned on, that endpoint now:
+
+- runs normally for the first request carrying a given `Idempotency-Key`
+- returns **409 Conflict** with a `ProblemDetails` body for any later request carrying the same key
+  within the [deduplication window](/guide/durability/idempotency#the-deduplication-window)
+- returns **400 Bad Request** with a `ProblemDetails` body for a request carrying no key at all
+
+Both refusal codes are registered as endpoint metadata, so they appear in the generated OpenAPI
+document. A 409 a client can receive but cannot discover from the spec is a contract change hidden
+from exactly the people who have to handle it.
+
+## When a replay is benign
+
+409 is the right default — it tells the caller plainly that this request was not the one that did the
+work. But some endpoints are genuinely safe to replay, and the caller would rather see success:
+
+```csharp
+// The second call gets a 204 rather than a 409
+[Deduplicated(DuplicateStatusCode = 204)]
+[WolverinePost("/schedules/{scheduleId}/occurrences")]
+public static async Task Post(string scheduleId, ScheduleOccurrence body)
+{
+    // ...
+}
+```
+
+Any 2xx code is written as a bare status with no body. Anything else is written as a problem
+document, so a refusal always carries a machine-readable reason rather than a status code the caller
+has to guess at.
+
+## Using a different key
+
+The header name and the source are both configurable, exactly as for message handlers:
+
+```csharp
+// A different header
+[Deduplicated("X-Request-Id")]
+
+// A member of the request body
+[Deduplicated(ValueSource.InputMember, nameof(CreateOrder.ClientReference))]
+
+// A route value
+[Deduplicated(ValueSource.RouteValue, "occurrenceId")]
+```
+
+## Optional keys
+
+`Required` defaults to `true`, so an unkeyed request is a 400. Set it to `false` when some clients
+send a key and some do not — the ones that do are protected, and the ones that do not are handled
+exactly as if the feature were off:
+
+```csharp
+[Deduplicated(Required = false)]
+[WolverinePost("/orders")]
+public static async Task<OrderCreated> Post(CreateOrder command) { /* ... */ }
+```
+
+## What this is not
+
+This is **not** full Stripe-style idempotency-key support. Wolverine does not store the original
+response and replay it to the second caller; it tells the second caller that the work was already
+done. That is enough to make a create endpoint safe to retry, and it is considerably less machinery
+than storing and versioning response bodies.
+
+If a client genuinely needs the original response body back, it has to fetch the created resource —
+which is why returning a `Location` header from the first request is worth doing.
+
+## Failed requests do not poison the key
+
+If your endpoint throws, the claim is released, and a retry with the same `Idempotency-Key` gets
+through. Where the endpoint carries transactional middleware the claim was written inside that
+transaction and rolls back with it; otherwise Wolverine issues a compensating release.

--- a/src/Http/Wolverine.Http.Tests/logical_deduplication_on_http_endpoints.cs
+++ b/src/Http/Wolverine.Http.Tests/logical_deduplication_on_http_endpoints.cs
@@ -1,0 +1,197 @@
+using Alba;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using JasperFx.Resources;
+using Shouldly;
+using Wolverine.Attributes;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+/// <summary>
+/// GH-4180. Logical deduplication on Wolverine.HTTP endpoints.
+///
+/// <para>
+/// An HTTP endpoint has no incoming <c>Envelope</c>, so unlike a message handler it cannot take its
+/// logical id from <c>Envelope.DeduplicationId</c>. It reads the conventional <c>Idempotency-Key</c>
+/// request header instead — the same header Stripe, Adyen and the IETF draft already use, so a
+/// caller that already sends one gets deduplication with no extra configuration.
+/// </para>
+///
+/// <para>
+/// And unlike a message handler, an endpoint owes its caller an answer, so a refusal is a status
+/// code rather than a silent discard. That also gives HTTP the request/reply half of idempotency for
+/// free, without Wolverine storing and replaying the original response.
+/// </para>
+/// </summary>
+public class logical_deduplication_on_http_endpoints : IAsyncLifetime
+{
+    private IAlbaHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Solo;
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "http_dedup");
+
+            opts.Durability.EnableMessageDeduplication = true;
+            opts.Durability.DeduplicationWindow = 1.Hours();
+
+            opts.Discovery.DisableConventionalDiscovery();
+
+            // Pin this assembly into the scan set. Wolverine caches the detected application assembly
+            // process-wide, so when this class runs after the shared WolverineWebApi-based fixture, this
+            // host inherits THAT application assembly and never sees the endpoints below -- every request
+            // 404s. The tests pass in isolation and fail in the full suite without this line.
+            opts.Discovery.IncludeAssembly(typeof(logical_deduplication_on_http_endpoints).Assembly);
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        // Narrow HTTP discovery to just this file's endpoints. The shared WolverineWebApi assembly is on
+        // the scan path and its endpoints need Marten/EF Core registrations this host deliberately does
+        // not have -- standing all that up would be testing those integrations, not deduplication.
+        theHost = await AlbaHost.For(builder, app => app.MapWolverineEndpoints(opts =>
+            opts.CustomizeHttpEndpointDiscovery(q =>
+                q.Excludes.WithCondition("Not a deduplication test endpoint",
+                    type => type != typeof(DeduplicatedEndpoint) && type != typeof(BenignReplayEndpoint)))));
+
+        await ((IHost)theHost).ResetResourceState();
+
+        DeduplicatedEndpoint.Calls.Clear();
+        BenignReplayEndpoint.Calls.Clear();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task first_request_runs_and_the_replay_is_refused_with_409()
+    {
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("first")).ToUrl("/dedup/create");
+            x.WithRequestHeader("Idempotency-Key", "order-123");
+            x.StatusCodeShouldBeOk();
+        });
+
+        // Same key, different body. Nothing but the logical id can refuse this one.
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("second")).ToUrl("/dedup/create");
+            x.WithRequestHeader("Idempotency-Key", "order-123");
+            x.StatusCodeShouldBe(409);
+        });
+
+        DeduplicatedEndpoint.Calls.ShouldHaveSingleItem().ShouldBe("first");
+    }
+
+    [Fact]
+    public async Task different_keys_both_run()
+    {
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("a")).ToUrl("/dedup/create");
+            x.WithRequestHeader("Idempotency-Key", "order-a");
+            x.StatusCodeShouldBeOk();
+        });
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("b")).ToUrl("/dedup/create");
+            x.WithRequestHeader("Idempotency-Key", "order-b");
+            x.StatusCodeShouldBeOk();
+        });
+
+        DeduplicatedEndpoint.Calls.ShouldBe(["a", "b"]);
+    }
+
+    [Fact]
+    public async Task a_missing_required_key_is_a_400_rather_than_a_silent_pass()
+    {
+        // Nothing has been done and nothing will be, so this must be visible to the caller. Passing an
+        // unkeyed request through would report the endpoint as protected while every duplicate ran.
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("no key")).ToUrl("/dedup/create");
+            x.StatusCodeShouldBe(400);
+        });
+
+        DeduplicatedEndpoint.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_replay_can_be_configured_as_benign_instead_of_a_conflict()
+    {
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("once")).ToUrl("/dedup/benign");
+            x.WithRequestHeader("Idempotency-Key", "benign-1");
+            x.StatusCodeShouldBeOk();
+        });
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("twice")).ToUrl("/dedup/benign");
+            x.WithRequestHeader("Idempotency-Key", "benign-1");
+            x.StatusCodeShouldBe(204);
+        });
+
+        BenignReplayEndpoint.Calls.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task the_refusal_status_is_advertised_in_the_endpoint_metadata()
+    {
+        // A 409 a client can receive but cannot discover from the generated OpenAPI document is a
+        // contract change hidden from exactly the people who have to handle it.
+        var graph = theHost.Services.GetRequiredService<WolverineHttpOptions>().Endpoints!;
+        var chain = graph.ChainFor("POST", "/dedup/create");
+        chain.ShouldNotBeNull();
+
+        var metadata = chain.BuildEndpoint(RouteWarmup.Lazy)
+            .Metadata.OfType<IProducesResponseTypeMetadata>().ToArray();
+
+        metadata.Any(x => x.StatusCode == 409).ShouldBeTrue("the duplicate refusal must be discoverable");
+        metadata.Any(x => x.StatusCode == 400).ShouldBeTrue("the missing-key refusal must be discoverable");
+    }
+}
+
+public record DedupRequest(string Name);
+
+public static class DeduplicatedEndpoint
+{
+    public static readonly List<string> Calls = [];
+
+    [Deduplicated]
+    [WolverinePost("/dedup/create")]
+    public static string Post(DedupRequest request)
+    {
+        Calls.Add(request.Name);
+        return "ok";
+    }
+}
+
+public static class BenignReplayEndpoint
+{
+    public static readonly List<string> Calls = [];
+
+    [Deduplicated(DuplicateStatusCode = 204)]
+    [WolverinePost("/dedup/benign")]
+    public static string Post(DedupRequest request)
+    {
+        Calls.Add(request.Name);
+        return "ok";
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Wolverine.Http.CodeGen;
 using Wolverine.Http.Resources;
+using Wolverine.Persistence.Codegen;
 using Wolverine.Logging;
 using Wolverine.Persistence;
 using Wolverine.Runtime;
@@ -46,6 +47,13 @@ public partial class HttpChain
             assembly.UsingNamespaces!.Fill(typeof(RoutingHttpContextExtensions).Namespace);
             assembly.UsingNamespaces.Fill("System.Linq");
             assembly.UsingNamespaces.Fill("System");
+
+            // GH-4180. Weave logical deduplication here rather than in the constructor's attribute pass:
+            // [Deduplicated] is applied there, but IsTransactional is not settled until the HTTP policies
+            // have run, and the compensating-release frame depends on it. AssembleTypes is the first
+            // point after both. Idempotent, so a chain assembled into two GeneratedAssemblies (which
+            // happens under `codegen write` -- see GH-3692) is woven once.
+            this.ApplyDeduplication();
 
             _generatedType = assembly.AddType(_fileName!, typeof(HttpHandler));
 

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -205,7 +205,37 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             parent.ApplyParameterMatching(this, call);
         }
 
+        // GH-4180. Register the deduplication refusal codes BEFORE applyMetadata() runs.
+        //
+        // The frames themselves cannot do this. They are woven in AssembleTypes, which is lazy and runs
+        // long after the endpoint metadata has been built -- so a Produces() call from there lands on an
+        // object nobody reads again, and the 409 a client can actually receive never appears in the
+        // generated OpenAPI document. The status codes are known from the requirement alone, so they do
+        // not need to wait for weaving.
+        registerDeduplicationMetadata();
+
         applyMetadata();
+    }
+
+    private void registerDeduplicationMetadata()
+    {
+        if (Deduplication is not { } requirement) return;
+
+        if (requirement.Required)
+        {
+            Metadata.Produces(400, contentType: "application/problem+json");
+        }
+
+        var status = requirement.DuplicateStatusCode;
+
+        if (status is >= 200 and < 300)
+        {
+            Metadata.Produces(status);
+        }
+        else
+        {
+            Metadata.Produces(status, contentType: "application/problem+json");
+        }
     }
 
     private bool tryFindResourceType(MethodCall method, out Type resourceType)
@@ -480,6 +510,46 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
     public override Frame[] AddStopConditionIfNull(Variable variable)
     {
         return [new SetStatusCodeAndReturnIfEntityIsNullFrame(variable)];
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     GH-4180. An HTTP endpoint owes its caller an answer, so a refused request gets a status code
+    ///     rather than the silent discard a message handler gets. Both codes are registered as endpoint
+    ///     metadata so they show up in OpenAPI — a 409 a client can receive but cannot discover from the
+    ///     generated spec is a contract change hidden from exactly the people who need it.
+    /// </remarks>
+    public override Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+    {
+        var key = requirement.Key ?? DeduplicationRequirement.DefaultHeaderName;
+
+        if (outcome == DeduplicationOutcome.MissingId)
+        {
+            // Metadata is registered in registerDeduplicationMetadata() during construction, not here --
+            // this runs during the lazy AssembleTypes pass, too late for the endpoint metadata build.
+            return
+            [
+                new DeduplicationProblemDetailsFrame(condition, 400,
+                    $"This endpoint requires a logical deduplication id in the '{key}' header")
+            ];
+        }
+
+        var status = requirement.DuplicateStatusCode;
+
+        // A success code means the application has declared a replayed request benign, so there is
+        // nothing to explain and a problem document would be actively wrong. Anything else is a
+        // refusal, and a refusal without a reason is a status code the caller has to guess at.
+        if (status is >= 200 and < 300)
+        {
+            return [new DeduplicationStatusCodeFrame(condition, status)];
+        }
+
+        return
+        [
+            new DeduplicationProblemDetailsFrame(condition, status,
+                $"A request with this '{key}' has already been handled")
+        ];
     }
 
     public override Frame[] AddStopConditionIfNull(Variable data, Variable? identity, IDataRequirement requirement)

--- a/src/Http/Wolverine.Http/Policies/DeduplicationHttpFrames.cs
+++ b/src/Http/Wolverine.Http/Policies/DeduplicationHttpFrames.cs
@@ -1,0 +1,105 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.AspNetCore.Http;
+
+namespace Wolverine.Http.Policies;
+
+/// <summary>
+/// GH-4180. The HTTP answer to a failed logical deduplication check.
+///
+/// <para>
+/// Unlike a message handler, an HTTP endpoint owes its caller an answer, so a refusal is a status
+/// code with a <c>ProblemDetails</c> body rather than a silent discard. This also gives HTTP the
+/// request/reply half of idempotency for free: the second caller gets a meaningful response without
+/// Wolverine having to store and replay the original one, which is the much larger Stripe-style
+/// idempotency-key feature the issue deliberately scoped out.
+/// </para>
+///
+/// <para>
+/// 409 Conflict is the default for a duplicate, and 400 for a missing-but-required key. An
+/// application that considers a replayed create benign can ask for 200 or 204 instead —
+/// see <c>[Deduplicated]</c>'s HTTP options.
+/// </para>
+/// </summary>
+internal class DeduplicationProblemDetailsFrame : AsyncFrame
+{
+    private readonly Variable _condition;
+    private readonly int _statusCode;
+    private readonly string _message;
+    private Variable? _httpContext;
+
+    public DeduplicationProblemDetailsFrame(Variable condition, int statusCode, string message)
+    {
+        _condition = condition;
+        _statusCode = statusCode;
+        _message = message;
+        uses.Add(condition);
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"GH-4180: {_statusCode} for a failed logical deduplication check");
+        writer.Write($"BLOCK:if ({_condition.Usage})");
+
+        var constant = Constant.For(_message);
+        writer.Write(
+            $"await {nameof(HttpHandler.WriteProblems)}({_statusCode}, {constant.Usage}, {_httpContext!.Usage}, null);");
+        writer.Write("return;");
+
+        writer.FinishBlock();
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _httpContext = chain.FindVariable(typeof(HttpContext));
+        yield return _httpContext;
+    }
+}
+
+/// <summary>
+/// GH-4180. Bare status-code variant, for applications that treat a replayed request as benign and
+/// want a 200 or 204 with no body rather than a 409 with a problem document.
+/// </summary>
+internal class DeduplicationStatusCodeFrame : SyncFrame
+{
+    private readonly Variable _condition;
+    private readonly int _statusCode;
+    private Variable? _httpResponse;
+
+    public DeduplicationStatusCodeFrame(Variable condition, int statusCode)
+    {
+        _condition = condition;
+        _statusCode = statusCode;
+        uses.Add(condition);
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"GH-4180: {_statusCode} for an already-handled logical deduplication id");
+        writer.Write($"BLOCK:if ({_condition.Usage})");
+        writer.Write($"{_httpResponse!.Usage}.{nameof(HttpResponse.StatusCode)} = {_statusCode};");
+
+        if (method.AsyncMode == AsyncMode.ReturnCompletedTask)
+        {
+            writer.Write($"return {typeof(Task).FullNameInCode()}.{nameof(Task.CompletedTask)};");
+        }
+        else
+        {
+            writer.Write("return;");
+        }
+
+        writer.FinishBlock();
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _httpResponse = chain.FindVariable(typeof(HttpResponse));
+        yield return _httpResponse;
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -483,6 +483,12 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
         yield return new IncomingEnvelopeTable(Durability, SchemaName);
         yield return new DeadLettersTable(Durability, SchemaName);
 
+        // GH-4180. Every store role, not just Main -- see the PostgreSQL twin.
+        if (Durability.EnableMessageDeduplication)
+        {
+            yield return new DeduplicationTable(SchemaName);
+        }
+
         if (Role == MessageStoreRole.Main)
         {
             var nodeTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeTableName));

--- a/src/Persistence/MySql/Wolverine.MySql/Schema/DeduplicationTable.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Schema/DeduplicationTable.cs
@@ -1,0 +1,26 @@
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.MySql.Schema;
+
+/// <summary>
+/// GH-4180. Storage for logical message deduplication claims. See the PostgreSQL twin for why this
+/// is its own table rather than a column on the incoming envelope table.
+/// </summary>
+internal class DeduplicationTable : Table
+{
+    public DeduplicationTable(string schemaName) : base(
+        new DbObjectName(schemaName, DatabaseConstants.DeduplicationTableName))
+    {
+        // 250 chars stays inside InnoDB's 3072-byte index key limit even at utf8mb4's 4 bytes per
+        // character, so this is a legal primary key without a prefix length.
+        AddColumn(DatabaseConstants.DeduplicationId, "varchar(250)").NotNull().AsPrimaryKey();
+        AddColumn<DateTimeOffset>(DatabaseConstants.Expires).NotNull();
+
+        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.DeduplicationTableName}_expires")
+        {
+            Columns = [DatabaseConstants.Expires]
+        });
+    }
+}

--- a/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs
+++ b/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs
@@ -1,0 +1,122 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Persistence;
+using Wolverine.Postgresql;
+
+namespace PersistenceTests.Samples;
+
+public record RebuildProjection(string ProjectionName, DateTimeOffset OccurrenceUtc);
+
+public record CreateOrder(string Sku, int Quantity);
+
+public interface ICreateCommand;
+
+public static class DeduplicationSamples
+{
+    public static async Task bootstrapping()
+    {
+        #region sample_enabling_message_deduplication
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql("connection string");
+
+                // Opt in to logical message deduplication. This provisions a new
+                // "wolverine_deduplication" table -- nothing else about your message
+                // storage changes, and leaving this off means no schema migration at all
+                opts.Durability.EnableMessageDeduplication = true;
+
+                // How long a logical id is honoured before the reaper removes it.
+                // The default is 24 hours. This IS the guarantee, so size it against
+                // how long a duplicate could plausibly arrive
+                opts.Durability.DeduplicationWindow = 24.Hours();
+            }).StartAsync();
+
+        #endregion
+    }
+
+    #region sample_deduplicated_message_handler
+
+    public static class RebuildProjectionHandler
+    {
+        // Wolverine will refuse to run this handler twice for the same
+        // Envelope.DeduplicationId within the deduplication window
+        [Deduplicated]
+        public static void Handle(RebuildProjection command)
+        {
+            // rebuild the projection...
+        }
+    }
+
+    #endregion
+
+    #region sample_publishing_with_a_deduplication_id
+
+    public static ValueTask ScheduleNightlyRebuild(IMessageBus bus, string projectionName, DateTimeOffset occurrence)
+    {
+        return bus.PublishAsync(new RebuildProjection(projectionName, occurrence), new DeliveryOptions
+        {
+            // The logical identity of the WORK, not of this particular delivery.
+            // An operator double-click, a console republish, and an agent that
+            // pre-published this occurrence yesterday all produce this same id
+            DeduplicationId = $"{projectionName}|{occurrence:O}"
+        });
+    }
+
+    #endregion
+
+    #region sample_deduplicated_from_the_message_body
+
+    public static class CreateOrderHandler
+    {
+        // Derive the logical id from a member of the message itself rather than
+        // asking every publisher to set DeliveryOptions
+        [Deduplicated(ValueSource.InputMember, nameof(CreateOrder.Sku))]
+        public static void Handle(CreateOrder command)
+        {
+            // create the order...
+        }
+    }
+
+    #endregion
+
+    public static async Task blanket_policy()
+    {
+        #region sample_requiring_deduplication_ids_by_policy
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql("connection string");
+                opts.Durability.EnableMessageDeduplication = true;
+
+                // Apply logical deduplication to every handler matching a filter, instead
+                // of decorating each one. Useful when the rule is "every create-style
+                // command is deduplicated" and some of the handlers are not yours
+                opts.Policies.RequireDeduplicationId(chain =>
+                    chain.MessageType.CanBeCastTo<ICreateCommand>());
+            }).StartAsync();
+
+        #endregion
+    }
+
+    #region sample_deduplication_with_optional_id
+
+    public static class MixedTrafficHandler
+    {
+        // Some publishers set a logical id and some do not. Those that do are
+        // protected; those that do not are handled exactly as if the feature
+        // were off, and pay no database round trip
+        [Deduplicated(Required = false)]
+        public static void Handle(CreateOrder command)
+        {
+            // ...
+        }
+    }
+
+    #endregion
+}

--- a/src/Persistence/PostgresqlTests/logical_message_deduplication.cs
+++ b/src/Persistence/PostgresqlTests/logical_message_deduplication.cs
@@ -40,14 +40,6 @@ public class logical_message_deduplication : IAsyncLifetime
                 opts.Durability.EnableMessageDeduplication = true;
                 opts.Durability.DeduplicationWindow = 1.Hours();
 
-                // These handlers are [WolverineIgnore]'d so that the OTHER hosts in this assembly do not
-                // discover them: a [Deduplicated] handler in a host that has not enabled deduplication is
-                // a hard bootstrap failure by design, and without this every other test class in
-                // PostgresqlTests fails to start. Included explicitly here instead.
-                opts.Discovery.IncludeType(typeof(DeduplicatedHandler));
-                opts.Discovery.IncludeType(typeof(UnkeyedHandler));
-                opts.Discovery.IncludeType(typeof(FailingDeduplicatedHandler));
-
                 opts.Policies.AutoApplyTransactions();
 
                 // Discard rather than retry, so each Send is exactly one handler attempt and the
@@ -194,7 +186,6 @@ public record UnkeyedMessage(string Name);
 
 public record FailingDeduplicatedMessage;
 
-[WolverineIgnore]
 public static class DeduplicatedHandler
 {
     public static readonly List<string> Received = [];
@@ -206,7 +197,6 @@ public static class DeduplicatedHandler
     }
 }
 
-[WolverineIgnore]
 public static class UnkeyedHandler
 {
     public static readonly List<string> Received = [];
@@ -218,7 +208,6 @@ public static class UnkeyedHandler
     }
 }
 
-[WolverineIgnore]
 public static class FailingDeduplicatedHandler
 {
     public static int Attempts;

--- a/src/Persistence/PostgresqlTests/logical_message_deduplication.cs
+++ b/src/Persistence/PostgresqlTests/logical_message_deduplication.cs
@@ -1,0 +1,232 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.ComplianceTests;
+using Wolverine.ErrorHandling;
+using Wolverine.Postgresql;
+using Wolverine.Persistence;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+
+namespace PostgresqlTests;
+
+/// <summary>
+/// GH-4180. End-to-end coverage for logical message deduplication against a real PostgreSQL store.
+///
+/// <para>
+/// These deliberately drive whole messages through the bus rather than
+/// calling <c>IDeduplicationStore</c> directly. The store is the easy half; what needs proving is
+/// that the generated handler resolves the id, claims it, and returns early — a store-level test
+/// would pass over a chain that never wove the frames in at all.
+/// </para>
+/// </summary>
+public class logical_message_deduplication : IAsyncLifetime
+{
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "dedup");
+                opts.Durability.EnableMessageDeduplication = true;
+                opts.Durability.DeduplicationWindow = 1.Hours();
+
+                // These handlers are [WolverineIgnore]'d so that the OTHER hosts in this assembly do not
+                // discover them: a [Deduplicated] handler in a host that has not enabled deduplication is
+                // a hard bootstrap failure by design, and without this every other test class in
+                // PostgresqlTests fails to start. Included explicitly here instead.
+                opts.Discovery.IncludeType(typeof(DeduplicatedHandler));
+                opts.Discovery.IncludeType(typeof(UnkeyedHandler));
+                opts.Discovery.IncludeType(typeof(FailingDeduplicatedHandler));
+
+                opts.Policies.AutoApplyTransactions();
+
+                // Discard rather than retry, so each Send is exactly one handler attempt and the
+                // poison-check assertion below is a count rather than a race.
+                opts.OnException<DivideByZeroException>().Discard();
+            }).StartAsync();
+
+        await theHost.RebuildAllEnvelopeStorageAsync();
+
+        DeduplicatedHandler.Received.Clear();
+        UnkeyedHandler.Received.Clear();
+        FailingDeduplicatedHandler.Attempts = 0;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task provisions_the_deduplication_table()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        var table = await new Table(new DbObjectName("dedup", DatabaseConstants.DeduplicationTableName))
+            .FetchExistingAsync(conn, TestContext.Current.CancellationToken);
+
+        table.ShouldNotBeNull();
+        table.HasColumn(DatabaseConstants.DeduplicationId).ShouldBeTrue();
+        table.HasColumn(DatabaseConstants.Expires).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task second_message_with_the_same_logical_id_is_discarded()
+    {
+        await theHost.SendMessageAndWaitAsync(new DeduplicatedMessage("first"),
+            new DeliveryOptions { DeduplicationId = "schedule-1|2026-08-29T03:00:00Z" });
+
+        // Same logical id, DIFFERENT payload and a different Envelope.Id -- so nothing but the logical
+        // id can be doing the work here. Envelope.Id idempotency would let this straight through.
+        await theHost.SendMessageAndWaitAsync(new DeduplicatedMessage("second"),
+            new DeliveryOptions { DeduplicationId = "schedule-1|2026-08-29T03:00:00Z" });
+
+        DeduplicatedHandler.Received.ShouldHaveSingleItem().ShouldBe("first");
+    }
+
+    [Fact]
+    public async Task different_logical_ids_both_run()
+    {
+        await theHost.SendMessageAndWaitAsync(new DeduplicatedMessage("a"),
+            new DeliveryOptions { DeduplicationId = "schedule-1|2026-08-29T03:00:00Z" });
+
+        await theHost.SendMessageAndWaitAsync(new DeduplicatedMessage("b"),
+            new DeliveryOptions { DeduplicationId = "schedule-1|2026-08-30T03:00:00Z" });
+
+        DeduplicatedHandler.Received.ShouldBe(["a", "b"]);
+    }
+
+    [Fact]
+    public async Task a_message_with_no_logical_id_is_unaffected_when_the_id_is_optional()
+    {
+        // Twice, with no deduplication id at all. An unkeyed stream on a Required = false chain must
+        // behave exactly as if the feature were off -- including paying no database round trip, which
+        // is why the generated claim is guarded by a null check rather than called unconditionally.
+        await theHost.SendMessageAndWaitAsync(new UnkeyedMessage("x"));
+        await theHost.SendMessageAndWaitAsync(new UnkeyedMessage("y"));
+
+        UnkeyedHandler.Received.ShouldBe(["x", "y"]);
+    }
+
+    [Fact]
+    public async Task a_missing_but_required_logical_id_throws_rather_than_discarding()
+    {
+        // The opposite of a duplicate: nothing has been done and nothing will be, so this must be loud.
+        var session = await theHost
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new DeduplicatedMessage("no id"));
+
+        session.AllExceptions().OfType<MissingDeduplicationIdException>().ShouldNotBeEmpty();
+        DeduplicatedHandler.Received.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_failed_execution_does_not_poison_the_logical_id()
+    {
+        // The single most damaging way to get this wrong: a handler that throws leaves its claim behind,
+        // every retry is refused as a duplicate of its own failed attempt, and the work is silently
+        // never done while the logs report successful deduplication.
+        await theHost.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new FailingDeduplicatedMessage(),
+                new DeliveryOptions { DeduplicationId = "poison-check" });
+
+        FailingDeduplicatedHandler.Attempts.ShouldBe(1);
+
+        // Second attempt at the SAME logical id must reach the handler again, because the compensating
+        // release removed the claim the failed attempt took.
+        await theHost.TrackActivity().DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(new FailingDeduplicatedMessage(),
+                new DeliveryOptions { DeduplicationId = "poison-check" });
+
+        FailingDeduplicatedHandler.Attempts.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task the_reaper_deletes_expired_claims_and_reports_how_many()
+    {
+        var store = theHost.GetRuntime().Storage.Deduplication;
+
+        await store.TryClaimAsync("expired-1", DateTimeOffset.UtcNow.Subtract(1.Hours()), TestContext.Current.CancellationToken);
+        await store.TryClaimAsync("expired-2", DateTimeOffset.UtcNow.Subtract(1.Hours()), TestContext.Current.CancellationToken);
+        await store.TryClaimAsync("still-live", DateTimeOffset.UtcNow.Add(1.Hours()), TestContext.Current.CancellationToken);
+
+        var deleted = await store.DeleteExpiredAsync(DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        deleted.ShouldBe(2);
+
+        // The live claim survives, and is still refused
+        (await store.TryClaimAsync("still-live", DateTimeOffset.UtcNow.Add(1.Hours()), TestContext.Current.CancellationToken)).ShouldBeFalse();
+
+        // The expired ones are claimable again
+        (await store.TryClaimAsync("expired-1", DateTimeOffset.UtcNow.Add(1.Hours()), TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task concurrent_claims_of_the_same_id_produce_exactly_one_winner()
+    {
+        // The race this feature exists for. A SELECT-then-INSERT implementation passes every other test
+        // in this file and fails only here.
+        var store = theHost.GetRuntime().Storage.Deduplication;
+        var expires = DateTimeOffset.UtcNow.Add(1.Hours());
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 20)
+            .Select(_ => store.TryClaimAsync("contended", expires, TestContext.Current.CancellationToken)));
+
+        results.Count(x => x).ShouldBe(1);
+    }
+}
+
+public record DeduplicatedMessage(string Name);
+
+public record UnkeyedMessage(string Name);
+
+public record FailingDeduplicatedMessage;
+
+[WolverineIgnore]
+public static class DeduplicatedHandler
+{
+    public static readonly List<string> Received = [];
+
+    [Deduplicated]
+    public static void Handle(DeduplicatedMessage message)
+    {
+        Received.Add(message.Name);
+    }
+}
+
+[WolverineIgnore]
+public static class UnkeyedHandler
+{
+    public static readonly List<string> Received = [];
+
+    [Deduplicated(Required = false)]
+    public static void Handle(UnkeyedMessage message)
+    {
+        Received.Add(message.Name);
+    }
+}
+
+[WolverineIgnore]
+public static class FailingDeduplicatedHandler
+{
+    public static int Attempts;
+
+    [Deduplicated]
+    public static void Handle(FailingDeduplicatedMessage message)
+    {
+        Attempts++;
+        throw new DivideByZeroException("nope");
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -181,6 +181,16 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConn
             $"(select ctid from {table} where {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}' and {DatabaseConstants.KeepUntil} <= :now limit {batchSize});";
     }
 
+    public override string? BatchedDeleteExpiredDeduplicationClaimsSql(int batchSize)
+    {
+        var table = $"{QuotedSchemaName}.{DatabaseConstants.DeduplicationTableName}";
+
+        // Bounded via ctid, the same shape as BatchedDeleteExpiredHandledEnvelopesSql, so each
+        // statement holds locks briefly instead of taking out a day's worth of claims at once.
+        return
+            $"delete from {table} where ctid in (select ctid from {table} where {DatabaseConstants.Expires} <= :now limit {batchSize});";
+    }
+
     /// <summary>
     /// GH-3971: a "loose index scan" (skip scan), which PostgreSQL will not plan on its own. Descends
     /// the <c>owner_id</c> index once per DISTINCT value instead of reading every row, so the steady
@@ -756,6 +766,13 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
         yield return new OutgoingEnvelopeTable(Durability, SchemaName);
         yield return new IncomingEnvelopeTable(Durability, SchemaName);
         yield return new DeadLettersTable(Durability, SchemaName);
+
+        // GH-4180. Every store role, not just Main: a handler chain with an AncillaryStoreType claims
+        // its logical id in that store so the claim and the work land in one transaction.
+        if (Durability.EnableMessageDeduplication)
+        {
+            yield return new DeduplicationTable(SchemaName);
+        }
 
         foreach (var table in _externalTables)
         {

--- a/src/Persistence/Wolverine.Postgresql/Schema/DeduplicationTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Schema/DeduplicationTable.cs
@@ -1,0 +1,38 @@
+using Weasel.Core;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.Postgresql.Schema;
+
+/// <summary>
+/// GH-4180. Storage for logical message deduplication claims. Provisioned only when
+/// <see cref="DurabilitySettings.EnableMessageDeduplication" /> is set.
+///
+/// <para>
+/// Two columns and nothing else. The primary key on <c>deduplication_id</c> IS the guarantee —
+/// claiming is an INSERT that either succeeds or trips this constraint, which is the only check
+/// that holds across concurrent nodes.
+/// </para>
+/// </summary>
+internal class DeduplicationTable : Table
+{
+    public DeduplicationTable(string schemaName) : base(
+        new DbObjectName(schemaName, DatabaseConstants.DeduplicationTableName))
+    {
+        // 250 characters matches the message_type / received_at convention on the envelope tables, and
+        // stays well inside every engine's maximum index key width. A logical id is meant to be legible
+        // in the database when someone is working out why a job did not fire -- "{scheduleId}|{occurrenceUtc:O}"
+        // and its like -- not to carry a payload.
+        AddColumn(DatabaseConstants.DeduplicationId, "varchar(250)").NotNull().AsPrimaryKey();
+        AddColumn<DateTimeOffset>(DatabaseConstants.Expires).NotNull();
+
+        // The reaper's only predicate. Without it, every cleanup cycle is a full scan of a table whose
+        // whole purpose is to be large.
+        Indexes.Add(new IndexDefinition(
+            PostgresqlIdentifier.Shorten($"idx_{DatabaseConstants.DeduplicationTableName}_expires"))
+        {
+            Columns = [DatabaseConstants.Expires]
+        });
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
@@ -48,6 +48,36 @@ public class DatabaseConstants
     /// </summary>
     public const string ListenersTableName = "wolverine_listeners";
 
+    /// <summary>
+    /// GH-4180. Table backing logical message deduplication. One row per claimed
+    /// application-defined deduplication id, with its own expiry.
+    ///
+    /// <para>
+    /// Deliberately NOT a column on <see cref="IncomingTable"/>. Under
+    /// <c>DurabilitySettings.EnableInboxPartitioning</c> that table is PARTITION BY LIST (status),
+    /// and PostgreSQL will not create a unique index on a partitioned table unless the index
+    /// carries the partition key -- but marking an envelope handled UPDATEs status, which moves
+    /// the row between partitions, so a (deduplication_id, status) index would let the same
+    /// logical id exist once as Incoming and once as Handled. A separate table sidesteps the
+    /// whole problem, carries its own retention window (which has to outlive the inbox row it
+    /// came from), and means the small, hot, constantly-written inbox table never migrates for
+    /// this feature at all.
+    /// </para>
+    ///
+    /// <para>
+    /// Provisioned only when <c>DurabilitySettings.EnableMessageDeduplication</c> is set.
+    /// </para>
+    /// </summary>
+    public const string DeduplicationTableName = "wolverine_deduplication";
+
+    /// <summary>
+    /// GH-4180. The application-defined logical id, and the primary key of
+    /// <see cref="DeduplicationTableName"/>. The uniqueness of this column IS the guarantee --
+    /// the claim is an INSERT that either succeeds or trips this constraint, never a SELECT
+    /// followed by an INSERT.
+    /// </summary>
+    public const string DeduplicationId = "deduplication_id";
+
     public const string Expires = "expires";
 
     public static readonly string IncomingFields =

--- a/src/Persistence/Wolverine.RDBMS/Deduplication/RdbmsDeduplicationStore.cs
+++ b/src/Persistence/Wolverine.RDBMS/Deduplication/RdbmsDeduplicationStore.cs
@@ -1,0 +1,136 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Weasel.Core;
+using Wolverine.Persistence.Durability;
+
+namespace Wolverine.RDBMS.Deduplication;
+
+/// <summary>
+/// GH-4180. Cross-provider <see cref="IDeduplicationStore" /> backed by the single
+/// <c>wolverine_deduplication</c> table.
+///
+/// <para>
+/// The table has exactly two columns — the logical id, which is also the primary key, and an
+/// expiry — so every operation is a plain INSERT / DELETE with no per-provider UPSERT or MERGE
+/// syntax. The same shape works on PostgreSQL, SQL Server, MySQL and SQLite unchanged; Oracle
+/// supplies its own because <c>OracleMessageStore</c> does not derive from
+/// <see cref="MessageDatabase{T}" />.
+/// </para>
+///
+/// <para>
+/// <b>Claiming is an INSERT, never a SELECT-then-INSERT.</b> That is not an optimisation, it is the
+/// feature: the duplicates this exists to stop are concurrent (an operator double-clicking, two
+/// nodes replaying the same schedule), and a check-then-act would let both through while passing
+/// every single-threaded test written against it. The database's own unique constraint is the only
+/// arbiter that holds across nodes. This mirrors <c>RdbmsListenerStore</c>'s try-insert /
+/// classify-the-violation pattern, reusing <see cref="MessageDatabase{T}" />'s existing per-provider
+/// duplicate-key classifier rather than growing a second one.
+/// </para>
+/// </summary>
+internal sealed class RdbmsDeduplicationStore : IDeduplicationStore
+{
+    private readonly DbDataSource _dataSource;
+    private readonly Func<Exception, bool> _isUniqueConstraintViolation;
+    private readonly string _insertSql;
+    private readonly string _deleteSql;
+    private readonly string _deleteExpiredSql;
+    private readonly Func<int, string?> _batchedDeleteExpiredSql;
+    private readonly int _batchSize;
+
+    /// <param name="table">
+    /// The fully rendered storage identifier for the deduplication table, as produced by
+    /// <see cref="MessageDatabase{T}.QuotedTableNameFor" /> — schema-qualified on engines that have
+    /// schemas, and a prefixed single identifier on SQLite (GH-3943).
+    /// </param>
+    /// <param name="batchedDeleteExpiredSql">
+    /// Provider hook returning a BOUNDED delete for expired claims, or null when the engine cannot
+    /// express one — the same shape as
+    /// <see cref="IMessageDatabase.BatchedDeleteExpiredHandledEnvelopesSql" />. Bounding matters here:
+    /// a busy chain under a 24-hour window accumulates a day's worth of rows, and reaping them in one
+    /// unbounded statement is exactly the long-lock problem that moved the handled-envelope cleanup
+    /// onto its own timer in the first place (issue #3116).
+    /// </param>
+    public RdbmsDeduplicationStore(
+        DbDataSource dataSource,
+        string table,
+        Func<Exception, bool> isUniqueConstraintViolation,
+        Func<int, string?> batchedDeleteExpiredSql,
+        int batchSize)
+    {
+        _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        _isUniqueConstraintViolation = isUniqueConstraintViolation
+                                       ?? throw new ArgumentNullException(nameof(isUniqueConstraintViolation));
+        _batchedDeleteExpiredSql = batchedDeleteExpiredSql
+                                   ?? throw new ArgumentNullException(nameof(batchedDeleteExpiredSql));
+        _batchSize = batchSize;
+
+        _insertSql =
+            $"insert into {table} ({DatabaseConstants.DeduplicationId}, {DatabaseConstants.Expires}) values (@id, @expires)";
+        _deleteSql = $"delete from {table} where {DatabaseConstants.DeduplicationId} = @id";
+        _deleteExpiredSql = $"delete from {table} where {DatabaseConstants.Expires} <= @now";
+    }
+
+    public async Task<bool> TryClaimAsync(string deduplicationId, DateTimeOffset expires,
+        CancellationToken cancellation = default)
+    {
+        if (deduplicationId.IsEmpty()) throw new ArgumentNullException(nameof(deduplicationId));
+
+        try
+        {
+            await using var cmd = _dataSource.CreateCommand(_insertSql)
+                .With("id", deduplicationId)
+                .With("expires", expires);
+
+            await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception e) when (_isUniqueConstraintViolation(e))
+        {
+            // Someone else holds this id. That is the answer, not an error.
+            //
+            // Note that an EXPIRED row also lands here: the reaper deletes on its own cadence, so a
+            // claim can outlive its expiry by up to DeduplicationCleanupPollingTime. Treating that as
+            // still-claimed is the conservative reading and errs toward refusing work that was already
+            // done, which is the direction this feature exists to err in.
+            return false;
+        }
+    }
+
+    public async Task ReleaseAsync(string deduplicationId, CancellationToken cancellation = default)
+    {
+        if (deduplicationId.IsEmpty()) return;
+
+        await using var cmd = _dataSource.CreateCommand(_deleteSql).With("id", deduplicationId);
+
+        // DELETE is naturally idempotent -- releasing an unclaimed id affects 0 rows without raising.
+        await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+    }
+
+    public async Task<int> DeleteExpiredAsync(DateTimeOffset utcNow, CancellationToken cancellation = default)
+    {
+        var batched = _batchedDeleteExpiredSql(_batchSize);
+
+        if (batched.IsEmpty())
+        {
+            // This provider cannot bound the delete. Still correct, just one statement.
+            await using var single = _dataSource.CreateCommand(_deleteExpiredSql).With("now", utcNow);
+            return await single.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+        }
+
+        var total = 0;
+
+        // Bounded by the caller's cadence rather than a max-batches cap: the reaper owns its own timer,
+        // so the natural stopping point is "nothing expired is left", and a short batch proves it.
+        while (!cancellation.IsCancellationRequested)
+        {
+            await using var cmd = _dataSource.CreateCommand(batched!).With("now", utcNow);
+            var deleted = await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+
+            total += deleted;
+
+            if (deleted < _batchSize) break;
+        }
+
+        return total;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredDeduplicationClaimsCommand.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/DeleteExpiredDeduplicationClaimsCommand.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+
+namespace Wolverine.RDBMS.Durability;
+
+/// <summary>
+/// GH-4180. The reaper for logical deduplication claims.
+///
+/// <para>
+/// This is not optional housekeeping. <c>wolverine_deduplication</c> is append-only on the write
+/// path — one row per deduplicated message, forever — so without a reaper, enabling the feature
+/// trades duplicate work for a table that grows without bound and takes the primary key index with
+/// it. The existing <c>DeleteExpiredHandledEnvelopesCommand</c> cannot cover it: that one deletes
+/// from the inbox on <c>keep_until</c>, and these claims deliberately live in their own table with
+/// their own, much longer, <see cref="DurabilitySettings.DeduplicationWindow" />.
+/// </para>
+///
+/// <para>
+/// Runs on its own timer in its own transaction, off the recovery loop — same isolation, and for the
+/// same reason, as the handled-envelope cleanup (issue #3116): a large delete must not be able to
+/// block inbox recovery.
+/// </para>
+///
+/// <para>
+/// Progress is reported rather than silent. A reaper that cannot say how much it removed turns an
+/// unbounded table into an unbounded table nobody is watching, so every cycle that deletes anything
+/// logs the count — a count that keeps climbing is the signal that the window is too long, the
+/// cadence too slow, or the volume higher than the settings assume.
+/// </para>
+/// </summary>
+internal class DeleteExpiredDeduplicationClaimsCommand : IAgentCommand
+{
+    private readonly IMessageDatabase _database;
+    private readonly ILogger _logger;
+
+    public DeleteExpiredDeduplicationClaimsCommand(IMessageDatabase database, ILogger logger)
+    {
+        _database = database;
+        _logger = logger;
+    }
+
+    public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime, CancellationToken cancellationToken)
+    {
+        if (_database.HasDisposed) return AgentCommands.Empty;
+
+        var now = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var deleted = await _database.Deduplication.DeleteExpiredAsync(now, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (deleted > 0)
+            {
+                _logger.LogInformation(
+                    "Deleted {Count} expired logical deduplication claims from database {Database}",
+                    deleted, _database.Name);
+            }
+        }
+        catch (Exception e)
+        {
+            // Never let reaper failure take down the durability agent -- the claims are still correct,
+            // they are just not being cleaned up, and the next cycle gets another go.
+            _logger.LogError(e, "Error trying to delete expired logical deduplication claims from database {Database}",
+                _database.Name);
+        }
+
+        return AgentCommands.Empty;
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RDBMS/DurabilityAgent.cs
@@ -33,6 +33,7 @@ internal class DurabilityAgent : IAgent
     private Timer? _handledCleanupTimer;
     private Timer? _nodeRecordPruningTimer;
     private Timer? _orphanSweepTimer;
+    private Timer? _deduplicationCleanupTimer;
 
     private readonly DurabilityHealthSignals _health;
     private DateTime _lastHealthCheck = DateTime.UtcNow;
@@ -142,6 +143,18 @@ internal class DurabilityAgent : IAgent
             _runningBlock.Post(command);
         }, _settings, 5.Seconds(), _settings.HandledMessageCleanupPollingTime);
 
+        // GH-4180: the deduplication table is append-only on the write path -- one row per deduplicated
+        // message -- so enabling the feature without a reaper trades duplicate work for a table that
+        // grows without bound. Its own timer, its own transaction, for the same reason as the handled
+        // cleanup above. Created only when the feature is on, so nothing changes for anyone else.
+        if (_settings.EnableMessageDeduplication)
+        {
+            _deduplicationCleanupTimer = new Timer(_ =>
+            {
+                _runningBlock.Post(new DeleteExpiredDeduplicationClaimsCommand(_database, _logger));
+            }, _settings, _settings.DeduplicationCleanupPollingTime, _settings.DeduplicationCleanupPollingTime);
+        }
+
         // GH-3701: node records only exist on the Main store, and their housekeeping is slow, unbounded-scan
         // work that has no business riding along on the recovery batch. See PruneNodeRecords.
         if (_database.Settings.Role == MessageStoreRole.Main)
@@ -198,6 +211,11 @@ internal class DurabilityAgent : IAgent
         if (_orphanSweepTimer != null)
         {
             await _orphanSweepTimer.DisposeAsync();
+        }
+
+        if (_deduplicationCleanupTimer != null)
+        {
+            await _deduplicationCleanupTimer.DisposeAsync();
         }
 
         Status = AgentStatus.Stopped;

--- a/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/IMessageDatabase.cs
@@ -137,6 +137,12 @@ public interface IMessageDatabase : IMessageStoreWithAgentSupport, ITenantDataba
     string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize);
 
     /// <summary>
+    /// GH-4180. A BOUNDED delete of expired logical deduplication claims, or null when this engine
+    /// cannot express one. Mirrors <see cref="BatchedDeleteExpiredHandledEnvelopesSql" />.
+    /// </summary>
+    string? BatchedDeleteExpiredDeduplicationClaimsSql(int batchSize) => null;
+
+    /// <summary>
     /// GH-3971: SQL returning every DISTINCT non-zero <c>owner_id</c> present in
     /// <paramref name="table"/>, so the orphan sweep can work out which owners are actually dead
     /// <i>in memory</i> and then issue an indexable <c>owner_id in (…)</c> update.

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -296,6 +296,16 @@ public abstract partial class MessageDatabase<T>
             await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.DeadLetterTable)}")
                 .ExecuteNonQueryAsync(_cancellation);
 
+            // GH-4180. Outside the Main-only block below on purpose: the deduplication table is
+            // provisioned for every store role, and ClearAllAsync means "no residue from the previous
+            // test". A surviving claim would silently refuse the next test's first message as a
+            // duplicate -- a green suite over a system that did nothing.
+            if (Durability.EnableMessageDeduplication)
+            {
+                await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.DeduplicationTableName)}")
+                    .ExecuteNonQueryAsync(_cancellation);
+            }
+
             if (_settings.Role == MessageStoreRole.Main)
             {
                 await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.AgentRestrictionsTableName)}")

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -17,6 +17,7 @@ using Wolverine.RDBMS.Transport;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
 using Wolverine.Transports;
+using Wolverine.RDBMS.Deduplication;
 using Wolverine.RDBMS.DynamicListeners;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
 
@@ -93,7 +94,35 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
             // ReSharper disable once VirtualMemberCallInConstructor
             Listeners = BuildListenerStore();
         }
+
+        // GH-4180. Logical deduplication storage, unlike the listener registry above, is built for
+        // EVERY store role rather than only Main. A handler chain carrying an AncillaryStoreType
+        // claims its id in that store, so that the claim and the work it guards land in one
+        // transaction; a claim that went to the Main store instead could commit while the ancillary
+        // transaction rolled back.
+        if (settings.EnableMessageDeduplication)
+        {
+            // ReSharper disable once VirtualMemberCallInConstructor
+            Deduplication = BuildDeduplicationStore();
+        }
     }
+
+    /// <summary>
+    /// Factory hook for the per-database <see cref="IDeduplicationStore" /> when
+    /// <see cref="DurabilitySettings.EnableMessageDeduplication" /> is set. The default returns
+    /// <see cref="RdbmsDeduplicationStore" />, which is portable across every provider that uses
+    /// <c>@</c>-prefixed bind variables and <see cref="DbDataSource" />-driven command creation
+    /// (Postgres, SqlServer, MySQL, SQLite). Oracle supplies its own.
+    /// </summary>
+    protected virtual IDeduplicationStore BuildDeduplicationStore()
+    {
+        return new RdbmsDeduplicationStore(_dataSource,
+            QuotedTableNameFor(DatabaseConstants.DeduplicationTableName), IsUniqueConstraintViolation,
+            BatchedDeleteExpiredDeduplicationClaimsSql, Durability.DeduplicationCleanupBatchSize);
+    }
+
+    /// <inheritdoc />
+    public IDeduplicationStore Deduplication { get; private set; } = NullDeduplicationStore.Instance;
 
     /// <summary>
     /// Factory hook for constructing the per-database <see cref="IListenerStore"/> when
@@ -294,6 +323,13 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     /// batched cleanup. See <see cref="IMessageDatabase.BatchedDeleteExpiredHandledEnvelopesSql"/>.
     /// </summary>
     public virtual string? BatchedDeleteExpiredHandledEnvelopesSql(int batchSize) => null;
+
+    /// <summary>
+    /// GH-4180. Provider hook for a BOUNDED delete of expired logical deduplication claims. Null means
+    /// "this engine cannot bound it", and the reaper falls back to one unbounded statement. Mirrors
+    /// <see cref="BatchedDeleteExpiredHandledEnvelopesSql" />.
+    /// </summary>
+    public virtual string? BatchedDeleteExpiredDeduplicationClaimsSql(int batchSize) => null;
 
     /// <summary>
     /// GH-3971. Portable default. PostgreSQL and SQL Server override it with a recursive index

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -157,6 +157,13 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
             $"where {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}' and {DatabaseConstants.KeepUntil} <= @now;";
     }
 
+    public override string? BatchedDeleteExpiredDeduplicationClaimsSql(int batchSize)
+    {
+        return
+            $"delete top ({batchSize}) from {SchemaName}.{DatabaseConstants.DeduplicationTableName} " +
+            $"where {DatabaseConstants.Expires} <= @now;";
+    }
+
     // GH-3971: deliberately NOT overriding DistinctOwnerIdsSql. The recursive index skip-scan
     // PostgreSQL uses cannot be expressed in T-SQL: SQL Server forbids aggregate functions, TOP and
     // subqueries in the recursive member of a recursive CTE, and every spelling of "next distinct value"
@@ -574,6 +581,12 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
         yield return new WolverineStoredProcedure("uspDiscardAndReassignOutgoing.sql", this);
         yield return new WolverineStoredProcedure("uspMarkIncomingOwnership.sql", this);
         yield return new WolverineStoredProcedure("uspMarkOutgoingOwnership.sql", this);
+
+        // GH-4180. Every store role, not just Main -- see the PostgreSQL twin.
+        if (Durability.EnableMessageDeduplication)
+        {
+            yield return new DeduplicationTable(SchemaName);
+        }
         
         foreach (var table in _externalTables)
         {

--- a/src/Persistence/Wolverine.SqlServer/Schema/DeduplicationTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Schema/DeduplicationTable.cs
@@ -1,0 +1,24 @@
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.SqlServer.Schema;
+
+/// <summary>
+/// GH-4180. Storage for logical message deduplication claims. See the PostgreSQL twin for why this
+/// is its own table rather than a column on the incoming envelope table.
+/// </summary>
+internal class DeduplicationTable : Table
+{
+    public DeduplicationTable(string schemaName) : base(
+        new DbObjectName(schemaName, DatabaseConstants.DeduplicationTableName))
+    {
+        AddColumn(DatabaseConstants.DeduplicationId, "varchar(250)").NotNull().AsPrimaryKey();
+        AddColumn<DateTimeOffset>(DatabaseConstants.Expires).NotNull();
+
+        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.DeduplicationTableName}_expires")
+        {
+            Columns = [DatabaseConstants.Expires]
+        });
+    }
+}

--- a/src/Persistence/Wolverine.Sqlite/Schema/DeduplicationTable.cs
+++ b/src/Persistence/Wolverine.Sqlite/Schema/DeduplicationTable.cs
@@ -1,0 +1,20 @@
+using Weasel.Sqlite;
+using Weasel.Sqlite.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.Sqlite.Schema;
+
+/// <summary>
+/// GH-4180. Storage for logical message deduplication claims. See the PostgreSQL twin for why this
+/// is its own table rather than a column on the incoming envelope table.
+/// </summary>
+internal class DeduplicationTable : Table
+{
+    public DeduplicationTable(string schemaName) : base(
+        new SqliteObjectName(TablePrefixing.Apply(schemaName, DatabaseConstants.DeduplicationTableName)))
+    {
+        // GH-3943: a SQLite "schema" is a table-name prefix, not a namespace, hence TablePrefixing above.
+        AddColumn(DatabaseConstants.DeduplicationId, "TEXT").NotNull().AsPrimaryKey();
+        AddColumn(DatabaseConstants.Expires, "TEXT").NotNull();
+    }
+}

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -470,6 +470,12 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
         yield return new IncomingEnvelopeTable(Durability, SchemaName);
         yield return new DeadLettersTable(Durability, SchemaName);
 
+        // GH-4180. Every store role, not just Main -- see the PostgreSQL twin.
+        if (Durability.EnableMessageDeduplication)
+        {
+            yield return new DeduplicationTable(SchemaName);
+        }
+
         foreach (var table in _externalTables)
         {
             yield return table;

--- a/src/Wolverine.Grpc.Tests/Deduplication/DeduplicationContracts.cs
+++ b/src/Wolverine.Grpc.Tests/Deduplication/DeduplicationContracts.cs
@@ -1,0 +1,62 @@
+using System.ServiceModel;
+using Grpc.Core;
+using ProtoBuf;
+using ProtoBuf.Grpc;
+using Wolverine.Attributes;
+
+namespace Wolverine.Grpc.Tests.Deduplication;
+
+/// <summary>
+///     GH-4180. Code-first contract exercising logical deduplication over gRPC.
+///
+///     <para>
+///     <c>[Deduplicated]</c> is on ONE method rather than the interface, which is the point of
+///     resolving the requirement per RPC: a gRPC chain is a whole service, and "all of this service's
+///     calls are deduplicated or none are" is rarely what anyone wants. <see cref="EchoUnguarded" />
+///     is the control — same service, same generated type, no deduplication.
+///     </para>
+/// </summary>
+[ServiceContract]
+[WolverineGrpcService]
+public interface IDeduplicatedEchoService
+{
+    [Deduplicated]
+    Task<DedupEchoReply> Echo(DedupEchoRequest request, CallContext context = default);
+
+    Task<DedupEchoReply> EchoUnguarded(DedupEchoRequest request, CallContext context = default);
+
+    [Deduplicated(Required = false)]
+    Task<DedupEchoReply> EchoOptional(DedupEchoRequest request, CallContext context = default);
+}
+
+[ProtoContract]
+public class DedupEchoRequest
+{
+    [ProtoMember(1)]
+    public string? Name { get; set; }
+}
+
+[ProtoContract]
+public class DedupEchoReply
+{
+    [ProtoMember(1)]
+    public string? Name { get; set; }
+}
+
+/// <summary>
+///     The observable end of the pipeline: what actually reached a handler, and how often.
+/// </summary>
+public static class DedupEchoHandler
+{
+    public static readonly List<string> Received = [];
+
+    public static DedupEchoReply Handle(DedupEchoRequest request)
+    {
+        lock (Received)
+        {
+            Received.Add(request.Name ?? "");
+        }
+
+        return new DedupEchoReply { Name = request.Name };
+    }
+}

--- a/src/Wolverine.Grpc.Tests/Deduplication/DeduplicationGrpcHost.cs
+++ b/src/Wolverine.Grpc.Tests/Deduplication/DeduplicationGrpcHost.cs
@@ -1,0 +1,121 @@
+using JasperFx;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Server;
+using Wolverine.Persistence;
+
+namespace Wolverine.Grpc.Tests.Deduplication;
+
+/// <summary>
+///     GH-4180. In-process ASP.NET Core + Wolverine gRPC host for the deduplication tests.
+///
+///     <para>
+///     Deliberately runs against a stub <see cref="IMessageDeduplicator" /> rather than a real message
+///     store. The durable half — the INSERT that either succeeds or trips the primary key, the reaper,
+///     the retention window — is covered against a real PostgreSQL database in
+///     <c>PostgresqlTests.logical_message_deduplication</c>. What is unproven for gRPC, and what these
+///     tests exist for, is the generated code: that the id is read out of request metadata, that the
+///     claim gates the forward, and that a failure releases. Standing up Postgres here would slow the
+///     gRPC CI job down to test something already tested elsewhere.
+///     </para>
+/// </summary>
+public sealed class DeduplicationGrpcHost : IAsyncDisposable
+{
+    private WebApplication? _app;
+
+    public GrpcChannel? Channel { get; private set; }
+
+    public StubMessageDeduplicator Deduplicator { get; } = new();
+
+    public IServiceProvider Services => _app?.Services
+        ?? throw new InvalidOperationException("Host has not been started yet.");
+
+    public static async Task<DeduplicationGrpcHost> StartAsync()
+    {
+        var host = new DeduplicationGrpcHost();
+
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(DeduplicationGrpcHost).Assembly;
+            opts.Durability.Mode = DurabilityMode.Solo;
+            opts.Durability.EnableMessageDeduplication = true;
+
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeType(typeof(DedupEchoHandler));
+
+            opts.Services.AddSingleton<IMessageDeduplicator>(host.Deduplicator);
+        });
+
+        builder.Services.AddCodeFirstGrpc();
+        builder.Services.AddWolverineGrpc();
+
+        host._app = builder.Build();
+
+        host._app.UseRouting();
+        host._app.MapWolverineGrpcServices();
+
+        await host._app.StartAsync();
+
+        var handler = host._app.GetTestServer().CreateHandler();
+        host.Channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = handler
+        });
+
+        return host;
+    }
+
+    public TService CreateClient<TService>() where TService : class
+        => Channel!.CreateGrpcService<TService>();
+
+    public async ValueTask DisposeAsync()
+    {
+        Channel?.Dispose();
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}
+
+/// <summary>
+///     Records every claim and release so the tests can assert on what the GENERATED code did, not
+///     merely on what the caller saw. A test that only checked the RPC status would pass over a
+///     generated method that never called the deduplicator at all.
+/// </summary>
+public sealed class StubMessageDeduplicator : IMessageDeduplicator
+{
+    private readonly HashSet<string> _claimed = [];
+
+    public List<string> Claims { get; } = [];
+    public List<string> Releases { get; } = [];
+
+    public ValueTask<bool> TryClaimAsync(string deduplicationId, Type? ancillaryStoreMarker,
+        CancellationToken cancellation)
+    {
+        lock (_claimed)
+        {
+            Claims.Add(deduplicationId);
+            return new ValueTask<bool>(_claimed.Add(deduplicationId));
+        }
+    }
+
+    public ValueTask ReleaseAsync(string deduplicationId, Type? ancillaryStoreMarker,
+        CancellationToken cancellation)
+    {
+        lock (_claimed)
+        {
+            Releases.Add(deduplicationId);
+            _claimed.Remove(deduplicationId);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Wolverine.Grpc.Tests/Deduplication/grpc_deduplication_tests.cs
+++ b/src/Wolverine.Grpc.Tests/Deduplication/grpc_deduplication_tests.cs
@@ -1,0 +1,146 @@
+using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.Deduplication;
+
+/// <summary>
+///     GH-4180. Logical deduplication over Wolverine gRPC services.
+///
+///     <para>
+///     A gRPC method owes its caller a status, so a refusal is an <c>RpcException</c> rather than the
+///     silent discard a message handler gets or the problem document an HTTP endpoint gets. The codes
+///     come from <see href="https://google.aip.dev/193">AIP-193</see>, the same table
+///     <c>WolverineGrpcExceptionInterceptor</c> already maps ordinary exceptions through.
+///     </para>
+/// </summary>
+public class grpc_deduplication_tests
+{
+    private static CallContext WithKey(string? key)
+    {
+        if (key == null) return new CallContext();
+
+        // gRPC lower-cases metadata keys on the wire; Metadata refuses a key with upper-case
+        // characters outright, which is exactly why the generated read lower-cases the configured
+        // header name rather than trusting it.
+        var headers = new Metadata { { "idempotency-key", key } };
+        return new CallContext(new CallOptions(headers));
+    }
+
+    [Fact]
+    public async Task the_second_call_with_the_same_key_is_refused_with_already_exists()
+    {
+        await using var host = await DeduplicationGrpcHost.StartAsync();
+        var client = host.CreateClient<IDeduplicatedEchoService>();
+
+        DedupEchoHandler.Received.Clear();
+
+        var first = await client.Echo(new DedupEchoRequest { Name = "first" }, WithKey("order-1"));
+        first.Name.ShouldBe("first");
+
+        // Same key, different payload. Nothing but the logical id can refuse this one.
+        var ex = await Should.ThrowAsync<RpcException>(async () =>
+            await client.Echo(new DedupEchoRequest { Name = "second" }, WithKey("order-1")));
+
+        ex.StatusCode.ShouldBe(StatusCode.AlreadyExists);
+
+        DedupEchoHandler.Received.ShouldHaveSingleItem().ShouldBe("first");
+        host.Deduplicator.Claims.ShouldBe(["order-1", "order-1"]);
+    }
+
+    [Fact]
+    public async Task different_keys_both_run()
+    {
+        await using var host = await DeduplicationGrpcHost.StartAsync();
+        var client = host.CreateClient<IDeduplicatedEchoService>();
+
+        DedupEchoHandler.Received.Clear();
+
+        await client.Echo(new DedupEchoRequest { Name = "a" }, WithKey("order-a"));
+        await client.Echo(new DedupEchoRequest { Name = "b" }, WithKey("order-b"));
+
+        DedupEchoHandler.Received.ShouldBe(["a", "b"]);
+    }
+
+    [Fact]
+    public async Task a_missing_required_key_is_invalid_argument_rather_than_a_silent_pass()
+    {
+        await using var host = await DeduplicationGrpcHost.StartAsync();
+        var client = host.CreateClient<IDeduplicatedEchoService>();
+
+        DedupEchoHandler.Received.Clear();
+
+        var ex = await Should.ThrowAsync<RpcException>(async () =>
+            await client.Echo(new DedupEchoRequest { Name = "no key" }, WithKey(null)));
+
+        ex.StatusCode.ShouldBe(StatusCode.InvalidArgument);
+
+        // Nothing ran, and nothing was claimed -- a missing id is the opposite of a duplicate.
+        DedupEchoHandler.Received.ShouldBeEmpty();
+        host.Deduplicator.Claims.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_optional_key_lets_unkeyed_calls_straight_through()
+    {
+        await using var host = await DeduplicationGrpcHost.StartAsync();
+        var client = host.CreateClient<IDeduplicatedEchoService>();
+
+        DedupEchoHandler.Received.Clear();
+
+        await client.EchoOptional(new DedupEchoRequest { Name = "x" }, WithKey(null));
+        await client.EchoOptional(new DedupEchoRequest { Name = "y" }, WithKey(null));
+
+        DedupEchoHandler.Received.ShouldBe(["x", "y"]);
+
+        // And no database round trip was paid for either of them -- the generated claim is guarded by
+        // a null check rather than called unconditionally.
+        host.Deduplicator.Claims.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_unguarded_method_on_the_same_service_is_untouched()
+    {
+        // The requirement is resolved per RPC method, not per chain. A gRPC chain is a whole service,
+        // so a chain-level requirement would force "all of this service's calls or none of them".
+        await using var host = await DeduplicationGrpcHost.StartAsync();
+        var client = host.CreateClient<IDeduplicatedEchoService>();
+
+        DedupEchoHandler.Received.Clear();
+
+        await client.EchoUnguarded(new DedupEchoRequest { Name = "one" }, WithKey("shared-key"));
+        await client.EchoUnguarded(new DedupEchoRequest { Name = "two" }, WithKey("shared-key"));
+
+        DedupEchoHandler.Received.ShouldBe(["one", "two"]);
+        host.Deduplicator.Claims.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_generated_code_weaves_deduplication_into_only_the_attributed_methods()
+    {
+        await using var host = await DeduplicationGrpcHost.StartAsync();
+
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+        var chain = graph.CodeFirstChains.Single(c => c.ServiceContractType == typeof(IDeduplicatedEchoService));
+
+        var source = chain.SourceCode;
+        source.ShouldNotBeNull();
+
+        // Two of the three RPCs are attributed, so exactly two claims are generated. Asserting the
+        // COUNT rather than mere presence is what catches a chain-level requirement leaking onto
+        // EchoUnguarded, which no behavioural test above would notice if the claim always returned true.
+        (source!.Split("TryClaimAsync").Length - 1).ShouldBe(2);
+
+        // The id comes out of request metadata, lower-cased, because gRPC lower-cases keys on the wire
+        source.ShouldContain("RequestHeaders?.GetValue(\"idempotency-key\")");
+
+        // Only the Required = true method generates the missing-id guard
+        (source.Split("missingDeduplicationId").Length - 1).ShouldBe(2);
+
+        // ...and every deduplicated method compensates on failure, because a gRPC service method is
+        // never in a Wolverine transaction of its own
+        (source.Split("ReleaseAsync").Length - 1).ShouldBe(2);
+    }
+}

--- a/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
@@ -198,6 +198,14 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
 
         InjectedField? tenantOptionsField = null;
 
+        // GH-4180. Declared once for the type, consumed per method; only when this chain opted in.
+        InjectedField? deduplicatorField = null;
+        if (GrpcDeduplication.AnyRequires(this, ServiceContractType, SupportedMethods.Select(x => x.Method)))
+        {
+            deduplicatorField = new InjectedField(typeof(IMessageDeduplicator), "deduplicator");
+            _generatedType.AllInjectedFields.Add(deduplicatorField);
+        }
+
         foreach (var rpc in SupportedMethods)
         {
             var generatedMethod = _generatedType.MethodFor(rpc.Method.Name);
@@ -230,6 +238,34 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
                 generatedMethod.AsyncMode = AsyncMode.AsyncTask;
                 generatedMethod.Frames.Add(new DetectGrpcTenantIdFrame(TenantDetection!, tenantOptionsField,
                     $"{contextArg!.Usage}.{nameof(CallContext.ServerCallContext)}", busField, null));
+            }
+
+            // GH-4180. Deduplication runs before any middleware. It is gated exactly like tenant
+            // detection above and for the same two reasons: the CallContext is the only route to the
+            // request metadata carrying the logical id, and a server-streaming method returns
+            // IAsyncEnumerable<T> directly so its body cannot await the claim.
+            var deduplication = deduplicatorField == null
+                ? null
+                : GrpcDeduplication.RequirementFor(this, ServiceContractType, rpc.Method);
+
+            if (deduplication != null)
+            {
+                if (contextArg == null || rpc.Kind is not (CodeFirstMethodKind.Unary or CodeFirstMethodKind.ClientStreaming))
+                {
+                    // Refuse rather than skip. Silently generating an unprotected method on a service
+                    // that asked for deduplication is the failure this whole feature exists to remove,
+                    // not one to introduce here.
+                    throw new NotSupportedException(
+                        $"Logical message deduplication is not supported on the {rpc.Kind} method '{rpc.Method.Name}' of {ServiceContractType.FullNameInCode()}. It requires a CallContext parameter (the only route to request metadata) and an awaitable return shape. Add a CallContext parameter, or remove [Deduplicated] from this service. See GH-4180");
+                }
+
+                generatedMethod.AsyncMode = AsyncMode.AsyncTask;
+
+                foreach (var frame in GrpcDeduplication.BuildFrames(this, deduplication,
+                             $"{contextArg.Usage}.{nameof(CallContext.ServerCallContext)}", deduplicatorField!))
+                {
+                    generatedMethod.Frames.Add(frame);
+                }
             }
 
             // Per-call middleware (including the Validate short-circuit) requires a concrete
@@ -290,7 +326,7 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
                     {
                         // When tenant detection made the method async, 'return _bus.InvokeAsync(...)'
                         // would no longer compile — the forward frame must await instead.
-                        ForceAwait = detectTenantId
+                        ForceAwait = detectTenantId || deduplication != null
                     });
                     break;
 
@@ -303,7 +339,7 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
                     {
                         // Same forcing rule as unary: tenant detection makes the method async,
                         // so 'return _bus.StreamAsync(...)' must become 'return await ...'.
-                        ForceAwait = detectTenantId
+                        ForceAwait = detectTenantId || deduplication != null
                     });
                     break;
             }

--- a/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
@@ -126,6 +126,18 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
     public override MiddlewareScoping Scoping => MiddlewareScoping.Grpc;
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
 
+    /// <inheritdoc />
+    /// <remarks>
+    ///     GH-4180. A gRPC method owes its caller a status, so a refusal is an <c>RpcException</c> rather
+    ///     than the silent discard a message handler gets or the problem document an HTTP endpoint gets.
+    ///     Shared across all three gRPC chain flavours — the refusal is identical in each, and three
+    ///     copies of the mapping would only drift.
+    /// </remarks>
+    public override Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+        => GrpcDeduplication.BuildStopCondition(condition, outcome, requirement);
+
+
     /// <summary>
     ///     Set by <see cref="GrpcTenantIdDetection"/> (the built-in <see cref="IGrpcChainPolicy"/>
     ///     behind <see cref="WolverineGrpcOptions.TenantId"/>) when tenant detection strategies are

--- a/src/Wolverine.Grpc/GrpcDeduplicationFrames.cs
+++ b/src/Wolverine.Grpc/GrpcDeduplicationFrames.cs
@@ -1,0 +1,87 @@
+using Grpc.Core;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+using Wolverine.Persistence;
+
+namespace Wolverine.Grpc;
+
+/// <summary>
+/// GH-4180. The gRPC answer to a failed logical deduplication check: an <see cref="RpcException" />
+/// carrying the canonical status code for the condition.
+///
+/// <para>
+/// A duplicate is <see cref="StatusCode.AlreadyExists" /> and a missing-but-required key is
+/// <see cref="StatusCode.InvalidArgument" />, both straight out of
+/// <see href="https://google.aip.dev/193">AIP-193</see> — the same table
+/// <c>WolverineGrpcExceptionInterceptor</c> already maps ordinary .NET exceptions through, so a gRPC
+/// client sees deduplication refusals in exactly the shape it already handles every other refusal in.
+/// </para>
+///
+/// <para>
+/// Throwing rather than returning is not a stylistic choice: a unary RPC method has to produce a
+/// response message, and there is no honest response body for "this was already done". The status is
+/// the answer.
+/// </para>
+/// </summary>
+internal class GrpcDeduplicationStopFrame : SyncFrame
+{
+    private readonly Variable _condition;
+    private readonly StatusCode _statusCode;
+    private readonly string _message;
+
+    public GrpcDeduplicationStopFrame(Variable condition, StatusCode statusCode, string message)
+    {
+        _condition = condition;
+        _statusCode = statusCode;
+        _message = message.Replace("\"", "'");
+        uses.Add(condition);
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var statusCode = typeof(StatusCode).FullNameInCode();
+        var status = typeof(Status).FullNameInCode();
+        var rpcException = typeof(RpcException).FullNameInCode();
+
+        writer.WriteComment($"GH-4180: {_statusCode} for a failed logical deduplication check");
+        writer.Write($"BLOCK:if ({_condition.Usage})");
+        writer.Write(
+            $"throw new {rpcException}(new {status}({statusCode}.{_statusCode}, \"{_message}\"));");
+        writer.FinishBlock();
+
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+/// GH-4180. Shared implementation of <see cref="IChain.BuildDeduplicationStopCondition" /> for all
+/// three gRPC chain flavours — proto-first, code-first, and hand-written. The refusal is identical
+/// in each; only the surrounding codegen differs, so the three overrides delegate here rather than
+/// repeating the mapping and drifting apart.
+/// </summary>
+internal static class GrpcDeduplication
+{
+    public static Frame[] BuildStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+    {
+        var key = requirement.Key ?? DeduplicationRequirement.DefaultHeaderName;
+
+        return outcome switch
+        {
+            DeduplicationOutcome.Duplicate =>
+            [
+                new GrpcDeduplicationStopFrame(condition, StatusCode.AlreadyExists,
+                    $"A call with this '{key}' has already been handled")
+            ],
+            DeduplicationOutcome.MissingId =>
+            [
+                new GrpcDeduplicationStopFrame(condition, StatusCode.InvalidArgument,
+                    $"This method requires a logical deduplication id in the '{key}' request metadata")
+            ],
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+        };
+    }
+}

--- a/src/Wolverine.Grpc/GrpcDeduplicationFrames.cs
+++ b/src/Wolverine.Grpc/GrpcDeduplicationFrames.cs
@@ -2,9 +2,12 @@ using Grpc.Core;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using System.Reflection;
 using JasperFx.Core.Reflection;
 using Wolverine.Configuration;
 using Wolverine.Persistence;
+using Wolverine.Persistence.Codegen;
+using Wolverine.Attributes;
 
 namespace Wolverine.Grpc;
 
@@ -57,6 +60,53 @@ internal class GrpcDeduplicationStopFrame : SyncFrame
 }
 
 /// <summary>
+/// GH-4180. Reads the logical deduplication id out of the incoming call's request metadata.
+///
+/// <para>
+/// gRPC lower-cases every metadata key on the wire, so the configured header name is lower-cased
+/// here too. A caller sending <c>Idempotency-Key</c> and a chain configured for
+/// <c>Idempotency-Key</c> would otherwise never match, and the failure would look like "the client
+/// is not sending a key" rather than a casing bug.
+/// </para>
+///
+/// <para>
+/// Takes the <see cref="ServerCallContext" /> as an expression string rather than a
+/// <see cref="Variable" />, matching <c>DetectGrpcTenantIdFrame</c>: gRPC generates each RPC method
+/// from the proto/contract signature, so the context is a method parameter whose name differs per
+/// method, and every chain flavour already threads that name through its own
+/// <c>AssembleTypes</c>.
+/// </para>
+/// </summary>
+internal class ReadGrpcDeduplicationIdFrame : SyncFrame
+{
+    private readonly string _serverCallContextExpression;
+    private readonly string _headerName;
+
+    public ReadGrpcDeduplicationIdFrame(string serverCallContextExpression, string headerName)
+    {
+        _serverCallContextExpression = serverCallContextExpression;
+        _headerName = headerName.ToLowerInvariant();
+        Variable = new Variable(typeof(string), "deduplicationId", this);
+    }
+
+    public Variable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"GH-4180: logical deduplication id from the '{_headerName}' request metadata");
+        writer.Write(
+            $"var {Variable.Usage} = {_serverCallContextExpression}.{nameof(ServerCallContext.RequestHeaders)}?.{nameof(Metadata.GetValue)}(\"{_headerName}\");");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield break;
+    }
+}
+
+/// <summary>
 /// GH-4180. Shared implementation of <see cref="IChain.BuildDeduplicationStopCondition" /> for all
 /// three gRPC chain flavours — proto-first, code-first, and hand-written. The refusal is identical
 /// in each; only the surrounding codegen differs, so the three overrides delegate here rather than
@@ -64,10 +114,116 @@ internal class GrpcDeduplicationStopFrame : SyncFrame
 /// </summary>
 internal static class GrpcDeduplication
 {
+    /// <summary>
+    /// Resolve the deduplication requirement for ONE RPC method, or null when it is not deduplicated.
+    ///
+    /// <para>
+    /// Read directly off the attributes rather than through <c>IChain.Deduplication</c>, because the
+    /// gRPC chains never run <c>applyAttributesAndConfigureMethods</c> — the pass that applies
+    /// <c>ModifyChainAttribute</c> for handler and HTTP chains. Wiring that pass in wholesale would
+    /// apply every chain-modifying attribute to gRPC services at once, which is a much larger
+    /// behaviour change than this feature is entitled to make.
+    /// </para>
+    ///
+    /// <para>
+    /// Resolution is per RPC method, not per chain, and the method attribute beats the service one.
+    /// A gRPC chain is a whole SERVICE — one type with many RPCs — so a chain-level requirement would
+    /// force "all of this service's calls are deduplicated or none are". Attributing one RPC is the
+    /// natural thing to want, and the natural thing to write.
+    /// </para>
+    /// </summary>
+    public static DeduplicationRequirement? RequirementFor(IChain chain, Type serviceType, MethodInfo rpcMethod)
+    {
+        var attribute = rpcMethod.GetCustomAttribute<DeduplicatedAttribute>()
+                        ?? serviceType.GetCustomAttribute<DeduplicatedAttribute>();
+
+        if (attribute == null) return chain.Deduplication;
+
+        return new DeduplicationRequirement
+        {
+            Source = attribute.Source,
+            Key = attribute.Key,
+            Required = attribute.Required,
+            DuplicateStatusCode = attribute.DuplicateStatusCode
+        };
+    }
+
+    /// <summary>
+    /// Does any RPC on this service need deduplication? Answers whether the generated type has to
+    /// declare an <see cref="IMessageDeduplicator" /> field at all — a service that did not opt in
+    /// takes on no extra dependency.
+    /// </summary>
+    public static bool AnyRequires(IChain chain, Type serviceType, IEnumerable<MethodInfo> rpcMethods)
+        => rpcMethods.Any(m => RequirementFor(chain, serviceType, m) != null);
+
+    /// <summary>
+    /// Weave the deduplication frames into ONE generated RPC method.
+    ///
+    /// <para>
+    /// Per method, and building fresh frames each time, rather than through the chain's
+    /// <c>Middleware</c> list the way handler and HTTP chains do. Frames carry per-method mutable
+    /// state (their resolved variables and their <c>Next</c> link), and gRPC's <c>CloneFrames</c>
+    /// only deep-copies <c>ConstructorFrame</c> and <c>MethodCall</c> — everything else is passed
+    /// through by reference. Sharing one instance across a service's RPC methods would corrupt all
+    /// but the last. This is the same rule <c>DetectGrpcTenantIdFrame</c> documents.
+    /// </para>
+    /// </summary>
+    /// <param name="deduplicatorField">
+    /// The generated type's injected <see cref="IMessageDeduplicator" />. Passed explicitly because
+    /// gRPC service types are composed from declared <c>InjectedField</c>s rather than the
+    /// container-driven variable sources handler and HTTP chains resolve against.
+    /// </param>
+    public static IEnumerable<Frame> BuildFrames(IChain chain, DeduplicationRequirement requirement,
+        string serverCallContextExpression, InjectedField deduplicatorField)
+    {
+        if (requirement.Source is not (ValueSource.Anything or ValueSource.Header))
+        {
+            throw new NotSupportedException(
+                $"Wolverine gRPC services can only source a logical deduplication id from request metadata (ValueSource.Header), not {requirement.Source}. Requested by {chain.Description}. See GH-4180");
+        }
+
+        var headerName = requirement.Key ?? DeduplicationRequirement.DefaultHeaderName;
+        var cancellation = $"{serverCallContextExpression}.{nameof(ServerCallContext.CancellationToken)}";
+
+        var read = new ReadGrpcDeduplicationIdFrame(serverCallContextExpression, headerName);
+        yield return read;
+
+        if (requirement.Required)
+        {
+            var missing = new DeduplicationIdMissingFrame(read.Variable);
+            yield return missing;
+
+            foreach (var frame in chain.BuildDeduplicationStopCondition(missing.Variable,
+                         DeduplicationOutcome.MissingId, requirement))
+            {
+                yield return frame;
+            }
+        }
+
+        var claim = new ClaimDeduplicationIdFrame(read.Variable, chain.AncillaryStoreType,
+            deduplicatorField.Usage, cancellation);
+        yield return claim;
+
+        foreach (var frame in chain.BuildDeduplicationStopCondition(claim.Variable,
+                     DeduplicationOutcome.Duplicate, requirement))
+        {
+            yield return frame;
+        }
+
+        // A gRPC service method is never enrolled in a Wolverine transaction of its own -- it forwards to
+        // the bus, and any transaction belongs to the handler on the other side. So the claim is always
+        // already committed by the time the forward runs, and the compensating release is always needed.
+        yield return new ReleaseDeduplicationIdOnFailureFrame(read.Variable, chain.AncillaryStoreType,
+            deduplicatorField.Usage, cancellation);
+    }
+
     public static Frame[] BuildStopCondition(Variable condition, DeduplicationOutcome outcome,
         DeduplicationRequirement requirement)
     {
-        var key = requirement.Key ?? DeduplicationRequirement.DefaultHeaderName;
+        // Lower-cased to match what a caller must actually send: Grpc.Core.Metadata rejects a key with
+        // upper-case characters outright, so naming the header as configured ("Idempotency-Key") in an
+        // error message would send the reader off to write a call that cannot compile.
+        var key = (requirement.Key ?? DeduplicationRequirement.DefaultHeaderName).ToLowerInvariant();
 
         return outcome switch
         {

--- a/src/Wolverine.Grpc/GrpcGraph.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.cs
@@ -167,6 +167,38 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
         {
             policy.Apply(_chains, _codeFirstChains, _handWrittenChains, Rules, Container);
         }
+
+        AssertNoUnsupportedDeduplication(chainableChains);
+    }
+
+    /// <summary>
+    /// GH-4180. Logical message deduplication is not wired into gRPC yet, and this makes that visible
+    /// instead of quiet.
+    ///
+    /// <para>
+    /// The refusal half IS implemented — <c>BuildDeduplicationStopCondition</c> on all three gRPC chain
+    /// types maps a duplicate to <c>AlreadyExists</c> and a missing id to <c>InvalidArgument</c>. What is
+    /// missing is the id-resolution half: gRPC generates each RPC method inside <c>AssembleTypes</c> with
+    /// a method-local <c>ServerCallContext</c> expression rather than through the <c>Middleware</c> list
+    /// that <c>ApplyDeduplication</c> weaves into, so reading the id out of request metadata needs
+    /// plumbing that does not exist yet.
+    /// </para>
+    ///
+    /// <para>
+    /// Throwing here rather than ignoring the attribute is the whole point. <c>[Deduplicated]</c> is a
+    /// <c>ModifyChainAttribute</c>, so it happily sets the requirement on a gRPC chain and then nothing
+    /// would consume it — an application that believes it is protected, is not, and has no log line or
+    /// failing test that says so. A bootstrap failure naming the limitation is strictly better than a
+    /// feature that silently is not there.
+    /// </para>
+    /// </summary>
+    private static void AssertNoUnsupportedDeduplication(IReadOnlyList<IChain> chains)
+    {
+        var offenders = chains.Where(x => x.Deduplication != null).ToArray();
+        if (offenders.Length == 0) return;
+
+        throw new NotSupportedException(
+            $"Logical message deduplication ([Deduplicated]) is not yet supported on Wolverine gRPC services, but was requested by {offenders.Select(x => x.Description).Join(", ")}. It is supported on message handlers and Wolverine.HTTP endpoints today. See GH-4180");
     }
 
     /// <summary>

--- a/src/Wolverine.Grpc/GrpcGraph.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.cs
@@ -167,38 +167,6 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
         {
             policy.Apply(_chains, _codeFirstChains, _handWrittenChains, Rules, Container);
         }
-
-        AssertNoUnsupportedDeduplication(chainableChains);
-    }
-
-    /// <summary>
-    /// GH-4180. Logical message deduplication is not wired into gRPC yet, and this makes that visible
-    /// instead of quiet.
-    ///
-    /// <para>
-    /// The refusal half IS implemented — <c>BuildDeduplicationStopCondition</c> on all three gRPC chain
-    /// types maps a duplicate to <c>AlreadyExists</c> and a missing id to <c>InvalidArgument</c>. What is
-    /// missing is the id-resolution half: gRPC generates each RPC method inside <c>AssembleTypes</c> with
-    /// a method-local <c>ServerCallContext</c> expression rather than through the <c>Middleware</c> list
-    /// that <c>ApplyDeduplication</c> weaves into, so reading the id out of request metadata needs
-    /// plumbing that does not exist yet.
-    /// </para>
-    ///
-    /// <para>
-    /// Throwing here rather than ignoring the attribute is the whole point. <c>[Deduplicated]</c> is a
-    /// <c>ModifyChainAttribute</c>, so it happily sets the requirement on a gRPC chain and then nothing
-    /// would consume it — an application that believes it is protected, is not, and has no log line or
-    /// failing test that says so. A bootstrap failure naming the limitation is strictly better than a
-    /// feature that silently is not there.
-    /// </para>
-    /// </summary>
-    private static void AssertNoUnsupportedDeduplication(IReadOnlyList<IChain> chains)
-    {
-        var offenders = chains.Where(x => x.Deduplication != null).ToArray();
-        if (offenders.Length == 0) return;
-
-        throw new NotSupportedException(
-            $"Logical message deduplication ([Deduplicated]) is not yet supported on Wolverine gRPC services, but was requested by {offenders.Select(x => x.Description).Join(", ")}. It is supported on message handlers and Wolverine.HTTP endpoints today. See GH-4180");
     }
 
     /// <summary>

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -262,6 +262,15 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
             _generatedType.AllInjectedFields.Add(tenantOptionsField);
         }
 
+        // GH-4180. Declared once for the type, consumed per method. Only added when this chain actually
+        // opted into logical deduplication, so a service that did not asks for no extra dependency.
+        InjectedField? deduplicatorField = null;
+        if (GrpcDeduplication.AnyRequires(this, StubType, SupportedMethods.Select(x => x.Method)))
+        {
+            deduplicatorField = new InjectedField(typeof(IMessageDeduplicator), "deduplicator");
+            _generatedType.AllInjectedFields.Add(deduplicatorField);
+        }
+
         var befores = DiscoveredBefores;
         var afters = DiscoveredAfters;
 
@@ -282,6 +291,28 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
                 generatedMethod.AsyncMode = AsyncMode.AsyncTask;
                 generatedMethod.Frames.Add(new DetectGrpcTenantIdFrame(TenantDetection!, tenantOptionsField,
                     contextName, busField, null));
+            }
+
+            // GH-4180. Deduplication runs before any middleware, and applies to EVERY RPC shape: the
+            // logical id comes from request metadata, which bidi and client-streaming calls carry just
+            // as unary ones do. Like tenant detection above, the frames await, so the method body must
+            // be async even for the unary shape that would otherwise return the bus task directly.
+            var deduplication = deduplicatorField == null
+                ? null
+                : GrpcDeduplication.RequirementFor(this, StubType, rpc.Method);
+
+            if (deduplication != null)
+            {
+                var rpcParameters = rpc.Method.GetParameters();
+                var contextName = ForwardUnaryToMessageBusFrame.ParameterName(rpcParameters, rpcParameters.Length - 1);
+
+                generatedMethod.AsyncMode = AsyncMode.AsyncTask;
+
+                foreach (var frame in GrpcDeduplication.BuildFrames(this, deduplication, contextName,
+                             deduplicatorField!))
+                {
+                    generatedMethod.Frames.Add(frame);
+                }
             }
 
             // Before-frames (including Validate short-circuit) require a concrete TRequest
@@ -312,9 +343,10 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
                         generatedMethod.AsyncMode = AsyncMode.AsyncTask;
                     generatedMethod.Frames.Add(new ForwardUnaryToMessageBusFrame(rpc.Method, busField)
                     {
-                        // When tenant detection made the method async, 'return _bus.InvokeAsync(...)'
-                        // would no longer compile — the forward frame must await instead.
-                        ForceAwait = tenantOptionsField != null
+                        // When tenant detection or deduplication (GH-4180) made the method async,
+                        // 'return _bus.InvokeAsync(...)' would no longer compile — the forward frame
+                        // must await instead.
+                        ForceAwait = tenantOptionsField != null || deduplication != null
                     });
                     break;
 

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -213,6 +213,18 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
 
     public override Frame[] AddStopConditionIfNull(Variable variable) => [];
 
+    /// <inheritdoc />
+    /// <remarks>
+    ///     GH-4180. A gRPC method owes its caller a status, so a refusal is an <c>RpcException</c> rather
+    ///     than the silent discard a message handler gets or the problem document an HTTP endpoint gets.
+    ///     Shared across all three gRPC chain flavours — the refusal is identical in each, and three
+    ///     copies of the mapping would only drift.
+    /// </remarks>
+    public override Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+        => GrpcDeduplication.BuildStopCondition(condition, outcome, requirement);
+
+
     public override void UseForResponse(MethodCall methodCall)
     {
         // no-op: proto-first chains don't synthesize response variables via MethodCall.

--- a/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
@@ -72,6 +72,18 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
     public override MiddlewareScoping Scoping => MiddlewareScoping.Grpc;
     public override IdempotencyStyle Idempotency { get; set; } = IdempotencyStyle.None;
 
+    /// <inheritdoc />
+    /// <remarks>
+    ///     GH-4180. A gRPC method owes its caller a status, so a refusal is an <c>RpcException</c> rather
+    ///     than the silent discard a message handler gets or the problem document an HTTP endpoint gets.
+    ///     Shared across all three gRPC chain flavours — the refusal is identical in each, and three
+    ///     copies of the mapping would only drift.
+    /// </remarks>
+    public override Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+        => GrpcDeduplication.BuildStopCondition(condition, outcome, requirement);
+
+
     /// <summary>
     ///     Set by <see cref="GrpcTenantIdDetection"/> (the built-in <see cref="IGrpcChainPolicy"/>
     ///     behind <see cref="WolverineGrpcOptions.TenantId"/>) when tenant detection strategies are

--- a/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
@@ -172,6 +172,14 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
 
         InjectedField? tenantOptionsField = null;
 
+        // GH-4180. Declared once for the type, consumed per method; only when this chain opted in.
+        InjectedField? deduplicatorField = null;
+        if (GrpcDeduplication.AnyRequires(this, ServiceClassType, SupportedMethods.Select(x => x.Method)))
+        {
+            deduplicatorField = new InjectedField(typeof(IMessageDeduplicator), "deduplicator");
+            _generatedType.AllInjectedFields.Add(deduplicatorField);
+        }
+
         var befores = DiscoveredBefores;
         var afters = DiscoveredAfters;
 
@@ -204,6 +212,32 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
                     $"{contextParam!.Name}.{nameof(CallContext.ServerCallContext)}", null, spField));
             }
 
+            // GH-4180. Deduplication runs before any middleware, gated exactly like tenant detection
+            // above and for the same two reasons: the CallContext is the only route to the request
+            // metadata carrying the logical id, and a streaming method returns IAsyncEnumerable<T>
+            // directly so its body cannot await the claim.
+            var deduplication = deduplicatorField == null
+                ? null
+                : GrpcDeduplication.RequirementFor(this, ServiceClassType, rpc.Method);
+
+            if (deduplication != null)
+            {
+                if (contextParam == null || rpc.Kind != HandWrittenMethodKind.Unary)
+                {
+                    // Refuse rather than skip -- see the code-first twin.
+                    throw new NotSupportedException(
+                        $"Logical message deduplication is not supported on the {rpc.Kind} method '{rpc.Method.Name}' of {ServiceClassType.FullNameInCode()}. It requires a CallContext parameter (the only route to request metadata) and an awaitable return shape. Add a CallContext parameter, or remove [Deduplicated] from this service. See GH-4180");
+                }
+
+                generatedMethod.AsyncMode = AsyncMode.AsyncTask;
+
+                foreach (var frame in GrpcDeduplication.BuildFrames(this, deduplication,
+                             $"{contextParam.Name}.{nameof(CallContext.ServerCallContext)}", deduplicatorField!))
+                {
+                    generatedMethod.Frames.Add(frame);
+                }
+            }
+
             // Before-frames require a concrete TRequest in scope. Skip for bidi methods where
             // the first parameter is IAsyncEnumerable<T> rather than a single message instance.
             // Also skip any before whose non-CallContext parameters don't match this RPC method's
@@ -233,10 +267,10 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
             if (hasAfters)
                 generatedMethod.AsyncMode = AsyncMode.AsyncTask;
 
-            // Tenant detection forces the method async, so the delegation frame must await the
-            // inner call even when there are no after-frames.
+            // Tenant detection and deduplication (GH-4180) both force the method async, so the
+            // delegation frame must await the inner call even when there are no after-frames.
             generatedMethod.Frames.Add(new DelegateToInnerServiceFrame(rpc.Method, spField, ServiceClassType,
-                hasAfters || detectTenantId));
+                hasAfters || detectTenantId || deduplication != null));
 
             if (hasAfters)
             {

--- a/src/Wolverine/Attributes/DeduplicatedAttribute.cs
+++ b/src/Wolverine/Attributes/DeduplicatedAttribute.cs
@@ -1,0 +1,104 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Configuration;
+using Wolverine.Persistence;
+
+namespace Wolverine.Attributes;
+
+/// <summary>
+/// GH-4180. Opt this message handler, HTTP endpoint, or gRPC method into <b>logical</b> message
+/// deduplication: Wolverine resolves an application-supplied id and refuses to execute a second
+/// time for the same id inside <see cref="DurabilitySettings.DeduplicationWindow" />.
+///
+/// <para>
+/// This is a different question from Wolverine's built-in idempotency, which keys on
+/// <see cref="Envelope.Id" /> and therefore identifies one <i>delivery</i>. Logical deduplication
+/// identifies one <i>intent</i> — "rebuild projection X for tonight's 03:00 run" — and so survives
+/// an operator double-clicking, a console republishing, or an agent pre-publishing an occurrence
+/// that later arrives again on its own.
+/// </para>
+///
+/// <para>
+/// Requires <c>opts.Durability.EnableMessageDeduplication = true</c>, which provisions the backing
+/// storage. Bootstrapping fails with a clear message if this attribute is used without it, rather
+/// than silently letting every duplicate through.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// // Message handler: uses Envelope.DeduplicationId, set by the publisher through DeliveryOptions
+/// [Deduplicated]
+/// public static void Handle(RebuildProjection command) { }
+///
+/// // HTTP endpoint: uses the conventional "Idempotency-Key" request header
+/// [Deduplicated]
+/// [WolverinePost("/schedules/{scheduleId}/occurrences")]
+/// public static async Task&lt;IResult&gt; Post(ScheduleOccurrence body) { }
+///
+/// // Derive the id from the message or request body instead
+/// [Deduplicated(ValueSource.InputMember, nameof(ScheduleOccurrence.OccurrenceKey))]
+/// public static void Handle(ScheduleOccurrence command) { }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class DeduplicatedAttribute : ModifyChainAttribute
+{
+    public DeduplicatedAttribute()
+    {
+    }
+
+    /// <param name="key">
+    /// The header name — or, with an explicit <see cref="Source" />, the member / route / query key —
+    /// holding the logical id.
+    /// </param>
+    public DeduplicatedAttribute(string key)
+    {
+        Key = key;
+        Source = ValueSource.Header;
+    }
+
+    public DeduplicatedAttribute(ValueSource source, string key)
+    {
+        Source = source;
+        Key = key;
+    }
+
+    /// <summary>
+    /// Where the logical id comes from. Defaults to this chain type's natural source:
+    /// <see cref="Envelope.DeduplicationId" /> for message handlers, and the
+    /// <see cref="DeduplicationRequirement.DefaultHeaderName" /> header for HTTP and gRPC.
+    /// </summary>
+    public ValueSource Source { get; set; } = ValueSource.Anything;
+
+    /// <summary>
+    /// The header / member / route key holding the logical id. Ignored when <see cref="Source" /> is
+    /// left at <see cref="ValueSource.Anything" />.
+    /// </summary>
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// Must the id be present? Defaults to <see langword="true" />; see
+    /// <see cref="DeduplicationRequirement.Required" /> for why the strict reading is the safe default.
+    /// </summary>
+    public bool Required { get; set; } = true;
+
+    /// <summary>
+    /// HTTP endpoints only: the status code for an already-claimed id. Default 409 Conflict; use 200 or
+    /// 204 where a replayed request is benign. See <see cref="DeduplicationRequirement.DuplicateStatusCode" />.
+    /// </summary>
+    public int DuplicateStatusCode { get; set; } = 409;
+
+    public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
+    {
+        // Records the intent only. The frames are woven later, from ApplyDeduplication(), because the
+        // shape of what gets woven depends on IChain.IsTransactional -- and that is not settled until
+        // the persistence providers' policies have run, well after attributes are applied.
+        chain.Deduplication = new DeduplicationRequirement
+        {
+            Source = Source,
+            Key = Key,
+            Required = Required,
+            DuplicateStatusCode = DuplicateStatusCode
+        };
+    }
+}

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -36,6 +36,43 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
 
     public abstract IdempotencyStyle Idempotency { get; set; }
 
+    /// <summary>
+    ///     GH-4180. Logical message deduplication for this chain, or null for none. A real property here
+    ///     rather than the interface's default so that every chain type Wolverine ships — handler, HTTP,
+    ///     and all three gRPC flavours — round-trips a set value instead of swallowing it.
+    /// </summary>
+    public DeduplicationRequirement? Deduplication { get; set; }
+
+    /// <inheritdoc />
+    public virtual bool RequiresDeduplication() => Deduplication is not null;
+
+    /// <inheritdoc />
+    public virtual Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+        => throw new NotSupportedException(
+            $"{GetType().FullNameInCode()} does not support logical message deduplication (GH-4180)");
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Mirrors the <see cref="IChain" /> default. It exists here as a <c>virtual</c> so that the chain
+    ///     types Wolverine ships can override it — a default interface member cannot be overridden by a
+    ///     class in the hierarchy, only reimplemented on the interface, which would not be picked up
+    ///     through a <see cref="Chain{TChain,TModifyAttribute}" />-typed reference.
+    /// </remarks>
+    public virtual Variable ResolveDeduplicationId(DeduplicationRequirement requirement)
+    {
+        var source = requirement.Source == ValueSource.Anything ? ValueSource.Header : requirement.Source;
+        var key = requirement.Key ?? DeduplicationRequirement.DefaultHeaderName;
+
+        if (TryFindVariable(key, source, typeof(string), out var variable))
+        {
+            return variable;
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot resolve a logical deduplication id for {Description}. No {source} value named '{key}' could be found. See GH-4180");
+    }
+
     public List<Frame> Postprocessors { get; } = [];
 
     /// <summary>

--- a/src/Wolverine/Configuration/IChain.cs
+++ b/src/Wolverine/Configuration/IChain.cs
@@ -105,6 +105,80 @@ public interface IChain
     IdempotencyStyle Idempotency { get; set; }
 
     /// <summary>
+    ///     GH-4180. When set, this chain enforces <b>logical</b> message deduplication: it resolves an
+    ///     application-supplied id and refuses to run a second time for the same id. Null — the default —
+    ///     means no logical deduplication, which is distinct from <see cref="Idempotency" />, whose
+    ///     subject is <see cref="Envelope.Id" /> and therefore one delivery rather than one intent.
+    /// </summary>
+    /// <remarks>
+    ///     Declared with a default implementation so that <see cref="IChain" /> implementors outside
+    ///     Wolverine's own <see cref="Chain{TChain,TModifyAttribute}" /> hierarchy keep compiling. Every
+    ///     chain type Wolverine ships overrides it with a real auto-property.
+    /// </remarks>
+    DeduplicationRequirement? Deduplication
+    {
+        get => null;
+        set { }
+    }
+
+    /// <summary>
+    ///     GH-4180. Does this chain need deduplication frames woven into it? Mirrors
+    ///     <see cref="RequiresOutbox" /> — a predicate the code generation asks rather than a flag policies
+    ///     have to keep in sync.
+    /// </summary>
+    bool RequiresDeduplication() => Deduplication is not null;
+
+    /// <summary>
+    ///     GH-4180. Build the frames that abort execution when the deduplication check fails.
+    ///
+    ///     <para>
+    ///     This is the ONLY part of logical deduplication that differs between chain types. Resolving the
+    ///     id and claiming it are identical everywhere and live in shared frames; what a caller is told
+    ///     about the refusal is not — a message handler discards and acks, an HTTP endpoint owes the
+    ///     caller a status code, and a gRPC method owes it a <c>StatusCode</c>. Splitting it here follows
+    ///     the same seam as <see cref="AddStopConditionIfNull(Variable)" /> and
+    ///     <see cref="CreateSimpleValidationFrame" />, so it composes with the existing middleware
+    ///     ordering and <see cref="TryCatchFinallyFrame" /> handling instead of introducing new rules.
+    ///     </para>
+    /// </summary>
+    /// <param name="condition">
+    ///     A <c>bool</c> variable that is <see langword="true" /> when execution must stop.
+    /// </param>
+    /// <param name="outcome">Which of the two failures this is — the two are not interchangeable.</param>
+    /// <param name="requirement">The requirement being enforced, for messages and metadata.</param>
+    Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+        => throw new NotSupportedException(
+            $"{GetType().FullNameInCode()} does not support logical message deduplication (GH-4180)");
+
+    /// <summary>
+    ///     GH-4180. Find the variable holding this chain's logical deduplication id.
+    ///
+    ///     <para>
+    ///     The default handles every source expressible through <see cref="TryFindVariable" /> — a request
+    ///     header, a member of the input type, a route value — and falls back to the conventional
+    ///     <see cref="DeduplicationRequirement.DefaultHeaderName" /> header, which is right for HTTP and
+    ///     gRPC. Message handlers override it, because their natural id lives on
+    ///     <see cref="Envelope.DeduplicationId" />: that value is a first-class envelope property which
+    ///     <c>EnvelopeSerializer</c> lifts off the wire into the property rather than leaving in
+    ///     <see cref="Envelope.Headers" />, so a header lookup would never find it.
+    ///     </para>
+    /// </summary>
+    Variable ResolveDeduplicationId(DeduplicationRequirement requirement)
+    {
+        var source = requirement.Source == ValueSource.Anything ? ValueSource.Header : requirement.Source;
+        var key = requirement.Key ?? DeduplicationRequirement.DefaultHeaderName;
+
+        if (TryFindVariable(key, source, typeof(string), out var variable))
+        {
+            return variable;
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot resolve a logical deduplication id for {Description}. No {source} value named '{key}' could be found. See GH-4180");
+    }
+
+    /// <summary>
     ///     Frames that would be initially placed in front of
     ///     the primary action(s)
     /// </summary>

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -228,6 +228,61 @@ public class DurabilitySettings : IDescribeMyself
     public int HandledMessageCleanupMaxBatchesPerCycle { get; set; } = 20;
 
     /// <summary>
+    ///     GH-4180. Opt in to storage for <b>logical</b> message deduplication ids — the
+    ///     <see cref="Envelope.DeduplicationId" /> an application sets to say "this is the same intent",
+    ///     as opposed to <see cref="Envelope.Id" />, which identifies one delivery.
+    ///
+    ///     <para>
+    ///     Off by default, and deliberately so: enabling it provisions a new
+    ///     <c>wolverine_deduplication</c> table, and forcing a schema change on every existing
+    ///     deployment is not something a patch upgrade should do. Nothing in the read or write path of
+    ///     the transactional inbox changes either way — the deduplication markers live in their own
+    ///     table (see <see cref="Persistence.Durability.IDeduplicationStore" /> for why).
+    ///     </para>
+    ///
+    ///     <para>
+    ///     Turning this on provisions storage; it does not by itself deduplicate anything. Individual
+    ///     message handlers, HTTP endpoints and gRPC methods opt in with <c>[Deduplicated]</c> or via
+    ///     <c>Policies.RequireDeduplicationId()</c>.
+    ///     </para>
+    /// </summary>
+    public bool EnableMessageDeduplication { get; set; }
+
+    /// <summary>
+    ///     GH-4180. How long a logical deduplication claim is honoured before the reaper removes it.
+    ///     Default is 24 hours.
+    ///
+    ///     <para>
+    ///     This is the whole guarantee, so it is stated rather than inherited. It is NOT
+    ///     <see cref="KeepAfterMessageHandling" />: that setting exists to absorb a broker redelivery
+    ///     and defaults to five minutes, which would turn "idempotent" into "idempotent for a while" —
+    ///     worse than no guarantee, because it holds in testing and fails in production.
+    ///     </para>
+    ///
+    ///     <para>
+    ///     Past this window the same logical id is accepted again. Size it against how long a duplicate
+    ///     could plausibly arrive: an operator double-click is seconds, a console republish is minutes,
+    ///     an agent that pre-publishes tomorrow's scheduled occurrences is a day.
+    ///     </para>
+    /// </summary>
+    public TimeSpan DeduplicationWindow { get; set; } = 24.Hours();
+
+    /// <summary>
+    ///     GH-4180. Polling interval for the reaper that deletes expired deduplication claims. Runs on
+    ///     its own timer in its own transaction, off the recovery loop, for the same reason the
+    ///     handled-envelope cleanup does (issue #3116). Default is 5 minutes — the table only needs to
+    ///     be kept bounded, not kept current, and a claim that outlives its expiry by a few minutes
+    ///     costs nothing but a row.
+    /// </summary>
+    public TimeSpan DeduplicationCleanupPollingTime { get; set; } = 5.Minutes();
+
+    /// <summary>
+    ///     GH-4180. Maximum number of expired deduplication claims deleted in a single bounded DELETE.
+    ///     Default is 5000, matching <see cref="HandledMessageCleanupBatchSize" />.
+    /// </summary>
+    public int DeduplicationCleanupBatchSize { get; set; } = 5000;
+
+    /// <summary>
     ///     Governs the page size for how many persisted incoming or outgoing messages
     ///     will be loaded at one time for attempted retries or scheduled jobs
     /// </summary>
@@ -640,6 +695,13 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(SendingAgentIdleTimeout), SendingAgentIdleTimeout);
         desc.AddValue(nameof(DrainTimeout), DrainTimeout);
         desc.AddValue(nameof(EnableInboxPartitioning), EnableInboxPartitioning);
+        desc.AddValue(nameof(EnableMessageDeduplication), EnableMessageDeduplication);
+        if (EnableMessageDeduplication)
+        {
+            desc.AddValue(nameof(DeduplicationWindow), DeduplicationWindow);
+            desc.AddValue(nameof(DeduplicationCleanupPollingTime), DeduplicationCleanupPollingTime);
+        }
+
         if (OutboxStaleTime.HasValue) desc.AddValue(nameof(OutboxStaleTime), OutboxStaleTime.Value);
         if (InboxStaleTime.HasValue) desc.AddValue(nameof(InboxStaleTime), InboxStaleTime.Value);
         if (MessageStorageSchemaName != null) desc.AddValue(nameof(MessageStorageSchemaName), MessageStorageSchemaName);

--- a/src/Wolverine/HostBuilderExtensions.cs
+++ b/src/Wolverine/HostBuilderExtensions.cs
@@ -131,6 +131,11 @@ public static class HostBuilderExtensions
         services.AddJasperFx();
         services.AddSingleton<MessageStoreCollection>();
 
+        // GH-4180. The single service that generated logical-deduplication code resolves, in message
+        // handlers, HTTP endpoints and gRPC methods alike. Registered unconditionally and cheap to
+        // construct -- it does nothing at all unless a chain opted in.
+        services.AddSingleton<IMessageDeduplicator, MessageDeduplicator>();
+
         // The Roslyn runtime compiler (JasperFx.RuntimeCompiler / AssemblyGenerator) is no
         // longer registered by, or referenced from, core WolverineFx. Apps running
         // TypeLoadMode.Dynamic/Auto reference the WolverineFx.RuntimeCompilation package,

--- a/src/Wolverine/IPolicies.cs
+++ b/src/Wolverine/IPolicies.cs
@@ -119,6 +119,28 @@ public interface IPolicies : IEnumerable<IWolverinePolicy>, IWithFailurePolicies
     void AutoApplyIdempotencyOnNonTransactionalHandlers();
 
     /// <summary>
+    ///     GH-4180. Require a <b>logical</b> deduplication id on every message handler chain matched by
+    ///     <paramref name="filter" />, as an alternative to decorating each one with
+    ///     <c>[Deduplicated]</c>.
+    ///
+    ///     <para>
+    ///     Requires <c>Durability.EnableMessageDeduplication</c>, which provisions the backing storage.
+    ///     Unlike the attribute, this reaches handlers you do not own — the usual case being a marker
+    ///     interface on every create-style command in an application.
+    ///     </para>
+    /// </summary>
+    /// <param name="filter">
+    ///     Which handler chains this applies to. Required rather than optional: applying logical
+    ///     deduplication to <i>every</i> handler would demand an id on traffic that has no business
+    ///     carrying one, and with <c>Required</c> defaulting to true that turns into a dead-lettered
+    ///     message per unkeyed send.
+    /// </param>
+    /// <param name="requirement">
+    ///     How the id is resolved. Defaults to <see cref="Envelope.DeduplicationId" />, required.
+    /// </param>
+    void RequireDeduplicationId(Func<HandlerChain, bool> filter, DeduplicationRequirement? requirement = null);
+
+    /// <summary>
     ///     Add Wolverine middleware to message handlers
     /// </summary>
     /// <param name="filter">If specified, limits the applicability of the middleware to certain message types</param>

--- a/src/Wolverine/Persistence/Codegen/ChainDeduplicationExtensions.cs
+++ b/src/Wolverine/Persistence/Codegen/ChainDeduplicationExtensions.cs
@@ -1,0 +1,66 @@
+using JasperFx.CodeGeneration.Frames;
+using Wolverine.Configuration;
+
+namespace Wolverine.Persistence.Codegen;
+
+/// <summary>
+/// GH-4180. Weaves the logical-deduplication frames into a chain that has opted in.
+///
+/// <para>
+/// Deliberately a shared extension rather than three near-identical policies: the frames, their
+/// order, and the transactional/non-transactional distinction are identical for message handlers,
+/// HTTP endpoints, and gRPC methods. The ONLY per-chain-type variation is what a refusal looks like
+/// to the caller, and that is delegated to
+/// <see cref="IChain.BuildDeduplicationStopCondition" />.
+/// </para>
+/// </summary>
+public static class ChainDeduplicationExtensions
+{
+    /// <summary>
+    /// Insert the deduplication frames at the front of <paramref name="chain" />'s middleware, if it
+    /// has opted in. Safe to call more than once — a chain that already carries the frames is left
+    /// alone, so a policy and an attribute both asking for deduplication do not double-claim the id
+    /// (which would deadlock the second claim against the first on some engines, and on the rest
+    /// would simply refuse every message as a duplicate of itself).
+    /// </summary>
+    public static void ApplyDeduplication(this IChain chain)
+    {
+        if (!chain.RequiresDeduplication()) return;
+        if (chain.Middleware.OfType<ClaimDeduplicationIdFrame>().Any()) return;
+
+        var requirement = chain.Deduplication!;
+        var id = chain.ResolveDeduplicationId(requirement);
+
+        var frames = new List<Frame>();
+
+        if (requirement.Required)
+        {
+            var missing = new DeduplicationIdMissingFrame(id);
+            frames.Add(missing);
+            frames.AddRange(
+                chain.BuildDeduplicationStopCondition(missing.Variable, DeduplicationOutcome.MissingId, requirement));
+        }
+
+        var claim = new ClaimDeduplicationIdFrame(id, chain.AncillaryStoreType);
+        frames.Add(claim);
+        frames.AddRange(
+            chain.BuildDeduplicationStopCondition(claim.Variable, DeduplicationOutcome.Duplicate, requirement));
+
+        // The compensating release is ONLY for chains with no ambient transaction. Where one exists the
+        // claim is written inside it, so a rollback already removes it -- and releasing on top of that
+        // would delete a claim that either no longer exists or, worse, has since been legitimately taken
+        // by a concurrent caller.
+        //
+        // Read here rather than at attribute time on purpose: IsTransactional is set by the persistence
+        // providers' own policies, so it is only trustworthy once those have run. This is the same phase
+        // EagerIdempotencyOnNonTransactionalChains reads it in.
+        if (!chain.IsTransactional)
+        {
+            frames.Add(new ReleaseDeduplicationIdOnFailureFrame(id, chain.AncillaryStoreType));
+        }
+
+        // Front of the queue: the entire point is to refuse before any work happens, including before
+        // any other middleware that might have side effects of its own.
+        chain.Middleware.InsertRange(0, frames);
+    }
+}

--- a/src/Wolverine/Persistence/Codegen/DeduplicationFrames.cs
+++ b/src/Wolverine/Persistence/Codegen/DeduplicationFrames.cs
@@ -61,15 +61,33 @@ internal class ClaimDeduplicationIdFrame : AsyncFrame
 {
     private readonly Variable _deduplicationId;
     private readonly Type? _ancillaryStoreMarker;
+    private readonly string? _deduplicatorUsage;
+    private readonly string? _cancellationUsage;
     private Variable? _deduplicator;
     private Variable? _cancellation;
 
-    public ClaimDeduplicationIdFrame(Variable deduplicationId, Type? ancillaryStoreMarker)
+    /// <param name="deduplicatorUsage">
+    /// Explicit expression for the <see cref="IMessageDeduplicator" />, or null to resolve it as an
+    /// ordinary chain variable. Wolverine's gRPC codegen supplies one: it composes generated service
+    /// types out of explicit <c>InjectedField</c>s rather than the container-driven variable sources
+    /// that handler and HTTP chains use, so a <c>FindVariable</c> there would come up empty.
+    /// </param>
+    /// <param name="cancellationUsage">
+    /// Explicit expression for the cancellation token, or null to resolve it as a chain variable.
+    /// gRPC supplies <c>context.CancellationToken</c> for the same reason.
+    /// </param>
+    public ClaimDeduplicationIdFrame(Variable deduplicationId, Type? ancillaryStoreMarker,
+        string? deduplicatorUsage = null, string? cancellationUsage = null)
     {
         _deduplicationId = deduplicationId;
         _ancillaryStoreMarker = ancillaryStoreMarker;
+        _deduplicatorUsage = deduplicatorUsage;
+        _cancellationUsage = cancellationUsage;
         Variable = new Variable(typeof(bool), "isDuplicateMessage", this);
     }
+
+    private string deduplicatorUsage => _deduplicatorUsage ?? _deduplicator!.Usage;
+    private string cancellationUsage => _cancellationUsage ?? _cancellation!.Usage;
 
     /// <summary>
     /// <see langword="true" /> when this execution must be refused as a duplicate. Deliberately phrased
@@ -87,7 +105,7 @@ internal class ClaimDeduplicationIdFrame : AsyncFrame
         writer.Write($"var {Variable.Usage} = false;");
         writer.Write($"BLOCK:if (!string.IsNullOrWhiteSpace({_deduplicationId.Usage}))");
         writer.Write(
-            $"{Variable.Usage} = !(await {_deduplicator!.Usage}.{nameof(IMessageDeduplicator.TryClaimAsync)}({_deduplicationId.Usage}, {marker}, {_cancellation!.Usage}).ConfigureAwait(false));");
+            $"{Variable.Usage} = !(await {deduplicatorUsage}.{nameof(IMessageDeduplicator.TryClaimAsync)}({_deduplicationId.Usage}, {marker}, {cancellationUsage}).ConfigureAwait(false));");
         writer.FinishBlock();
 
         Next?.GenerateCode(method, writer);
@@ -97,11 +115,17 @@ internal class ClaimDeduplicationIdFrame : AsyncFrame
     {
         yield return _deduplicationId;
 
-        _deduplicator = chain.FindVariable(typeof(IMessageDeduplicator));
-        yield return _deduplicator;
+        if (_deduplicatorUsage == null)
+        {
+            _deduplicator = chain.FindVariable(typeof(IMessageDeduplicator));
+            yield return _deduplicator;
+        }
 
-        _cancellation = chain.FindVariable(typeof(CancellationToken));
-        yield return _cancellation;
+        if (_cancellationUsage == null)
+        {
+            _cancellation = chain.FindVariable(typeof(CancellationToken));
+            yield return _cancellation;
+        }
     }
 }
 
@@ -126,14 +150,23 @@ internal class ReleaseDeduplicationIdOnFailureFrame : AsyncFrame
 {
     private readonly Variable _deduplicationId;
     private readonly Type? _ancillaryStoreMarker;
+    private readonly string? _deduplicatorUsage;
+    private readonly string? _cancellationUsage;
     private Variable? _deduplicator;
     private Variable? _cancellation;
 
-    public ReleaseDeduplicationIdOnFailureFrame(Variable deduplicationId, Type? ancillaryStoreMarker)
+    /// <inheritdoc cref="ClaimDeduplicationIdFrame(Variable, Type, string, string)" />
+    public ReleaseDeduplicationIdOnFailureFrame(Variable deduplicationId, Type? ancillaryStoreMarker,
+        string? deduplicatorUsage = null, string? cancellationUsage = null)
     {
         _deduplicationId = deduplicationId;
         _ancillaryStoreMarker = ancillaryStoreMarker;
+        _deduplicatorUsage = deduplicatorUsage;
+        _cancellationUsage = cancellationUsage;
     }
+
+    private string deduplicatorUsage => _deduplicatorUsage ?? _deduplicator!.Usage;
+    private string cancellationUsage => _cancellationUsage ?? _cancellation!.Usage;
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
@@ -151,7 +184,7 @@ internal class ReleaseDeduplicationIdOnFailureFrame : AsyncFrame
         writer.Write("BLOCK:catch");
         writer.Write($"BLOCK:if (!string.IsNullOrWhiteSpace({_deduplicationId.Usage}))");
         writer.Write(
-            $"await {_deduplicator!.Usage}.{nameof(IMessageDeduplicator.ReleaseAsync)}({_deduplicationId.Usage}, {marker}, {_cancellation!.Usage}).ConfigureAwait(false);");
+            $"await {deduplicatorUsage}.{nameof(IMessageDeduplicator.ReleaseAsync)}({_deduplicationId.Usage}, {marker}, {cancellationUsage}).ConfigureAwait(false);");
         writer.FinishBlock();
         writer.Write("throw;");
         writer.FinishBlock();
@@ -161,10 +194,16 @@ internal class ReleaseDeduplicationIdOnFailureFrame : AsyncFrame
     {
         yield return _deduplicationId;
 
-        _deduplicator = chain.FindVariable(typeof(IMessageDeduplicator));
-        yield return _deduplicator;
+        if (_deduplicatorUsage == null)
+        {
+            _deduplicator = chain.FindVariable(typeof(IMessageDeduplicator));
+            yield return _deduplicator;
+        }
 
-        _cancellation = chain.FindVariable(typeof(CancellationToken));
-        yield return _cancellation;
+        if (_cancellationUsage == null)
+        {
+            _cancellation = chain.FindVariable(typeof(CancellationToken));
+            yield return _cancellation;
+        }
     }
 }

--- a/src/Wolverine/Persistence/Codegen/DeduplicationFrames.cs
+++ b/src/Wolverine/Persistence/Codegen/DeduplicationFrames.cs
@@ -1,0 +1,170 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Persistence.Codegen;
+
+/// <summary>
+/// GH-4180. Tests whether a required logical deduplication id is absent, producing the
+/// <c>bool</c> that the chain-specific stop condition branches on.
+///
+/// <para>
+/// Emitted only when <see cref="DeduplicationRequirement.Required" /> is set. When it is not, a
+/// missing id simply means "this message is not deduplicated", and no test is generated at all.
+/// </para>
+/// </summary>
+internal class DeduplicationIdMissingFrame : SyncFrame
+{
+    private readonly Variable _deduplicationId;
+
+    public DeduplicationIdMissingFrame(Variable deduplicationId)
+    {
+        _deduplicationId = deduplicationId;
+        Variable = new Variable(typeof(bool), "missingDeduplicationId", this);
+    }
+
+    public Variable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"var {Variable.Usage} = string.IsNullOrWhiteSpace({_deduplicationId.Usage});");
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield return _deduplicationId;
+    }
+}
+
+/// <summary>
+/// GH-4180. Claims the logical deduplication id, producing the <c>bool</c> that says whether this
+/// execution is a duplicate.
+///
+/// <para>
+/// The claim is an INSERT that either succeeds or trips a unique constraint — never a SELECT
+/// followed by an INSERT. That distinction is the whole feature: the motivating duplicates are
+/// concurrent (an operator double-click, two nodes replaying the same schedule), and a
+/// check-then-act would let both through while passing every single-threaded test written against
+/// it. See <see cref="Durability.IDeduplicationStore.TryClaimAsync" />.
+/// </para>
+///
+/// <para>
+/// When the id is optional and absent, the claim is skipped and execution continues — the emitted
+/// guard is <c>if (!string.IsNullOrWhiteSpace(id))</c> rather than an unconditional call, so
+/// unkeyed traffic on a mixed stream costs no database round trip at all.
+/// </para>
+/// </summary>
+internal class ClaimDeduplicationIdFrame : AsyncFrame
+{
+    private readonly Variable _deduplicationId;
+    private readonly Type? _ancillaryStoreMarker;
+    private Variable? _deduplicator;
+    private Variable? _cancellation;
+
+    public ClaimDeduplicationIdFrame(Variable deduplicationId, Type? ancillaryStoreMarker)
+    {
+        _deduplicationId = deduplicationId;
+        _ancillaryStoreMarker = ancillaryStoreMarker;
+        Variable = new Variable(typeof(bool), "isDuplicateMessage", this);
+    }
+
+    /// <summary>
+    /// <see langword="true" /> when this execution must be refused as a duplicate. Deliberately phrased
+    /// as "is duplicate" rather than "was claimed" so the generated stop condition reads
+    /// <c>if (isDuplicateMessage)</c>, matching every other stop condition in the codebase.
+    /// </summary>
+    public Variable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var marker = _ancillaryStoreMarker == null
+            ? "null"
+            : $"typeof({_ancillaryStoreMarker.FullNameInCode()})";
+
+        writer.Write($"var {Variable.Usage} = false;");
+        writer.Write($"BLOCK:if (!string.IsNullOrWhiteSpace({_deduplicationId.Usage}))");
+        writer.Write(
+            $"{Variable.Usage} = !(await {_deduplicator!.Usage}.{nameof(IMessageDeduplicator.TryClaimAsync)}({_deduplicationId.Usage}, {marker}, {_cancellation!.Usage}).ConfigureAwait(false));");
+        writer.FinishBlock();
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield return _deduplicationId;
+
+        _deduplicator = chain.FindVariable(typeof(IMessageDeduplicator));
+        yield return _deduplicator;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}
+
+/// <summary>
+/// GH-4180. Releases the logical deduplication claim when execution failed, so that a retry is not
+/// discarded as a duplicate of its own failed attempt.
+///
+/// <para>
+/// Emitted ONLY into non-transactional chains. When the chain is transactional the claim is written
+/// inside the same transaction as the handler's work, so a rollback removes it and a compensating
+/// release would be both redundant and wrong — it would delete a claim that no longer exists, or
+/// worse, one that a concurrent caller has since legitimately taken.
+/// </para>
+///
+/// <para>
+/// Without this, the first failed attempt permanently poisons the id: every retry is refused as a
+/// duplicate, the work is silently never done, and the logs show a successful deduplication rather
+/// than a lost message. That is a strictly worse outcome than not having the feature.
+/// </para>
+/// </summary>
+internal class ReleaseDeduplicationIdOnFailureFrame : AsyncFrame
+{
+    private readonly Variable _deduplicationId;
+    private readonly Type? _ancillaryStoreMarker;
+    private Variable? _deduplicator;
+    private Variable? _cancellation;
+
+    public ReleaseDeduplicationIdOnFailureFrame(Variable deduplicationId, Type? ancillaryStoreMarker)
+    {
+        _deduplicationId = deduplicationId;
+        _ancillaryStoreMarker = ancillaryStoreMarker;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var marker = _ancillaryStoreMarker == null
+            ? "null"
+            : $"typeof({_ancillaryStoreMarker.FullNameInCode()})";
+
+        // Wraps everything downstream, then rethrows. `throw;` rather than `throw e;` so the original
+        // stack trace survives to the error policies -- this frame compensates for a failure, it does
+        // not handle one, and swallowing here would turn every handler exception into a silent success.
+        writer.Write("BLOCK:try");
+        Next?.GenerateCode(method, writer);
+        writer.FinishBlock();
+
+        writer.Write("BLOCK:catch");
+        writer.Write($"BLOCK:if (!string.IsNullOrWhiteSpace({_deduplicationId.Usage}))");
+        writer.Write(
+            $"await {_deduplicator!.Usage}.{nameof(IMessageDeduplicator.ReleaseAsync)}({_deduplicationId.Usage}, {marker}, {_cancellation!.Usage}).ConfigureAwait(false);");
+        writer.FinishBlock();
+        writer.Write("throw;");
+        writer.FinishBlock();
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield return _deduplicationId;
+
+        _deduplicator = chain.FindVariable(typeof(IMessageDeduplicator));
+        yield return _deduplicator;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+}

--- a/src/Wolverine/Persistence/Codegen/DeduplicationIdFromEnvelopeFrame.cs
+++ b/src/Wolverine/Persistence/Codegen/DeduplicationIdFromEnvelopeFrame.cs
@@ -1,0 +1,45 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Wolverine.Configuration;
+
+namespace Wolverine.Persistence.Codegen;
+
+/// <summary>
+/// GH-4180. Reads the logical deduplication id straight off the incoming <see cref="Envelope" />.
+/// This is the default id source for message handlers, corresponding to a publisher that set
+/// <c>DeliveryOptions.DeduplicationId</c> (or <c>Envelope.DeduplicationId</c> directly).
+///
+/// <para>
+/// <see cref="Envelope.DeduplicationId" /> already round-trips on every transport — it is written by
+/// <c>EnvelopeSerializer</c> under the <c>deduplication-id</c> wire header and read back on the far
+/// side — so nothing transport-specific is needed here, including for the two transports that also
+/// consume it natively (SQS/SNS FIFO and GCP Pub/Sub).
+/// </para>
+/// </summary>
+[FSharpEmit(Skip = true,
+    Reason = "Emits a null-conditional read into a C# local. Logical deduplication is opt-in per chain " +
+             "and unreachable in an F# handler chain that has not opted in.")]
+internal class DeduplicationIdFromEnvelopeFrame : SyncFrame
+{
+    public DeduplicationIdFromEnvelopeFrame()
+    {
+        Variable = new Variable(typeof(string), "deduplicationId", this);
+    }
+
+    public Variable Variable { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // Null-conditional rather than `!`: an envelope is always present on the listening path, but
+        // this same generated handler is reachable through IMessageBus.InvokeAsync() in tests, where a
+        // NullReferenceException here would be a very confusing way to learn that.
+        writer.Write($"var {Variable.Usage} = context.Envelope?.{nameof(Envelope.DeduplicationId)};");
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        yield break;
+    }
+}

--- a/src/Wolverine/Persistence/Codegen/HandlerDeduplicationStopFrame.cs
+++ b/src/Wolverine/Persistence/Codegen/HandlerDeduplicationStopFrame.cs
@@ -1,0 +1,93 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Persistence.Codegen;
+
+/// <summary>
+/// GH-4180. The message-handler answer to a failed deduplication check: stop before the handler
+/// runs, and let the message be acknowledged normally.
+///
+/// <para>
+/// Returning — rather than throwing <c>DuplicateIncomingEnvelopeException</c> — is deliberate. That
+/// exception is the <i>storage-level</i> signal for a duplicate <see cref="Envelope.Id" />, and
+/// <c>DurableReceiver.handleDuplicateIncomingEnvelope</c> routes it through a redelivery-count check
+/// that can dead-letter the message. A logical duplicate is not a delivery problem: the work was
+/// already done, on purpose, and the correct outcome is a benign discard with an ack.
+/// </para>
+///
+/// <para>
+/// Returning early also means the executor records exactly one terminal event for this envelope
+/// (<c>MessageSucceeded</c>), which is the invariant the tracking model depends on. Emitting a
+/// second, discard-specific terminal record here would produce two terminal events on one path,
+/// which cannot be ordered.
+/// </para>
+///
+/// <para>
+/// The discard is not silent — <see cref="MessageDeduplicator" /> logs it at Information — because a
+/// duplicate that vanishes without a trace is indistinguishable from a message that was lost.
+/// </para>
+/// </summary>
+internal class HandlerDeduplicationStopFrame : SyncFrame
+{
+    private readonly Variable _condition;
+
+    public HandlerDeduplicationStopFrame(Variable condition)
+    {
+        _condition = condition;
+        uses.Add(condition);
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment(
+            "GH-4180: this logical deduplication id has already been handled, so discard this message");
+
+        if (method.AsyncMode == AsyncMode.AsyncTask)
+        {
+            writer.Write($"if ({_condition.Usage}) return;");
+        }
+        else
+        {
+            writer.Write(
+                $"if ({_condition.Usage}) return {typeof(Task).FullNameInCode()}.{nameof(Task.CompletedTask)};");
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+/// GH-4180. The message-handler answer to a <i>required</i> logical deduplication id that never
+/// arrived.
+///
+/// <para>
+/// Throws, rather than discarding. A missing id is the opposite of a duplicate: nothing has been
+/// done and nothing will be, so treating it as benign would silently drop real work. Throwing hands
+/// it to the ordinary error policies, which means it retries and ultimately dead-letters with a
+/// message that names the cause — the visible failure a misconfigured publisher deserves.
+/// </para>
+/// </summary>
+internal class MissingDeduplicationIdFrame : SyncFrame
+{
+    private readonly Variable _condition;
+    private readonly string _description;
+
+    public MissingDeduplicationIdFrame(Variable condition, string description)
+    {
+        _condition = condition;
+        _description = description.Replace("\"", "'");
+        uses.Add(condition);
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write($"BLOCK:if ({_condition.Usage})");
+        writer.Write(
+            $"throw new {typeof(MissingDeduplicationIdException).FullNameInCode()}(\"{_description}\");");
+        writer.FinishBlock();
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Wolverine/Persistence/DeduplicationHandlerPolicy.cs
+++ b/src/Wolverine/Persistence/DeduplicationHandlerPolicy.cs
@@ -1,0 +1,69 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.CodeGeneration;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Persistence.Codegen;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// GH-4180. Weaves the logical deduplication frames into every message handler chain that opted in,
+/// through <c>[Deduplicated]</c> or <c>Policies.RequireDeduplicationId()</c>.
+///
+/// <para>
+/// Runs as a policy rather than from the attribute itself because the frames it emits depend on
+/// <see cref="IChain.IsTransactional" />, which the persistence providers set from their own
+/// policies. Reading it any earlier would see <see langword="false" /> on a chain that is about to
+/// become transactional and emit a compensating release that the transaction makes wrong. This is
+/// the same phase, and for the same reason, that
+/// <see cref="EagerIdempotencyOnNonTransactionalChains" /> reads it in.
+/// </para>
+/// </summary>
+internal class DeduplicationHandlerPolicy : IHandlerPolicy
+{
+    private readonly WolverineOptions _options;
+
+    public DeduplicationHandlerPolicy(WolverineOptions options)
+    {
+        _options = options;
+    }
+
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        // Validation only -- the frames themselves are woven later, from HandlerChain.applyCustomizations,
+        // which is the first point where both [Deduplicated] and IsTransactional are settled.
+        //
+        // HasAttribute is checked alongside the already-set requirement because [Deduplicated] is a
+        // ModifyChainAttribute and has NOT been applied yet at this point in the bootstrap; only the
+        // requirements set by RequireDeduplicationIdPolicy are visible on the chain so far.
+        var opted = chains
+            .Where(x => x.RequiresDeduplication() || x.HasAttribute<DeduplicatedAttribute>())
+            .ToArray();
+
+        if (opted.Length == 0) return;
+
+        AssertDeduplicationIsEnabled(_options, opted.Select(x => x.Description));
+    }
+
+    /// <summary>
+    /// Fail at bootstrap rather than at runtime when a chain asked for logical deduplication but the
+    /// storage that backs it was never turned on.
+    ///
+    /// <para>
+    /// The alternative — <see cref="NullDeduplicationStore" /> quietly answering "yes, that's new" for
+    /// every id — is the worst available outcome: the application reports itself as protected, every
+    /// duplicate runs, and there is no log line, no metric, and no failing test that distinguishes it
+    /// from a working configuration. A misconfiguration this quiet is only ever found in production.
+    /// </para>
+    /// </summary>
+    internal static void AssertDeduplicationIsEnabled(WolverineOptions options, IEnumerable<string> descriptions)
+    {
+        if (options.Durability.EnableMessageDeduplication) return;
+
+        throw new InvalidOperationException(
+            $"Logical message deduplication was requested by {descriptions.Join(", ")}, but {nameof(DurabilitySettings)}.{nameof(DurabilitySettings.EnableMessageDeduplication)} is false, so there is no storage to enforce it. Set opts.Durability.{nameof(DurabilitySettings.EnableMessageDeduplication)} = true (this provisions a new table) or remove the [Deduplicated] usage. See GH-4180");
+    }
+}

--- a/src/Wolverine/Persistence/DeduplicationHandlerPolicy.cs
+++ b/src/Wolverine/Persistence/DeduplicationHandlerPolicy.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.CodeGeneration;
+using Microsoft.Extensions.Logging;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
 using Wolverine.Persistence.Codegen;
@@ -44,26 +45,40 @@ internal class DeduplicationHandlerPolicy : IHandlerPolicy
             .ToArray();
 
         if (opted.Length == 0) return;
+        if (_options.Durability.EnableMessageDeduplication) return;
 
-        AssertDeduplicationIsEnabled(_options, opted.Select(x => x.Description));
+        WarnDeduplicationIsNotEnabled(container, opted.Select(x => x.Description));
     }
 
     /// <summary>
-    /// Fail at bootstrap rather than at runtime when a chain asked for logical deduplication but the
-    /// storage that backs it was never turned on.
+    /// Warn — loudly, and once per host — when a chain asked for logical deduplication but the storage
+    /// that backs it was never turned on.
     ///
     /// <para>
-    /// The alternative — <see cref="NullDeduplicationStore" /> quietly answering "yes, that's new" for
-    /// every id — is the worst available outcome: the application reports itself as protected, every
-    /// duplicate runs, and there is no log line, no metric, and no failing test that distinguishes it
-    /// from a working configuration. A misconfiguration this quiet is only ever found in production.
+    /// This deliberately warns rather than throws, and the reason is worth stating because "fail fast"
+    /// is the obvious instinct here and it is the wrong one. <c>[Deduplicated]</c> lives on a handler
+    /// TYPE, and handler types get discovered by every host that scans the assembly they live in.
+    /// A modular monolith where one module enables deduplication and a sibling host does not is an
+    /// entirely legitimate setup, and a hard failure makes the attribute unusable in any shared
+    /// assembly — the sibling host cannot start, through no fault of its own configuration.
+    /// </para>
+    ///
+    /// <para>
+    /// The property that actually matters — an application is never <i>silently</i> unprotected — is
+    /// not weakened by warning here, because it is not enforced here. It is enforced at the point of
+    /// use: <see cref="MessageDeduplicator.TryClaimAsync" /> throws on a store whose
+    /// <see cref="IDeduplicationStore.Enabled" /> is false rather than answering "yes, that's new" to
+    /// every id. A misconfigured host still cannot process a single duplicate quietly; it just gets to
+    /// start, and to tell its operator why at startup instead of at the first message.
     /// </para>
     /// </summary>
-    internal static void AssertDeduplicationIsEnabled(WolverineOptions options, IEnumerable<string> descriptions)
+    private static void WarnDeduplicationIsNotEnabled(IServiceContainer container, IEnumerable<string> descriptions)
     {
-        if (options.Durability.EnableMessageDeduplication) return;
+        var logger = container.GetInstance<ILoggerFactory>().CreateLogger<DeduplicationHandlerPolicy>();
 
-        throw new InvalidOperationException(
-            $"Logical message deduplication was requested by {descriptions.Join(", ")}, but {nameof(DurabilitySettings)}.{nameof(DurabilitySettings.EnableMessageDeduplication)} is false, so there is no storage to enforce it. Set opts.Durability.{nameof(DurabilitySettings.EnableMessageDeduplication)} = true (this provisions a new table) or remove the [Deduplicated] usage. See GH-4180");
+        logger.LogWarning(
+            "Logical message deduplication was requested by {Chains}, but {Setting} is false, so there is no storage to enforce it. These handlers will throw on their first message. Set opts.Durability.{Setting} = true (this provisions a new table) or remove the [Deduplicated] usage. See GH-4180",
+            descriptions.Join(", "), nameof(DurabilitySettings.EnableMessageDeduplication),
+            nameof(DurabilitySettings.EnableMessageDeduplication));
     }
 }

--- a/src/Wolverine/Persistence/DeduplicationOutcome.cs
+++ b/src/Wolverine/Persistence/DeduplicationOutcome.cs
@@ -1,0 +1,28 @@
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// GH-4180. Which of the two ways a logical deduplication check can refuse to run the chain.
+///
+/// <para>
+/// These are kept apart rather than collapsed into one "rejected" state because they mean opposite
+/// things operationally, and the response each deserves is different in every chain type. A
+/// <see cref="Duplicate" /> is the feature working: the traffic is fine, the work has already been
+/// done, and the right answer is a benign refusal. A <see cref="MissingId" /> is a bug in the
+/// caller or the configuration: nothing has been done, nothing will be, and treating it as benign
+/// would silently drop real work.
+/// </para>
+/// </summary>
+public enum DeduplicationOutcome
+{
+    /// <summary>
+    /// The logical id was resolved and has already been claimed inside the configured
+    /// <see cref="DurabilitySettings.DeduplicationWindow" />.
+    /// </summary>
+    Duplicate,
+
+    /// <summary>
+    /// The chain requires a logical id (<see cref="DeduplicationRequirement.Required" />) and the
+    /// incoming message, request, or call did not carry one.
+    /// </summary>
+    MissingId
+}

--- a/src/Wolverine/Persistence/DeduplicationRequirement.cs
+++ b/src/Wolverine/Persistence/DeduplicationRequirement.cs
@@ -1,0 +1,77 @@
+using Wolverine.Attributes;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// GH-4180. Describes how one chain — a message handler, an HTTP endpoint, or a gRPC method —
+/// resolves its <b>logical</b> deduplication id, and what should happen when that id has already
+/// been seen.
+///
+/// <para>
+/// The id itself is application-defined and application-supplied. Wolverine does not derive one:
+/// a framework-derived key is either the delivery id (which <see cref="Envelope.Id" /> already is,
+/// and which cannot express "the same intent, published twice") or a content hash, which silently
+/// changes meaning the moment an irrelevant field is added to the message type.
+/// </para>
+/// </summary>
+public sealed class DeduplicationRequirement
+{
+    /// <summary>
+    /// Where the logical id comes from. <see cref="ValueSource.Anything" /> means "use this chain
+    /// type's natural default", which is <see cref="Envelope.DeduplicationId" /> for message
+    /// handlers, the <see cref="DefaultHeaderName" /> request header for HTTP endpoints, and the
+    /// same name in request metadata for gRPC.
+    /// </summary>
+    public ValueSource Source { get; init; } = ValueSource.Anything;
+
+    /// <summary>
+    /// The header name, message/request member name, or route/query key holding the logical id.
+    /// Ignored when <see cref="Source" /> is <see cref="ValueSource.Anything" />.
+    /// </summary>
+    public string? Key { get; init; }
+
+    /// <summary>
+    /// Must a logical id be present? Default is <see langword="true" />.
+    ///
+    /// <para>
+    /// This defaults to strict because the lenient reading is the dangerous one. A chain that asked
+    /// for deduplication and then quietly processed every keyless message would report itself as
+    /// protected while providing nothing, and the failure is invisible: the traffic succeeds, the
+    /// duplicates run, and no log line distinguishes it from a working configuration. Set
+    /// <see langword="false" /> only when a mixed stream is genuinely expected — some publishers
+    /// supply an id and some do not — and you want the ones that do to be protected.
+    /// </para>
+    /// </summary>
+    public bool Required { get; init; } = true;
+
+    /// <summary>
+    /// HTTP only: the status code returned when the logical id has already been claimed. Default is
+    /// 409 Conflict with a <c>ProblemDetails</c> body.
+    ///
+    /// <para>
+    /// Set to 200 or 204 when a replayed request is benign for this endpoint and the caller should see
+    /// success rather than a conflict — a create that is safe to repeat, say. Any other value is
+    /// written as a problem document, so the caller gets a machine-readable reason rather than a bare
+    /// code.
+    /// </para>
+    ///
+    /// <para>
+    /// This lives on the chain-agnostic requirement rather than an HTTP-only subclass because it is a
+    /// single nullable hint, and a parallel type hierarchy for one integer would cost more than it
+    /// explains. Message handler and gRPC chains ignore it.
+    /// </para>
+    /// </summary>
+    public int DuplicateStatusCode { get; init; } = 409;
+
+    /// <summary>
+    /// The conventional header/metadata name carrying a logical idempotency key, matching the IETF
+    /// draft that Stripe, Adyen and others already follow. Used as the default for HTTP and gRPC so
+    /// that a caller who already sends this header gets deduplication with no extra configuration.
+    /// </summary>
+    public const string DefaultHeaderName = "Idempotency-Key";
+
+    public override string ToString()
+        => Source == ValueSource.Anything
+            ? $"Deduplicated (chain default, Required = {Required})"
+            : $"Deduplicated by {Source} '{Key}' (Required = {Required})";
+}

--- a/src/Wolverine/Persistence/Durability/IDeduplicationStore.cs
+++ b/src/Wolverine/Persistence/Durability/IDeduplicationStore.cs
@@ -1,0 +1,130 @@
+namespace Wolverine.Persistence.Durability;
+
+/// <summary>
+/// GH-4180. Persistence contract for <b>logical</b> message deduplication — the "has this
+/// application-defined intent already been carried out?" check that <see cref="Envelope.Id" />
+/// cannot answer.
+///
+/// <para>
+/// This is deliberately a SEPARATE store from the transactional inbox rather than a column on
+/// <c>wolverine_incoming_envelopes</c>. Three reasons, in descending order of how expensive they
+/// would be to discover later:
+/// </para>
+///
+/// <list type="number">
+/// <item>
+/// <b>Partitioning.</b> With <see cref="DurabilitySettings.EnableInboxPartitioning" /> the inbox table is
+/// <c>PARTITION BY LIST (status)</c>, and PostgreSQL refuses a unique index on a partitioned table
+/// unless the index includes every partition-key column. A <c>(deduplication_id, status)</c> index
+/// would satisfy the engine but not the guarantee: marking an envelope handled updates
+/// <c>status</c>, which MOVES the row between partitions, so the same logical id could exist once as
+/// <c>Incoming</c> and once as <c>Handled</c>. The constraint would be structurally incapable of
+/// enforcing uniqueness, silently, and only for users who enabled partitioning.
+/// </item>
+/// <item>
+/// <b>Retention.</b> A deduplication marker has to outlive the inbox row it came from. Inbox rows are
+/// reaped on <see cref="DurabilitySettings.KeepAfterMessageHandling" />, which defaults to five
+/// minutes — long enough to absorb a broker redelivery, nowhere near long enough for
+/// "this job runs at 03:00 tonight". Its own table carries its own
+/// <see cref="DurabilitySettings.DeduplicationWindow" /> without stretching an unrelated setting.
+/// </item>
+/// <item>
+/// <b>Reshaping cost.</b> <c>wolverine_incoming_envelopes</c> is small, hot, and written by every
+/// running node. Adding a column is a migration; changing or dropping one later needs an
+/// ACCESS EXCLUSIVE lock that queues behind in-flight inbox writes. Keeping this in its own table
+/// means the inbox schema never moves for this feature at all.
+/// </item>
+/// </list>
+///
+/// <para>
+/// Opt-in via <see cref="DurabilitySettings.EnableMessageDeduplication" /> — when disabled, providers
+/// MUST return <see cref="NullDeduplicationStore.Instance" /> and MUST NOT provision the backing
+/// table, so existing deployments see no schema migration churn on upgrade.
+/// </para>
+/// </summary>
+public interface IDeduplicationStore
+{
+    /// <summary>
+    /// Is this a real, durable store? <see langword="false" /> for <see cref="NullDeduplicationStore" />.
+    /// Code generation consults this so a chain that asked for deduplication against a store that
+    /// cannot provide it fails loudly at bootstrap rather than silently passing every message.
+    /// </summary>
+    bool Enabled => true;
+
+    /// <summary>
+    /// Claim <paramref name="deduplicationId" /> for the caller. Returns <see langword="true" /> when the
+    /// claim was recorded — i.e. this is the FIRST time the id has been seen — and
+    /// <see langword="false" /> when it was already present.
+    ///
+    /// <para>
+    /// Implementations MUST make this atomic against concurrent callers on other nodes. The only
+    /// race-free way to answer "has anyone else claimed this?" is to attempt the write and let the
+    /// database's unique constraint arbitrate; a <c>SELECT</c> followed by an <c>INSERT</c> is exactly
+    /// the check-then-act race this feature exists to close, and it will pass every test and fail in
+    /// production under the operator double-click it was built for.
+    /// </para>
+    /// </summary>
+    /// <param name="deduplicationId">The application-defined logical id. Never null or empty.</param>
+    /// <param name="expires">
+    /// When this claim may be reaped. Callers pass <c>UtcNow + <see cref="DurabilitySettings.DeduplicationWindow" /></c>;
+    /// the value is stored rather than computed at read time so that shortening the window in
+    /// configuration does not retroactively un-claim ids that were recorded under the longer one.
+    /// </param>
+    Task<bool> TryClaimAsync(string deduplicationId, DateTimeOffset expires,
+        CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Release a previously successful claim, so the same logical id may be claimed again.
+    ///
+    /// <para>
+    /// This is the compensating half of <see cref="TryClaimAsync" /> for the NON-transactional case.
+    /// When the claim rides inside the handler's ambient transaction, a rollback removes it and this
+    /// is never called. When there is no ambient transaction — a Buffered or Inline endpoint, or an
+    /// HTTP endpoint without transactional middleware — the claim is already committed by the time
+    /// the handler runs, so a handler that throws MUST release it. Otherwise the first failed attempt
+    /// permanently poisons that logical id and every retry is discarded as a duplicate: the message
+    /// is lost, the guarantee inverted, and nothing in the logs says so.
+    /// </para>
+    ///
+    /// <para>
+    /// Idempotent — releasing an id that is not claimed is a no-op rather than an error.
+    /// </para>
+    /// </summary>
+    Task ReleaseAsync(string deduplicationId, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Delete every claim whose expiry has passed. Returns the number of rows removed so the caller
+    /// can report reaper progress; a reaper that cannot say how far behind it is turns an unbounded
+    /// table into a silent one.
+    /// </summary>
+    Task<int> DeleteExpiredAsync(DateTimeOffset utcNow, CancellationToken cancellation = default);
+}
+
+/// <summary>
+/// Default no-op deduplication store. Returned by <see cref="IMessageStore.Deduplication" /> when
+/// <see cref="DurabilitySettings.EnableMessageDeduplication" /> is <see langword="false" />, or when
+/// the message store has no durable backing at all (<c>NullMessageStore</c>).
+///
+/// <para>
+/// <see cref="TryClaimAsync" /> returns <see langword="true" /> — every id looks new — because the
+/// alternative, returning <see langword="false" />, would discard all traffic on a misconfigured
+/// host. The real protection against reaching this accidentally is <see cref="Enabled" />, which
+/// code generation checks at bootstrap.
+/// </para>
+/// </summary>
+public sealed class NullDeduplicationStore : IDeduplicationStore
+{
+    public static NullDeduplicationStore Instance { get; } = new();
+
+    public bool Enabled => false;
+
+    public Task<bool> TryClaimAsync(string deduplicationId, DateTimeOffset expires,
+        CancellationToken cancellation = default)
+        => Task.FromResult(true);
+
+    public Task ReleaseAsync(string deduplicationId, CancellationToken cancellation = default)
+        => Task.CompletedTask;
+
+    public Task<int> DeleteExpiredAsync(DateTimeOffset utcNow, CancellationToken cancellation = default)
+        => Task.FromResult(0);
+}

--- a/src/Wolverine/Persistence/Durability/IMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStore.cs
@@ -112,6 +112,22 @@ public interface IMessageStore : IAsyncDisposable
     /// </summary>
     IListenerStore Listeners { get; }
 
+    /// <summary>
+    /// GH-4180. Storage for logical message deduplication ids. Opt-in via
+    /// <see cref="DurabilitySettings.EnableMessageDeduplication" />; providers must return
+    /// <see cref="NullDeduplicationStore.Instance" /> (and skip provisioning the deduplication
+    /// table) when the flag is <c>false</c>, so an upgrade is a no-op for anyone who has not asked
+    /// for the feature.
+    ///
+    /// <para>
+    /// Defaulted rather than abstract on purpose: a provider that has no answer for logical
+    /// deduplication should inherit the no-op instead of being forced to write one, and
+    /// <see cref="IDeduplicationStore.Enabled" /> is what code generation checks before it will emit
+    /// a deduplication assertion against this store.
+    /// </para>
+    /// </summary>
+    IDeduplicationStore Deduplication => NullDeduplicationStore.Instance;
+
     IMessageStoreAdmin Admin { get; }
 
     IDeadLetters DeadLetters { get; }

--- a/src/Wolverine/Persistence/IMessageDeduplicator.cs
+++ b/src/Wolverine/Persistence/IMessageDeduplicator.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// GH-4180. The single seam that generated deduplication code calls into, in message handlers,
+/// HTTP endpoints, and gRPC methods alike.
+///
+/// <para>
+/// This exists so that codegen has ONE dependency to resolve rather than reaching through
+/// <c>IWolverineRuntime.Storage.Deduplication</c> and computing the expiry inline. HTTP and gRPC
+/// chains have no <see cref="Runtime.MessageContext" /> to hang the call off — the way
+/// <c>AssertEagerIdempotencyAsync</c> hangs off one for message handlers — so a plain injectable
+/// service is the only shape that generates identically in all three.
+/// </para>
+/// </summary>
+public interface IMessageDeduplicator
+{
+    /// <summary>
+    /// Claim <paramref name="deduplicationId" />. Returns <see langword="true" /> when the caller is the
+    /// first to claim it and execution should continue, <see langword="false" /> when it has already
+    /// been claimed inside the configured <see cref="DurabilitySettings.DeduplicationWindow" />.
+    /// </summary>
+    /// <param name="ancillaryStoreMarker">
+    /// The <see cref="Configuration.IChain.AncillaryStoreType" /> of the chain being executed, or null for the
+    /// main store. Routing the claim to the same store the handler writes to is what makes the claim
+    /// and the work land in one transaction when the chain is transactional.
+    /// </param>
+    ValueTask<bool> TryClaimAsync(string deduplicationId, Type? ancillaryStoreMarker,
+        CancellationToken cancellation);
+
+    /// <summary>
+    /// Release a claim so the id may be claimed again. Called from the failure path of a
+    /// non-transactional chain — see <see cref="IDeduplicationStore.ReleaseAsync" /> for why skipping it
+    /// would permanently poison the id.
+    /// </summary>
+    ValueTask ReleaseAsync(string deduplicationId, Type? ancillaryStoreMarker, CancellationToken cancellation);
+}
+
+internal class MessageDeduplicator : IMessageDeduplicator
+{
+    private readonly IWolverineRuntime _runtime;
+    private readonly ILogger<MessageDeduplicator> _logger;
+
+    public MessageDeduplicator(IWolverineRuntime runtime, ILogger<MessageDeduplicator> logger)
+    {
+        _runtime = runtime;
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryClaimAsync(string deduplicationId, Type? ancillaryStoreMarker,
+        CancellationToken cancellation)
+    {
+        var store = storeFor(ancillaryStoreMarker);
+
+        if (!store.Enabled)
+        {
+            // The flag is on but this store has no implementation -- NullDeduplicationStore answers
+            // "yes, that's new" to everything. Failing here is the whole reason IDeduplicationStore.Enabled
+            // exists: letting it through would report the application as protected while every duplicate
+            // ran, with no log line and no failing test to distinguish it from a working configuration.
+            throw new InvalidOperationException(
+                $"Logical message deduplication is enabled, but the message store backing this chain does not implement it. See {nameof(IDeduplicationStore)} for the providers that do. GH-4180");
+        }
+
+        // Stored rather than computed at read time, so that shortening the window later cannot
+        // retroactively un-claim ids that were recorded under the longer one.
+        var expires = DateTimeOffset.UtcNow.Add(_runtime.Options.Durability.DeduplicationWindow);
+
+        var claimed = await store.TryClaimAsync(deduplicationId, expires, cancellation).ConfigureAwait(false);
+
+        if (!claimed)
+        {
+            // GH-4180: a duplicate that vanishes silently is indistinguishable from a message that was
+            // lost, which is the failure mode this whole feature is supposed to remove rather than move.
+            // Information rather than Debug on purpose -- this is a business event ("that work was
+            // already done"), not pipeline noise, and it is rare by construction.
+            _logger.LogInformation(
+                "Discarding duplicate work for logical deduplication id '{DeduplicationId}'; it was already claimed within the {Window} deduplication window",
+                deduplicationId, _runtime.Options.Durability.DeduplicationWindow);
+        }
+
+        return claimed;
+    }
+
+    public async ValueTask ReleaseAsync(string deduplicationId, Type? ancillaryStoreMarker,
+        CancellationToken cancellation)
+    {
+        try
+        {
+            await storeFor(ancillaryStoreMarker).ReleaseAsync(deduplicationId, cancellation).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            // Never let the compensating release mask the original handler failure -- the caller is
+            // already unwinding an exception that matters more than this one. The cost of swallowing it
+            // is that the id stays claimed until it expires, so say so loudly enough to be actionable.
+            _logger.LogError(e,
+                "Failed to release the logical deduplication claim '{DeduplicationId}' after a failed execution. Retries of this work will be discarded as duplicates until the claim expires",
+                deduplicationId);
+        }
+    }
+
+    private IDeduplicationStore storeFor(Type? ancillaryStoreMarker)
+    {
+        var store = ancillaryStoreMarker == null
+            ? _runtime.Storage
+            : _runtime.Stores.FindAncillaryStore(ancillaryStoreMarker);
+
+        return store.Deduplication;
+    }
+}

--- a/src/Wolverine/Persistence/MissingDeduplicationIdException.cs
+++ b/src/Wolverine/Persistence/MissingDeduplicationIdException.cs
@@ -1,0 +1,21 @@
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// GH-4180. Thrown when a chain requires a logical deduplication id
+/// (<see cref="DeduplicationRequirement.Required" />) and the incoming message, request, or call did
+/// not carry one.
+///
+/// <para>
+/// Deliberately NOT discarded by a built-in error policy, unlike
+/// <see cref="Durability.DuplicateIncomingEnvelopeException" />. A duplicate means the work is
+/// already done and discarding is correct; a missing id means the work has not been done and never
+/// will be, so it needs to be as loud as any other unhandled failure.
+/// </para>
+/// </summary>
+public class MissingDeduplicationIdException : Exception
+{
+    public MissingDeduplicationIdException(string description) : base(
+        $"A logical deduplication id is required but was not supplied for {description}. Either have the caller supply one, or set Required = false on the [Deduplicated] attribute to allow unkeyed traffic through unchecked. See GH-4180")
+    {
+    }
+}

--- a/src/Wolverine/Persistence/RequireDeduplicationIdPolicy.cs
+++ b/src/Wolverine/Persistence/RequireDeduplicationIdPolicy.cs
@@ -1,0 +1,38 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Configuration;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+/// GH-4180. Applies a <see cref="DeduplicationRequirement" /> to every handler chain matching a
+/// filter, for applications that would rather express "all create-style commands are deduplicated"
+/// once than decorate each handler with <c>[Deduplicated]</c>.
+///
+/// <para>
+/// Sets the requirement only. <see cref="DeduplicationHandlerPolicy" /> does the weaving afterwards,
+/// so a chain reached by both this policy and the attribute is configured once and woven once.
+/// A chain that already carries an explicit requirement is left alone — the attribute on the
+/// handler is the more specific statement and wins over the blanket rule.
+/// </para>
+/// </summary>
+internal class RequireDeduplicationIdPolicy : IHandlerPolicy
+{
+    private readonly Func<HandlerChain, bool> _filter;
+    private readonly DeduplicationRequirement _requirement;
+
+    public RequireDeduplicationIdPolicy(Func<HandlerChain, bool> filter, DeduplicationRequirement requirement)
+    {
+        _filter = filter;
+        _requirement = requirement;
+    }
+
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains.Where(x => x.Deduplication == null && _filter(x)))
+        {
+            chain.Deduplication = _requirement;
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Handlers/HandlerChain.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerChain.cs
@@ -18,6 +18,7 @@ using Wolverine.ErrorHandling;
 using Wolverine.Logging;
 using Wolverine.Middleware;
 using Wolverine.Persistence;
+using Wolverine.Persistence.Codegen;
 using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime.Partitioning;
 using Wolverine.Runtime.Routing;
@@ -498,6 +499,37 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
         return [frame, new HandlerContinuationFrame(frame)];
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    ///     GH-4180. A message handler's natural logical id is <see cref="Envelope.DeduplicationId" />,
+    ///     which is not reachable through <see cref="TryFindVariable" />: <c>EnvelopeSerializer</c> lifts
+    ///     the <c>deduplication-id</c> wire header off into the first-class property rather than leaving
+    ///     it in <see cref="Envelope.Headers" />, so the inherited header lookup would find nothing. Any
+    ///     explicitly configured source falls through to the base implementation.
+    /// </remarks>
+    public override Variable ResolveDeduplicationId(DeduplicationRequirement requirement)
+    {
+        if (requirement.Source != ValueSource.Anything)
+        {
+            return base.ResolveDeduplicationId(requirement);
+        }
+
+        var frame = new DeduplicationIdFromEnvelopeFrame();
+        return frame.Variable;
+    }
+
+    /// <inheritdoc />
+    public override Frame[] BuildDeduplicationStopCondition(Variable condition, DeduplicationOutcome outcome,
+        DeduplicationRequirement requirement)
+    {
+        return outcome switch
+        {
+            DeduplicationOutcome.Duplicate => [new HandlerDeduplicationStopFrame(condition)],
+            DeduplicationOutcome.MissingId => [new MissingDeduplicationIdFrame(condition, Description)],
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+        };
+    }
+
     [UnconditionalSuppressMessage("Trimming", "IL2026",
         Justification = "EntityIsNotNullGuardFrame<> closed over runtime entity type at codegen time; user types statically rooted. See AOT guide.")]
     [UnconditionalSuppressMessage("AOT", "IL3050",
@@ -738,6 +770,14 @@ public class HandlerChain : Chain<HandlerChain, ModifyHandlerChainAttribute>, IW
         }
 
         ApplyImpliedMiddlewareFromHandlers(rules);
+
+        // GH-4180. Weave logical deduplication HERE rather than from an IHandlerPolicy, because this is
+        // the first point at which both inputs are settled: [Deduplicated] is a ModifyChainAttribute and
+        // is only applied a few lines above -- well after HandlerGraph.Compile() ran the policies -- and
+        // IsTransactional is only final once [Transactional] and the stores' own policies have both had
+        // their say. Reading either one earlier produced a chain that silently wove nothing in.
+        // Idempotent, so a chain reached twice is woven once.
+        this.ApplyDeduplication();
 
         // Use Wolverine Parameter Attribute on any middleware
         foreach (var methodCall in Middleware.OfType<MethodCall>().ToArray())

--- a/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
+++ b/src/Wolverine/Runtime/Handlers/HandlerGraph.cs
@@ -575,8 +575,11 @@ public partial class HandlerGraph : ICodeFileCollectionWithServices, IWithFailur
     /// </remarks>
     private IEnumerable<IHandlerPolicy> handlerPolicies(WolverineOptions options)
     {
+        // GH-4180: DeduplicationHandlerPolicy is pulled to the end for exactly the same reason as the
+        // idempotency policy beside it -- the frames it weaves differ depending on IsTransactional, so
+        // it can only run once every store's policy has had its say.
         var registered = options.RegisteredPolicies
-            .OrderBy(x => x is EagerIdempotencyOnNonTransactionalChains ? 1 : 0)
+            .OrderBy(x => x is EagerIdempotencyOnNonTransactionalChains or DeduplicationHandlerPolicy ? 1 : 0)
             .ToArray();
 
         foreach (var policy in registered)

--- a/src/Wolverine/WolverineOptions.Policies.cs
+++ b/src/Wolverine/WolverineOptions.Policies.cs
@@ -56,6 +56,14 @@ public sealed partial class WolverineOptions : IPolicies
         RegisteredPolicies.Add(new EagerIdempotencyOnNonTransactionalChains());
     }
 
+    void IPolicies.RequireDeduplicationId(Func<HandlerChain, bool> filter, DeduplicationRequirement? requirement)
+    {
+        if (filter == null) throw new ArgumentNullException(nameof(filter));
+
+        RegisteredPolicies.Add(new RequireDeduplicationIdPolicy(filter,
+            requirement ?? new DeduplicationRequirement()));
+    }
+
     void IPolicies.Add<T>()
     {
         this.As<IPolicies>().Add(new T());

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -293,6 +293,12 @@ public sealed partial class WolverineOptions
         // eager policies (e.g. Marten's MartenStoreEagerPolicy). See StorageAttributeEagerPolicy.
         Policies.Add<StorageAttributeEagerPolicy>();
 
+        // GH-4180. Weaves logical deduplication frames into handler chains that opted in with
+        // [Deduplicated] or Policies.RequireDeduplicationId(). Always registered; it is a no-op for the
+        // (overwhelmingly common) case where no chain asked for deduplication. HandlerGraph pulls it to
+        // the end of the policy list -- see handlerPolicies().
+        RegisteredPolicies.Add(new DeduplicationHandlerPolicy(this));
+
         this.OnException<DuplicateIncomingEnvelopeException>().Discard();
 
         // GH-3289: a batch handler can throw ApplyItemException to isolate poison items from a batch.


### PR DESCRIPTION
Closes #4180.

Promotes `DeduplicationId` from its broker-specific role into a first-class **logical message id**, and uses it for handler-level idempotency. Storage is opt-in (`Durability.EnableMessageDeduplication`), so an upgrade is a no-op for anyone who does not want it.

## The distinction this rests on

`Envelope.Id` identifies **one delivery**. That is the right identity for "the broker handed me this twice", and the wrong one for "the operator clicked *Rebuild* twice", "the console republished after a timeout", "the agent pre-published tonight's occurrence yesterday". Those are different deliveries of the *same intent* — different `Envelope.Id`s, and every one gets through today.

`Envelope.DeduplicationId` already round-tripped on every transport. What was missing was storage, enforcement, and a retention policy.

## Design decisions worth reviewing

**A separate `wolverine_deduplication` table, not a nullable column on the inbox.** The issue left this open; the column turned out not to work:

- Under `EnableInboxPartitioning` the inbox is `PARTITION BY LIST (status)`, and PostgreSQL refuses a unique index on a partitioned table unless the index carries the partition key. But marking an envelope handled `UPDATE`s `status`, which *moves the row between partitions* — so a `(deduplication_id, status)` index would let the same logical id exist once as `Incoming` and once as `Handled`. Structurally incapable of enforcing the guarantee, silently, and only for users who enabled partitioning.
- A marker has to outlive the inbox row it came from, and the inbox is reaped on `KeepAfterMessageHandling` — five minutes by default. `DeduplicationWindow` defaults to 24h and is stated rather than inherited.
- Per your own comment on the issue: the inbox is small, hot, and written by every node. Its own table means that schema never moves for this feature at all.

**Claiming is an `INSERT`, never a `SELECT`-then-`INSERT`.** The duplicates this exists to stop are concurrent. A check-then-act passes every single-threaded test written against it and fails under the operator double-click it was built for. There is a test that only a real claim survives (`concurrent_claims_of_the_same_id_produce_exactly_one_winner`).

**A failed non-transactional execution releases its claim.** Without this the first failure permanently claims the id, every retry is discarded as a duplicate of its own failed attempt, and the work silently never happens *while the logs report successful deduplication* — strictly worse than not having the feature.

## `IChain` and the per-chain-type divergence

`IChain` gains `Deduplication`, `RequiresDeduplication()`, `ResolveDeduplicationId(...)` and `BuildDeduplicationStopCondition(...)`. Resolving the id and claiming it are shared frames; only the refusal differs — the same seam as `AddStopConditionIfNull` / `CreateSimpleValidationFrame`.

| | Duplicate | Missing required id |
|---|---|---|
| **HandlerChain** | discard + ack. Deliberately **not** `DuplicateIncomingEnvelopeException` — that is the storage-level signal and `DurableReceiver.handleDuplicateIncomingEnvelope` routes it through a redelivery check that can dead-letter. Returning early also keeps exactly one terminal tracking event on the path. | throw → error policies → DLQ |
| **HttpChain** | `409` + `ProblemDetails`, configurable to a 2xx where a replay is benign | `400` + `ProblemDetails` |
| **GrpcChain** | `AlreadyExists` (AIP-193) | `InvalidArgument` |

Generated handler code:

```csharp
var deduplicationId = context.Envelope?.DeduplicationId;
var missingDeduplicationId = string.IsNullOrWhiteSpace(deduplicationId);
if (missingDeduplicationId) throw new MissingDeduplicationIdException(...);

var isDuplicateMessage = false;
if (!string.IsNullOrWhiteSpace(deduplicationId))
{
    isDuplicateMessage = !(await _messageDeduplicator.TryClaimAsync(deduplicationId, null, cancellation));
}
if (isDuplicateMessage) return;
try { /* handler */ }
catch { if (...) await _messageDeduplicator.ReleaseAsync(...); throw; }
```

Note the claim is guarded by a null check, so unkeyed traffic on a `Required = false` chain pays no database round trip.

## Two things to flag

**gRPC is only half-wired, on purpose.** The refusal semantics are implemented on all three gRPC chain types. The id-resolution half is not: gRPC generates each RPC method inside `AssembleTypes` with a method-local `ServerCallContext` expression rather than through the `Middleware` list that `ApplyDeduplication` weaves into. Rather than let `[Deduplicated]` silently do nothing there, `GrpcGraph` throws at bootstrap naming the limitation. Happy to do the plumbing in a follow-up if you want it in this release.

**A `[Deduplicated]` handler in an assembly shared with hosts that have not enabled deduplication is a hard bootstrap failure.** This is by design — the alternative is a host reporting itself as protected while every duplicate runs — but it bit me in the test suite and it will bite users in a modular monolith. Worth a docs callout beyond what is already there if you think the sharp edge is too sharp.

## Codegen phase gotcha

The frames are woven from `HandlerChain.applyCustomizations` / `HttpChain.AssembleTypes`, **not** from an `IHandlerPolicy`. `[Deduplicated]` is a `ModifyChainAttribute` and is applied well after `HandlerGraph.Compile()` runs the policies, and `IsTransactional` is not final until the stores' policies have run. Weaving from a policy produced a chain with the attribute set and no frames at all — which is how the first test run failed.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean, 0 warnings
- CoreTests: 2666 passed
- Wolverine.Http.Tests: 1002 passed
- PostgresqlTests: 508 passed (includes 8 new deduplication tests, and 5 new HTTP ones)
- Baseline confirmed against a clean `origin/main` worktree

Storage: PostgreSQL, SQL Server, MySQL, SQLite. Other stores report unsupported and fail loudly rather than answering "yes, that's new" to every id. Scope is fire-and-forget; replaying the original response of a deduplicated `InvokeAsync<T>` is separate, larger machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
