### PR TITLE
GH-4180 follow up: derive the DeduplicationId from the message

### DIFF
--- a/docs/guide/durability/idempotency.md
+++ b/docs/guide/durability/idempotency.md
@@ -25,7 +25,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Durability.KeepAfterMessageHandling = 10.Minutes();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L188-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_keepaftermessagehandling' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DocumentationSamples.cs#L204-L214' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_keepaftermessagehandling' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Logical Message Deduplication <Badge type="tip" text="6.31" />
@@ -35,9 +35,13 @@ This is opt-in, and turning it on provisions a new `wolverine_deduplication` tab
 means no schema change at all on upgrade.
 :::
 
-Everything above keys on `Envelope.Id`, which identifies **one delivery**. That is the right identity
-for "the broker handed me this same message twice", and it is the wrong identity for a different
-question:
+Everything above keys on `Envelope.Id`, which identifies **one delivery**. That's helpful to make sure that Wolverine 
+doesn't handle the exact same message more than once, but that's only keying off the Wolverine assigned message identity
+and doesn't really help you when what you're concerned about is some logical message being accidentally sent to Wolverine
+multiple times. Using the new *logical message deduplication* is allowing you to specify business logic concerns as
+the identity for another level of protection.
+
+For example:
 
 > The operator clicked *Rebuild* twice. The console republished the command after a timeout. A
 > scheduling agent pre-published tonight's 03:00 occurrence yesterday, and the scheduler published it
@@ -53,9 +57,33 @@ by Wolverine's own serialization, so it survives Rabbit MQ, Kafka, Azure Service
 rest without any transport-specific configuration. (Two transports also consume it natively: SQS/SNS
 FIFO queues and topics, and GCP Pub/Sub.)
 
+::: info
+We probably should have added this feature ages ago, but we did so in 6.31 to get ready for Wolverine to have a first
+class chron message scheduler and use the deduplication id as a way of preventing multiple executions in a chaotic world.
+:::
+
 ### Turning it on
 
 <!-- snippet: sample_enabling_message_deduplication -->
+<a id='snippet-sample_enabling_message_deduplication'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.PersistMessagesWithPostgresql("connection string");
+
+        // Opt in to logical message deduplication. This provisions a new
+        // "wolverine_deduplication" table -- nothing else about your message
+        // storage changes, and leaving this off means no schema migration at all
+        opts.Durability.EnableMessageDeduplication = true;
+
+        // How long a logical id is honoured before the reaper removes it.
+        // The default is 24 hours. This IS the guarantee, so size it against
+        // how long a duplicate could plausibly arrive
+        opts.Durability.DeduplicationWindow = 24.Hours();
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L21-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_message_deduplication' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning
@@ -74,11 +102,39 @@ process a duplicate.
 ### Deduplicating a message handler
 
 <!-- snippet: sample_deduplicated_message_handler -->
