### PR TITLE
GH-4181 + GH-4182: stop claiming the trigger label, and read a collection response as its element type

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Marten/event_model_read_model_collection_4182.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/event_model_read_model_collection_4182.cs
@@ -1,0 +1,57 @@
+using JasperFx.Events.EventModeling;
+using Shouldly;
+using Wolverine.Http.Diagnostics;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+// GH-4182. A query endpoint that returns a COLLECTION of a read model is a view over that read model.
+// Before this, EventModelRoles.Describe took the response type verbatim, so the slice's read model
+// rendered as the closed generic's assembly-qualified CLR string --
+// "System.Collections.Generic.IReadOnlyList`1[[WolverineWebApi.Marten.Order, WolverineWebApi, Version=..."
+// -- an unreadable canvas node sitting next to the "Order" node the sibling single-document routes name.
+public class event_model_read_model_collection_4182(AppFixture fixture) : IntegrationContext(fixture)
+{
+    [Fact]
+    public void a_list_response_reads_the_element_type_as_its_read_model()
+    {
+        // GET /api/orders/list is Get(IQuerySession, CancellationToken) => Task<IReadOnlyList<Order>>
+        var chain = HttpChains.ChainFor("GET", "/api/orders/list");
+        chain.ShouldNotBeNull();
+
+        var slice = HttpEventModelSource.ForChain(chain);
+
+        slice.Pattern.ShouldBe(SlicePattern.View);
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(Order)]);
+    }
+
+    [Fact]
+    public void the_read_model_is_the_same_node_the_single_document_route_names()
+    {
+        // The point of the unwrap: "a list of Order" and "an Order" fold onto ONE canvas node. Asserted
+        // on FullName because that is what a viewer keys the node by -- matching on Name alone would
+        // pass even if one slice still carried the closed generic
+        var list = HttpEventModelSource.ForChain(HttpChains.ChainFor("GET", "/api/orders/list")!);
+        var single = HttpEventModelSource.ForChain(HttpChains.ChainFor("GET", "/orders/latest/{id}")!);
+
+        list.ReadModelTypes.Single().FullName
+            .ShouldBe(single.ReadModelTypes.Single().FullName);
+
+        list.ReadModelTypes.Single().FullName.ShouldBe(typeof(Order).FullName);
+    }
+
+    [Fact]
+    public void a_paged_list_response_unwraps_too()
+    {
+        // GET /api/orders/query returns Marten's IPagedList<Order>, which is not any of the framework
+        // collection types -- it only IS one through IReadOnlyList<T>. A page of Order is still a view
+        // over Order, which is why the unwrap walks interfaces rather than matching a whitelist
+        var chain = HttpChains.ChainFor("GET", "/api/orders/query");
+        chain.ShouldNotBeNull();
+
+        var slice = HttpEventModelSource.ForChain(chain);
+
+        slice.Pattern.ShouldBe(SlicePattern.View);
+        slice.ReadModelTypes.Select(x => x.Name).ShouldBe([nameof(Order)]);
+    }
+}

--- a/src/Http/Wolverine.Http.Tests/Marten/event_model_roles_3988.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/event_model_roles_3988.cs
@@ -26,7 +26,12 @@ public class event_model_roles_3988(AppFixture fixture) : IntegrationContext(fix
         slice.TriggerKind.ShouldBe(TriggerKind.Http);
         slice.TriggerOrigin!.HttpMethod.ShouldBe("POST");
         slice.TriggerOrigin.HttpRoute.ShouldBe("/orders/ship3");
-        slice.TriggerLabel.ShouldBe("POST /orders/ship3");
+
+        // GH-4181: the route is named by the ORIGIN, which carries it losslessly. The TriggerLabel role
+        // is left unclaimed so a declared label ("Customer at the ATM") can win it -- see
+        // event_model_trigger_label_4181
+        slice.TriggerLabel.ShouldBeNull();
+        slice.TriggerOrigin.Label.ShouldBe("POST /orders/ship3");
         slice.CommandType!.Name.ShouldBe(nameof(ShipOrder));
         slice.HandlerType!.Name.ShouldBe(nameof(MarkItemEndpoint));
         slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });

