### PR TITLE
GH-4198: scope priming must not manufacture the session it is guarding on

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.8.0" />
-    <PackageVersion Include="JasperFx" Version="2.57.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.57.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.57.2" />
+    <PackageVersion Include="JasperFx" Version="2.58.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.58.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.58.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.57.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.58.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.8.0" />
-    <PackageVersion Include="JasperFx" Version="2.58.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.58.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.58.0" />
+    <PackageVersion Include="JasperFx" Version="2.59.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.58.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.59.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.23.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -505,6 +505,11 @@ injected into a service that a handler depends on. Outside a handler scope (host
 tooling, plain `CreateScope()`), nothing is primed and the registration falls back to the store's own
 session factory, so an ordinary DI scope still gets an ordinary scoped session.
 
+Priming only ever hands over a session the handler or endpoint **already has**. A chain with no
+persistence in it — no session parameter, no `[Transactional]`, no storage side effect — does not open
+one just because it happens to service-locate something, and anything resolved from its scope falls
+back to the store's own session factory exactly as it would anywhere else.
+
 ::: warning New in RavenDb
 `Wolverine.RavenDb` previously registered no `IAsyncDocumentSession` in DI at all — RavenDb sessions
 only ever reached a handler through code generation, so a service-located one could not resolve.

--- a/src/Http/Wolverine.Http.Tests/CodeGeneration/scope_priming_does_not_manufacture_a_session.cs
+++ b/src/Http/Wolverine.Http.Tests/CodeGeneration/scope_priming_does_not_manufacture_a_session.cs
@@ -1,0 +1,136 @@
+using Alba;
+using IntegrationTests;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Marten;
+using Wolverine.Runtime;
+
+namespace Wolverine.Http.Tests.CodeGeneration;
+
+/// <summary>
+/// GH-4198. The GH-3001 scope priming guarded itself with a CREATING lookup, so the question "does this
+/// endpoint have a Marten session?" answered itself by opening one. Every endpoint that service-located
+/// anything -- for any reason, with or without persistence -- gained an outbox-enrolled session that is
+/// opened, handed to the priming holder, and never read again. Its cascading messages then left through
+/// an outbox nothing commits (arriving hundreds of milliseconds later, outside the tracked call that was
+/// supposed to wait for them), and under sharded multi-tenancy an endpoint declared as un-tenanted threw
+/// out of <c>OutboxedSessionFactory.OpenSession</c> on a database it never touches.
+///
+/// The sibling tests in <see cref="service_provider_source_compliance"/> could not catch this: their
+/// probe genuinely wants an <see cref="IDocumentSession"/>, and where a session is legitimate a creating
+/// lookup and a passive one are indistinguishable.
+/// </summary>
+public class scope_priming_does_not_manufacture_a_session : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeAssembly(typeof(scope_priming_does_not_manufacture_a_session).Assembly);
+            opts.ServiceLocationPolicy = ServiceLocationPolicy.AlwaysAllowed;
+
+            // An opaque scoped lambda with no persistence in it at all. Its only effect on an endpoint
+            // that takes it is that the endpoint has to service-locate.
+            opts.Services.AddScoped<IPersistenceFreeThing>(_ => new PersistenceFreeThing());
+        });
+
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(Servers.PostgresConnectionString);
+            opts.DatabaseSchemaName = "priming_no_session";
+            opts.DisableNpgsqlLogging = true;
+        }).IntegrateWithWolverine().UseLightweightSessions();
+
+        builder.Services.AddWolverineHttp();
+
+        _host = await AlbaHost.For(builder, app => app.MapWolverineEndpoints(
+            opts => opts.ServiceProviderSource = ServiceProviderSource.IsolatedAndScoped));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        await _host.DisposeAsync();
+    }
+
+    private string sourceFor(string method, string url)
+    {
+        var chains = _host.Services.GetRequiredService<WolverineHttpOptions>().Endpoints!;
+        var chain = chains.ChainFor(method, url);
+        chain.ShouldNotBeNull();
+        chain.As<ICodeFile>().InitializeSynchronously(chains.Rules, chains, _host.Services);
+        chain.SourceCode.ShouldNotBeNull();
+
+        return chain.SourceCode;
+    }
+
+    [Fact]
+    public void an_endpoint_with_no_persistence_opens_no_session()
+    {
+        var code = sourceFor("POST", "/priming/no-persistence");
+
+        // The endpoint really does service-locate, so the scope -- and the priming -- are in play...
+        code.ShouldContain("_serviceScopeFactory.Create");
+        code.ShouldContain("ScopedMessageContextHolder");
+
+        // ...and this is the whole bug: an endpoint that touches no documents, is not [Transactional],
+        // and never calls SaveChangesAsync should not be opening a Marten session
+        code.ShouldNotContain("OpenSession");
+        code.ShouldNotContain("ScopedDocumentSessionHolder");
+    }
+
+    [Fact]
+    public void an_endpoint_that_uses_a_session_is_still_primed_with_it()
+    {
+        var code = sourceFor("POST", "/priming/with-session");
+
+        code.ShouldContain("_outboxedSessionFactory.OpenSession");
+        code.ShouldContain("ScopedDocumentSessionHolder");
+    }
+}
+
+public record PrimingCascade;
+
+public interface IPersistenceFreeThing;
+
+public class PersistenceFreeThing : IPersistenceFreeThing;
+
+public static class PrimingEndpoints
+{
+    [WolverinePost("/priming/no-persistence")]
+    public static (IResult, OutgoingMessages) NoPersistence(IPersistenceFreeThing thing)
+    {
+        return (Results.Ok(), [new PrimingCascade()]);
+    }
+
+    [WolverinePost("/priming/with-session")]
+    public static IResult WithSession(IPersistenceFreeThing thing, IDocumentSession session)
+    {
+        session.Store(new PrimingDoc());
+        return Results.Ok();
+    }
+
+}
+
+// Somewhere for the cascaded message to land
+public static class PrimingCascadeHandler
+{
+    public static void Handle(PrimingCascade cascade)
+    {
+    }
+}
+
+public class PrimingDoc
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/src/Persistence/MartenTests/scope_priming_only_primes_an_existing_session.cs
+++ b/src/Persistence/MartenTests/scope_priming_only_primes_an_existing_session.cs
@@ -1,0 +1,135 @@
+using IntegrationTests;
+using JasperFx.CodeGeneration.Model;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Marten;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests;
+
+/// <summary>
+/// GH-4198. The GH-3001 scope priming is documented as self-guarding: a chain with no session of its own
+/// primes nothing. It was not. The guard asked <c>TryFindVariable(typeof(IDocumentSession),
+/// VariableSource.NotServices)</c>, and a variable source is a FACTORY -- Wolverine.Marten's
+/// <c>SessionVariableSource</c> answers that question by building an outbox-enrolled session. So every
+/// chain that service-located anything, for any reason, gained a Marten session it never asked for:
+/// opened, handed to the priming holder, never read, and never committed. Its cascading messages then
+/// left through the un-committed outbox rather than inline, and under sharded multi-tenancy
+/// <c>OutboxedSessionFactory.OpenSession</c> threw outright on a handler that touches no database.
+/// </summary>
+/// <remarks>
+/// These assert on the GENERATED SOURCE because that is where the difference lives. Both shapes run and
+/// both pass their own assertions -- the manufactured session is invisible at runtime right up until it
+/// is not, which is why <see cref="Wolverine.Http.Tests.CodeGeneration"/>'s priming tests could not see
+/// it: every one of them uses a probe that genuinely wants a session, where a creating lookup and a
+/// passive one give the same answer.
+/// </remarks>
+public class scope_priming_only_primes_an_existing_session : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private IHost _host = null!;
+
+    public scope_priming_only_primes_an_existing_session(ITestOutputHelper output) => _output = output;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(NoPersistenceHandler))
+                    .IncludeType(typeof(WritesThroughASessionHandler));
+
+                opts.ServiceLocationPolicy = ServiceLocationPolicy.AlwaysAllowed;
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // An 'opaque' scoped lambda with nothing to do with Marten. Its only effect is that any
+                // chain needing it has to service-locate, which creates the child scope that the
+                // priming attaches to.
+                opts.Services.AddScoped<IOpaqueThing>(_ => new OpaqueThing());
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "scope_priming";
+                }).IntegrateWithWolverine().UseLightweightSessions();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private string sourceFor<T>()
+    {
+        _host.GetRuntime().Handlers.HandlerFor<T>();
+        var chain = _host.GetRuntime().Handlers.ChainFor<T>();
+        chain.ShouldNotBeNull();
+        chain.SourceCode.ShouldNotBeNull();
+        _output.WriteLine(chain.SourceCode);
+        return chain.SourceCode;
+    }
+
+    [Fact]
+    public void a_chain_with_no_persistence_gets_no_session_at_all()
+    {
+        var code = sourceFor<NoPersistenceCommand>();
+
+        // The scope really is created -- this chain does service-locate...
+        code.ShouldContain("_serviceScopeFactory.Create");
+        // ...and the MessageContext priming still happens, because that context IS the chain's own
+        code.ShouldContain("ScopedMessageContextHolder");
+
+        // ...but nothing here wanted a Marten session, so nothing opens one
+        code.ShouldNotContain("OpenSession");
+        code.ShouldNotContain("ScopedDocumentSessionHolder");
+    }
+
+    [Fact]
+    public void a_chain_that_really_has_a_session_is_still_primed_with_it()
+    {
+        var code = sourceFor<WriteThroughASession>();
+
+        // GH-3001, unchanged: the located IOpaqueThing shares the handler's own enrolled session
+        code.ShouldContain("_outboxedSessionFactory.OpenSession");
+        code.ShouldContain("ScopedDocumentSessionHolder");
+
+        // ...and exactly one session, not one for the handler and another for the scope
+        code.Split("OpenSession").Length.ShouldBe(2);
+    }
+}
+
+public record NoPersistenceCommand;
+
+public record WriteThroughASession;
+
+public interface IOpaqueThing;
+
+public class OpaqueThing : IOpaqueThing;
+
+[WolverineIgnore]
+public static class NoPersistenceHandler
+{
+    // No Marten anywhere: not a parameter, not a side effect, not [Transactional]
+    public static void Handle(NoPersistenceCommand command, IOpaqueThing thing)
+    {
+    }
+}
+
+[WolverineIgnore]
+public static class WritesThroughASessionHandler
+{
+    public static void Handle(WriteThroughASession command, IDocumentSession session, IOpaqueThing thing)
+    {
+        session.Store(new Part { Name = "widget" });
+    }
+}