+<a id='snippet-sample_deduplicated_message_handler'></a>
+```cs
+public static class RebuildProjectionHandler
+{
+    // Wolverine will refuse to run this handler twice for the same
+    // Envelope.DeduplicationId within the deduplication window
+    [Deduplicated]
+    public static void Handle(RebuildProjection command)
+    {
+        // rebuild the projection...
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L42-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplicated_message_handler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and on the publishing side:
 
 <!-- snippet: sample_publishing_with_a_deduplication_id -->
+<a id='snippet-sample_publishing_with_a_deduplication_id'></a>
+```cs
+public static ValueTask ScheduleNightlyRebuild(IMessageBus bus, string projectionName, DateTimeOffset occurrence)
+{
+    return bus.PublishAsync(new RebuildProjection(projectionName, occurrence), new DeliveryOptions
+    {
+        // The logical identity of the WORK, not of this particular delivery.
+        // An operator double-click, a console republish, and an agent that
+        // pre-published this occurrence yesterday all produce this same id
+        DeduplicationId = $"{projectionName}|{occurrence:O}"
+    });
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L57-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publishing_with_a_deduplication_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A logical id is a `string` rather than a `Guid` on purpose: it is meant to be legible in the database
@@ -94,6 +150,20 @@ By default a message handler reads `Envelope.DeduplicationId`. You can point at 
 message itself instead, so publishers do not have to set `DeliveryOptions`:
 
 <!-- snippet: sample_deduplicated_from_the_message_body -->
+<a id='snippet-sample_deduplicated_from_the_message_body'></a>
+```cs
+public static class CreateOrderHandler
+{
+    // Derive the logical id from a member of the message itself rather than
+    // asking every publisher to set DeliveryOptions
+    [Deduplicated(ValueSource.InputMember, nameof(CreateOrder.Sku))]
+    public static void Handle(CreateOrder command)
+    {
+        // create the order...
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L72-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplicated_from_the_message_body' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `ValueSource.Header` reads an envelope header, and `ValueSource.Anything` uses the chain type's
@@ -112,6 +182,21 @@ duplicates run, and no log line distinguishes it from a working configuration.
 Set `Required = false` when a mixed stream is genuinely expected:
 
 <!-- snippet: sample_deduplication_with_optional_id -->
+<a id='snippet-sample_deduplication_with_optional_id'></a>
+```cs
+public static class MixedTrafficHandler
+{
+    // Some publishers set a logical id and some do not. Those that do are
+    // protected; those that do not are handled exactly as if the feature
+    // were off, and pay no database round trip
+    [Deduplicated(Required = false)]
+    public static void Handle(CreateOrder command)
+    {
+        // ...
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L107-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplication_with_optional_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Unkeyed messages on such a handler pay no database round trip at all.
@@ -119,6 +204,22 @@ Unkeyed messages on such a handler pay no database round trip at all.
 ### Applying it across many handlers
 
 <!-- snippet: sample_requiring_deduplication_ids_by_policy -->
+<a id='snippet-sample_requiring_deduplication_ids_by_policy'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.PersistMessagesWithPostgresql("connection string");
+        opts.Durability.EnableMessageDeduplication = true;
+
+        // Apply logical deduplication to every handler matching a filter, instead
+        // of decorating each one. Useful when the rule is "every create-style
+        // command is deduplicated" and some of the handlers are not yours
+        opts.Policies.RequireDeduplicationId(chain =>
+            chain.MessageType.CanBeCastTo<ICreateCommand>());
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L89-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_requiring_deduplication_ids_by_policy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The filter is required rather than optional. Applying logical deduplication to *every* handler would
@@ -152,6 +253,10 @@ logical id, every retry would be discarded as a duplicate of its own failed atte
 would silently never happen while the logs reported successful deduplication.
 
 ### Why a separate table
+
+::: info
+This section does not apply to RavenDb or CosmosDb backed message persistence.
+:::
 
 The claims live in `wolverine_deduplication` rather than as a column on
 `wolverine_incoming_envelopes`, for three reasons:

--- a/docs/guide/durability/idempotency.md
+++ b/docs/guide/durability/idempotency.md
@@ -83,7 +83,7 @@ using var host = await Host.CreateDefaultBuilder()
         opts.Durability.DeduplicationWindow = 24.Hours();
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L21-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_message_deduplication' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L37-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_message_deduplication' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning
@@ -115,7 +115,7 @@ public static class RebuildProjectionHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L42-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplicated_message_handler' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L58-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplicated_message_handler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and on the publishing side:
@@ -134,7 +134,7 @@ public static ValueTask ScheduleNightlyRebuild(IMessageBus bus, string projectio
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L57-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publishing_with_a_deduplication_id' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L73-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_publishing_with_a_deduplication_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A logical id is a `string` rather than a `Guid` on purpose: it is meant to be legible in the database
@@ -163,11 +163,95 @@ public static class CreateOrderHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L72-L85' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplicated_from_the_message_body' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L88-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplicated_from_the_message_body' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `ValueSource.Header` reads an envelope header, and `ValueSource.Anything` uses the chain type's
 natural default.
+
+### Deriving the id on the publishing side <Badge type="tip" text="6.32" />
+
+Everything above is the *receiving* half. On the publishing side, asking every call site to remember
+`DeliveryOptions.DeduplicationId` is exactly the kind of repetition that eventually gets forgotten at
+one call site and silently un-protects a message. So a message type can declare its own logical
+identity once, the same way it can already declare a topic name with `[Topic]` or a saga id with
+`[SagaIdentity]`:
+
+<!-- snippet: sample_deduplication_identity_on_a_member -->
+<a id='snippet-sample_deduplication_identity_on_a_member'></a>
+```cs
+// The message type declares its own logical identity once, and every publisher
+// gets it -- no DeliveryOptions at any call site
+public record ArchiveInvoice([property: DeduplicationIdentity] string InvoiceNumber, DateOnly AsOf);
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L13-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplication_identity_on_a_member' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+or, for a contract whose members you cannot decorate, name the member from the type:
+
+<!-- snippet: sample_deduplication_identity_naming_a_member -->
+<a id='snippet-sample_deduplication_identity_naming_a_member'></a>
+```cs
+// The same thing for a contract whose members you cannot decorate
+[DeduplicationIdentity(nameof(ReceiveShipment.ShipmentId))]
+public record ReceiveShipment(Guid ShipmentId, string Warehouse);
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L21-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplication_identity_naming_a_member' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Either form is applied as an `IEnvelopeRule` when the message is routed, so it reaches every
+transport, the local queues, and the outbox alike. Non-string members are converted with
+`ToString()`.
+
+When the identity is not a single member -- or the message type is generated and you cannot put an
+attribute on it at all -- configure it instead:
+
+<!-- snippet: sample_deriving_deduplication_ids -->
+<a id='snippet-sample_deriving_deduplication_ids'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .UseWolverine(opts =>
+    {
+        opts.PersistMessagesWithPostgresql("connection string");
+        opts.Durability.EnableMessageDeduplication = true;
+
+        // Compose the logical id from more than one member, or from anything
+        // else you can reach from the message
+        opts.MessageDeduplication.ByMessage<RebuildProjection>(
+            x => $"{x.ProjectionName}|{x.OccurrenceUtc:O}");
+
+        // Or, for generated message types you can neither decorate nor be
+        // bothered writing a lambda for, use the first member that matches
+        // one of these names
+        opts.MessageDeduplication.ByMemberNamed("IdempotencyKey", "DeduplicationId");
+
+        // Same thing as ByMessage<T>(), reached through the message type policies
+        opts.Policies.ForMessagesOfType<CreateOrder>()
+            .DeduplicateBy(x => $"{x.Sku}|{x.Quantity}");
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L105-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deriving_deduplication_ids' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning
+Deriving an id does not deduplicate anything by itself. It only *stamps* `Envelope.DeduplicationId`.
+Enforcement is still `[Deduplicated]` on the receiving handler or endpoint, plus
+`Durability.EnableMessageDeduplication`. The two halves are deliberately separate: the publisher and
+the consumer are frequently different applications, and the publisher should not have to know whether
+anyone downstream is deduplicating.
+:::
+
+Precedence, when more than one of these could apply to the same message:
+
+1. An explicit `DeliveryOptions.DeduplicationId` at the call site always wins.
+2. Then anything registered on `opts.MessageDeduplication` (including
+   `Policies.ForMessagesOfType<T>().DeduplicateBy()`), in registration order. Configuration beats the
+   attribute on purpose -- an application should be able to override an identity baked into a
+   contract it merely consumes.
+3. Then `[DeduplicationIdentity]` on the message type.
+
+No rule ever overwrites an id that is already set, and a rule that returns null or an empty string
+leaves the message without one -- which is how you opt a particular message out.
 
 ### Required or optional?
 
@@ -196,7 +280,7 @@ public static class MixedTrafficHandler
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L107-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplication_with_optional_id' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L151-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deduplication_with_optional_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Unkeyed messages on such a handler pay no database round trip at all.
@@ -219,7 +303,7 @@ using var host = await Host.CreateDefaultBuilder()
             chain.MessageType.CanBeCastTo<ICreateCommand>());
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L89-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_requiring_deduplication_ids_by_policy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs#L133-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_requiring_deduplication_ids_by_policy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The filter is required rather than optional. Applying logical deduplication to *every* handler would

--- a/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs
+++ b/src/Persistence/PersistenceTests/Samples/DeduplicationSamples.cs
@@ -10,6 +10,22 @@ namespace PersistenceTests.Samples;
 
 public record RebuildProjection(string ProjectionName, DateTimeOffset OccurrenceUtc);
 
+#region sample_deduplication_identity_on_a_member
+
+// The message type declares its own logical identity once, and every publisher
+// gets it -- no DeliveryOptions at any call site
+public record ArchiveInvoice([property: DeduplicationIdentity] string InvoiceNumber, DateOnly AsOf);
+
+#endregion
+
+#region sample_deduplication_identity_naming_a_member
+
+// The same thing for a contract whose members you cannot decorate
+[DeduplicationIdentity(nameof(ReceiveShipment.ShipmentId))]
+public record ReceiveShipment(Guid ShipmentId, string Warehouse);
+
+#endregion
+
 public record CreateOrder(string Sku, int Quantity);
 
 public interface ICreateCommand;
@@ -83,6 +99,34 @@ public static class DeduplicationSamples
     }
 
     #endregion
+
+    public static async Task deriving_the_id_from_the_message()
+    {
+        #region sample_deriving_deduplication_ids
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql("connection string");
+                opts.Durability.EnableMessageDeduplication = true;
+
+                // Compose the logical id from more than one member, or from anything
+                // else you can reach from the message
+                opts.MessageDeduplication.ByMessage<RebuildProjection>(
+                    x => $"{x.ProjectionName}|{x.OccurrenceUtc:O}");
+
+                // Or, for generated message types you can neither decorate nor be
+                // bothered writing a lambda for, use the first member that matches
+                // one of these names
+                opts.MessageDeduplication.ByMemberNamed("IdempotencyKey", "DeduplicationId");
+
+                // Same thing as ByMessage<T>(), reached through the message type policies
+                opts.Policies.ForMessagesOfType<CreateOrder>()
+                    .DeduplicateBy(x => $"{x.Sku}|{x.Quantity}");
+            }).StartAsync();
+
+        #endregion
+    }
 
     public static async Task blanket_policy()
     {

--- a/src/Persistence/PostgresqlTests/logical_message_deduplication.cs
+++ b/src/Persistence/PostgresqlTests/logical_message_deduplication.cs
@@ -42,6 +42,11 @@ public class logical_message_deduplication : IAsyncLifetime
 
                 opts.Policies.AutoApplyTransactions();
 
+                // GH-4180 follow up: the id is derived from the message type rather than supplied by
+                // the publisher at each call site
+                opts.MessageDeduplication
+                    .ByMessage<ComposedIdentityMessage>(x => $"{x.Tenant}|{x.Sequence}");
+
                 // Discard rather than retry, so each Send is exactly one handler attempt and the
                 // poison-check assertion below is a count rather than a race.
                 opts.OnException<DivideByZeroException>().Discard();
@@ -51,6 +56,7 @@ public class logical_message_deduplication : IAsyncLifetime
 
         DeduplicatedHandler.Received.Clear();
         UnkeyedHandler.Received.Clear();
+        DerivedIdentityHandler.Received.Clear();
         FailingDeduplicatedHandler.Attempts = 0;
     }
 
@@ -146,6 +152,48 @@ public class logical_message_deduplication : IAsyncLifetime
         FailingDeduplicatedHandler.Attempts.ShouldBe(2);
     }
 
+    // GH-4180 follow up. The publishing-side derivation is only worth anything if the id it stamps is
+    // the same id the receiving handler enforces -- these two halves are wired up in completely
+    // different places, and a routing-level test alone would pass over a handler that never sees it.
+    [Fact]
+    public async Task an_id_derived_from_a_marked_member_is_enforced()
+    {
+        await theHost.SendMessageAndWaitAsync(new MarkedIdentityMessage("invoice-17", "first"));
+
+        // Same identity member, different payload, different Envelope.Id
+        await theHost.SendMessageAndWaitAsync(new MarkedIdentityMessage("invoice-17", "second"));
+
+        await theHost.SendMessageAndWaitAsync(new MarkedIdentityMessage("invoice-18", "third"));
+
+        DerivedIdentityHandler.Received.ShouldBe(["first", "third"]);
+    }
+
+    [Fact]
+    public async Task an_id_derived_from_a_configured_lambda_is_enforced()
+    {
+        await theHost.SendMessageAndWaitAsync(new ComposedIdentityMessage("acme", 1, "first"));
+        await theHost.SendMessageAndWaitAsync(new ComposedIdentityMessage("acme", 1, "second"));
+
+        // Only the tenant differs, so this is a different logical message
+        await theHost.SendMessageAndWaitAsync(new ComposedIdentityMessage("globex", 1, "third"));
+
+        DerivedIdentityHandler.Received.ShouldBe(["first", "third"]);
+    }
+
+    [Fact]
+    public async Task an_explicit_delivery_option_still_wins_over_the_derived_id()
+    {
+        await theHost.SendMessageAndWaitAsync(new MarkedIdentityMessage("invoice-19", "first"),
+            new DeliveryOptions { DeduplicationId = "override" });
+
+        // A DIFFERENT identity member, but the same explicit override -- so if the derived id were
+        // winning, both of these would run
+        await theHost.SendMessageAndWaitAsync(new MarkedIdentityMessage("invoice-20", "second"),
+            new DeliveryOptions { DeduplicationId = "override" });
+
+        DerivedIdentityHandler.Received.ShouldHaveSingleItem().ShouldBe("first");
+    }
+
     [Fact]
     public async Task the_reaper_deletes_expired_claims_and_reports_how_many()
     {
@@ -182,6 +230,10 @@ public class logical_message_deduplication : IAsyncLifetime
 
 public record DeduplicatedMessage(string Name);
 
+public record MarkedIdentityMessage([property: DeduplicationIdentity] string InvoiceNumber, string Name);
+
+public record ComposedIdentityMessage(string Tenant, int Sequence, string Name);
+
 public record UnkeyedMessage(string Name);
 
 public record FailingDeduplicatedMessage;
@@ -192,6 +244,23 @@ public static class DeduplicatedHandler
 
     [Deduplicated]
     public static void Handle(DeduplicatedMessage message)
+    {
+        Received.Add(message.Name);
+    }
+}
+
+public static class DerivedIdentityHandler
+{
+    public static readonly List<string> Received = [];
+
+    [Deduplicated]
+    public static void Handle(MarkedIdentityMessage message)
+    {
+        Received.Add(message.Name);
+    }
+
+    [Deduplicated]
+    public static void Handle(ComposedIdentityMessage message)
     {
         Received.Add(message.Name);
     }

--- a/src/Testing/CoreTests/Runtime/Deduplication/deriving_the_deduplication_id_from_a_message.cs
+++ b/src/Testing/CoreTests/Runtime/Deduplication/deriving_the_deduplication_id_from_a_message.cs
@@ -1,0 +1,206 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Runtime.Deduplication;
+using Xunit;
+
+namespace CoreTests.Runtime.Deduplication;
+
+// GH-4180 follow up. Envelope.DeduplicationId is the LOGICAL identity of a message, and until now
+// the only way to set one was DeliveryOptions at every publishing call site. These cover deriving it
+// from the message itself the way a topic name or a saga id already is.
+public class deriving_the_deduplication_id_from_a_message
+{
+    private static async Task<Envelope> publish(object message, Action<WolverineOptions>? configure = null,
+        DeliveryOptions? options = null)
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PublishAllMessages().ToLocalQueue("deduplication");
+                configure?.Invoke(opts);
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var bus = host.MessageBus();
+
+        return options == null
+            ? bus.PreviewSubscriptions(message).Single()
+            : bus.PreviewSubscriptions(message, options).Single();
+    }
+
+    [Fact]
+    public async Task no_identity_declared_means_no_deduplication_id()
+    {
+        var envelope = await publish(new PlainMessage("nothing to see here"));
+        envelope.DeduplicationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task derive_from_a_member_marked_with_the_attribute()
+    {
+        var envelope = await publish(new MarkedMemberMessage("nightly|2026-08-30T03:00:00Z", "Orders"));
+        envelope.DeduplicationId.ShouldBe("nightly|2026-08-30T03:00:00Z");
+    }
+
+    [Fact]
+    public async Task derive_from_a_member_named_by_a_type_level_attribute()
+    {
+        var envelope = await publish(new NamedMemberMessage("Orders", "occurrence-1"));
+        envelope.DeduplicationId.ShouldBe("occurrence-1");
+    }
+
+    // The identity member does not have to be a string -- an operator reading the deduplication
+    // table wants something legible, and ToString() is what makes a Guid or a DateTimeOffset legible.
+    [Fact]
+    public async Task a_non_string_identity_member_is_converted()
+    {
+        var id = Guid.NewGuid();
+        var envelope = await publish(new GuidIdentityMessage(id));
+        envelope.DeduplicationId.ShouldBe(id.ToString());
+    }
+
+    [Fact]
+    public async Task a_null_identity_member_leaves_the_id_alone()
+    {
+        var envelope = await publish(new MarkedMemberMessage(null!, "Orders"));
+        envelope.DeduplicationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task derive_from_a_configured_lambda()
+    {
+        var envelope = await publish(new PlainMessage("Orders"),
+            opts => opts.MessageDeduplication.ByMessage<PlainMessage>(x => $"plain|{x.Name}"));
+
+        envelope.DeduplicationId.ShouldBe("plain|Orders");
+    }
+
+    [Fact]
+    public async Task derive_from_a_configured_lambda_through_message_type_policies()
+    {
+        var envelope = await publish(new PlainMessage("Orders"),
+            opts => opts.Policies.ForMessagesOfType<PlainMessage>().DeduplicateBy(x => $"policy|{x.Name}"));
+
+        envelope.DeduplicationId.ShouldBe("policy|Orders");
+    }
+
+    // A lambda that opts a particular message out has to leave the id empty rather than stamping
+    // an empty string, or a [Deduplicated(Required = true)] handler would see a present-but-useless id
+    [Fact]
+    public async Task a_lambda_returning_null_leaves_the_id_alone()
+    {
+        var envelope = await publish(new PlainMessage("Orders"),
+            opts => opts.MessageDeduplication.ByMessage<PlainMessage>(_ => null));
+
+        envelope.DeduplicationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_lambda_registered_for_a_base_type_applies_to_the_subclass()
+    {
+        var envelope = await publish(new SpecificMessage { Key = "abc" },
+            opts => opts.MessageDeduplication.ByMessage<IHaveAKey>(x => x.Key));
+
+        envelope.DeduplicationId.ShouldBe("abc");
+    }
+
+    [Fact]
+    public async Task derive_by_member_name()
+    {
+        var envelope = await publish(new PlainMessage("Orders"),
+            opts => opts.MessageDeduplication.ByMemberNamed("Nope", "Name"));
+
+        envelope.DeduplicationId.ShouldBe("Orders");
+    }
+
+    // Matches() is asked once per message type at routing-compile time, so a message type without any
+    // of the named members has to route cleanly rather than throwing when the rule is built
+    [Fact]
+    public async Task derive_by_member_name_ignores_a_message_type_without_the_member()
+    {
+        var envelope = await publish(new NoMatchingMemberMessage("Orders"),
+            opts => opts.MessageDeduplication.ByMemberNamed("IdempotencyKey"));
+
+        envelope.DeduplicationId.ShouldBeNull();
+    }
+
+    // Precedence. The publisher's explicit intent has to be the last word, or a message contract that
+    // grew a [DeduplicationIdentity] would silently start overriding call sites that already set one.
+    [Fact]
+    public async Task explicit_delivery_options_win_over_the_attribute()
+    {
+        var envelope = await publish(new MarkedMemberMessage("from-the-message", "Orders"),
+            options: new DeliveryOptions { DeduplicationId = "from-the-caller" });
+
+        envelope.DeduplicationId.ShouldBe("from-the-caller");
+    }
+
+    [Fact]
+    public async Task explicit_delivery_options_win_over_a_configured_lambda()
+    {
+        var envelope = await publish(new PlainMessage("Orders"),
+            opts => opts.MessageDeduplication.ByMessage<PlainMessage>(x => x.Name),
+            new DeliveryOptions { DeduplicationId = "from-the-caller" });
+
+        envelope.DeduplicationId.ShouldBe("from-the-caller");
+    }
+
+    // An application's own configuration is the more local statement of intent, so it beats an
+    // attribute baked into a contract the application merely consumes
+    [Fact]
+    public async Task configured_rules_win_over_the_attribute()
+    {
+        var envelope = await publish(new MarkedMemberMessage("from-the-attribute", "Orders"),
+            opts => opts.MessageDeduplication
+                .ByMessage<MarkedMemberMessage>(x => $"configured|{x.ProjectionName}"));
+
+        envelope.DeduplicationId.ShouldBe("configured|Orders");
+    }
+
+    [Fact]
+    public void more_than_one_marked_member_is_a_configuration_error()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            DeduplicationIdentity.DetermineIdentityMember(typeof(TwoMarkedMembersMessage)));
+
+        ex.Message.ShouldContain("more than one member");
+    }
+
+    [Fact]
+    public void naming_a_member_that_does_not_exist_is_a_configuration_error()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            DeduplicationIdentity.DetermineIdentityMember(typeof(BadMemberNameMessage)));
+
+        ex.Message.ShouldContain("no public property or field by that name");
+    }
+}
+
+public record PlainMessage(string Name);
+
+public record NoMatchingMemberMessage(string Description);
+
+public record MarkedMemberMessage([property: DeduplicationIdentity] string OccurrenceKey, string ProjectionName);
+
+[DeduplicationIdentity(nameof(OccurrenceKey))]
+public record NamedMemberMessage(string ProjectionName, string OccurrenceKey);
+
+public record GuidIdentityMessage([property: DeduplicationIdentity] Guid CommandId);
+
+public record TwoMarkedMembersMessage(
+    [property: DeduplicationIdentity] string One,
+    [property: DeduplicationIdentity] string Two);
+
+[DeduplicationIdentity("NotARealMember")]
+public record BadMemberNameMessage(string Name);
+
+public interface IHaveAKey
+{
+    string Key { get; }
+}
+
+public class SpecificMessage : IHaveAKey
+{
+    public string Key { get; set; } = string.Empty;
+}

