### PR TITLE
Bump JasperFx to 2.57.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.8.0" />
-    <PackageVersion Include="JasperFx" Version="2.57.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.57.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.57.1" />
+    <PackageVersion Include="JasperFx" Version="2.57.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.57.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.57.2" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.57.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.57.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Moves the 2.57.x line from 2.57.1 to 2.57.2:

| Package | From | To |
|---|---|---|
| `JasperFx` | 2.57.1 | 2.57.2 |
| `JasperFx.Events` | 2.57.1 | 2.57.2 |
| `JasperFx.Events.SourceGenerator` | 2.57.1 | 2.57.2 |
| `JasperFx.SourceGenerator` | 2.57.1 | 2.57.2 |

The two source generator packages are in because they ship as part of the same line — leaving them a patch behind the runtime they generate against is the kind of skew that surfaces as a codegen mismatch rather than a restore error. Say the word if you'd rather hold them at 2.57.1 and I'll trim the diff.

`JasperFx.RuntimeCompiler` stays at 5.0.0. It is on its own line, as the comment in `Directory.Packages.props` already notes.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — **0 errors, 0 warnings**. This is the check that matters for a JasperFx bump specifically: a tightening change upstream (a new AOT/trim annotation, a type lifted from Marten/Polecat into `JasperFx.Events`) shows up as warnings in exactly the projects `wolverine_slim.slnx` omits, so a clean slim build would prove nothing here.
- `CoreTests` in Release on net9.0 — 2689 passed, 0 failed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)