--- a/src/Http/Wolverine.Http.Tests/Marten/event_model_trigger_label_4181.cs
+++ b/src/Http/Wolverine.Http.Tests/Marten/event_model_trigger_label_4181.cs
@@ -1,0 +1,80 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+using Wolverine.Http.Diagnostics;
+using WolverineWebApi.Marten;
+
+namespace Wolverine.Http.Tests.Marten;
+
+// GH-4181. An HTTP slice used to claim TriggerLabel with "{verb} {route}", which is a Derived claim on a
+// role per-role precedence (jasperfx#703) then made unbeatable -- so an overlay's human trigger label
+// ("Customer at the ATM") always lost, and every labelled endpoint minted a SourceDisagreement hotspot
+// for the privilege. The route is already carried losslessly on TriggerOrigin, so the claim added no
+// information and only occupied the one slot a declaration could use.
+public class event_model_trigger_label_4181(AppFixture fixture) : IntegrationContext(fixture)
+{
+    private const string DeclaredLabel = "Customer at the ATM";
+
+    private EventModelSliceDescriptor theDerivedSlice()
+    {
+        var chain = HttpChains.ChainFor("POST", "/orders/ship3");
+        chain.ShouldNotBeNull();
+
+        return HttpEventModelSource.ForChain(chain);
+    }
+
+    [Fact]
+    public void the_derived_slice_leaves_the_trigger_label_unclaimed()
+    {
+        var slice = theDerivedSlice();
+
+        slice.TriggerLabel.ShouldBeNull();
+
+        // and nothing is lost: the verb and the route are still there, structured
+        slice.TriggerKind.ShouldBe(TriggerKind.Http);
+        slice.TriggerOrigin!.Label.ShouldBe("POST /orders/ship3");
+        slice.TriggerOrigin.HttpMethod.ShouldBe("POST");
+        slice.TriggerOrigin.HttpRoute.ShouldBe("/orders/ship3");
+    }
+
+    [Fact]
+    public void the_wireframe_trigger_element_still_names_the_route()
+    {
+        // Elements are computed from the roles, and a trigger is the one element kind with three
+        // possible sources -- TriggerType, TriggerLabel and TriggerOrigin. Withholding the label must
+        // not cost the canvas its trigger, which is the whole reason the origin is safe to rely on
+        var trigger = theDerivedSlice().Elements.Single(x => x.Kind == EventModelElementKind.Trigger);
+
+        trigger.Label.ShouldBe("POST /orders/ship3");
+    }
+
+    [Fact]
+    public void a_declared_label_wins_the_role_and_records_no_disagreement()
+    {
+        // The overlay is merged FIRST on purpose: it must win on the ladder, not on ordering
+        var declared = new EventModelDescriptor("trigger-label-4181", [
+            new EventModelSliceDescriptor(
+                nameof(ShipOrder), DeclaredLabel, null, null, null,
+                Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>())
+        ]);
+
+        var derived = new EventModelDescriptor("trigger-label-4181", [theDerivedSlice()])
+            .WithProvenance(EventModelProvenance.Derived);
+
+        var merged = EventModelDescriptor.Merge("trigger-label-4181", [declared, derived]);
+        var slice = merged.Slices.Single(x => x.Name == nameof(ShipOrder));
+
+        slice.TriggerLabel.ShouldBe(DeclaredLabel);
+
+        // the derived roles are untouched -- the overlay filled a gap, it did not take anything
+        slice.TriggerKind.ShouldBe(TriggerKind.Http);
+        slice.TriggerOrigin!.HttpRoute.ShouldBe("/orders/ship3");
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe([nameof(Order)]);
+        slice.EmittedEvents.Select(x => x.Name).ShouldContain(nameof(OrderShipped));
+
+        // and the label was a gap, not a disagreement: five labelled endpoints used to mean five of
+        // these hotspots drowning out any real finding
+        slice.Hotspots.ShouldNotContain(x =>
+            x.Origin == HotspotOrigin.SourceDisagreement && x.Role == EventModelRole.TriggerLabel);
+    }
+}

