### PR TITLE
GH-4186: report a NativeAck listener's real queue depth and last receipt

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_queue_depth_4186.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/native_ack_queue_depth_4186.cs
@@ -1,0 +1,193 @@
+using System.Reflection;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4186. ListeningAgent read the receiver's depth through ILocalQueue, and neither NativeAckReceiver nor
+/// InlineReceiver is one -- deliberately, because a delivery in those two modes settles against the listener that
+/// brought it rather than against a local queue. Both maintain a real depth over a real block, and both used to
+/// contribute a constant 0 to EndpointHealthSnapshot: a saturated NativeAck listener was indistinguishable from
+/// an idle one, and rendered downstream as a reassuring green zero rather than as "unknown".
+///
+/// The companion half is LastQueueActivityAt, whose change-detection heuristic has exactly one writer --
+/// BackPressureAgent -- which correctly does not run for either mode (see Endpoint.ShouldEnforceBackPressure),
+/// leaving the timestamp frozen at listener construction forever.
+/// </summary>
+public class native_ack_queue_depth_4186 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private WolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+        NativeAckPingHandler.Handled.Clear();
+        NativeAckPingHandler.Gate = null;
+        NativeAckPingHandler.Entered = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        NativeAckPingHandler.Gate = null;
+        NativeAckPingHandler.Entered = null;
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task depth_and_receipt_activity_reach_the_endpoint_health_snapshot()
+    {
+        var endpoint = new NativeAckStubEndpoint("na-4186", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+        var agent = theRuntime.Endpoints.FindListeningAgent(endpoint.Uri).ShouldNotBeNull();
+
+        // Guard against a vacuous pass: a BufferedReceiver here already reported its depth before GH-4186,
+        // and the test would prove nothing.
+        receiverOf(agent).ShouldBeOfType<NativeAckReceiver>();
+
+        var idle = snapshotFor(endpoint.Uri);
+        idle.QueueCount.ShouldBe(0);
+
+        // Not a wait on anything -- pure clock separation, so that the "moved" assertion below cannot pass or
+        // fail on DateTimeOffset.UtcNow's granularity (~15ms on Windows) rather than on the fix.
+        await Task.Delay(50.Milliseconds(), TestContext.Current.CancellationToken);
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        NativeAckPingHandler.Gate = gate;
+
+        try
+        {
+            // Deliberately not awaited: with every handler parked on the gate, a large enough batch will fill
+            // the block's bounded channel and the post itself will block. Backgrounding it keeps this test
+            // agnostic about that capacity.
+            var flood = Task.Run(() => agent.EnqueueDirectlyAsync(
+                Enumerable.Range(0, 200).Select(i => pingEnvelope("flood-" + i)).ToArray()), TestContext.Current.CancellationToken);
+
+            await waitUntil(() => snapshotFor(endpoint.Uri).QueueCount > 0,
+                "the NativeAck listener never reported a non-zero QueueCount");
+
+            var saturated = snapshotFor(endpoint.Uri);
+
+            // The whole point of the issue: the depth is real, and it is now visible.
+            saturated.QueueCount.ShouldBeGreaterThan(0);
+
+            // ...and the listener no longer looks like it has been idle since boot.
+            saturated.LastQueueActivityAt.ShouldNotBeNull();
+            saturated.LastQueueActivityAt.Value.ShouldBeGreaterThan(idle.LastQueueActivityAt!.Value);
+
+            gate.SetResult();
+            await flood;
+        }
+        finally
+        {
+            gate.TrySetResult();
+        }
+
+        // And it is a live number rather than a one-time stamp -- it comes back down as the block drains.
+        await waitUntil(() => snapshotFor(endpoint.Uri).QueueCount == 0,
+            "the NativeAck listener's reported QueueCount never returned to zero");
+    }
+
+    [Fact]
+    public async Task inline_receiver_depth_reaches_the_snapshot_too()
+    {
+        var endpoint = new StubEndpoint("inline-4186", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.Inline;
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+        var agent = theRuntime.Endpoints.FindListeningAgent(endpoint.Uri).ShouldNotBeNull();
+        receiverOf(agent).ShouldBeOfType<InlineReceiver>();
+
+        snapshotFor(endpoint.Uri).QueueCount.ShouldBe(0);
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        NativeAckPingHandler.Gate = gate;
+        NativeAckPingHandler.Entered = entered;
+
+        try
+        {
+            // Inline invokes the pipeline on the caller's stack, so this cannot be awaited before asserting.
+            var inFlight = Task.Run(() => agent.EnqueueDirectlyAsync([pingEnvelope("inline")]), TestContext.Current.CancellationToken);
+
+            await entered.Task.WaitAsync(5.Seconds(), TestContext.Current.CancellationToken);
+
+            // Inline has no queue, but it does have in-flight work, and that is the number an operator wants.
+            snapshotFor(endpoint.Uri).QueueCount.ShouldBe(1);
+
+            gate.SetResult();
+            await inFlight;
+        }
+        finally
+        {
+            gate.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Shape 1 in the issue -- making NativeAckReceiver implement ILocalQueue -- would have been the smaller
+    /// diff and the wrong one: ListeningAgent.EnqueueDirectlyAsync type-switches on ILocalQueue *before* it
+    /// reaches the NativeAck branch that GH-4011 added, so a NativeAck receiver claiming to be a local queue
+    /// would silently take the wrong path on every DLQ replay.
+    /// </summary>
+    [Fact]
+    public void a_native_ack_receiver_reports_a_depth_without_claiming_to_be_a_local_queue()
+    {
+        var endpoint = new NativeAckStubEndpoint("na-4186-shape", new StubTransport());
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.Compile(theRuntime);
+
+        var receiver = new NativeAckReceiver(endpoint, theRuntime,
+            new HandlerPipeline(theRuntime, theRuntime, endpoint));
+
+        receiver.ShouldBeAssignableTo<IHasQueueDepth>();
+        receiver.ShouldNotBeAssignableTo<ILocalQueue>();
+    }
+
+    private EndpointHealthSnapshot snapshotFor(Uri uri)
+    {
+        return theRuntime.Endpoints.CollectEndpointHealth()
+            .Single(x => x.Uri == uri && x.Direction == EndpointDirection.Listening);
+    }
+
+    private static Envelope pingEnvelope(string name)
+    {
+        return new Envelope(new NativeAckPing(name)) { MessageType = typeof(NativeAckPing).ToMessageTypeName() };
+    }
+
+    private static async Task waitUntil(Func<bool> condition, string failure)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(25);
+        }
+
+        throw new TimeoutException(failure);
+    }
+
+    private static IReceiver receiverOf(IListeningAgent agent)
+    {
+        var field = typeof(ListeningAgent).GetField("_receiver", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IReceiver)field.GetValue(agent)!;
+    }
+}

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
@@ -11,7 +11,7 @@ namespace Wolverine.Runtime.Partitioning;
 /// that match global partitioning rules and re-route them through Wolverine's
 /// message routing for proper partition assignment.
 /// </summary>
-internal class GlobalPartitionedInterceptor : IReceiver
+internal class GlobalPartitionedInterceptor : IReceiver, IHasQueueDepth
 {
     private readonly IReceiver _inner;
     private readonly IWolverineRuntime _runtime;
@@ -27,6 +27,13 @@ internal class GlobalPartitionedInterceptor : IReceiver
     }
 
     public IHandlerPipeline Pipeline => _inner.Pipeline;
+
+    // GH-4186. A pass-through wrapper has to pass the depth through too. Without this the wrapped receiver's
+    // depth stopped at the wrapper and every endpoint in a global-partitioned topology reported a constant 0 --
+    // which for a Buffered or Durable receiver also meant BackPressureAgent could never fire.
+    public int QueueCount => _inner is IHasQueueDepth q ? q.QueueCount : 0;
+
+    public DateTimeOffset? LastReceivedAt => (_inner as IHasQueueDepth)?.LastReceivedAt;
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope[] messages)
     {

--- a/src/Wolverine/Runtime/WorkerQueues/IHasQueueDepth.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/IHasQueueDepth.cs
@@ -1,0 +1,34 @@
+namespace Wolverine.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4186. Optional capability for an <see cref="Wolverine.Transports.IReceiver"/> that holds deliveries in an
+/// in-memory structure and can say how deep it currently is. <see cref="ILocalQueue"/> extends this, so
+/// <c>BufferedReceiver</c> and <c>DurableReceiver</c> satisfy it for free; the receivers that are deliberately
+/// *not* local queues -- <c>InlineReceiver</c> and <c>NativeAckReceiver</c> -- implement it directly.
+///
+/// <para>
+/// This is a separate interface rather than a widening of <see cref="ILocalQueue"/> because
+/// <c>ListeningAgent.EnqueueDirectlyAsync</c> type-switches on <see cref="ILocalQueue"/> to decide how a replayed
+/// envelope re-enters a listener, and a native-ack receiver needs its own branch there (GH-4011) precisely
+/// because it must not be enqueued into like a local queue. Reporting a depth had to be separable from being one.
+/// </para>
+/// </summary>
+public interface IHasQueueDepth
+{
+    /// <summary>
+    /// How many messages this receiver is currently holding in memory. Read by <c>ListeningAgent.QueueCount</c>,
+    /// which is what reaches <see cref="Wolverine.Configuration.EndpointHealthSnapshot.QueueCount"/> and the
+    /// back pressure checks.
+    /// </summary>
+    int QueueCount { get; }
+
+    /// <summary>
+    /// GH-4186. Approximate timestamp of the last delivery this receiver accepted, stamped on receipt rather than
+    /// inferred from a depth change. Null for receivers that do not stamp it, in which case
+    /// <c>ListeningAgent.LastQueueActivityAt</c> falls back to the <c>BackPressureAgent</c>-driven change-detection
+    /// heuristic. The modes that have no <c>BackPressureAgent</c> at all -- <c>Inline</c> and <c>NativeAck</c>,
+    /// see <see cref="Wolverine.Configuration.Endpoint.ShouldEnforceBackPressure"/> -- stamp it, because for them
+    /// nothing else ever would.
+    /// </summary>
+    DateTimeOffset? LastReceivedAt => null;
+}

--- a/src/Wolverine/Runtime/WorkerQueues/ILocalQueue.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/ILocalQueue.cs
@@ -9,8 +9,9 @@ public interface ILocalReceiver
     ValueTask EnqueueAsync(Envelope envelope);
 }
 
