### PR TITLE
GH-4191: unwrap before testing for a faulted receiver, and stop restacking the interceptor

### DIFF
--- a/src/Testing/CoreTests/Runtime/WorkerQueues/wrapped_receiver_fault_detection_4191.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/wrapped_receiver_fault_detection_4191.cs
@@ -1,0 +1,179 @@
+using System.Reflection;
+using JasperFx.Blocks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Partitioning;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4191. The last two raw-_receiver type tests in ListeningAgent, plus one unguarded wrap in the same method.
+///
+/// ReceiverHasFaulted and StartAsync's "never re-attach a listener to a terminally faulted receiver" guard both
+/// tested IFaultTrackingReceiver against the raw field. Neither pass-through wrapper implements that interface --
+/// only BufferedReceiver, DurableReceiver and NativeAckReceiver do -- so for any endpoint carrying an incoming
+/// envelope rule (which includes a bare endpoint-level MessageType or TenantId) a terminally faulted receiver
+/// reported healthy forever and was never rebuilt. That is exactly the silently-dead-listener case CritterWatch#942
+/// added the machinery to catch, defeated on the endpoints most likely to be non-trivially configured.
+///
+/// Third, unrelated to Unwrap() but in the same method: StartAsync is also the back pressure RESUME path, and its
+/// GlobalPartitionedInterceptor wrap was unconditional, so every latch/resume cycle added a layer.
+/// </summary>
+public class wrapped_receiver_fault_detection_4191 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private WolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        theRuntime.Options.MessagePartitioning.GlobalPartitionedTopologies.Clear();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task a_faulted_receiver_behind_an_incoming_rule_is_reported_as_faulted()
+    {
+        var endpoint = bufferedEndpoint("fault-4191");
+
+        await using var agent = await startAgentAsync(endpoint);
+
+        // Guard against a vacuous pass: an unwrapped receiver was already reported correctly.
+        var wrapper = receiverOf(agent).ShouldBeOfType<ReceiverWithRules>();
+        var inner = wrapper.Inner.ShouldBeOfType<BufferedReceiver>();
+
+        agent.ReceiverHasFaulted.ShouldBeFalse();
+
+        faultTerminally(inner);
+
+        // The receiver itself knows. Everything that has to act on it read through the wrapper and saw nothing.
+        inner.HasFaulted.ShouldBeTrue();
+        agent.ReceiverHasFaulted.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// The rebuild half, driven the way it actually happens rather than through a stop/start. StopAndDrainCoreAsync
+    /// nulls _receiver before it drains, so RestartAsync never reaches the guard at all -- a stop-then-start test
+    /// passes on unfixed code and proves nothing. MarkAsTooBusyAndStopReceivingAsync deliberately KEEPS the
+    /// receiver (its queue is what has to drain) and only drops the Listener, which is both the path that reaches
+    /// the guard and the literal CritterWatch#942 scenario: a faulted receiver's frozen QueueCount is what latches
+    /// the listener in the first place.
+    /// </summary>
+    [Fact]
+    public async Task a_faulted_receiver_behind_an_incoming_rule_is_rebuilt_on_resume()
+    {
+        var endpoint = bufferedEndpoint("rebuild-4191");
+
+        await using var agent = await startAgentAsync(endpoint);
+
+        var inner = receiverOf(agent).ShouldBeOfType<ReceiverWithRules>().Inner.ShouldBeOfType<BufferedReceiver>();
+        faultTerminally(inner);
+
+        await agent.MarkAsTooBusyAndStopReceivingAsync();
+        agent.Status.ShouldBe(ListeningStatus.TooBusy);
+
+        // Still the same faulted receiver -- MarkAsTooBusy deliberately does not touch it.
+        receiverOf(agent).ShouldBeOfType<ReceiverWithRules>().Inner.ShouldBeSameAs(inner);
+
+        await agent.StartAsync();
+
+        // Rebuilt, and re-wrapped: the endpoint still has its incoming rule.
+        var rebuilt = receiverOf(agent).ShouldBeOfType<ReceiverWithRules>();
+        rebuilt.Inner.ShouldBeOfType<BufferedReceiver>().ShouldNotBeSameAs(inner);
+        agent.ReceiverHasFaulted.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Third defect, same method. StartAsync's `??=` guards the rebuild but the interceptor wrap was unconditional,
+    /// and StartAsync is the back pressure resume path, so the chain grew by one layer per latch/resume cycle
+    /// forever. Never wrong -- every layer delegates -- just unbounded.
+    /// </summary>
+    [Fact]
+    public async Task resuming_from_back_pressure_does_not_stack_another_interceptor()
+    {
+        var topology = new GlobalPartitionedMessageTopology(theRuntime.Options);
+        topology.Message<UnrelatedPartitionedMessage>();
+        theRuntime.Options.MessagePartitioning.GlobalPartitionedTopologies.Add(topology);
+
+        var endpoint = new StubEndpoint("nesting-4191", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+
+        await using var agent = await startAgentAsync(endpoint);
+
+        var first = receiverOf(agent).ShouldBeOfType<GlobalPartitionedInterceptor>();
+        first.Inner.ShouldBeOfType<BufferedReceiver>();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await agent.MarkAsTooBusyAndStopReceivingAsync();
+            agent.Status.ShouldBe(ListeningStatus.TooBusy);
+            await agent.StartAsync();
+            agent.Status.ShouldBe(ListeningStatus.Accepting);
+        }
+
+        // One layer, still over the same receiver. Pre-fix this was an interceptor over an interceptor over an
+        // interceptor over the BufferedReceiver, and nothing would ever have unwound it.
+        var after = receiverOf(agent).ShouldBeOfType<GlobalPartitionedInterceptor>();
+        after.Inner.ShouldBeOfType<BufferedReceiver>();
+    }
+
+    private static StubEndpoint bufferedEndpoint(string name)
+    {
+        var endpoint = new StubEndpoint(name, new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+
+        // The cheapest real incoming rule -- this alone is what installs ReceiverWithRules.
+        endpoint.TenantId = "one";
+
+        return endpoint;
+    }
+
+    /// <summary>
+    /// Flip HasFaulted through the production path rather than by writing the backing field. The receivers assign
+    /// their own onBlockError onto IBlock.OnError, and that handler sets HasFaulted on exactly one condition --
+    /// a null envelope, which is the jasperfx#506 terminal-fault signature the block itself raises.
+    /// </summary>
+    private static void faultTerminally(BufferedReceiver receiver)
+    {
+        var field = typeof(BufferedReceiver)
+            .GetField("_receivingBlock", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var block = (IBlock<Envelope>)field.GetValue(receiver)!;
+
+        // The delegate is Action<T, Exception>; the receivers' own handler declares the envelope nullable and
+        // branches on exactly that, so null! is the terminal-fault signature and not a lie about the contract.
+        block.OnError!(null!, new DivideByZeroException("terminal"));
+    }
+
+    private async Task<ListeningAgent> startAgentAsync(Endpoint endpoint)
+    {
+        endpoint.Compile(theRuntime);
+
+        var agent = new ListeningAgent(endpoint, theRuntime);
+        await agent.StartAsync();
+
+        return agent;
+    }
+
+    private static IReceiver receiverOf(ListeningAgent agent)
+    {
+        var field = typeof(ListeningAgent).GetField("_receiver", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IReceiver)field.GetValue(agent)!;
+    }
+}

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -163,7 +163,11 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     /// CritterWatch#942 — see <see cref="IListeningAgent.ReceiverHasFaulted"/>. True when the
     /// current receiver's execution block has faulted terminally (jasperfx#506).
     /// </summary>
-    public bool ReceiverHasFaulted => _receiver is IFaultTrackingReceiver { HasFaulted: true };
+    // GH-4191: Unwrap() first. Neither pass-through wrapper implements IFaultTrackingReceiver, so reading the raw
+    // field made a terminally faulted receiver behind one report healthy forever -- and this flag is the only
+    // thing BackPressureAgent has to notice it by. ReceiverWithRules is installed for any incoming envelope rule,
+    // which includes a bare endpoint-level MessageType or TenantId, so "behind a wrapper" is the common case.
+    public bool ReceiverHasFaulted => _receiver?.Unwrap() is IFaultTrackingReceiver { HasFaulted: true };
 
     // GH-4186: IHasQueueDepth, not ILocalQueue. InlineReceiver and NativeAckReceiver both maintain a depth over
     // the same kind of block a BufferedReceiver does, but neither is a local queue -- deliberately, because a
@@ -422,11 +426,20 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
         // block (jasperfx#506) rejects every post and its QueueCount freezes, so reusing it turns a
         // restart into a zombie: the receive loop polls, fails to enqueue, and (for brokers that
         // settle at receipt) drops messages, forever. Rebuild instead.
-        if (_receiver is IFaultTrackingReceiver { HasFaulted: true } faulted)
+        //
+        // GH-4191: detect through Unwrap(), for the same reason ReceiverHasFaulted does. Unlike that flag this
+        // half is mode-independent -- it is reached on any restart, not only via BackPressureAgent -- so before
+        // this a wrapped faulted receiver was re-attached to a fresh listener on every restart.
+        if (_receiver?.Unwrap() is IFaultTrackingReceiver { HasFaulted: true } faulted)
         {
             _logger.LogWarning(
                 "The receiver for {Uri} had terminally faulted and is being rebuilt before the listener restarts",
                 Uri);
+
+            // Deliberately disposing the UNWRAPPED receiver rather than the outer one. The wrappers hold nothing
+            // of their own -- they forward Dispose() to Inner -- but they are IDisposable only, so disposing the
+            // outer would silently take the sync branch below and skip DurableReceiver.DisposeAsync entirely.
+            // Nulling the field drops the wrappers, and the rebuild below re-applies both of them.
             _receiver = null;
             try
             {
@@ -457,9 +470,16 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             }
         }
         // If there are global partitioned topologies and this is NOT a paired endpoint, intercept matching messages
+        // GH-4191: the `is not GlobalPartitionedInterceptor` guard. Unlike the `??=` above, this wrap used to be
+        // unconditional -- and StartAsync is also the back pressure RESUME path. MarkAsTooBusyAndStopReceivingAsync
+        // deliberately keeps _receiver alive (the queue it holds is exactly what has to drain before the listener
+        // resumes) and only drops the Listener, so every latch/resume cycle added another interceptor layer, with
+        // nothing ever removing one. Each layer only delegates, so it was never wrong -- just an unbounded chain
+        // whose per-message cost grew with the number of cycles the endpoint had been through.
         else if (_runtime.Options.MessagePartitioning.GlobalPartitionedTopologies.Count > 0
                  && !Endpoint.UsedInShardedTopology
-                 && Endpoint.Uri.Scheme != "local")
+                 && Endpoint.Uri.Scheme != "local"
+                 && _receiver is not GlobalPartitionedInterceptor)
         {
             _receiver = new GlobalPartitionedInterceptor(_receiver, _runtime);
         }


### PR DESCRIPTION
Closes #4191. Follows #4190.

Three defects in `ListeningAgent`, all in how it reasons about a receiver that is actually a pass-through wrapper. The first two are the ones #4191 describes; the third turned up while verifying them and is in the same method.

## 1–2. The last two raw-`_receiver` fault tests

```csharp
public bool ReceiverHasFaulted => _receiver is IFaultTrackingReceiver { HasFaulted: true };   // ~:166
if (_receiver is IFaultTrackingReceiver { HasFaulted: true } faulted)                          // ~:425
```

`IFaultTrackingReceiver` is implemented by `BufferedReceiver`, `DurableReceiver` and `NativeAckReceiver` — and by neither wrapper. `ReceiverWithRules` is installed for any incoming envelope rule, which includes a bare endpoint-level `MessageType` or `TenantId`, so "behind a wrapper" is the ordinary case. A terminally faulted receiver behind one reported healthy forever and was never rebuilt: the silently-dead-listener case CritterWatch#942 exists to catch, defeated on exactly the endpoints most likely to be non-trivially configured.

Both now detect through #4190's `Unwrap()`. The two halves do **not** have the same blast radius, which is worth stating since the issue is the only place it is written down: `ReceiverHasFaulted` is read only by `BackPressureAgent`, which does not run for `Inline` or `NativeAck` at all (`Endpoint.ShouldEnforceBackPressure`, GH-3708) — so that half is **Buffered and Durable only**, and there was never a periodic detector to lose for the other two modes. The `StartAsync` guard is the mode-independent one.

### The disposal subtlety

The rebuild disposes the **unwrapped** receiver, not the outer one. The wrappers hold nothing of their own and forward `Dispose()` to `Inner`, but they are `IDisposable` only — so `faulted is IAsyncDisposable ? DisposeAsync() : Dispose()` applied to the outer silently takes the sync branch and skips `DurableReceiver.DisposeAsync` entirely. Nulling the field drops the wrappers; the rebuild re-applies both.

## 3. `StartAsync` restacked the interceptor on every back-pressure resume

Not an `Unwrap()` problem. The receiver rebuild is guarded by `??=`; the wrap next to it was not:

```csharp
_receiver ??= Endpoint.MaybeWrapReceiver(await buildReceiverAsync());   // guarded
...
_receiver = new GlobalPartitionedInterceptor(_receiver, _runtime);      // NOT guarded
```

`StartAsync` is also the back-pressure **resume** path. `MarkAsTooBusyAndStopReceivingAsync` deliberately keeps `_receiver` alive — the queue it holds is precisely what has to drain before the listener resumes — and only drops the `Listener`. So every latch/resume cycle on a Buffered or Durable endpoint in a global-partitioned topology added another interceptor layer, with nothing ever removing one.

Never *incorrect*, because every layer delegates and `Dispose`/`DrainAsync` forward to inner. Just an unbounded chain whose per-message cost grows with how long the endpoint has been flapping. It wants its own guard rather than riding on `Unwrap()`, which is depth-agnostic by construction: it keeps working at any depth and so tells you nothing about the depth being wrong. Worth noting that #4190 is what makes this silent rather than fatal — before it, anything behind the interceptor threw from `EnqueueDirectlyAsync` regardless of depth, so nesting could never have been observed there.

## Evidence

`wrapped_receiver_fault_detection_4191`, three tests, each verified red first and for its own reason:

| test | pre-fix failure |
|---|---|
| faulted receiver behind a rule is reported | `agent.ReceiverHasFaulted should be True but was False` |
| faulted receiver is rebuilt on resume | `should not be same as BufferedReceiver (39097574) but was BufferedReceiver (39097574)` |
| resume does not stack an interceptor | `after.Inner should be of type BufferedReceiver but was GlobalPartitionedInterceptor` |

Two things about how they are written:

**They fault a real receiver, not a fake.** The receivers assign their own `onBlockError` onto the public settable `IBlock.OnError`, and that handler sets `HasFaulted` on exactly one condition — a null envelope, the jasperfx#506 terminal signature the block itself raises. The test reflects the block field and invokes the handler the block would have invoked, rather than writing `<HasFaulted>k__BackingField` or standing in a stub.

**The rebuild test drives `MarkAsTooBusy`, not a stop/start.** `StopAndDrainCoreAsync` nulls `_receiver` before it drains, so `RestartAsync` never reaches the guard — a stop-then-start test passes on unfixed code and proves nothing. `MarkAsTooBusyAndStopReceivingAsync` → `StartAsync` is both the path that reaches the guard and the literal CritterWatch#942 scenario, since a faulted receiver's frozen `QueueCount` is what latches the listener in the first place. Both of these came from a third session that had been started on this same issue from a task chip and stood down when we reconciled — it produced no code, and these two findings were the whole of what it contributed. Without the second one I would have written a stop-then-start test that went vacuously green.

CoreTests 2685/2685 with 2 pre-existing skips, on the rebased post-#4190 base. `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