--- a/src/Wolverine/Attributes/DeduplicationIdentityAttribute.cs
+++ b/src/Wolverine/Attributes/DeduplicationIdentityAttribute.cs
@@ -1,0 +1,58 @@
+namespace Wolverine.Attributes;
+
+/// <summary>
+/// GH-4180 follow up. Declares which part of a message type carries its <b>logical</b> deduplication
+/// identity, so that <see cref="Envelope.DeduplicationId" /> is derived from the message itself
+/// instead of every publisher having to remember to set <c>DeliveryOptions.DeduplicationId</c>.
+///
+/// <para>
+/// Put it on the member that holds the identity:
+/// </para>
+/// <example>
+/// <code>
+/// public record RebuildProjection([property: DeduplicationIdentity] string OccurrenceKey, string ProjectionName);
+/// </code>
+/// </example>
+///
+/// <para>
+/// or on the message type naming the member, which is the option that works for a contract you do
+/// not own the members of:
+/// </para>
+/// <example>
+/// <code>
+/// [DeduplicationIdentity(nameof(OccurrenceKey))]
+/// public record RebuildProjection(string OccurrenceKey, string ProjectionName);
+/// </code>
+/// </example>
+///
+/// <para>
+/// The member value is stamped onto the outgoing envelope through <see cref="IEnvelopeRule" />, and is
+/// only used when nothing has already set an id — an explicit <c>DeliveryOptions.DeduplicationId</c>
+/// always wins. It never <i>enforces</i> anything on its own: enforcement is
+/// <c>[Deduplicated]</c> on the receiving handler plus
+/// <c>opts.Durability.EnableMessageDeduplication</c>.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class |
+                AttributeTargets.Struct | AttributeTargets.Interface)]
+public class DeduplicationIdentityAttribute : Attribute
+{
+    public DeduplicationIdentityAttribute()
+    {
+    }
+
+    /// <param name="memberName">
+    /// The name of the property or field on the message type holding the logical identity. Only
+    /// meaningful when this attribute is placed on the message type itself.
+    /// </param>
+    public DeduplicationIdentityAttribute(string memberName)
+    {
+        MemberName = memberName;
+    }
+
+    /// <summary>
+    /// The name of the property or field on the message type holding the logical identity, when this
+    /// attribute is placed on the message type rather than directly on the member.
+    /// </summary>
+    public string? MemberName { get; }
+}