-public interface ILocalQueue : IReceiver, ILocalReceiver
+// GH-4186: QueueCount now comes from IHasQueueDepth, which the receivers that are NOT local queues
+// (InlineReceiver, NativeAckReceiver) can implement without also claiming they can be enqueued into.
+public interface ILocalQueue : IReceiver, ILocalReceiver, IHasQueueDepth
 {
-    int QueueCount { get; }
     Uri Uri { get; }
 }

--- a/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InlineReceiver.cs
@@ -7,7 +7,7 @@ using Wolverine.Transports;
 
 namespace Wolverine.Runtime.WorkerQueues;
 
-internal class InlineReceiver : IReceiver, ILatchedReceiver
+internal class InlineReceiver : IReceiver, ILatchedReceiver, IHasQueueDepth
 {
     private readonly ILogger _logger;
     private readonly Endpoint _endpoint;
@@ -34,7 +34,33 @@ internal class InlineReceiver : IReceiver, ILatchedReceiver
 
     public IHandlerPipeline Pipeline => _pipeline;
 
+    // GH-4186. Reachable through IHasQueueDepth. There is no queue in this mode -- the count is what is
+    // currently executing -- but that is still the number an operator wants, and it used to contribute a
+    // constant 0 to EndpointHealthSnapshot because nothing read it.
     public int QueueCount => Volatile.Read(ref _inFlightCount);
+
+    /// <summary>
+    /// GH-4186. Stamped on receipt. Inline runs no BackPressureAgent (see
+    /// <see cref="Endpoint.ShouldEnforceBackPressure"/>), and that agent is the only thing that advances
+    /// ListeningAgent's change-detection heuristic, so without this LastQueueActivityAt never moved off the
+    /// listener's construction time.
+    /// </summary>
+    public DateTimeOffset? LastReceivedAt
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastReceivedTicks);
+            return ticks == 0 ? null : new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+
+    // A DateTimeOffset is too wide to write atomically, so the stamp is kept as UTC ticks.
+    private long _lastReceivedTicks;
+
+    private void stampReceipt()
+    {
+        Interlocked.Exchange(ref _lastReceivedTicks, DateTimeOffset.UtcNow.UtcTicks);
+    }
 
     public void Dispose()
     {
@@ -74,6 +100,7 @@ internal class InlineReceiver : IReceiver, ILatchedReceiver
     {
         if (messages.Length == 0) return;
 
+        stampReceipt();
         Interlocked.Add(ref _inFlightCount, messages.Length);
 
         foreach (var envelope in messages)
@@ -91,6 +118,7 @@ internal class InlineReceiver : IReceiver, ILatchedReceiver
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
+        stampReceipt();
         Interlocked.Increment(ref _inFlightCount);
 
         try

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -36,7 +36,7 @@ namespace Wolverine.Runtime.WorkerQueues;
 /// this mode exists to provide.
 /// </para>
 /// </summary>
-internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedReceiver
+internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedReceiver, IHasQueueDepth
 {
     private readonly RetryBlock<Envelope> _completeBlock;
     private readonly RetryBlock<Envelope> _deferBlock;
@@ -113,7 +113,33 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
 
     public IHandlerPipeline Pipeline { get; }
 
+    // GH-4186. Reachable through IHasQueueDepth rather than ILocalQueue: this receiver is deliberately not a
+    // local queue -- it cannot be enqueued into, because every delivery settles against the listener that
+    // brought it -- but its lane depth is exactly the saturation signal an operator wants from this mode, and
+    // it used to contribute a constant 0 to EndpointHealthSnapshot.
     public int QueueCount => (int)_receivingBlock.Count;
+
+    /// <summary>
+    /// GH-4186. Stamped on receipt rather than derived from a depth change, because this mode runs no
+    /// BackPressureAgent and the change-detection heuristic that agent drives is the only other writer -- so
+    /// LastQueueActivityAt sat frozen at listener construction for the whole life of the process.
+    /// </summary>
+    public DateTimeOffset? LastReceivedAt
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastReceivedTicks);
+            return ticks == 0 ? null : new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+
+    // A DateTimeOffset is too wide to write atomically, so the stamp is kept as UTC ticks.
+    private long _lastReceivedTicks;
+
+    private void stampReceipt(DateTimeOffset now)
+    {
+        Interlocked.Exchange(ref _lastReceivedTicks, now.UtcTicks);
+    }
 
     /// <summary>CritterWatch#942 -- set when the receiving block faults terminally (jasperfx#506).</summary>
     public bool HasFaulted { get; private set; }
@@ -149,6 +175,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
         }
 
         var now = DateTimeOffset.Now;
+        stampReceipt(now);
 
         // GH-4091. TWO passes, deliberately. Posting blocks once the execution block is at capacity, so a
         // single admit-then-post loop leaves every envelope after the first blocked one untracked -- with its
@@ -172,7 +199,10 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
-        if (await admitAsync(listener, envelope, DateTimeOffset.Now).ConfigureAwait(false) is { } entry)
+        var now = DateTimeOffset.Now;
+        stampReceipt(now);
+
+        if (await admitAsync(listener, envelope, now).ConfigureAwait(false) is { } entry)
         {
             await postAllAsync([entry]).ConfigureAwait(false);
         }

--- a/src/Wolverine/Transports/IReceiver.cs
+++ b/src/Wolverine/Transports/IReceiver.cs
@@ -84,6 +84,11 @@ internal class ReceiverWithRules : IReceiver, ILocalQueue
                                             envelope.Destination);
     }
 
