### PR TITLE
GH-4193: restart a locally-owned shard that stopped with nothing to report

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/paused_shard_failure_surfacing.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/paused_shard_failure_surfacing.cs
@@ -378,13 +378,97 @@ public class paused_shard_failure_surfacing
 
             await controller.StartAgentAsync(uri);
 
-            // An ordinary stop, or a wedged shard GH-3519's recovery owns. Reporting it here would fire
-            // on every deliberate stop and drown the signal this whole sweep exists to raise.
+            // A wedged shard with nothing to report is not a FAILURE to surface -- reporting it would
+            // fire on every deliberate stop and drown the signal this whole sweep exists to raise.
+            // GH-4193 does now RESTART it here (see below); this test pins that it is still not
+            // reported as a failure while doing so.
             agent.SimulateFailure(AgentStatus.Stopped, null);
 
             await controller.ReportFailedLocalAgentsAsync();
 
             await _observer.DidNotReceive().AgentPaused(Arg.Any<Uri>(), Arg.Any<ShardFailure?>());
+        }
+
+        // GH-4193. The sweep used to `continue` past a Stopped agent with no failure, on the grounds
+        // that "GH-3519's recovery in StartAgentAsync owns that one". It never got the chance:
+        // StartAgentAsync only runs when the leader emits an assignment command, and
+        // AssignmentGrid.Agent.TryBuildAssignmentCommand returns false while AssignedNode ==
+        // OriginalNode. A local stop leaves the persisted assignment row alone, so the two stay equal
+        // and no command is ever built -- both recovery paths deferred to each other and the shard's
+        // sequence never moved again. Reachable deliberately through
+        // EventStoreAgents.TryRebuildRegisteredProjectionAsync (GH-3163).
+
+        [Fact]
+        public async Task restarts_a_locally_owned_shard_that_stopped_with_nothing_to_report()
+        {
+            var uri = new Uri("event-subscriptions://marten/incident/all");
+            var agent = new FakeSubscriptionAgent(uri);
+            var controller = controllerFor(agent);
+
+            await controller.StartAgentAsync(uri);
+            agent.StartCount.ShouldBe(1);
+
+            agent.SimulateFailure(AgentStatus.Stopped, null);
+
+            await controller.ReportFailedLocalAgentsAsync();
+
+            agent.StartCount.ShouldBe(2);
+        }
+
+        [Fact]
+        public async Task restarts_it_once_per_transition_not_once_per_tick()
+        {
+            var uri = new Uri("event-subscriptions://marten/incident/all");
+            var agent = new FakeSubscriptionAgent(uri) { StaysStoppedAfterStart = true };
+            var controller = controllerFor(agent);
+
+            await controller.StartAgentAsync(uri);
+            agent.SimulateFailure(AgentStatus.Stopped, null);
+
+            // A shard that will not come back up must not be re-driven on every health tick.
+            await controller.ReportFailedLocalAgentsAsync();
+            await controller.ReportFailedLocalAgentsAsync();
+            await controller.ReportFailedLocalAgentsAsync();
+
+            agent.StartCount.ShouldBe(2);
+        }
+
+        [Fact]
+        public async Task re_arms_the_restart_after_the_shard_is_seen_running_again()
+        {
+            var uri = new Uri("event-subscriptions://marten/incident/all");
+            var agent = new FakeSubscriptionAgent(uri);
+            var controller = controllerFor(agent);
+
+            await controller.StartAgentAsync(uri);
+
+            agent.SimulateFailure(AgentStatus.Stopped, null);
+            await controller.ReportFailedLocalAgentsAsync();   // restart #1
+            await controller.ReportFailedLocalAgentsAsync();   // observes Running, clears the ledger
+
+            agent.SimulateFailure(AgentStatus.Stopped, null);
+            await controller.ReportFailedLocalAgentsAsync();   // restart #2
+
+            agent.StartCount.ShouldBe(3);
+        }
+
+        [Fact]
+        public async Task leaves_a_paused_shard_with_no_reported_reason_to_its_own_owner()
+        {
+            var uri = new Uri("event-subscriptions://marten/incident/all");
+            var agent = new FakeSubscriptionAgent(uri);
+            var controller = controllerFor(agent);
+
+            await controller.StartAgentAsync(uri);
+
+            // Paused with nothing to report is an owner that schedules its own resume -- an error
+            // backoff, or the blue/green side-effect gate. Restarting it here would fight that owner,
+            // which is what every anti-thrash guard in this class exists to prevent.
+            agent.SimulateFailure(AgentStatus.Paused, null);
+
+            await controller.ReportFailedLocalAgentsAsync();
+
+            agent.StartCount.ShouldBe(1);
         }
     }
 