--- a/src/Http/WolverineWebApi/Marten/Orders.cs
+++ b/src/Http/WolverineWebApi/Marten/Orders.cs
@@ -495,3 +495,14 @@ public static class MarkItemReadyHandler
 #endregion
 
 public record OrderTimeline(long Version, string[] EventTypes);
+
+// GH-4182. A query endpoint whose response is a *collection* of a read model. Kept beside
+// QueryOrdersEndpoint on purpose: that one returns Marten's IPagedList<Order>, this one the bare
+// IReadOnlyList<Order> the issue was reported against, and the Event Model slice has to name Order as
+// the read model for both rather than the closed generic's assembly-qualified CLR string.
+public static class ListOrdersEndpoint
+{
+    [WolverineGet("/api/orders/list")]
+    public static Task<IReadOnlyList<Order>> Get(IQuerySession session, CancellationToken token)
+        => session.Query<Order>().ToListAsync(token);
+}

--- a/src/Testing/CoreTests/Acceptance/event_model_per_rpc_4000.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_per_rpc_4000.cs
@@ -67,7 +67,13 @@ public class event_model_per_rpc_4000 : IAsyncLifetime
         slice.HandlerType.ShouldBeNull();
         slice.Pattern.ShouldBe(SlicePattern.Command);
         slice.TriggerKind.ShouldBe(TriggerKind.Grpc);
-        slice.TriggerLabel.ShouldBe("Orders/Cancel");
+
+        // GH-4181: the RPC is named by the ORIGIN, and the TriggerLabel role is left unclaimed so a
+        // declared label can take it without losing to a derived duplicate of what the origin says
+        slice.TriggerLabel.ShouldBeNull();
+        slice.TriggerOrigin!.Label.ShouldBe("Orders/Cancel");
+        slice.TriggerOrigin.GrpcService.ShouldBe("Orders");
+        slice.TriggerOrigin.GrpcMethod.ShouldBe("Cancel");
     }
 
     [Fact]

--- a/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
@@ -154,13 +154,22 @@ public static class EventModelRoles
             pattern = SlicePattern.View;
             if (seed.ResponseType is { } response && response != typeof(void))
             {
-                roles.ReadModels.Add(response);
+                roles.ReadModels.Add(readModelOf(response));
             }
         }
 
+        // GH-4181. TriggerLabel is deliberately NOT claimed here. Every structural fact a derived
+        // trigger knows -- the route and verb, the gRPC service and method -- already rides on
+        // TriggerOrigin, losslessly, and a viewer resolves the trigger element from TriggerType /
+        // TriggerLabel / TriggerOrigin together. Claiming the label as well duplicated the origin onto
+        // the Derived rung, where per-role precedence (jasperfx#703) made it beat any label an overlay
+        // declared -- and minted a SourceDisagreement hotspot per labelled route for the privilege.
+        // A trigger *label* is a naming concern ("Customer at the ATM"), which is exactly what the SDD
+        // decisions reserve for declarations: the code cannot express it. Leaving the role unclaimed
+        // means an overlay's label wins by default, because nothing else claims it.
         return new EventModelSliceDescriptor(
             seed.SliceName,
-            seed.TriggerOrigin?.Label,
+            null,
             null,
             seed.CommandType is null ? null : TypeDescriptor.For(seed.CommandType),
             seed.HandlerType is null ? null : TypeDescriptor.For(seed.HandlerType),
@@ -312,6 +321,88 @@ public static class EventModelRoles
             // exception to throw at codegen time, not this reader's
             return null;
         }