-    public int QueueCount => Inner is ILocalQueue q ? q.QueueCount : 0;
+    // GH-4186: IHasQueueDepth rather than ILocalQueue, so a wrapped InlineReceiver or NativeAckReceiver -- neither
+    // of which is a local queue -- still reports its real depth instead of a constant zero.
+    public int QueueCount => Inner is IHasQueueDepth q ? q.QueueCount : 0;
+
+    public DateTimeOffset? LastReceivedAt => (Inner as IHasQueueDepth)?.LastReceivedAt;
+
     public Uri Uri => Inner is ILocalQueue q ? q.Uri : new Uri("none://none");
 }

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -45,8 +45,10 @@ public interface IListeningAgent : IListenerCircuit
     Uri Uri { get; }
 
     /// <summary>
-    /// Approximate timestamp of the last time queue activity was observed on this listener.
-    /// Based on QueueCount change detection, not individual message receipt.
+    /// Approximate timestamp of the last time queue activity was observed on this listener. Usually QueueCount
+    /// change detection rather than individual message receipt -- but GH-4186 made the receivers that run
+    /// without a BackPressureAgent (Inline, NativeAck) stamp their own receipts, because for those the change
+    /// detection has no writer at all and the value would otherwise never move off construction time.
     /// </summary>
     DateTimeOffset LastQueueActivityAt { get; }
 