@@ -435,10 +519,19 @@ public class paused_shard_failure_surfacing
             Failure = null;
         }
 
+        // GH-4193: a shard that will not stay up. Lets a test hold the agent Stopped ACROSS a restart
+        // attempt, which is the only way to observe the sweep's once-per-transition guard -- otherwise
+        // the very next sweep sees Running, clears the ledger, and re-arms.
+        public bool StaysStoppedAfterStart { get; set; }
+
         public Task StartAsync(CancellationToken cancellationToken)
         {
             StartCount++;
-            Status = AgentStatus.Running;
+            if (!StaysStoppedAfterStart)
+            {
+                Status = AgentStatus.Running;
+            }
+
             Failure = null;
             return Task.CompletedTask;
         }

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -51,6 +51,12 @@ public partial class NodeAgentController
     // than on every sweep tick. Only touched from the serialized health-check path.
     private readonly HashSet<Uri> _reportedUnreleasable = new();
 
+    // GH-4193: agents this node has already tried to restart after finding them Stopped with no failure
+    // to report. Dropped the moment the agent is seen Running again, exactly like _reportedFailures, so
+    // a shard that recovers and later wedges anew gets a fresh attempt while one that cannot stay up
+    // does not re-drive a start on every tick. Only touched from the serialized health-check path.
+    private readonly HashSet<Uri> _restartedWedgedAgents = new();
+
     // GH-3970: consecutive failures to BUILD or START an agent here, keyed by agent Uri. A failed build
     // leaves nothing in Agents, so the GH-3888 stall detector -- which sweeps the agents this node is
     // actually running -- structurally cannot see it, and no restart budget is ever consumed. Counting
@@ -538,6 +544,47 @@ public partial class NodeAgentController
     }
 
     /// <summary>
+    /// GH-4193: re-drive a locally-owned agent found <see cref="AgentStatus.Stopped" /> with no failure
+    /// to report. <see cref="StartAgentAsync" /> already knows how to replace a dead registration -- it
+    /// evicts, stops, and starts again with retries -- so this only has to call it; the gap was that
+    /// nothing ever did.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately <see cref="AgentStatus.Stopped" /> only. A <see cref="AgentStatus.Paused" /> agent
+    /// with no failure is one whose owner schedules its own resume -- an error backoff, or the
+    /// blue/green side-effect gate -- and restarting it here would fight that owner, which is the thing
+    /// the anti-thrash guards in this class exist to prevent.
+    /// </remarks>
+    private async Task restartWedgedLocalAgentAsync(Uri agentUri, AgentStatus status)
+    {
+        if (status != AgentStatus.Stopped)
+        {
+            return;
+        }
+
+        // Once per transition into the wedged state, cleared when the agent is next seen Running.
+        if (!_restartedWedgedAgents.Add(agentUri))
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "Agent {AgentUri} on node {NodeNumber} is still assigned here but its shard is stopped with no failure reported; restarting it",
+            agentUri, _runtime.Options.Durability.AssignedNodeNumber);
+
+        try
+        {
+            await StartAgentAsync(agentUri);
+        }
+        catch (Exception e)
+        {
+            // A failed start is already counted and escalated by _failedStarts / the release path; the
+            // sweep must not be taken down by one agent.
+            _logger.LogError(e, "Error restarting wedged agent {AgentUri}", agentUri);
+        }
+    }
+
+    /// <summary>
     /// Sweep this node's own agents for any that have stopped or paused underneath us on a reported
     /// failure. Runs on every node on every health-check tick, independently of leadership: the daemon
     /// pauses a shard on the node that owns it, and before this nothing in the assignment plane ever