--- a/src/Wolverine/Persistence/PrimeScopedSessionFrame.cs
+++ b/src/Wolverine/Persistence/PrimeScopedSessionFrame.cs
@@ -16,7 +16,9 @@ namespace Wolverine.Persistence;
 /// <remarks>
 /// Registered by each store integration through <c>WolverineOptions.ScopingFrameSources</c>. The frame
 /// self-guards: a chain that never created one of this store's sessions emits nothing, which is what
-/// lets a host integrate several stores at once.
+/// lets a host integrate several stores at once. That guard has to be a non-creating lookup, or it
+/// manufactures the very thing it is testing for -- see the note in <see cref="FindVariables" /> and
+/// GH-4198.
 /// </remarks>
 internal sealed class PrimeScopedSessionFrame<TSession, THolder> : SyncFrame, IUsesServiceProviderFrame
     where TSession : class
@@ -31,9 +33,15 @@ internal sealed class PrimeScopedSessionFrame<TSession, THolder> : SyncFrame, IU
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {
-        // The enrolled session the chain's own transactional frame created (NotServices: never the
-        // container's own scoped session registration).
-        _session = chain.TryFindVariable(typeof(TSession), VariableSource.NotServices);
+        // The enrolled session the chain's own transactional frame created -- and ONLY that. This has
+        // to be VariableSource.Existing: All/NotServices run the registered IVariableSource
+        // implementations, and a variable source is a factory, so asking either of those whether the
+        // chain has a session MANUFACTURES one. Every store integration registers such a source (see
+        // Wolverine.Marten's SessionVariableSource), so the creating form gave every chain that
+        // service-locates anything an outbox-enrolled session it never asked for: opened, handed to
+        // the holder below, never read and never committed -- and under sharded multi-tenancy, an
+        // outright throw on a database the chain does not use. See GH-4198.
+        _session = chain.TryFindVariable(typeof(TSession), VariableSource.Existing);
         if (_session != null)
         {
             yield return _session;

--- a/src/Wolverine/Runtime/Handlers/PrimeScopedMessageContextFrame.cs
+++ b/src/Wolverine/Runtime/Handlers/PrimeScopedMessageContextFrame.cs
@@ -30,6 +30,13 @@ internal sealed class PrimeScopedMessageContextFrame : SyncFrame, IUsesServicePr
         // Wolverine's codegen creates, and not all of them belong to a message handler or an HTTP
         // endpoint. A handler finds its MessageContext argument and an HTTP chain finds one through
         // MessageBusSource; anything else primes nothing rather than forcing a context into existence.
+        //
+        // NotServices, not Existing, and deliberately so: a variable source is a factory, so this DOES
+        // build a MessageContext for a chain that had no other reason to name one. That is the right
+        // answer here -- the context is the one the chain would use for any message it sends, and
+        // priming the scope with it is the whole point of GH-3001. The persistence sessions in
+        // PrimeScopedSessionFrame are the opposite case: manufacturing one invents a database
+        // connection and an outbox enrolment that nothing in the chain will ever commit. See GH-4198.
         _context = chain.TryFindVariable(typeof(MessageContext), VariableSource.NotServices);
         if (_context != null)
         {


### PR DESCRIPTION
Closes #4198.

> ⚠️ **Draft: blocked on [jasperfx#719](https://github.com/JasperFx/jasperfx/pull/719) and a JasperFx **2.58.0** release.** `Directory.Packages.props` is already pinned to `2.58.0`, so restore fails until that is published and then this goes green on a re-run. jasperfx#719 is green.

## What is broken

Since 6.30.3, every message handler and HTTP endpoint that service-locates **anything** — for any reason, with or without persistence — opens an outbox-enrolled Marten session it never asked for:

```csharp
// Building the Marten session
await using var documentSession = _outboxedSessionFactory.OpenSession(context);
await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
...GetRequiredService<ScopedDocumentSessionHolder>(serviceScope.ServiceProvider).Session = documentSession;
var featureClient = ...GetRequiredService<IFeatureClient>(serviceScope.ServiceProvider);
```

`documentSession` appears exactly twice: opened, and handed to the holder. Nothing reads it. It is not free:

- the chain's `MessageContext` becomes outbox-enrolled, so cascading messages leave through an outbox nothing ever commits and arrive hundreds of milliseconds later — outside the `TrackedHttpCall` that was supposed to wait for them;
- under sharded multi-tenancy `OutboxedSessionFactory.OpenSession` throws, so an endpoint or handler deliberately declared un-tenanted fails on a database it does not use.

The two reporters on #4198 counted 17 and 30 affected chains in one application each, with 15 hard failures across two integration suites.

## Root cause

`PrimeScopedSessionFrame` documents itself as self-guarding — a chain with none of this store's sessions primes nothing. The guard was a **creating** lookup:

```csharp
_session = chain.TryFindVariable(typeof(TSession), VariableSource.NotServices);
```

`IMethodVariables.TryFindVariable` resolves in two halves. The first is a lookup; the second calls `IVariableSource.Create`, and a variable source is a factory. `Wolverine.Marten`'s `SessionVariableSource` answers "does this chain have a session?" by **building one**, and yielding it as a dependency drags the `OpenMartenSessionFrame` into the generated method. `Wolverine.Fisher`, `Wolverine.Polecat` and `Wolverine.RavenDb` register the same generic frame and shared the behavior.

## The fix

Ask the honest question. [jasperfx#719](https://github.com/JasperFx/jasperfx/pull/719) adds `VariableSource.Existing`, which answers only from what the method already has and never consults a source:

```csharp
_session = chain.TryFindVariable(typeof(TSession), VariableSource.Existing);
```

A chain that genuinely owns a session is primed with it exactly as before — GH-3001 is unchanged. A chain with none primes nothing, and anything resolved from its scope falls back to the store's own session factory through `ScopedSessionRegistration`, as it did before 6.30.3. All four store integrations are fixed by the one core change.

`PrimeScopedMessageContextFrame` deliberately keeps the creating lookup, with a comment on why the two cases differ: a manufactured `MessageContext` is the one the chain would use for any message it sends, where a manufactured session invents a database connection and an outbox enrolment nothing will commit.

## Tests

`scope_priming_only_primes_an_existing_session` (handler) and `scope_priming_does_not_manufacture_a_session` (HTTP), each with the negative case and its counterfactual. Both negatives fail without the fix, verified by A/B against `origin/main` with the same JasperFx build.

They assert on the **generated source**, because that is where the difference lives. This is also why the existing `service_provider_source_compliance` and `scope_priming_without_an_explicit_service_provider` tests could not catch it: their probes genuinely want a session, and where a session is legitimate a creating lookup and a passive one are indistinguishable. I wrote and then deleted an end-to-end tracked-call test for the same reason — it passed with and without the fix in an in-memory host, so it proved nothing.

## Verification

Against a local JasperFx build of jasperfx#719:

| | |
|---|---|
| `CoreTests` | 2705 passed, 2 skipped |
| `MartenTests` | 622/622 (baseline on `origin/main`: 621/622, the one failure being this PR's regression test) |
| `Wolverine.Http.Tests` | 1010 passed, 10 skipped |
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |
| JasperFx `CodegenTests` | 433/433 on net9.0 and net10.0 |

## Note for anyone hitting this before the release

`opts.ServiceProviderSource = ServiceProviderSource.FromHttpContextRequestServices` in `MapWolverineEndpoints` restores the pre-6.30.3 generated code for HTTP chains — and, as erdtsieck notes on the issue, that is the behavior every existing HTTP application was already running on, since Wolverine.HTTP ignored the setting until GH-4171. It does **not** reach message handlers, which have no equivalent knob.