@@ -163,15 +165,35 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     /// </summary>
     public bool ReceiverHasFaulted => _receiver is IFaultTrackingReceiver { HasFaulted: true };
 
-    public int QueueCount => (_receiver is ILocalQueue q ? q.QueueCount : 0)
+    // GH-4186: IHasQueueDepth, not ILocalQueue. InlineReceiver and NativeAckReceiver both maintain a depth over
+    // the same kind of block a BufferedReceiver does, but neither is a local queue -- deliberately, because a
+    // delivery in those modes settles against the listener that brought it. Reading through ILocalQueue meant
+    // both contributed a constant 0, so a saturated NativeAck listener was indistinguishable from an idle one.
+    public int QueueCount => (_receiver is IHasQueueDepth q ? q.QueueCount : 0)
                              + _runtime.BatchingPendingCounts.PendingFor(Endpoint.Uri);
 
     /// <summary>
-    /// Approximate timestamp of the last time a message was received on this listener,
-    /// tracked by observing QueueCount changes. Updated by BackPressureAgent polling
-    /// or explicit calls to <see cref="UpdateQueueCountObservation"/>.
+    /// Approximate timestamp of the last time a message was received on this listener. Receivers that stamp
+    /// their own receipts (<c>InlineReceiver</c>, <c>NativeAckReceiver</c>) report it directly; everything else
+    /// falls back to observing QueueCount changes, which is driven by BackPressureAgent polling or explicit
+    /// calls to <see cref="UpdateQueueCountObservation"/>.
     /// </summary>
