### PR TITLE
Never forward an agent command to the node it is already on, and split the bool

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/InvokeOnAgentOrForwardAsyncTests.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/InvokeOnAgentOrForwardAsyncTests.cs
@@ -133,3 +133,128 @@ public class invoke_on_typed_agent_or_forward_tests
         actionCalled.ShouldBeFalse();
     }
 }
+
+/// <summary>
+/// CritterWatch#1171 — the two questions this routing asks are answered by two different sources, and
+/// nothing handled them disagreeing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>"Run it here?"</b> is answered by the in-process <c>NodeController.Agents</c> dictionary
+/// (<see cref="IAgentRuntime.AllRunningAgentUris"/>). <b>"Forward it where?"</b> is answered by the
+/// durable <c>wolverine_nodes</c> table. During a startup window the table is already populated while
+/// the dictionary is still empty — so on a single-node service the envelope was sent to
+/// <c>node.ControlUri</c>, which is this node, where it took the same branch again. The method
+/// returned <c>true</c> for that, and every caller reads <c>true</c> as "done".
+/// </para>
+/// <para>
+/// Proven downstream by sampling both sources every 250 ms across 10 isolated runs: 2 failed, and one
+/// variable separated them — the agent was running on all 8 passes and on neither failure. The
+/// commands were acked as successful and the daemon never acted, which read as a daemon defect for
+/// weeks because the URI resolution that precedes this goes through the store's shard REGISTRY and
+/// answers happily either way.
+/// </para>
+/// </remarks>
+public class no_self_forward_when_the_node_table_and_the_agent_dictionary_disagree
+{
+    private readonly MockWolverineRuntime _runtime = new();
+    private readonly Uri _agentUri = new("typedfake://alpha");
+
+    /// <summary>The node table claims the agent for THIS node while it is not running here.</summary>
+    private void TableClaimsAgentFor(Guid nodeId, Uri? controlUri)
+    {
+        _runtime.Agents.AllRunningAgentUris().Returns(Array.Empty<Uri>());
+        _runtime.Storage.Nodes.LoadAllNodesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<WolverineNode>
+            {
+                new() { NodeId = nodeId, ControlUri = controlUri, ActiveAgents = { _agentUri } }
+            });
+    }
+
+    [Fact]
+    public async Task does_not_forward_to_itself_and_says_so()
+    {
+        TableClaimsAgentFor(_runtime.Options.UniqueNodeId, new Uri("dbcontrol://one"));
+
+        var context = new MessageContext(_runtime);
+        var actionCalled = false;
+
+        var outcome = await context.InvokeOnAgentAsync(_agentUri, (_, _) =>
+        {
+            actionCalled = true;
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+
+        outcome.ShouldBe(AgentInvocationOutcome.NotRunningLocally);
+        actionCalled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task the_bool_overload_reports_that_as_a_failure()
+    {
+        // The whole point. It used to answer `true` here — "executed locally or forwarded" — for a
+        // command that did neither, so a caller with a working fallback skipped it and a caller
+        // without one acked a success.
+        TableClaimsAgentFor(_runtime.Options.UniqueNodeId, new Uri("dbcontrol://one"));
+
+        var context = new MessageContext(_runtime);
+
+        var result = await context.InvokeOnAgentOrForwardAsync(
+            _agentUri, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_node_that_owns_the_agent_but_has_no_control_endpoint_is_not_an_owner()
+    {
+        // Guarding the null-forgiving `node!.ControlUri!` this replaced: it would have thrown a
+        // NullReferenceException from inside the routing rather than letting the caller fall back.
+        TableClaimsAgentFor(Guid.NewGuid(), controlUri: null);
+
+        var context = new MessageContext(_runtime);
+
+        var outcome = await context.InvokeOnAgentAsync(
+            _agentUri, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        outcome.ShouldBe(AgentInvocationOutcome.NoOwner);
+    }
+
+    [Fact]
+    public async Task running_locally_is_still_reported_as_executed_rather_than_forwarded()
+    {
+        // The other half of splitting the bool: "the work is done" and "somebody else will do it" are
+        // now different answers, so a caller can tell whether to wait for anything.
+        _runtime.Agents.AllRunningAgentUris().Returns([_agentUri]);
+
+        var context = new MessageContext(_runtime);
+        var actionCalled = false;
+
+        var outcome = await context.InvokeOnAgentAsync(_agentUri, (_, _) =>
+        {
+            actionCalled = true;
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+
+        outcome.ShouldBe(AgentInvocationOutcome.ExecutedLocally);
+        actionCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task no_node_at_all_is_distinct_from_this_node_not_running_it()
+    {
+        // Two different failures that a single `false` collapsed together, and they want different
+        // diagnostics: nobody has been assigned the agent, versus we have been assigned it and are
+        // not running it yet.
+        _runtime.Agents.AllRunningAgentUris().Returns(Array.Empty<Uri>());
+        _runtime.Storage.Nodes.LoadAllNodesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<WolverineNode>());
+
+        var context = new MessageContext(_runtime);
+
+        var outcome = await context.InvokeOnAgentAsync(
+            _agentUri, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        outcome.ShouldBe(AgentInvocationOutcome.NoOwner);
+    }
+}

--- a/src/Wolverine/Runtime/AgentMessagingExtensions.cs
+++ b/src/Wolverine/Runtime/AgentMessagingExtensions.cs
@@ -5,10 +5,124 @@ using Wolverine.Runtime.Agents;
 namespace Wolverine.Runtime;
 
 /// <summary>
+/// What actually happened to an agent command routed by
+/// <see cref="AgentMessagingExtensions.InvokeOnAgentAsync(IMessageContext,Uri,Func{IWolverineRuntime,CancellationToken,Task},CancellationToken)"/>.
+/// </summary>
+/// <remarks>
+/// This exists because a <c>bool</c> cannot carry it. "Executed here" and "handed to another node"
+/// are both successes for the caller, but only the first means the work is done — and the two
+/// failures below are not the same failure and do not want the same fallback.
+/// </remarks>
+public enum AgentInvocationOutcome
+{
+    /// <summary>The action ran on this node. The work is done.</summary>
+    ExecutedLocally,
+
+    /// <summary>Another node owns the agent and the message was sent to it. The work is not done yet.</summary>
+    Forwarded,
+
+    /// <summary>No node in the durable node table claims the agent.</summary>
+    NoOwner,
+
+    /// <summary>
+    /// The node table says THIS node owns the agent, but it is not running here.
+    /// </summary>
+    /// <remarks>
+    /// The routing decision and the execution decision read two different sources — the durable
+    /// <c>wolverine_nodes</c> table and the in-process <c>NodeController.Agents</c> dictionary — and
+    /// during a startup window the table is populated while the dictionary is still empty. There is
+    /// nothing useful to do with the message here: forwarding it would send it to the node it is
+    /// already on, which is a silent no-op. Callers should fall back or fail honestly.
+    /// </remarks>
+    NotRunningLocally
+}
+
+/// <summary>
 /// Extension methods for routing agent commands to the correct node in a Wolverine cluster.
 /// </summary>
 public static class AgentMessagingExtensions
 {
+    /// <summary>
+    /// Executes an action locally if the specified agent is running on this node, otherwise forwards
+    /// the current message to the node that owns the agent, and reports which of those happened.
+    /// </summary>
+    /// <param name="context">The current message context.</param>
+    /// <param name="agentUri">The URI identifying the target agent.</param>
+    /// <param name="action">The action to execute if the agent is local to this node.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task<AgentInvocationOutcome> InvokeOnAgentAsync(this IMessageContext context, Uri agentUri,
+        Func<IWolverineRuntime, CancellationToken, Task> action, CancellationToken cancellationToken)
+    {
+        var messageContext = context.As<MessageContext>();
+        var runtime = messageContext.Runtime;
+
+        if (runtime.Agents.AllRunningAgentUris().Contains(agentUri))
+        {
+            await action(runtime, cancellationToken);
+            return AgentInvocationOutcome.ExecutedLocally;
+        }
+
+        var all = await runtime.Storage.Nodes.LoadAllNodesAsync(cancellationToken);
+        var node = all.FirstOrDefault(x => x.ActiveAgents.Contains(agentUri));
+
+        if (node == null) return AgentInvocationOutcome.NoOwner;
+
+        // Never forward to ourselves. The check above asked the in-process agent dictionary and this
+        // one asks the durable node table; when they disagree — the table already claims the agent
+        // while the dictionary is still filling during startup — sending the envelope to
+        // node.ControlUri delivers it back to this node, where it takes the same branch again. The
+        // caller was previously told "true" for that, so a command that did nothing at all was
+        // reported as handled. FanOutToAllNodes below has always excluded self for the same reason.
+        if (node.NodeId == runtime.Options.UniqueNodeId)
+        {
+            runtime.Logger.LogWarning(
+                "Node {NodeId} is recorded as the owner of agent {AgentUri} in node storage, but that agent is not running on this node. Not forwarding the message to ourselves.",
+                node.NodeId, agentUri);
+
+            return AgentInvocationOutcome.NotRunningLocally;
+        }
+
+        if (node.ControlUri == null)
+        {
+            runtime.Logger.LogWarning(
+                "Node {NodeId} owns agent {AgentUri} but has no control endpoint, so the message cannot be forwarded to it",
+                node.NodeId, agentUri);
+
+            return AgentInvocationOutcome.NoOwner;
+        }
+
+        await messageContext.EndpointFor(node.ControlUri).SendAsync(context.Envelope!.Message);
+        return AgentInvocationOutcome.Forwarded;
+    }
+
+    /// <summary>
+    /// Executes an action on a specific running agent (cast to type T) if the agent is on this node,
+    /// otherwise forwards the current message to the node that owns the agent, and reports which of
+    /// those happened.
+    /// </summary>
+    /// <typeparam name="T">The expected agent type implementing IAgent.</typeparam>
+    /// <param name="context">The current message context.</param>
+    /// <param name="agentUri">The URI identifying the target agent.</param>
+    /// <param name="action">The action to execute on the typed agent if found locally.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static Task<AgentInvocationOutcome> InvokeOnAgentAsync<T>(this IMessageContext context, Uri agentUri,
+        Func<T, Task> action, CancellationToken cancellationToken) where T : class, IAgent
+    {
+        return context.InvokeOnAgentAsync(agentUri, async (runtime, ct) =>
+        {
+            if (runtime.Agents.TryFindActiveAgent<T>(agentUri, out var agent))
+            {
+                await action(agent);
+            }
+            else
+            {
+                runtime.Logger.LogWarning(
+                    "Agent at {AgentUri} was expected to be of type {ExpectedType} but was not found or is a different type",
+                    agentUri, typeof(T).Name);
+            }
+        }, cancellationToken);
+    }
+
     /// <summary>
     /// Executes an action locally if the specified agent is running on this node,
     /// otherwise forwards the current message to the node that owns the agent.
@@ -19,27 +133,19 @@ public static class AgentMessagingExtensions
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// <c>true</c> if the action was executed locally or the message was successfully forwarded;
-    /// <c>false</c> if no node currently owns the specified agent.
+    /// <c>false</c> if the command could not be delivered to a running agent.
     /// </returns>
+    /// <remarks>
+    /// ⚠️ A caller that needs to know whether the WORK IS DONE cannot use this — <c>true</c> also
+    /// means "handed to another node, which will do it later". Use
+    /// <see cref="InvokeOnAgentAsync(IMessageContext,Uri,Func{IWolverineRuntime,CancellationToken,Task},CancellationToken)"/>
+    /// and read <see cref="AgentInvocationOutcome"/>.
+    /// </remarks>
     public static async Task<bool> InvokeOnAgentOrForwardAsync(this IMessageContext context, Uri agentUri,
         Func<IWolverineRuntime, CancellationToken, Task> action, CancellationToken cancellationToken)
     {
-        var messageContext = context.As<MessageContext>();
-        var runtime = messageContext.Runtime;
-
-        if (runtime.Agents.AllRunningAgentUris().Contains(agentUri))
-        {
-            await action(runtime, cancellationToken);
-            return true;
-        }
-
-        var all = await runtime.Storage.Nodes.LoadAllNodesAsync(cancellationToken);
-        var node = all.FirstOrDefault(x => x.ActiveAgents.Contains(agentUri));
-
-        if (node == null) return false;
-
-        await messageContext.EndpointFor(node!.ControlUri!).SendAsync(context.Envelope!.Message);
-        return true;
+        var outcome = await context.InvokeOnAgentAsync(agentUri, action, cancellationToken);
+        return outcome is AgentInvocationOutcome.ExecutedLocally or AgentInvocationOutcome.Forwarded;
     }
 
     /// <summary>
@@ -53,24 +159,13 @@ public static class AgentMessagingExtensions
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// <c>true</c> if the action was executed locally or the message was successfully forwarded;
-    /// <c>false</c> if no node currently owns the specified agent.
+    /// <c>false</c> if the command could not be delivered to a running agent.
     /// </returns>
-    public static Task<bool> InvokeOnAgentOrForwardAsync<T>(this IMessageContext context, Uri agentUri,
+    public static async Task<bool> InvokeOnAgentOrForwardAsync<T>(this IMessageContext context, Uri agentUri,
         Func<T, Task> action, CancellationToken cancellationToken) where T : class, IAgent
     {
-        return context.InvokeOnAgentOrForwardAsync(agentUri, async (runtime, ct) =>
-        {
-            if (runtime.Agents.TryFindActiveAgent<T>(agentUri, out var agent))
-            {
-                await action(agent);
-            }
-            else
-            {
-                runtime.Logger.LogWarning(
-                    "Agent at {AgentUri} was expected to be of type {ExpectedType} but was not found or is a different type",
-                    agentUri, typeof(T).Name);
-            }
-        }, cancellationToken);
+        var outcome = await context.InvokeOnAgentAsync(agentUri, action, cancellationToken);
+        return outcome is AgentInvocationOutcome.ExecutedLocally or AgentInvocationOutcome.Forwarded;
     }
 
     /// <summary>


### PR DESCRIPTION
## The defect

`InvokeOnAgentOrForwardAsync` asks **two different sources about the same fact**:

| question | source |
|---|---|
| *"run it here?"* | the in-process `NodeController.Agents` dictionary, via `AllRunningAgentUris()` |
| *"forward it where?"* | the durable `wolverine_nodes` table |

Nothing handled them disagreeing. During a startup window the table is already populated while the
dictionary is still empty — so on a **single-node** service the envelope was sent to
`node.ControlUri`, which is this node, where it took the same branch again. The method returned
`true` for that, and every caller reads `true` as *"done"*.

`FanOutToAllNodes`, ten lines below in the same file, has always excluded self.

## How it was found

Reported downstream as [CritterWatch#1171](https://github.com/JasperFx/CritterWatch/issues/1171):
four intermittent tests across two suites shared one sentence — *a projection command reaches the
monitored service, is accepted, and the daemon does not act*.

It read as a **daemon** defect for weeks, because the agent-URI resolution that precedes this call
goes through the store's shard **registry** — so it returns a URI happily either way and emits no
failure ack. The command was acked as successful and nothing happened.

Proven by sampling both sources every 250 ms across 10 isolated runs: 2 failed, and exactly one
variable separated them — the agent was running on all 8 passes and on **neither** failure. An
end-state dump could not see it: a rewind that never reset progress and one that reset and caught
back up land on the same number, so only a trajectory tells them apart.

## The change

**1. A node that is THIS node is not a forwarding destination.** Log it and report it, so the caller
can fall back or fail honestly instead of being told the work is done.

**2. One `bool` cannot mean both "executed" and "forwarded".** The caller cannot tell whether the work
is finished or merely handed off, and the two failure modes are not the same failure. New
`InvokeOnAgentAsync` returns an `AgentInvocationOutcome`:

| outcome | meaning |
|---|---|
| `ExecutedLocally` | the action ran here; the work is done |
| `Forwarded` | another node owns it and was sent the message; not done yet |
| `NoOwner` | no node claims the agent |
| `NotRunningLocally` | the table says this node owns it, but it is not running here |

`InvokeOnAgentOrForwardAsync` **keeps its `bool` signature** and is now defined over the new method,
so no existing caller has to change. It answers `false` for the self case, which is the behavioural
fix — downstream, that turns a rebuild that silently skipped its working fallback into one that takes
it, and a rewind that acked success into one that acks a failure naming the cause.

Also replaces the null-forgiving `node!.ControlUri!` with a real check: an owner with no control
endpoint reports `NoOwner` rather than throwing a `NullReferenceException` from inside the routing.

## Verification

Five new tests in `InvokeOnAgentOrForwardAsyncTests.cs`. **Falsified rather than merely green** —
reverting the self check reds 2 of the 5. `CoreTests` agent suite is **358/358 on net9.0 and
net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
