### PR TITLE
GH-4116: bound broker startup by a clock, not just by an attempt count

### DIFF
--- a/docs/guide/messaging/transports/index.md
+++ b/docs/guide/messaging/transports/index.md
@@ -8,6 +8,33 @@ Community-built transports maintained outside this repository:
   Salesforce platform events (topics, custom channels, and managed event subscriptions) as ordinary
   Wolverine messages
 
+## Broker Startup Retries <Badge type="tip" text="6.31" />
+
+When a Wolverine host starts, every broker transport connects and provisions whatever it was told to
+auto-provision. A failed attempt is retried every five seconds, up to twenty attempts, until a wall-clock
+budget elapses:
+
+```csharp
+builder.Host.UseWolverine(opts =>
+{
+    // The default. Startup gives up after this and throws a BrokerInitializationException
+    // carrying the last underlying failure.
+    opts.BrokerInitializationTimeout = 2.Minutes();
+});
+```
+
+The budget is checked *between* attempts. Broker client SDKs do not accept a `CancellationToken` on their
+provisioning calls, so an attempt already in flight is never interrupted and the real worst case is the
+budget plus one client request timeout.
+
+Before 6.31 there was no clock here at all — only the count of twenty attempts. Because a single attempt
+costs whatever the broker client's own request timeout is (60 seconds for librdkafka, which backs the Kafka
+transport), an unreachable or degraded broker made host startup take **21 minutes and 38 seconds** to fail,
+measured. That is longer than most orchestrator start probes will wait, and it produced a hang rather than
+the error that was already available. Raise the budget if your broker is genuinely slow to accept
+connections at deploy time; lower it if you would rather fail fast and let your orchestrator restart the
+process.
+
 ## Building a new Transport
 
 In Wolverine parlance, a "transport" refers to one of Wolverine's adapter libraries that enable the usage of an

--- a/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
+++ b/src/Testing/CoreTests/Runtime/MockWolverineRuntime.cs
@@ -116,7 +116,8 @@ public class MockWolverineRuntime : IWolverineRuntime, IObserver<IWolverineEvent
         throw new NotImplementedException();
     }
 
-    public CancellationToken Cancellation => default;
+    // GH-4116: settable so a test can prove that a startup loop actually observes cancellation.
+    public CancellationToken Cancellation { get; set; } = default;
 
     public IMessageStore Storage { get; } = Substitute.For<IMessageStore>();
     public ILogger Logger { get; } = Substitute.For<ILogger>();