@@ -571,14 +618,28 @@ public partial class NodeAgentController
             {
                 _reportedFailures.TryRemove(entry.Key, out _);
                 _reportedUnreleasable.Remove(entry.Key);
+                _restartedWedgedAgents.Remove(entry.Key);
                 continue;
             }
 
             var failure = subscription.Failure;
             if (failure == null)
             {
-                // Stopped with nothing to report is the ordinary wedged-shard case; GH-3519's recovery in
-                // StartAgentAsync owns that one, and reporting it here would fire on every stop.
+                // GH-4193: this used to `continue`, on the grounds that GH-3519's recovery in
+                // StartAgentAsync owns the ordinary wedged-shard case. It does not get the chance:
+                // StartAgentAsync only runs when the leader emits an assignment command, and
+                // AssignmentGrid.Agent.TryBuildAssignmentCommand returns false on
+                // `AssignedNode == OriginalNode`. A local stop does not touch the persisted assignment
+                // row, so the two stay equal forever and no command is ever built. Both recovery paths
+                // deferred to each other and the shard's sequence never moved again -- reachable
+                // deliberately through EventStoreAgents.TryRebuildRegisteredProjectionAsync (GH-3163),
+                // whose transient rebuild stops the continuous agent and has no resumeContinuousAsync.
+                //
+                // The old comment's other reason -- "would fire on every stop" -- does not hold for an
+                // agent still present in Agents: StopAgentAsync removes it from the dictionary and drops
+                // the assignment row, so Stopped-and-still-registered is BY CONSTRUCTION a wedged shard
+                // and never a deliberate stop.
+                await restartWedgedLocalAgentAsync(entry.Key, status);
                 continue;
             }
 


### PR DESCRIPTION
Closes #4193.

An event-subscription agent that stops locally **with no `Failure`** while keeping its assignment row
is invisible to both of the recovery paths that exist for exactly this case, because each one defers to
the other.

```csharp
// NodeAgentController.ReportFailedLocalAgentsAsync — runs on every node on every health tick
var failure = subscription.Failure;
if (failure == null)
{
    // Stopped with nothing to report is the ordinary wedged-shard case; GH-3519's recovery in
    // StartAgentAsync owns that one, and reporting it here would fire on every stop.
    continue;
}
```

```csharp
// AssignmentGrid.Agent.TryBuildAssignmentCommand — what decides whether StartAgentAsync ever runs
if (AssignedNode == OriginalNode)
{
    return false;
}
```