--- a/src/Wolverine/DeliveryOptions.cs
+++ b/src/Wolverine/DeliveryOptions.cs
@@ -192,7 +192,10 @@ public class DeliveryOptions
     public string? GroupId { get; set; }
 
     /// <summary>
-    /// MessageDeduplicationId for Amazon SQS FIFO Queue
+    /// GH-4180. The application defined *logical* identity of this message, enforced by
+    /// <c>[Deduplicated]</c> handlers and endpoints. Also used as the native MessageDeduplicationId
+    /// for Amazon SQS/SNS FIFO and GCP Pub/Sub. Setting it here always wins over any rule that
+    /// derives an id from the message itself. See <see cref="Envelope.DeduplicationId"/>.
     /// </summary>
     public string? DeduplicationId { get; set; }
     

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -396,7 +396,15 @@ public partial class Envelope : IHasTenantId
     public string? GroupId { get; set; }
 
     /// <summary>
-    /// MessageDeduplicationId for Amazon SQS FIFO Queue
+    /// GH-4180. The application defined *logical* identity of this message -- "rebuild projection X
+    /// for tonight's 03:00 run" -- as opposed to <see cref="Id"/>, which identifies one delivery.
+    /// Round-trips on every transport under the "deduplication-id" wire header, and is additionally
+    /// used as the native MessageDeduplicationId for Amazon SQS/SNS FIFO and GCP Pub/Sub.
+    ///
+    /// Set it explicitly with <c>DeliveryOptions.DeduplicationId</c>, or let Wolverine derive it from
+    /// the message with <c>[DeduplicationIdentity]</c> or <c>opts.MessageDeduplication</c>. It is
+    /// enforced by <c>[Deduplicated]</c> handlers when
+    /// <c>opts.Durability.EnableMessageDeduplication</c> is on.
     /// </summary>
     public string? DeduplicationId { get; set; }
 