-    public DateTimeOffset LastQueueActivityAt => _lastQueueCountChangeAt;
+    public DateTimeOffset LastQueueActivityAt
+    {
+        get
+        {
+            // GH-4186. The change-detection heuristic has exactly one writer, and that writer is
+            // BackPressureAgent -- which deliberately does not run for Inline or NativeAck endpoints. For those
+            // two the fallback below would return the construction timestamp forever, so prefer whatever the
+            // receiver stamped on receipt when it is the more recent of the two.
+            if (_receiver is IHasQueueDepth { LastReceivedAt: { } received } && received > _lastQueueCountChangeAt)
+            {
+                return received;
+            }
+
+            return _lastQueueCountChangeAt;
+        }
+    }
 
     /// <summary>
     /// Call periodically to update the heuristic for last message received.

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -198,7 +198,7 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         return _receiver!.EnqueueAsync(envelope);
     }
 
-    int ILocalQueue.QueueCount => _receiver?.QueueCount ?? 0;
+    int IHasQueueDepth.QueueCount => _receiver?.QueueCount ?? 0;
 
     public Uri Destination { get; }
 


### PR DESCRIPTION
Closes #4186.

## What was wrong

`ListeningAgent` read the receiver's depth through `ILocalQueue`:

```csharp
public int QueueCount => (_receiver is ILocalQueue q ? q.QueueCount : 0) + ...
```