`StartAgentAsync` does house the right recovery ("still registered on this node but its shard is
stopped; restarting it", GH-3519) — but it only runs when the leader emits an assignment command, and
`OriginalNode` comes from the persisted `wolverine_node_assignments` row, which a **local** stop does
not touch. So `AssignedNode == OriginalNode` forever, no command is ever built, and the sweep's
deferral goes nowhere. The status is correct, the assignment is correct, and nothing joins the two.

### How it is reached

`EventStoreAgents.TryRebuildRegisteredProjectionAsync` (GH-3163) — the transient rebuild that exists so
an operator can rebuild a **paused or not-currently-distributed** projection. The daemon's
`rebuildProjection` opens with `stopRunningAgents(subscriptionName)`, and unlike
`EventSubscriptionAgent.RebuildAsync` the transient path has no `resumeContinuousAsync` (GH-3520) to
bring the continuous agent back.

Downstream that is [CritterWatch#1176](https://github.com/JasperFx/CritterWatch/issues/1176): the
console offers Rebuild against a projection whose agent is not currently running, the rebuild
completes, **acks success**, and leaves the shard dead with its assignment intact.

## The change

`ReportFailedLocalAgentsAsync`'s `failure == null` branch restarts the agent through the existing
`StartAgentAsync` path, which already knows how to replace a dead registration.

- **`Stopped` only.** A `Paused` agent with no failure has an owner scheduling its own resume — an error
  backoff, or the blue/green side-effect gate — and restarting it here would fight that owner.
- **Once per transition**, cleared when the agent is next seen `Running`, in the same shape
  `_reportedFailures` already uses.
- The old comment's other reason — *"would fire on every stop"* — does not hold for an agent still in
  `Agents`: `StopAgentAsync` does `Agents.TryRemove(agentUri, out _)` after stopping and drops the
  assignment row. **Stopped-and-still-registered is by construction a wedged shard, never a deliberate
  stop.**

⚠️ **Deliberate limit, stated rather than hidden:** a shard that comes up and immediately stops again is
restarted once per health tick. That is a *flapping* shard rather than a wedged one, every attempt is
logged at Information, and capping it wants its own issue rather than a guess here.

## Verification

End to end on a CritterWatch fleet, one variable, against a **deterministic** reproduction — wait until
the agent is genuinely in `AllRunningAgentUris()`, then call the transient rebuild directly (this does
*not* depend on the timing race that originally surfaced it). WolverineFx core packed from this branch
at `V6.30.1` as `6.30.1.1-cw1176.1` and consumed through a folder feed; the 16 satellite ids floor at
`>= 6.30.1` so nothing else needed repacking. Assembly identity confirmed in the build output.

| WolverineFx | result |
|---|---|
| published `6.30.1` | frozen at 554 for **161 s**; siblings advanced 554 → 1058; five `CheckAssignmentPeriod` cycles, no recovery |
| this branch | **recovers 8.4 s after the rebuild — 3 runs of 3, at the same tick every time** |

```
[ 13.30s]  ***  trip/all agent confirmed LIVE
[ 14.81s]  ***  TryRebuildRegisteredProjectionAsync(Trip:All) SENT
[ 14.85s]  ***  progression right after the transient rebuild = 52; waiting for recovery
[ 19.92s]       Trip:All:52   <- wedged, siblings at 70
[ 23.20s]  CHANGE  Trip:All:82  <- restarted by the sweep, back in step
```

**Regression:** `CoreTests` `~Agents` **362/362** on net9.0 and net10.0 after rebasing onto current
`main`; CritterWatch `ClusterTests` **47/47, 0 retries** on a fresh fleet against the patched package
(the agent-lifecycle-heaviest suite downstream).

## The tests are proven non-vacuous

Four added to `paused_shard_failure_surfacing.local_sweep`. Reverting **only** the production line fails
exactly three of them — and leaves `leaves_a_paused_shard_with_no_reported_reason_to_its_own_owner`
passing, which is the one that would catch the fix going too far:

```
with the fix:  Passed: 19
without it:    Failed: 3, Passed: 16
```

`says_nothing_about_a_shard_stopped_with_no_reason_to_report` still passes unchanged — the sweep
restarts such a shard now but still does not *report* it as a failure. Its comment is updated to say so
rather than left claiming GH-3519 owns the case.

`FakeSubscriptionAgent` gains one opt-in `StaysStoppedAfterStart` flag, defaulting to today's
behaviour: without it the fake flips to `Running` on start, so the once-per-transition guard cannot be
observed.

## Not in this PR, worth knowing

There is no Wolverine-side integration coverage of the transient rebuild running against a **live**
agent — which is how this reached a release. The reproduction above would port cleanly into
`src/Persistence/MartenTests/Distribution` alongside `inline_projection_rebuild.cs`; happy to add it
here or as a follow-up, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