+    }
+
+    /// <summary>
+    ///     The read model behind a <see cref="SlicePattern.View" /> slice's response. A response that is a
+    ///     <em>collection</em> of a type is a view over that type -- "a list of Account" reads the same
+    ///     Account read model the sibling single-document routes name -- so the element type is what the
+    ///     slice reports, and the slice folds onto the canvas node that already exists rather than minting
+    ///     an unreadable one out of the closed generic's assembly-qualified name (GH-4182).
+    /// </summary>
+    /// <remarks>
+    ///     Only a <em>composite</em> element unwraps. A <c>byte[]</c> download is not a view over
+    ///     <c>byte</c>, and folding every list-of-string route onto one <c>String</c> node would be a
+    ///     worse canvas than the one this fixes, so a scalar element leaves the response type exactly as
+    ///     it was before this method existed.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Response types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    private static Type readModelOf(Type responseType)
+    {
+        var type = responseType;
+
+        // Wolverine.HTTP hands over an already-unwrapped resource type and a gRPC response is bare, but
+        // the seed only promises "the response", so the wrapper is unwrapped rather than assumed away
+        if (type.Closes(typeof(Task<>)) || type.Closes(typeof(ValueTask<>)))
+        {
+            type = type.GetGenericArguments()[0];
+        }
+
+        var element = elementTypeOf(type);
+        if (element is null) return type;
+
+        if (element.IsPrimitive || element.IsEnum || element == typeof(string) || element == typeof(decimal) ||
+            element == typeof(object) || element == typeof(Guid) || element == typeof(DateTime) ||
+            element == typeof(DateTimeOffset) || element == typeof(TimeSpan))
+        {
+            return type;
+        }
+
+        return element;
+    }
+
+    /// <summary>
+    ///     The single element type a response enumerates, or null when it is not a collection of one thing.
+    /// </summary>
+    /// <remarks>
+    ///     The interface walk is deliberate rather than a whitelist of collection types: Marten hands a
+    ///     query endpoint back an <c>IPagedList&lt;T&gt;</c>, and a page of Order is every bit as much a
+    ///     view over Order as a list of Order is.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Response types come from handler discovery, which already roots them; only the interface list is read. Diagnostic surface only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Response types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
+    private static Type? elementTypeOf(Type type)
+    {
+        // string is IEnumerable<char> and is never a collection of read models
+        if (type == typeof(string)) return null;
+
+        if (type.IsArray) return type.GetElementType();
+
+        // A map enumerates as KeyValuePair<TKey, TValue>, which would unwrap to a type nobody drew. It is
+        // not a collection of one read model, so it does not unwrap at all
+        if (type.Closes(typeof(IDictionary<,>)) || type.Closes(typeof(IReadOnlyDictionary<,>))) return null;
+
+        // A streaming endpoint's response
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        // Exactly one closed IEnumerable<T>, or nothing: a type that enumerates as two different things
+        // has no single element type, and guessing one would be worse than leaving the response alone
+        var closed = type.GetInterfaces()
+            .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            .ToArray();
+
+        return closed.Length == 1 ? closed[0].GetGenericArguments()[0] : null;
     }
 
     private static IEnumerable<Type> returnedTypes(IChain chain, EventModelSliceSeed seed)

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -337,7 +337,10 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
     private static EventModelSliceDescriptor grpcTriggerOnlySlice(GrpcEndpointDescriptor endpoint, PublisherOrigin origin)
         => new(
             endpoint.RequestType.Name,
-            origin.Label,
+            // GH-4181: TriggerLabel unclaimed, for the same reason EventModelRoles.Describe leaves it
+            // unclaimed -- this slice sets the origin two lines down, so claiming the label as well only
+            // duplicated the origin onto the Derived rung and beat any label an overlay declared
+            null,
             null,
             JasperFx.Descriptors.TypeDescriptor.For(endpoint.RequestType),
             null,


### PR DESCRIPTION
Closes #4181, closes #4182.

Two Event Model derivation defects found while wiring the four-source test vehicle (JasperFx/bobcat#172, part of the SDD effort). Both land in `EventModelRoles.Describe`, which is why they ship together.

## GH-4181 — HTTP and gRPC slices claimed `TriggerLabel`

`Describe` passed `seed.TriggerOrigin?.Label` into the `TriggerLabel` slot, and `HttpEventModelSource.ForChain` always populates that origin with `"{verb} {route}"`. So every HTTP slice *claimed* the role on the **Derived** rung, per-role precedence (jasperfx#703) made it beat the overlay's Declared claim, and the merge recorded a `SourceDisagreement` hotspot for the dropped claim. Five labelled endpoints meant five noise hotspots drowning out any real finding.

The claim carried no information. The route and verb already ride on `TriggerOrigin`, structured and lossless, and a viewer resolves the trigger element from `TriggerType` / `TriggerLabel` / `TriggerOrigin` together — asserted in the new test, so withholding the label costs the canvas nothing. A trigger *label* is a naming concern ("Customer at the ATM"), exactly what the SDD decisions reserve for declarations: the code cannot express it. With the role unclaimed, an overlay's label wins by default because nothing else claims it — which is the contract jasperfx#703's own remarks state.

`grpcTriggerOnlySlice` had the same duplication (it sets the origin two lines below the claim) and gets the same treatment.

**Deliberately not changed:** `ApplyExternalSystems` still claims `TriggerLabel`. When a listener triggers a slice that already has an origin, the slice keeps its own origin and the external label lives nowhere else — so unlike the two above, that claim is not a duplicate of something already carried, and nulling it would lose the label outright.

## GH-4182 — a collection response reported the raw generic CLR string

A `View` slice took `seed.ResponseType` verbatim, so

```csharp
[WolverineGet("/api/orders/list")]
public static Task<IReadOnlyList<Order>> Get(...)
```

reported `System.Collections.Generic.IReadOnlyList`1[[WolverineWebApi.Marten.Order, WolverineWebApi, Version=…` as its read model — an unreadable canvas node sitting right next to the `Order` node its single-document siblings name.

A collection response now reads its **element** type, folding the slice onto the node that already exists. The unwrap walks interfaces rather than matching a whitelist of collection types, so Marten's `IPagedList<Order>` (a page of Order is still a view over Order) unwraps too. Left alone: maps (a `Dictionary<K,V>` enumerates as `KeyValuePair<,>`, which is not a read model anybody drew), `string`, a type that enumerates as two different things, and scalar elements — a `byte[]` download is not a view over `byte`, and folding every list-of-string route onto one `String` node would be a worse canvas than the one this fixes.

## Tests

- `event_model_trigger_label_4181` (new) — the derived slice leaves the role unclaimed while the origin still names the route; the wireframe trigger element still renders `POST /orders/ship3`; and a Declared overlay label merged **first** wins the role with no `SourceDisagreement` hotspot, without taking any derived role with it.
- `event_model_read_model_collection_4182` (new) — `IReadOnlyList<Order>` and `IPagedList<Order>` both read `Order`, asserted on `FullName` against the single-document route so a match on `Name` alone cannot pass it vacuously.
- `event_model_roles_3988` (HTTP) and `event_model_per_rpc_4000` (CoreTests) now assert the route/RPC off `TriggerOrigin.Label` — the fact moved, it did not disappear.
- One new endpoint in `WolverineWebApi` (`GET /api/orders/list`) for the literal shape #4182 was reported against.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — clean.
- Wolverine.Http.Tests **1003 passed**, 0 failed; CoreTests **2671 passed**, 0 failed; Wolverine.Grpc.Tests **306 passed**, 0 failed; MartenTests `EventModeling` 7/7.

## Follow-ups outside this PR

Both filed against the bobcat vehicle, and both gated on `samples/BankAccountES/BankAccountES.csproj` bumping its `WolverineFx.*` pin off 6.30.1 to whatever release carries this:

- **JasperFx/bobcat#174** — the vehicle encodes the #4181 workaround deliberately: `Program.cs` withholds `TriggeredBy` from all five HTTP slices, and `EventModel.feature` asserts the *broken* behaviour as a tripwire with a pointer back to the issue. Both need restoring, and the restored scenario should assert `reports no source disagreement` — five labelled endpoints used to bury the planted disagreement that vehicle exists to surface.
- **JasperFx/bobcat#175** — #4182 was caught by eye on the canvas rather than by a spec, because nothing in the vehicle asserts *which type* a slice reads. Needs a read-model step, and separately its slice-name steps take `{word}`, so they cannot address a View slice at all (a query endpoint with no request type is named `"GET /api/clients/{clientId}/accounts"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