`NativeAckReceiver` and `InlineReceiver` are deliberately **not** local queues — a delivery in either mode settles against the listener that brought it, not against a queue — so both contributed a constant `0` to `EndpointHealthSnapshot`, despite each already maintaining a real depth over a real block. The issue's inference was correct: a saturated NativeAck listener was indistinguishable from an idle one.

`LastQueueActivityAt` was the same root cause. Its change-detection heuristic has exactly one writer, `UpdateQueueCountObservation()`, whose only caller is `BackPressureAgent` — which correctly does *not* run for these two modes (`Endpoint.ShouldEnforceBackPressure`, GH-3708). So the timestamp stayed at the `DateTimeOffset.UtcNow` it was initialised with at construction, for the life of the process.

**No back-pressure behaviour was changed for `NativeAck` or `Inline`.** They still have no `BackPressureAgent`, as designed.

## The shape

Shape 2 from the issue, and the test pins *why* rather than just the outcome. A new narrow `IHasQueueDepth` that `ILocalQueue` extends:

- `BufferedReceiver` / `DurableReceiver` satisfy it for free, unchanged.
- `NativeAckReceiver` / `InlineReceiver` implement it directly — reporting a depth without claiming they can be enqueued into.

Shape 1 (`NativeAckReceiver : ILocalQueue`) was the smaller diff and the wrong one: `EnqueueDirectlyAsync` type-switches on `ILocalQueue` **before** it reaches the NativeAck branch GH-4011 added, so a NativeAck receiver claiming to be a local queue would silently take the wrong path on every DLQ replay. `a_native_ack_receiver_reports_a_depth_without_claiming_to_be_a_local_queue` guards that.

`LastReceivedAt` is a default-`null` member on the same interface, stamped on receipt by the two receivers that need it. `ListeningAgent` prefers it when it is the more recent of the two, so every other receiver keeps the existing heuristic byte-for-byte.

## One thing beyond the issue, called out deliberately

The two pass-through wrappers — `ReceiverWithRules` and `GlobalPartitionedInterceptor` — were also swallowing the depth. Delegating through them is required for the NativeAck fix to hold when incoming envelope rules or a global-partitioned topology are in play.

For `ReceiverWithRules` that is reporting only. For `GlobalPartitionedInterceptor` wrapping a **Buffered or Durable** receiver it is not: `QueueCount` read `0`, so `BackPressureAgent` could never fire on a global-partitioned endpoint and the buffer could grow unbounded. That is a real fix, but it is a behaviour change on a path the issue did not name, so flagging it rather than burying it.

## Evidence

`native_ack_queue_depth_4186` asserts on `CollectEndpointHealth()` end to end, exactly as the issue asked for — listener started through `IEndpointCollection`, handlers parked on a gate, snapshot read from the real collection.

Verified red first: with `ListeningAgent` reverted to the `ILocalQueue` read, `depth_and_receipt_activity_reach_the_endpoint_health_snapshot` times out on `QueueCount > 0` and `inline_receiver_depth_reaches_the_snapshot_too` gets `0` where it wants `1`.

Green after: 3/3 here, and CoreTests 2674/2674 with 2 pre-existing skips. `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)