--- a/src/Wolverine/MessageTypePolicies.cs
+++ b/src/Wolverine/MessageTypePolicies.cs
@@ -4,6 +4,7 @@ using JasperFx.Core.Reflection;
 using Wolverine.ErrorHandling;
 using Wolverine.Logging;
 using Wolverine.RateLimiting;
+using Wolverine.Runtime.Deduplication;
 using Wolverine.Runtime.Serialization.Encryption;
 
 namespace Wolverine;
@@ -185,6 +186,35 @@ public class MessageTypePolicies<T>
             : FaultPublishingMode.DlqOnly;
         _parent.FaultPublishing.SetOverride(
             typeof(T), mode, includeExceptionMessage, includeStackTrace);
+        return this;
+    }
+
+    /// <summary>
+    /// GH-4180 follow up. Derive the <b>logical</b> <see cref="Envelope.DeduplicationId"/> for every
+    /// outgoing message assignable to <typeparamref name="T"/> from the message itself, so publishers
+    /// do not have to set <c>DeliveryOptions.DeduplicationId</c> at every call site.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This never overwrites an id that is already present -- an explicit
+    /// <c>DeliveryOptions.DeduplicationId</c> wins -- and <paramref name="source"/> may return null or
+    /// an empty string to leave a particular message without one.
+    /// </para>
+    /// <para>
+    /// Deriving an id does not deduplicate anything on its own. Enforcement is <c>[Deduplicated]</c>
+    /// on the receiving handler or endpoint, plus
+    /// <see cref="DurabilitySettings.EnableMessageDeduplication"/>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// opts.Policies.ForMessagesOfType&lt;RebuildProjection&gt;()
+    ///     .DeduplicateBy(x => $"{x.ProjectionName}|{x.Occurrence:O}");
+    /// </code>
+    /// </example>
+    public MessageTypePolicies<T> DeduplicateBy(Func<T, string?> source)
+    {
+        _parent.MessageDeduplication.ByMessage(source);
         return this;
     }
 