--- a/src/Testing/CoreTests/Transports/broker_initialization_budget_4116.cs
+++ b/src/Testing/CoreTests/Transports/broker_initialization_budget_4116.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using CoreTests.Runtime;
+using Shouldly;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+/// GH-4116. BrokerTransport.InitializeAsync retried a failed startup twenty times with a five second pause,
+/// and nothing bounded it by a clock. "Twenty attempts" bounds tries, not time -- and one try costs whatever
+/// the broker client's own request timeout is, which is 60s for librdkafka. Against an unreachable Kafka
+/// broker that made a Wolverine host take over twenty minutes to fail to start, measured. Longer than any
+/// sane orchestrator start probe, and longer than this repository's own 20-minute CI job cap, which is what
+/// turns a readable startup failure into a job cancellation whose logs are then discarded (GH-4098).
+///
+/// The delay also ignored cancellation outright, so a host being shut down could not break out of the loop.
+/// </summary>
+public class broker_initialization_budget_4116
+{
+    [Fact]
+    public async Task gives_up_on_the_budget_rather_than_on_the_attempt_count()
+    {
+        var runtime = new MockWolverineRuntime();
+        runtime.Options.BrokerInitializationTimeout = 2.Seconds();
+
+        var transport = new SlowFailingTransport { AttemptDuration = 250.Milliseconds() };
+
+        var stopwatch = Stopwatch.StartNew();
+        await Should.ThrowAsync<BrokerInitializationException>(async () =>
+            await transport.InitializeAsync(runtime));
+        stopwatch.Stop();
+
+        // Twenty attempts at 250ms plus nineteen five-second pauses is ~100 seconds. The budget has to be
+        // what ends this, not the attempt count.
+        transport.Attempts.ShouldBeLessThan(20);
+        stopwatch.Elapsed.ShouldBeLessThan(30.Seconds());
+    }
+
+    [Fact]
+    public async Task a_cancelled_runtime_breaks_out_of_the_retry_pause()
+    {
+        using var cancellation = new CancellationTokenSource();
+
+        var runtime = new MockWolverineRuntime
+        {
+            Cancellation = cancellation.Token
+        };
+
+        // Long enough that only cancellation can end this in any reasonable time.
+        runtime.Options.BrokerInitializationTimeout = 10.Minutes();
+
+        var transport = new SlowFailingTransport
+        {
+            AttemptDuration = TimeSpan.Zero,
+            OnAttempt = attempt =>
+            {
+                if (attempt == 2) cancellation.Cancel();
+            }
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        await Should.ThrowAsync<BrokerInitializationException>(async () =>
+            await transport.InitializeAsync(runtime));
+        stopwatch.Stop();
+
+        transport.Attempts.ShouldBe(2);
+
+        // Before GH-4116 the pause was an untokened Task.Delay, so cancelling here bought nothing and the
+        // loop ran all twenty attempts across ~95 seconds of pauses.
+        stopwatch.Elapsed.ShouldBeLessThan(30.Seconds());
+    }
+
+    [Fact]
+    public async Task a_successful_start_still_costs_one_attempt_and_no_pause()
+    {
+        var runtime = new MockWolverineRuntime();
+        var transport = new SlowFailingTransport { AttemptDuration = TimeSpan.Zero, SucceedOnAttempt = 1 };
+
+        await transport.InitializeAsync(runtime);
+
+        transport.Attempts.ShouldBe(1);
+    }
+}
+
+/// <summary>Stands in for a broker whose provisioning call is slow and then fails.</summary>
+public class SlowFailingTransport : BrokerTransport<FakeEndpoint>
+{
+    public SlowFailingTransport() : base("slowfake", "SlowFake", ["fake"])
+    {
+    }
+
+    public TimeSpan AttemptDuration { get; set; } = TimeSpan.Zero;
+
+    /// <summary>Attempt number (1-based) on which ConnectAsync should succeed instead of throwing.</summary>
+    public int? SucceedOnAttempt { get; set; }
+
+    public Action<int>? OnAttempt { get; set; }
+
+    public int Attempts { get; private set; }
+
+    protected override IEnumerable<FakeEndpoint> endpoints() => [];
+
+    protected override FakeEndpoint findEndpointByUri(Uri uri) => throw new NotSupportedException();
+
+    public override Uri ResourceUri { get; } = new("slowfake://transport");
+
+    public override async ValueTask ConnectAsync(IWolverineRuntime runtime)
+    {
+        Attempts++;
+        OnAttempt?.Invoke(Attempts);
+
+        if (AttemptDuration > TimeSpan.Zero)
+        {
+            await Task.Delay(AttemptDuration);
+        }
+
+        if (SucceedOnAttempt.HasValue && Attempts >= SucceedOnAttempt.Value) return;
+
+        throw new TimeoutException("The broker did not answer");
+    }
+
+    public override IEnumerable<PropertyColumn> DiagnosticColumns() => [];
+}

--- a/src/Wolverine/Transports/BrokerTransport.cs
+++ b/src/Wolverine/Transports/BrokerTransport.cs
@@ -93,6 +93,15 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
         // attempt 20 either -- and it read as a timeout for four months.
         Exception? lastFailure = null;
 
+        // GH-4116. Bounded by a WALL CLOCK, not only by an attempt count. "Twenty attempts" bounds tries,
+        // not time, and one try costs whatever the broker client's own request timeout is -- 60s for
+        // librdkafka -- so an unreachable or degraded broker turned host startup into a ~21 minute hang
+        // with no way out. Measured against a closed port: >20 minutes. Longer than any sane orchestrator
+        // start probe, and longer than our own 20-minute CI job cap, which is what turns a readable startup
+        // failure into an unreadable job cancellation with its logs discarded. See also GH-4100.
+        var budget = runtime.Options.BrokerInitializationTimeout;
+        var deadline = DateTimeOffset.UtcNow + budget;
+
         for (int i = 0; i < 20; i++)
         {
             try
@@ -104,10 +113,32 @@ public abstract class BrokerTransport<TEndpoint> : TransportBase<TEndpoint>, IBr
             {
                 lastFailure = e;
                 runtime.Logger.LogError(e, "Error trying to start message broker {Broker} on Attempt {Attempt} of 20", Protocol, i + 1);
+
+                // The attempt just above cannot be interrupted -- broker client SDKs do not take a
+                // CancellationToken on their provisioning calls -- so the budget is checked between
+                // attempts and the real worst case is the budget plus one attempt.
+                if (DateTimeOffset.UtcNow >= deadline)
+                {
+                    runtime.Logger.LogError(
+                        "Giving up on starting message broker {Broker} after {Attempts} attempt(s); the {Budget} budget in WolverineOptions.BrokerInitializationTimeout has elapsed",
+                        Protocol, i + 1, budget);
+                    break;
+                }
+
                 if (i < 19)
                 {
                     runtime.Logger.LogInformation("Will retry to start broker {Broker} in 5 seconds", Protocol);
-                    await Task.Delay(5.Seconds());
+
+                    // Also GH-4116: the delay used to ignore cancellation entirely, so a host being shut
+                    // down -- or a Ctrl-C -- could not break out of this loop either.
+                    try
+                    {
+                        await Task.Delay(5.Seconds(), runtime.Cancellation);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
                 }
             }
         }

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -528,6 +528,16 @@ public sealed partial class WolverineOptions
     public TimeSpan DefaultRemoteInvocationTimeout { get; set; } = 5.Seconds();
 
     /// <summary>
+    ///     GH-4116. The wall-clock budget for connecting to and provisioning an external broker at startup.
+    ///     <see cref="Wolverine.Transports.BrokerTransport{TEndpoint}"/> retries a failed attempt every five
+    ///     seconds until this elapses; a single attempt already in flight is not interrupted, so the real
+    ///     worst case is this budget plus one broker client request timeout. Was effectively unbounded before:
+    ///     the loop counted twenty attempts without a clock, and one attempt is as slow as the client's own
+    ///     request timeout -- 60s for librdkafka -- which made an unreachable broker a ~21 minute startup hang.
+    /// </summary>
+    public TimeSpan BrokerInitializationTimeout { get; set; } = 2.Minutes();
+
+    /// <summary>
     ///     Register additional services to the underlying IoC container with either .NET standard IServiceCollection extension
     ///     methods. This usage will have access to the application's
     ///     full ServiceCollection *at the time of this call*


### PR DESCRIPTION
Refs #4116. Refs #4100, #4098.

## The measurement

A Wolverine host takes **21 minutes and 38 seconds** to fail to start against an unreachable Kafka broker.

```
PROBE-4116 elapsed=00:21:38.3621011 failure=BrokerInitializationException:
  Unable to initialize the Broker kafka in time
```

That is a real run, `UseKafka("localhost:9099").AutoProvision()` against a closed port on `main`. The CI job cap is **20 minutes**.

## Why

`BrokerTransport.InitializeAsync` retries a failed startup twenty times with a five-second pause. Twenty attempts bounds *tries*, not *time* — and one try costs whatever the broker client's own request timeout is. librdkafka's is 60 seconds. 20 × (60 + 5) ≈ 21½ minutes, which is exactly what got measured.

Two consequences:

- **In CI**, host startup alone can outlive the job cap. The job is cancelled rather than failed, and a cancelled job's logs are discarded (#4098) — the same conversion of a readable failure into an unreadable cancellation that #4100 part 1 was about, arriving by a different route.
- **In production**, it is longer than most orchestrator start probes will wait, so the pod is killed mid-loop instead of surfacing the `BrokerInitializationException` that was already available on attempt one.

The retry pause also ignored cancellation entirely — `await Task.Delay(5.Seconds())` with no token — so a host being shut down, or a Ctrl-C, could not break out of the loop either. That is proven by the second test below: cancelling on attempt 2 still ran all 20.

## The change

`WolverineOptions.BrokerInitializationTimeout`, default **2 minutes**, checked between attempts. The existing loop's intended patience was 20 × 5s = 100 seconds of *waiting*, so the default preserves that intent and a little more.

Broker client SDKs take no `CancellationToken` on their provisioning calls, so an attempt already in flight is not interrupted. The honest bound is **the budget plus one client request timeout** — roughly three minutes for Kafka rather than twenty-two. The doc says so rather than claiming a hard two minutes.

## What this does and does not claim about #4116

It is the issue's own first hypothesis: *"`AlbaHost.For<Program>` startup — e.g. a Kafka admin/consumer connection retrying unboundedly while the broker container is degraded, before the tracked session even starts."* That placement is what explains the sharp clue in the issue — the test's `.Timeout(60.Seconds())` could not fire because the hang was outside the tracked session entirely.

It does **not** prove this is what happened on 2026-08-24; that evidence is gone, and #4115's SIGTERM relay has not caught a recurrence since (the only cancelled `tests.yml` job since is `33168694171`, which was CIMarten, #4083). What it does is remove the mechanism by which any broker trouble at host startup becomes a twenty-minute wedge with no diagnostics, on every transport rather than only Kafka.

On the issue's second hypothesis, teardown: Kafka's listener drain is already bounded by an explicit budget (GH-3434), and the producer flush is a bounded `Flush(10s)`, which makes startup the likelier of the two — an observation, not a proof. I have left #4116 open.

## Evidence

Three guard tests in `broker_initialization_budget_4116`, using a fake `BrokerTransport` whose `ConnectAsync` is slow and then throws.

Verified red first, on stock `main`:

| test | without the fix |
|---|---|
| `gives_up_on_the_budget_rather_than_on_the_attempt_count` | 20 attempts, ~100s |
| `a_cancelled_runtime_breaks_out_of_the_retry_pause` | `Attempts should be 2 but was 20`, 1m35s |
| `a_successful_start_still_costs_one_attempt_and_no_pause` | passes (guards against fixing this by breaking the happy path) |

Green after: 3/3, and CoreTests 2674/2674 with 2 pre-existing skips. `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)