### PR TITLE
GH-4188: see past the pass-through receiver wrappers before branching on the receiver

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/wrapped_receiver_enqueue_directly_4188.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/wrapped_receiver_enqueue_directly_4188.cs
@@ -1,0 +1,234 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4188. GH-4011 gave EnqueueDirectlyAsync a branch for NativeAckReceiver, but the type switch reads the raw
+/// _receiver field -- and that field is routinely a pass-through wrapper instead of the receiver being tested for.
+///
+/// ReceiverWithRules (any incoming envelope rule: an IncomingRules entry, an endpoint MessageType, an endpoint
+/// TenantId) unconditionally implements ILocalQueue, so a wrapped NativeAckReceiver or InlineReceiver matches the
+/// ILocalQueue branch ahead of its own and then throws from inside ReceiverWithRules.EnqueueAsync, whose Inner is
+/// not a local queue. Same exception, same call sites -- DLQ replay per GH-1942 and scheduled-message firing --
+/// as the bug GH-4011 was supposed to have closed.
+///
+/// GlobalPartitionedInterceptor is the second wrapper on the same path; it is not an ILocalQueue at all, so
+/// everything behind it fell through to the throwing else.
+/// </summary>
+public class wrapped_receiver_enqueue_directly_4188 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private WolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+        NativeAckPingHandler.Handled.Clear();
+        NativeAckPingHandler.Gate = null;
+        NativeAckPingHandler.Entered = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        NativeAckPingHandler.Gate = null;
+        NativeAckPingHandler.Entered = null;
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task native_ack_endpoint_with_an_incoming_rule_still_reaches_its_receiver()
+    {
+        var endpoint = new NativeAckStubEndpoint("na-4188", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        // The cheapest real incoming rule. Anything RulesForIncoming() yields -- an IncomingRules entry or an
+        // endpoint-level MessageType -- produces the same wrapper.
+        endpoint.TenantId = "one";
+
+        await using var agent = await startAgentAsync(endpoint);
+
+        // Guard against a vacuous pass: without the wrapper this is the plain GH-4011 test.
+        receiverOf(agent).ShouldBeOfType<ReceiverWithRules>()
+            .Inner.ShouldBeOfType<NativeAckReceiver>();
+
+        var envelope = envelopeFor("na-rule");
+
+        await agent.EnqueueDirectlyAsync([envelope]);
+
+        await waitForHandledAsync("na-rule");
+
+        // The wrapper still has to do its job -- dispatching around it would silently drop the rules.
+        envelope.TenantId.ShouldBe("one");
+    }
+
+    [Fact]
+    public async Task inline_endpoint_with_an_incoming_rule_still_reaches_its_receiver()
+    {
+        var endpoint = new StubEndpoint("inline-4188", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.Inline;
+        endpoint.TenantId = "two";
+
+        await using var agent = await startAgentAsync(endpoint);
+
+        receiverOf(agent).ShouldBeOfType<ReceiverWithRules>()
+            .Inner.ShouldBeOfType<InlineReceiver>();
+
+        var envelope = envelopeFor("inline-rule");
+
+        await agent.EnqueueDirectlyAsync([envelope]);
+
+        await waitForHandledAsync("inline-rule");
+        envelope.TenantId.ShouldBe("two");
+    }
+
+    /// <summary>
+    /// The quieter half of the same defect: a wrapped BufferedReceiver matches the generic ILocalQueue branch
+    /// instead of its own, so the replay is enqueued rather than dispatched through a
+    /// RetryOnInlineChannelCallback -- and that callback is the only thing that marks the inbox row handled on
+    /// completion (GH-1942). The message runs; the row is left behind.
+    /// </summary>
+    [Fact]
+    public async Task buffered_endpoint_with_an_incoming_rule_still_takes_the_buffered_branch()
+    {
+        var endpoint = new StubEndpoint("buffered-4188", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+        endpoint.TenantId = "three";
+
+        await using var agent = await startAgentAsync(endpoint);
+
+        receiverOf(agent).ShouldBeOfType<ReceiverWithRules>()
+            .Inner.ShouldBeOfType<BufferedReceiver>();
+
+        var envelope = envelopeFor("buffered-rule");
+
+        await agent.EnqueueDirectlyAsync([envelope]);
+
+        await waitForHandledAsync("buffered-rule");
+
+        // BufferedReceiver.ReceivedAsync stamps the listener it was handed; the ILocalQueue branch never
+        // supplies one. This is the observable difference between the two branches.
+        envelope.Listener.ShouldBeOfType<RetryOnInlineChannelCallback>();
+        envelope.TenantId.ShouldBe("three");
+    }
+
+    [Fact]
+    public async Task native_ack_endpoint_behind_a_global_partitioned_interceptor_still_reaches_its_receiver()
+    {
+        // A topology over some other message type: the interceptor gets installed, but NativeAckPing itself
+        // passes straight through to the inner receiver rather than being re-routed.
+        var topology = new GlobalPartitionedMessageTopology(theRuntime.Options);
+        topology.Message<UnrelatedPartitionedMessage>();
+        theRuntime.Options.MessagePartitioning.GlobalPartitionedTopologies.Add(topology);
+
+        try
+        {
+            var endpoint = new NativeAckStubEndpoint("na-4188-gp", new StubTransport()) { IsListener = true };
+            endpoint.Mode = EndpointMode.NativeAck;
+
+            await using var agent = await startAgentAsync(endpoint);
+
+            receiverOf(agent).ShouldBeOfType<GlobalPartitionedInterceptor>();
+
+            await agent.EnqueueDirectlyAsync([envelopeFor("na-interceptor")]);
+
+            await waitForHandledAsync("na-interceptor");
+        }
+        finally
+        {
+            theRuntime.Options.MessagePartitioning.GlobalPartitionedTopologies.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The same blindness on the other consumer of the receiver's real type. LatchReceiver hand-rolled a
+    /// one-level ReceiverWithRules unwrap (GH-3709), so anything behind a GlobalPartitionedInterceptor was
+    /// never latched -- and an unlatched receiver's DrainAsync returns immediately instead of waiting for
+    /// in-flight handlers.
+    /// </summary>
+    [Fact]
+    public async Task latch_receiver_reaches_through_a_global_partitioned_interceptor()
+    {
+        var topology = new GlobalPartitionedMessageTopology(theRuntime.Options);
+        topology.Message<UnrelatedPartitionedMessage>();
+        theRuntime.Options.MessagePartitioning.GlobalPartitionedTopologies.Add(topology);
+
+        try
+        {
+            var endpoint = new NativeAckStubEndpoint("na-4188-latch", new StubTransport()) { IsListener = true };
+            endpoint.Mode = EndpointMode.NativeAck;
+
+            await using var agent = await startAgentAsync(endpoint);
+
+            var receiver = receiverOf(agent).ShouldBeOfType<GlobalPartitionedInterceptor>();
+
+            agent.LatchReceiver();
+
+            var listener = new RecordingListener();
+            await receiver.ReceivedAsync(listener, envelopeFor("latched"));
+
+            // A latched NativeAckReceiver hands the delivery straight back to the broker rather than executing it.
+            await listener.WaitUntilAtLeast(1);
+            listener.Deferred.Count.ShouldBe(1);
+            listener.Completed.ShouldBeEmpty();
+            NativeAckPingHandler.Handled.ShouldNotContain("latched");
+        }
+        finally
+        {
+            theRuntime.Options.MessagePartitioning.GlobalPartitionedTopologies.Clear();
+        }
+    }
+
+    private async Task<ListeningAgent> startAgentAsync(Endpoint endpoint)
+    {
+        endpoint.Compile(theRuntime);
+
+        var agent = new ListeningAgent(endpoint, theRuntime);
+        await agent.StartAsync();
+
+        return agent;
+    }
+
+    private static Envelope envelopeFor(string name)
+    {
+        return new Envelope(new NativeAckPing(name))
+        {
+            MessageType = typeof(NativeAckPing).ToMessageTypeName()
+        };
+    }
+
+    private static async Task waitForHandledAsync(string name)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!NativeAckPingHandler.Handled.Contains(name) && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Yield();
+        }
+
+        NativeAckPingHandler.Handled.ShouldContain(name);
+    }
+
+    private static IReceiver receiverOf(ListeningAgent agent)
+    {
+        var field = typeof(ListeningAgent).GetField("_receiver", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IReceiver)field.GetValue(agent)!;
+    }
+}
+
+public record UnrelatedPartitionedMessage(string Name);

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
@@ -11,7 +11,7 @@ namespace Wolverine.Runtime.Partitioning;
 /// that match global partitioning rules and re-route them through Wolverine's
 /// message routing for proper partition assignment.
 /// </summary>
-internal class GlobalPartitionedInterceptor : IReceiver, IHasQueueDepth
+internal class GlobalPartitionedInterceptor : IReceiver, IHasQueueDepth, IReceiverWrapper
 {
     private readonly IReceiver _inner;
     private readonly IWolverineRuntime _runtime;
@@ -27,6 +27,11 @@ internal class GlobalPartitionedInterceptor : IReceiver, IHasQueueDepth
     }
 
     public IHandlerPipeline Pipeline => _inner.Pipeline;
+
+    // GH-4188. ListeningAgent has to be able to see past this wrapper to the receiver that actually executes
+    // messages -- otherwise everything behind it falls through EnqueueDirectlyAsync's type switch onto the throw,
+    // and LatchReceiver silently latches nothing.
+    public IReceiver Inner => _inner;
 
     // GH-4186. A pass-through wrapper has to pass the depth through too. Without this the wrapped receiver's
     // depth stopped at the wrapper and every endpoint in a global-partitioned topology reported a constant 0 --

--- a/src/Wolverine/Transports/IReceiver.cs
+++ b/src/Wolverine/Transports/IReceiver.cs
@@ -13,7 +13,40 @@ public interface IReceiver : IDisposable
     IHandlerPipeline Pipeline { get; }
 }
 
-internal class ReceiverWithRules : IReceiver, ILocalQueue
+/// <summary>
+/// GH-4188. A receiver that delegates to another receiver rather than executing messages itself.
+/// <see cref="ListeningAgent.EnqueueDirectlyAsync"/> and <see cref="ListeningAgent.LatchReceiver"/> both have to
+/// reason about the *real* receiver -- which of NativeAck, Inline, Buffered or Durable it is -- and a wrapper
+/// hides that. Worse than hiding it, <see cref="ReceiverWithRules"/> is itself an <see cref="ILocalQueue"/>, so
+/// a wrapped NativeAck or Inline receiver actively matched the wrong branch. Wrappers can nest
+/// (a GlobalPartitionedInterceptor over a ReceiverWithRules), so unwrap with <see cref="ReceiverExtensions.Unwrap"/>
+/// rather than a single cast.
+/// </summary>
+internal interface IReceiverWrapper : IReceiver
+{
+    IReceiver Inner { get; }
+}
+
+internal static class ReceiverExtensions
+{
+    /// <summary>
+    /// GH-4188. Peel every pass-through wrapper off a receiver to reach the one that actually executes messages.
+    /// Use this for *deciding* what kind of receiver you have; dispatch still belongs on the outer receiver
+    /// wherever the wrappers' own behavior -- applying incoming envelope rules, global-partition re-routing --
+    /// has to happen.
+    /// </summary>
+    internal static IReceiver Unwrap(this IReceiver receiver)
+    {
+        while (receiver is IReceiverWrapper wrapper)
+        {
+            receiver = wrapper.Inner;
+        }
+
+        return receiver;
+    }
+}
+
+internal class ReceiverWithRules : IReceiver, ILocalQueue, IReceiverWrapper
 {
     public ReceiverWithRules(IReceiver inner, IEnumerable<IEnvelopeRule> rules)
     {

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -211,12 +211,25 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
     public async Task EnqueueDirectlyAsync(IEnumerable<Envelope> envelopes)
     {
-        if (_receiver is BufferedReceiver)
+        // GH-4188. Branch on the receiver that actually executes messages, not on whatever wrapper happens to be
+        // in front of it. Endpoint.MaybeWrapReceiver wraps in ReceiverWithRules for any incoming envelope rule --
+        // and ReceiverWithRules is unconditionally an ILocalQueue, so a wrapped NativeAck or Inline receiver used
+        // to match the ILocalQueue branch below and throw from inside ReceiverWithRules.EnqueueAsync, exactly
+        // re-creating the GH-4011 failure. A GlobalPartitionedInterceptor is not an ILocalQueue at all, so
+        // anything behind it fell all the way through to the throw.
+        //
+        // Dispatch still goes through the OUTER receiver everywhere it can, so the wrappers keep doing their jobs
+        // (applying the incoming rules, re-routing globally partitioned messages). Only the ILocalQueue branch
+        // enqueues into the unwrapped receiver -- which is what ReceiverWithRules.EnqueueAsync delegates to anyway.
+        // Null until StartAsync has built one; that falls through to the same throw it always did.
+        var actual = _receiver?.Unwrap();
+
+        if (actual is BufferedReceiver)
         {
             // Agent is latched if listener is null
-            await _receiver.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
+            await _receiver!.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
         }
-        else if (_receiver is ILocalQueue queue)
+        else if (actual is ILocalQueue queue)
         {
             var uniqueNodeId = _runtime.DurabilitySettings.AssignedNodeNumber;
             foreach (var envelope in envelopes)
@@ -225,12 +238,12 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
                 await queue.EnqueueAsync(envelope);
             }
         }
-        else if (_receiver is InlineReceiver inline)
+        else if (actual is InlineReceiver)
         {
             // Agent is latched if listener is null
-            await inline.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
+            await _receiver!.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
         }
-        else if (_receiver is NativeAckReceiver nativeAck)
+        else if (actual is NativeAckReceiver)
         {
             // GH-4011. Same shape as the InlineReceiver case above, and for the same reason: a receiver whose
             // settlement rides the listener rather than a local queue. These envelopes come from the message
@@ -240,14 +253,14 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             // also has persistence configured -- durable outbox for sending, native acks on one flooding
             // listener, a perfectly legitimate combination -- threw on any DLQ replay targeting it.
             // Agent is latched if listener is null
-            await nativeAck.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
+            await _receiver!.ReceivedAsync(new RetryOnInlineChannelCallback(Listener!, _runtime), envelopes.ToArray());
         }
-        else if (_receiver is GlobalPartitionedReceiverBridge bridge)
+        else if (actual is GlobalPartitionedReceiverBridge)
         {
             // Forward to the companion local queue for sequential processing
             foreach (var envelope in envelopes)
             {
-                await bridge.ReceivedAsync(Listener!, envelope);
+                await _receiver!.ReceivedAsync(Listener!, envelope);
             }
         }
         else
@@ -275,7 +288,9 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
         // so a stop-and-drain closed the transport channel underneath running work, the unsettled deliveries
         // were requeued, and on an exclusive listener handoff the new owner re-ran them concurrently with
         // the old owner. That is exactly the intra-group concurrency the partitioned modes forbid.
-        var actual = _receiver is ReceiverWithRules rwr ? rwr.Inner : _receiver;
+        // GH-4188: Unwrap() rather than a single ReceiverWithRules cast -- the wrappers nest, and a receiver
+        // behind a GlobalPartitionedInterceptor was silently never latched at all.
+        var actual = _receiver?.Unwrap();
         if (actual is ILatchedReceiver latched)
         {
             latched.Latch();


### PR DESCRIPTION
Closes #4188.

## The defect

`ListeningAgent.EnqueueDirectlyAsync` type-switches over receiver implementations to decide how a replayed envelope re-enters the pipeline. It reads the raw `_receiver` field — but that field is routinely a **pass-through wrapper**, not the receiver the switch is looking for.

`Endpoint.MaybeWrapReceiver` installs `ReceiverWithRules` whenever `RulesForIncoming()` yields anything: an `IncomingRules` entry, an endpoint-level `MessageType`, or an endpoint-level `TenantId`. `ReceiverWithRules` is unconditionally an `ILocalQueue`, so a wrapped `NativeAckReceiver` or `InlineReceiver` matched the `ILocalQueue` branch **ahead of its own** and then threw from inside `ReceiverWithRules.EnqueueAsync`, whose `Inner` is not a local queue:

```
System.InvalidOperationException: There is no active, local queue for this listening endpoint at <uri>
```

Same exception, same call sites — DLQ replay per GH-1942 and scheduled-message firing — as the bug #4011 was supposed to have closed. #4011 added the missing branch; it did not fix the branch never being reached.

`GlobalPartitionedInterceptor` is the second wrapper on the same path. It is not an `ILocalQueue` at all, so everything behind it fell through to the throwing `else`.

A wrapped `BufferedReceiver` is the quieter third case: it matched the generic `ILocalQueue` branch instead of its own, so the replay was enqueued rather than dispatched through a `RetryOnInlineChannelCallback` — and that callback is the only thing that marks the inbox row handled on completion (GH-1942). The message ran; the row was left behind.

Noticed while working #4187 (GH-4186) and deliberately left out of scope there.

## The fix

Both wrappers now implement a small internal `IReceiverWrapper { IReceiver Inner { get; } }`, and `Unwrap()` peels them off — they nest, `GlobalPartitionedInterceptor(ReceiverWithRules(inner))` — so branch **selection** sees the receiver that actually executes messages.

**Dispatch stays on the outer receiver** everywhere it can, so the wrappers keep doing their jobs: incoming envelope rules still get applied, globally partitioned messages still get re-routed. Only the `ILocalQueue` branch enqueues into the unwrapped receiver, which is exactly what `ReceiverWithRules.EnqueueAsync` delegated to anyway.

Branch order is unchanged — `BufferedReceiver` is still tested ahead of the generic `ILocalQueue` branch, so #4011 does not regress — and a null `_receiver` still reaches the same throw it always did.

### One behavior change beyond the throw

The wrapped-`BufferedReceiver` case now dispatches through `ReceivedAsync` instead of `EnqueueAsync`, so **incoming envelope rules are applied to a replayed envelope where before they were skipped**. That is a deliberate consequence, not a side effect of fixing the inbox row: a replay should look like a delivery, and every other path into that endpoint already stamps the endpoint's `TenantId` / `MessageType`. For the two rules `RulesForIncoming()` synthesizes on its own — `TenantIdRule` and `MessageTypeRule`, both unconditional assignments — re-running them on a DLQ replay is a no-op, because the envelope was stamped by the same rules when it first arrived. A user-supplied rule in `IncomingRules` carries no such guarantee, but re-running one on a replay is exactly what a broker redelivery already does. For a scheduled message the result is what a live delivery to that endpoint would have produced. The buffered test asserts it (`envelope.TenantId`).

It is limited to that one case. Wrapped NativeAck and Inline threw before, so they have no prior behavior to change, and an unwrapped `BufferedReceiver` has no rules to apply.

`LatchReceiver` hand-rolled a one-level `ReceiverWithRules` unwrap for the same reason (GH-3709) and so never latched anything behind the interceptor. It uses the shared helper now, which matters: an unlatched receiver's `DrainAsync` returns immediately instead of waiting for in-flight handlers.

## Tests

`CoreTests/Runtime/WorkerQueues/wrapped_receiver_enqueue_directly_4188.cs` — five tests, all red before the change and each verified to fail for the right reason:

| test | pre-fix failure |
|---|---|
| NativeAck + incoming rule | `InvalidOperationException` from `ReceiverWithRules.EnqueueAsync` |
| Inline + incoming rule | same |
| NativeAck behind a `GlobalPartitionedInterceptor` | the throwing `else` |
| Buffered + incoming rule takes the Buffered branch | `envelope.Listener` was null — no `RetryOnInlineChannelCallback` |
| `LatchReceiver` through the interceptor | the envelope was executed instead of deferred |

Each asserts the receiver's real shape first, so none of them can pass vacuously against an unwrapped receiver. The rule-carrying tests also assert the rule was applied (`envelope.TenantId`), which would fail if dispatch bypassed the wrapper.

## Verification

- Full `CoreTests` green — 2679 passed, 2 skipped — including the existing #4011, GH-4186 and `native_ack_receiver` suites.
- `Bug_1942_replay_dlq_to_buffered_or_inline` green against Postgres.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings.

## Follow-up, not in this PR

Filed as #4191: `ReceiverHasFaulted` and the receiver-rebuild path in `StartAsync` type-test `IFaultTrackingReceiver` against the raw `_receiver` too, so for any endpoint with an incoming rule a terminally faulted receiver (jasperfx#506, CritterWatch#942) is never rebuilt. Same family, same `Unwrap()` helper — which is why #4191 is blocked on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