--- a/src/Wolverine/Runtime/Deduplication/DeduplicationIdRules.cs
+++ b/src/Wolverine/Runtime/Deduplication/DeduplicationIdRules.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Runtime.Deduplication;
+
+/// <summary>
+/// Derives the logical deduplication id for any message that can be cast to <typeparamref name="T" />
+/// from a user supplied lambda. Registered through
+/// <c>opts.MessageDeduplication.ByMessage&lt;T&gt;()</c> or
+/// <c>opts.Policies.ForMessagesOfType&lt;T&gt;().DeduplicateBy()</c>.
+/// </summary>
+internal class LambdaDeduplicationIdRule<T> : IDeduplicationIdRule
+{
+    private readonly Func<T, string?> _source;
+
+    public LambdaDeduplicationIdRule(Func<T, string?> source)
+    {
+        _source = source;
+    }
+
+    public bool Matches(Type messageType) => messageType.CanBeCastTo<T>();
+
+    public void Modify(Envelope envelope)
+    {
+        // Never overwrite. The publisher's explicit DeliveryOptions.DeduplicationId is applied after
+        // the rules run and wins outright, but another rule may have already resolved an id, and a
+        // second rule quietly replacing it would make the effective identity depend on registration
+        // order.
+        if (envelope.DeduplicationId.IsNotEmpty()) return;
+
+        if (envelope.Message is T message)
+        {
+            var id = _source(message);
+            if (id.IsNotEmpty())
+            {
+                envelope.DeduplicationId = id;
+            }
+        }
+    }
+
+    public override string ToString()
+        => $"Deduplication id derived from a lambda on {typeof(T).FullNameInCode()}";
+}
+
+/// <summary>
+/// Derives the logical deduplication id from a single member of the message type — either one marked
+/// with <c>[DeduplicationIdentity]</c>, or one named by
+/// <c>opts.MessageDeduplication.ByMemberNamed()</c>.
+/// </summary>
+internal class MemberDeduplicationIdRule : IDeduplicationIdRule
+{
+    private readonly Type _messageType;
+    private readonly IDeduplicationIdSource _source;
+    private readonly string _memberName;
+
+    public MemberDeduplicationIdRule(Type messageType, string memberName, IDeduplicationIdSource source)
+    {
+        _messageType = messageType;
+        _memberName = memberName;
+        _source = source;
+    }
+
+    public bool Matches(Type messageType) => _messageType.IsAssignableFrom(messageType);
+
+    public void Modify(Envelope envelope)
+    {
+        if (envelope.DeduplicationId.IsNotEmpty()) return;
+
+        // A route is built for a declared message type, but the envelope can carry a subclass, and
+        // the compiled accessor is only valid for the type it was built against.
+        if (envelope.Message == null || !_messageType.IsInstanceOfType(envelope.Message)) return;
+
+        var id = _source.Resolve(envelope.Message);
+        if (id.IsNotEmpty())
+        {
+            envelope.DeduplicationId = id;
+        }
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closes MemberDeduplicationIdSource<,> over the message type and its identity member's type, both statically rooted by message routing. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed MemberDeduplicationIdSource<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
+    public static MemberDeduplicationIdRule For(Type messageType, System.Reflection.MemberInfo member)
+    {
+        var source = typeof(MemberDeduplicationIdSource<,>)
+            .CloseAndBuildAs<IDeduplicationIdSource>(member, messageType, member.GetMemberType()!);
+
+        return new MemberDeduplicationIdRule(messageType, member.Name, source);
+    }
+
+    public override string ToString()
+        => $"Deduplication id from {_messageType.FullNameInCode()}.{_memberName}";
+}

--- a/src/Wolverine/Runtime/Deduplication/DeduplicationIdSource.cs
+++ b/src/Wolverine/Runtime/Deduplication/DeduplicationIdSource.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Runtime.Deduplication;
+
+/// <summary>
+/// Reads the logical deduplication id off one member of a message. Split out from
+/// <see cref="MemberDeduplicationIdRule" /> so the compiled accessor can be strongly typed over the
+/// member's own type without the rule itself becoming generic.
+/// </summary>
+internal interface IDeduplicationIdSource
+{
+    string? Resolve(object message);
+}
+
+internal class MemberDeduplicationIdSource<TMessage, TValue> : IDeduplicationIdSource
+{
+    private readonly Func<TMessage, TValue> _source;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "LambdaBuilder.Getter compiles a member-access expression via FastExpressionCompiler. The member originates from a [DeduplicationIdentity] on the application's own message type, which is statically rooted by message routing. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Member-access lambda compiled via FastExpressionCompiler; AOT consumers running pre-generated handlers via TypeLoadMode.Static avoid this code path.")]
+    public MemberDeduplicationIdSource(MemberInfo member)
+    {
+        _source = LambdaBuilder.Getter<TMessage, TValue>(member);
+    }
+
+    public string? Resolve(object message)
+    {
+        return _source((TMessage)message)?.ToString();
+    }
+}

--- a/src/Wolverine/Runtime/Deduplication/DeduplicationIdentity.cs
+++ b/src/Wolverine/Runtime/Deduplication/DeduplicationIdentity.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using ImTools;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+
+namespace Wolverine.Runtime.Deduplication;
+
+/// <summary>
+/// Discovers the <c>[DeduplicationIdentity]</c> convention on a message type and compiles it into an
+/// <see cref="IEnvelopeRule" />. The mirror of <c>TopicRouting.DetermineTopicName()</c> for topic
+/// names and <c>SagaChain.DetermineSagaIdMember()</c> for saga identity: the message type declares
+/// its own identity once, and every publisher gets it without repeating itself.
+/// </summary>
+internal static class DeduplicationIdentity
+{
+    private static ImHashMap<Type, IDeduplicationIdRule?> _rules = ImHashMap<Type, IDeduplicationIdRule?>.Empty;
+
+    /// <summary>
+    /// The rule for this message type's declared deduplication identity, or null when it declares
+    /// none. Cached per message type — the answer is a property of the type's attributes and cannot
+    /// change at runtime.
+    /// </summary>
+    public static IDeduplicationIdRule? TryFindRule(Type messageType)
+    {
+        if (_rules.TryFind(messageType, out var rule))
+        {
+            return rule;
+        }
+
+        var member = DetermineIdentityMember(messageType);
+        rule = member == null ? null : MemberDeduplicationIdRule.For(messageType, member);
+
+        _rules = _rules.AddOrUpdate(messageType, rule);
+
+        return rule;
+    }
+
+    /// <summary>
+    /// The member carrying this message type's logical deduplication identity, or null for none.
+    /// A <c>[DeduplicationIdentity("Name")]</c> on the type itself wins over a marked member, so a
+    /// consuming application can point at a different member of a contract it inherits.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Reads the public members of a message type that has opted in with [DeduplicationIdentity]; such types are statically rooted through message routing. See AOT guide.")]
+    internal static MemberInfo? DetermineIdentityMember(Type messageType)
+    {
+        var members = messageType.GetFields().OfType<MemberInfo>()
+            .Concat(messageType.GetProperties())
+            .ToArray();
+
+        if (messageType.TryGetAttribute<DeduplicationIdentityAttribute>(out var attribute) &&
+            attribute.MemberName.IsNotEmpty())
+        {
+            return members.FirstOrDefault(x => x.Name == attribute.MemberName)
+                   ?? throw new InvalidOperationException(
+                       $"Message type {messageType.FullNameInCode()} is marked with [DeduplicationIdentity(\"{attribute.MemberName}\")], but has no public property or field by that name");
+        }
+
+        var marked = members.Where(x => x.HasAttribute<DeduplicationIdentityAttribute>()).ToArray();
+
+        if (marked.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"Message type {messageType.FullNameInCode()} has more than one member marked with [DeduplicationIdentity] ({marked.Select(x => x.Name).Join(", ")}). A message has exactly one logical identity; combine the parts with opts.MessageDeduplication.ByMessage<T>() instead");
+        }
+
+        return marked.FirstOrDefault();
+    }
+}

--- a/src/Wolverine/Runtime/Deduplication/IDeduplicationIdRule.cs
+++ b/src/Wolverine/Runtime/Deduplication/IDeduplicationIdRule.cs
@@ -1,0 +1,14 @@
+namespace Wolverine.Runtime.Deduplication;
+
+/// <summary>
+/// An <see cref="IEnvelopeRule" /> that derives <see cref="Envelope.DeduplicationId" /> from the
+/// outgoing message. <see cref="Matches" /> is asked once per message type when the route is built,
+/// so a rule that cannot apply to a message type costs nothing per message.
+/// </summary>
+internal interface IDeduplicationIdRule : IEnvelopeRule
+{
+    /// <summary>
+    /// Can this rule derive an id for messages of this type? Evaluated at routing-compile time.
+    /// </summary>
+    bool Matches(Type messageType);
+}

--- a/src/Wolverine/Runtime/Deduplication/MessageDeduplicationRules.cs
+++ b/src/Wolverine/Runtime/Deduplication/MessageDeduplicationRules.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using ImTools;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.Runtime.Deduplication;
+
+/// <summary>
+/// GH-4180 follow up. Application wide rules for deriving <see cref="Envelope.DeduplicationId" /> —
+/// the <b>logical</b> identity of a message, as opposed to <see cref="Envelope.Id" />, which
+/// identifies one delivery — from the message itself.
+///
+/// <para>
+/// Every rule registered here is applied to outgoing envelopes as an <see cref="IEnvelopeRule" />,
+/// and none of them ever overwrite an id that is already set: an explicit
+/// <c>DeliveryOptions.DeduplicationId</c> always wins, and the first rule to resolve an id keeps it.
+/// </para>
+///
+/// <para>
+/// Deriving an id does not by itself deduplicate anything. Enforcement is <c>[Deduplicated]</c> on
+/// the receiving handler / endpoint plus <c>opts.Durability.EnableMessageDeduplication</c>.
+/// </para>
+/// </summary>
+public class MessageDeduplicationRules
+{
+    private readonly List<IDeduplicationIdRule> _rules = new();
+
+    /// <summary>
+    /// Derive the logical deduplication id for any message that can be cast to
+    /// <typeparamref name="T" />. Return null or an empty string to leave a particular message
+    /// without an id.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// opts.MessageDeduplication.ByMessage&lt;RebuildProjection&gt;(
+    ///     x => $"{x.ProjectionName}|{x.Occurrence:O}");
+    /// </code>
+    /// </example>
+    public MessageDeduplicationRules ByMessage<T>(Func<T, string?> source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        _rules.Add(new LambdaDeduplicationIdRule<T>(source));
+        return this;
+    }
+
+    /// <summary>
+    /// Derive the logical deduplication id from the first matching property or field name found on
+    /// each message type. Useful when your message types are generated (from <c>.proto</c> files,
+    /// say) and you can neither mark a member with <c>[DeduplicationIdentity]</c> nor be bothered
+    /// writing a lambda per type. Values are converted with <c>ToString()</c>.
+    /// </summary>
+    /// <param name="memberNames">Member names to look for, in order of preference</param>
+    public MessageDeduplicationRules ByMemberNamed(params string[] memberNames)
+    {
+        if (memberNames == null || memberNames.Length == 0)
+        {
+            throw new ArgumentException("At least one member name is required", nameof(memberNames));
+        }
+
+        _rules.Add(new MemberNameDeduplicationIdRule(memberNames));
+        return this;
+    }
+
+    internal bool HasAnyRules() => _rules.Count != 0;
+
+    /// <summary>
+    /// The rules that can apply to this message type. Resolved once per route rather than per
+    /// message, so a rule for an unrelated message type costs nothing on the sending path.
+    /// </summary>
+    internal IEnumerable<IEnvelopeRule> RulesFor(Type messageType)
+    {
+        foreach (var rule in _rules)
+        {
+            if (rule.Matches(messageType))
+            {
+                yield return rule;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Resolves the logical deduplication id by looking for one of a set of member names on each message
+/// type. The per-type lookup is cached, so the reflection happens once per message type.
+/// </summary>
+internal class MemberNameDeduplicationIdRule : IDeduplicationIdRule
+{
+    private readonly string[] _memberNames;
+    private ImHashMap<Type, IDeduplicationIdSource?> _sources = ImHashMap<Type, IDeduplicationIdSource?>.Empty;
+
+    public MemberNameDeduplicationIdRule(string[] memberNames)
+    {
+        _memberNames = memberNames;
+    }
+
+    public bool Matches(Type messageType) => sourceFor(messageType) != null;
+
+    public void Modify(Envelope envelope)
+    {
+        if (envelope.DeduplicationId.IsNotEmpty()) return;
+        if (envelope.Message == null) return;
+
+        var source = sourceFor(envelope.Message.GetType());
+        if (source == null) return;
+
+        var id = source.Resolve(envelope.Message);
+        if (id.IsNotEmpty())
+        {
+            envelope.DeduplicationId = id;
+        }
+    }
+
+    private IDeduplicationIdSource? sourceFor(Type messageType)
+    {
+        if (_sources.TryFind(messageType, out var source))
+        {
+            return source;
+        }
+
+        source = tryBuildSource(messageType);
+        _sources = _sources.AddOrUpdate(messageType, source);
+
+        return source;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Member-name deduplication is opt-in; consumers preserve the target member via DAM or a trim descriptor. See AOT guide.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed MemberDeduplicationIdSource<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed MemberDeduplicationIdSource<,> resolved from runtime types; AOT consumers preserve via TrimmerRootDescriptor. See AOT guide.")]
+    private IDeduplicationIdSource? tryBuildSource(Type messageType)
+    {
+        foreach (var memberName in _memberNames)
+        {
+            MemberInfo? member = messageType.GetProperty(memberName);
+            member ??= messageType.GetField(memberName);
+
+            if (member != null)
+            {
+                return typeof(MemberDeduplicationIdSource<,>)
+                    .CloseAndBuildAs<IDeduplicationIdSource>(member, messageType, member.GetMemberType()!);
+            }
+        }
+
+        return null;
+    }
+
+    public override string ToString()
+        => $"Deduplication id from the first member named {string.Join(", ", _memberNames)}";
+}

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -6,6 +6,7 @@ using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
 using Wolverine.Attributes;
 using Wolverine.Configuration;
+using Wolverine.Runtime.Deduplication;
 using Wolverine.Runtime.Partitioning;
 using Wolverine.Runtime.RemoteInvocation;
 using Wolverine.Runtime.Scheduled;
@@ -82,6 +83,13 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         }
 
         Rules.AddRange(endpoint.OutgoingRules);
+
+        // GH-4180 follow up. Explicitly configured deduplication rules go in FIRST so that an
+        // application's own opts.MessageDeduplication registration wins over a [DeduplicationIdentity]
+        // baked into a message contract it merely consumes -- the rules only fill an empty id, so
+        // whichever runs first decides.
+        Rules.AddRange(runtime.Options.MessageDeduplication.RulesFor(messageType));
+
         Rules.AddRange(RulesForMessageType(messageType));
 
         MessageType = messageType;
@@ -294,6 +302,16 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         }
 
         rules = type.GetAllAttributes<ModifyEnvelopeAttribute>().OfType<IEnvelopeRule>().ToList();
+
+        // GH-4180 follow up. [DeduplicationIdentity] is not a ModifyEnvelopeAttribute because it is
+        // valid on a member as well as on the message type, and a member attribute is never seen by
+        // the type level scan above.
+        var deduplication = DeduplicationIdentity.TryFindRule(type);
+        if (deduplication != null)
+        {
+            rules.Add(deduplication);
+        }
+
         _rulesByMessageType = _rulesByMessageType.AddOrUpdate(type, rules);
 
         return rules;

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -13,6 +13,7 @@ using Wolverine.ErrorHandling;
 using Wolverine.Persistence;
 using Wolverine.Persistence.Durability;
 using Wolverine.Persistence.MultiTenancy;
+using Wolverine.Runtime.Deduplication;
 using Wolverine.Runtime.Handlers;
 using Wolverine.Runtime.Partitioning;
 using Wolverine.Runtime.Scheduled;
@@ -396,6 +397,17 @@ public sealed partial class WolverineOptions
     /// any explicitly defined Envelope.GroupId
     /// </summary>
     public MessagePartitioningRules MessagePartitioning { get; }
+
+    /// <summary>
+    /// GH-4180 follow up. Use to establish rules for deriving the <see cref="Envelope.DeduplicationId"/>
+    /// -- the *logical* identity of a message -- from the message itself, so that publishers do not
+    /// have to set <c>DeliveryOptions.DeduplicationId</c> by hand at every call site.
+    ///
+    /// These are applied to all outgoing messages, but never override an explicitly set
+    /// <see cref="Envelope.DeduplicationId"/>. See also the <c>[DeduplicationIdentity]</c> attribute
+    /// for declaring the identity on the message type itself.
+    /// </summary>
+    public MessageDeduplicationRules MessageDeduplication { get; } = new();
 
     /// <summary>
     /// List of <see cref="IEnvelopeRule"/> instances applied to every outgoing envelope.


### PR DESCRIPTION
Follow up to #4183. That PR shipped the *receiving* half of logical message deduplication. The publishing half was still "remember `DeliveryOptions.DeduplicationId` at every call site" — the kind of repetition that gets forgotten at exactly one call site and silently un-protects a message, with no failure to see, because an unkeyed message on a `Required = false` chain looks identical to a working one.

A message type can now declare its own logical identity once, the same way it already declares a topic name with `[Topic]` or a saga id with `[SagaIdentity]`.

## The API

```csharp
// On the member
public record ArchiveInvoice([property: DeduplicationIdentity] string InvoiceNumber, DateOnly AsOf);

// Or naming the member, for a contract whose members you cannot decorate
[DeduplicationIdentity(nameof(ReceiveShipment.ShipmentId))]
public record ReceiveShipment(Guid ShipmentId, string Warehouse);
```

and where the identity is not a single member, or the message type is generated and cannot carry an attribute at all:

```csharp
opts.MessageDeduplication.ByMessage<RebuildProjection>(x => $"{x.ProjectionName}|{x.OccurrenceUtc:O}");
opts.MessageDeduplication.ByMemberNamed("IdempotencyKey", "DeduplicationId");
opts.Policies.ForMessagesOfType<CreateOrder>().DeduplicateBy(x => $"{x.Sku}|{x.Quantity}");
```

All of these are `IEnvelopeRule` at the message type level, resolved once when the route is built rather than per message — so they reach every transport, the local queues, and the outbox alike, and a rule for an unrelated message type costs nothing on the sending path. Non-string members are converted with `ToString()`, because an operator reading the deduplication table wants something legible.

`[DeduplicationIdentity]` is deliberately **not** a `ModifyEnvelopeAttribute`: it is valid on a member as well as on the type, and the existing type-level attribute scan would never see a member attribute.

## Precedence

1. An explicit `DeliveryOptions.DeduplicationId` always wins. Otherwise a message contract that grew a `[DeduplicationIdentity]` would start overriding call sites that already set one.
2. Then `opts.MessageDeduplication` registrations, in registration order. Configuration beats the attribute on purpose — an application has to be able to override an identity baked into a contract it merely consumes.
3. Then `[DeduplicationIdentity]`.

No rule ever overwrites an id that is already set, and a rule returning null or empty leaves the message without one — which is how a particular message opts out.

## Scope

Deriving an id still does not deduplicate anything on its own. Enforcement remains `[Deduplicated]` plus `Durability.EnableMessageDeduplication`. The two halves stay separate because publisher and consumer are frequently different applications, and the publisher should not have to know whether anyone downstream is deduplicating.

## Testing

- 16 routing-level tests in `CoreTests` covering both attribute forms, both configured forms, non-string members, null members, subclass matching, the configuration-error cases, and every precedence rule.
- 3 end-to-end tests against real PostgreSQL storage in `logical_message_deduplication`. The derivation and the enforcement are wired up in completely different places, and a routing-level test alone would pass over a handler that never sees the id.

Local: `wolverine.slnx` builds clean in Release pinned to net9.0; full `CoreTests` green (2701 passed, 0 failed); `logical_message_deduplication` green (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)