### PR TITLE
Add WolverineFx.AmazonS3: an IPersistenceFrameProvider for S3-backed documents (rebase of #4165)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
           - CIAWSSqs
           - CIAWSSqsCompliance
           - CIAWSSns
+          - CIAmazonS3
           # Wolverine.AzureServiceBus.Tests is one project sharded three ways by CLASS, balanced on
           # MEASURED per-class durations. Namespaces cannot split it — 264 of its 306 tests are in the
           # root namespace. CIAzureServiceBus is the "everything else" shard, so a newly added class

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -626,6 +626,23 @@ partial class Build
             }
         });
 
+    /// <summary>
+    /// GH-4160. WolverineFx.AmazonS3 stores documents and sagas as S3 objects. The suite keeps its own
+    /// LocalStack skip guard so a developer without the emulator still gets a clean local run.
+    /// </summary>
+    Target CIAmazonS3 => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var project = RootDirectory / "src" / "Persistence" / "Wolverine.AmazonS3.Tests" /
+                "Wolverine.AmazonS3.Tests.csproj";
+
+            BuildTestProjects(project);
+            StartDockerServices("localstack");
+
+            RunTestProject(project);
+        });
+
     Target CISqlite => _ => _
         .ProceedAfterFailure()
         .Executes(() =>

--- a/build/build.cs
+++ b/build/build.cs
@@ -318,6 +318,7 @@ partial class Build : NukeBuild
                 Solution.Persistence.Oracle.Wolverine_Oracle,
                 Solution.Persistence.Sqlite.Wolverine_Sqlite,
                 Solution.Persistence.CosmosDb.Wolverine_CosmosDb,
+                Solution.Persistence.AmazonS3.Wolverine_AmazonS3,
                 Solution.Persistence.ClaimCheck.Wolverine_ClaimCheck_AmazonS3,
                 Solution.Persistence.ClaimCheck.Wolverine_ClaimCheck_AzureBlobStorage,
                 Solution.Persistence.ClaimCheck.Wolverine_ClaimCheck_GoogleCloudStorage,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -354,6 +354,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Oracle Integration', link: '/guide/durability/oracle'},
                         {text: 'RavenDb Integration', link: '/guide/durability/ravendb'},
                         {text: 'CosmosDB Integration', link: '/guide/durability/cosmosdb'},
+                        {text: 'Amazon S3 Integration', link: '/guide/durability/amazon-s3'},
                         {text: 'Entity Framework Core Integration', collapsed: false, link: '/guide/durability/efcore', items: [
                                 {text: 'Transactional Middleware', link: '/guide/durability/efcore/transactional-middleware'},
                                 {text: 'Transactional Inbox and Outbox', link: '/guide/durability/efcore/outbox-and-inbox'},

--- a/docs/guide/durability/amazon-s3.md
+++ b/docs/guide/durability/amazon-s3.md
@@ -1,0 +1,157 @@
+# Amazon S3 Integration <Badge type="tip" text="6.31" />
+
+::: tip
+`WolverineFx.AmazonS3` stores **documents and sagas** as S3 objects. It is not the same thing as
+[claim checks](/guide/durability/claim-checks), which off-load a large *message payload* to shared
+storage and ship a token through the broker. Claim checks live in
+`WolverineFx.ClaimCheck.AmazonS3`, and the two are independent — install either or both.
+:::
+
+Plenty of real entities are not in any database. An invoice's rendered content, a generated report, a
+document scan: they live in a bucket, addressed by a key the application decides. Without a
+persistence provider for that, handlers drop out of Wolverine's [declarative
+persistence](/guide/handlers/persistence) entirely — inject a client, `await` it, and re-implement the
+"what if it is not there" half by hand in every handler that reads it.
+
+This package teaches Wolverine to read and write registered types as S3 objects, so a plain `[Entity]`
+parameter and the declarative `Storage.Store()` / `Storage.Delete()` return values work against a
+bucket.
+
+```sh
+dotnet add package WolverineFx.AmazonS3
+```
+
+## Registering documents
+
+```csharp
+builder.Services.AddSingleton<IAmazonS3>(sp => new AmazonS3Client(/* ... */));
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.UseAmazonS3Persistence(s3 =>
+    {
+        s3.Store<InvoiceContent>(x =>
+        {
+            x.BucketName = "invoice-content";
+            x.KeyFor = ctx => $"invoices/v7/{ctx.TenantId}/{ctx.Id}.json";
+        });
+    });
+});
+```
+
+`IAmazonS3` comes from your own registration, so the client keeps whatever credential chain, region
+and retry policy the rest of your application uses.
+
+Registration is explicit, type by type, and both `BucketName` and `KeyFor` are **required**. There is
+deliberately no default key layout: the identity-to-key mapping is the part only the application
+knows, and a convention Wolverine owned would not survive contact with a bucket that already exists.
+
+Explicit registration is also what keeps this provider **selective**. Wolverine resolves an entity to
+the first persistence provider that claims its type, so a provider that claimed anything an object
+store could theoretically hold would compete with Marten or EF Core for their own documents. This one
+claims only what you registered, and is otherwise invisible.
+
+### The key function
+
+`KeyFor` receives an `S3KeyContext` — the entity type, the resolved identity, and the tenant — and
+returns the object key. That is enough for the keys real buckets actually use:
+
+```csharp
+x.KeyFor = ctx => $"invoices/v{Generation}/{ctx.TenantId}/{Sanitize(ctx.Id)}.json.br";
+```
+
+`TenantId` is null when there is no tenant; Wolverine's default-tenant sentinel is normalised away, so
+a key function never has to know it exists.
+
+### Serialization
+
+Documents are written as `System.Text.Json` by default. Ask for compression, and the object's
+`Content-Encoding` is set to match:
+
+```csharp
+x.Serializer = new S3DocumentSerializer(compression: S3Compression.Brotli);
+```
+
+For anything else — a different format, an envelope around the payload, a checksum, encryption —
+implement `IS3DocumentSerializer` and set it on the mapping.
+
+## Reading a document
+
+A registered type resolves through `[Entity]` like any other, keeping `Required`, `OnMissing` and
+`MissingMessage`:
+
+```csharp
+[WolverineGet("/api/invoices/{id}/content")]
+public static InvoiceContent Get(
+    [Entity(OnMissing = OnMissing.ProblemDetailsWith404,
+        MissingMessage = "That invoice's content has not been written yet")]
+    InvoiceContent content) => content;
+```
+
+The identity is discovered exactly as it is for any other store — the route argument, query string or
+message member named `Id` or `{TypeName}Id`. Its type comes from the document's own identity member,
+or from `IdentityType` on the mapping if you set it.
+
+## Writing a document
+
+The declarative storage return values work unchanged:
+
+```csharp
+public static IStorageAction<InvoiceContent> Handle(RenderInvoice command)
+{
+    return Storage.Store(new InvoiceContent(command.Id, command.Body));
+}
+```
+
+`Insert`, `Update` and `Store` are all the same write: a `PutObject` overwrites whatever is at the
+key, so S3 has no insert-versus-update to honour and these are last-write-wins.
+
+You can also take `IS3DocumentSession` directly for the same key mapping outside a handler.
+
+## Alongside another store
+
+S3 documents and Marten (or Polecat, Fisher, EF Core, RavenDb, CosmosDb) documents coexist in one
+application, and one handler can take an `[Entity]` of each:
+
+```csharp
+public static IMartenOp Handle(
+    ApproveInvoice command,
+    [Entity] Invoice invoice,          // Marten
+    [Entity] InvoiceContent content)   // S3
+{
+    // ...
+}
+```
+
+Nothing has to be said to make that work. Wolverine resolves each entity type to the first
+persistence provider that claims it, consulting **selective** providers ahead of catch-all document
+stores. This provider is selective, so a type you registered with `Store<T>()` resolves to S3 and
+everything else falls through to whichever store would have had it anyway -- whichever order the two
+integrations were registered in.
+
+Two consequences worth knowing:
+
+- **Sagas stay with the transactional store.** Saga chains resolve on a different question (which
+  provider owns this *chain*), and this provider claims none, so a saga in a mixed application is
+  persisted by Marten or your database exactly as before.
+- **There is no atomicity across the two.** The Marten write commits in its transaction; the S3 write
+  already happened. A handler that writes both and then throws has written the S3 object and not the
+  Marten document. If that matters, write the S3 object from a projection or a follow-on message
+  triggered by the committed Marten write, rather than in the same handler.
+
+## What this deliberately does not do
+
+**No message store.** S3 is a poor transactional inbox and outbox, and this package does not offer to
+be one. Durability stays with Postgres, SQL Server, Marten or whichever database you already use;
+S3 documents sit alongside it.
+
+**No unit of work.** S3 has no transaction, so every write takes effect immediately. A handler that
+writes two documents and then throws has written one of them. Wolverine will not pretend otherwise:
+there is nothing to commit and nothing to roll back.
+
+**No querying.** `[All]`, `[FirstOrDefault]` and `[Queryable]` are not supported and fail at
+bootstrapping naming this provider. `ListObjectsV2` over a key prefix is a paged scan, not a query,
+and a scan that looks like a query is worse than an honest refusal.
+
+**No soft delete.** `MaybeSoftDeleted` does not apply. Only your serializer knows what deleted means
+for its payload; answer `null` for anything that should count as missing.

--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -81,6 +81,11 @@ mechanism, this would be using `IDocumentSession.LoadAsync<Todo2>(id)` to load t
 you were using EF Core and had an `Todo2DbContext` service registered in your system, it would
 be using `Todo2DbContext.FindAsync<Todo2>(id)`. 
 
+The same attribute works against a document stored as an Amazon S3 object, once its type is
+registered with `UseAmazonS3Persistence()` -- see the [Amazon S3 integration](/guide/durability/amazon-s3).
+There the identity is mapped to an object key by the key function you registered, rather than by the
+store.
+
 By default, Wolverine is assuming that any parameter value marked with `[Entity]` is required, so if the `Todo2` entity was not found in the database, then:
 
 * As a message handler, it will just log that the entity could not be found and otherwise exit cleanly without doing any further processing

--- a/src/LocalStack.cs
+++ b/src/LocalStack.cs
@@ -1,8 +1,7 @@
 using System.Runtime.CompilerServices;
-using IntegrationTests;
 using Amazon.S3;
 
-namespace Wolverine.ClaimCheck.AmazonS3.Tests;
+namespace IntegrationTests;
 
 /// <summary>
 /// Where LocalStack lives, and whether it is up. Tests skip cleanly when it is not.

--- a/src/Persistence/Wolverine.AmazonS3.Tests/AmazonS3Fixture.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/AmazonS3Fixture.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using Amazon.S3;
+using Amazon.S3.Model;
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// One LocalStack bucket and one Wolverine host with S3 document persistence registered, shared by
+/// the suites that need a real round trip.
+/// </summary>
+public class AmazonS3Fixture : IAsyncLifetime
+{
+    public AmazonS3Client Client { get; private set; } = null!;
+    public IHost Host { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        if (!LocalStack.IsRunning)
+        {
+            return;
+        }
+
+        Client = LocalStack.CreateClient();
+
+        await EnsureBucketAsync();
+
+        Host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType(typeof(InvoiceHandler));
+
+                opts.Services.AddSingleton<IAmazonS3>(LocalStack.CreateClient());
+
+                opts.UseAmazonS3Persistence(s3 =>
+                {
+                    s3.Store<InvoiceContent>(x =>
+                    {
+                        x.BucketName = InvoiceKeys.Bucket;
+                        x.KeyFor = InvoiceKeys.For;
+                    });
+                });
+            })
+            .StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Host != null)
+        {
+            await Host.StopAsync();
+            Host.Dispose();
+        }
+
+        Client?.Dispose();
+    }
+
+    public async Task EnsureBucketAsync()
+    {
+        try
+        {
+            await Client.PutBucketAsync(new PutBucketRequest { BucketName = InvoiceKeys.Bucket });
+        }
+        catch (AmazonS3Exception e) when (e.ErrorCode is "BucketAlreadyOwnedByYou" or "BucketAlreadyExists")
+        {
+        }
+    }
+
+    /// <summary>
+    /// Write an invoice straight through the AWS client, so a test can prove Wolverine <em>read</em>
+    /// rather than proving Wolverine can read back its own writes.
+    /// </summary>
+    public async Task PutAsync(InvoiceContent invoice, string? tenantId = null)
+    {
+        await Client.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = InvoiceKeys.Bucket,
+            Key = InvoiceKeys.For(new S3KeyContext(typeof(InvoiceContent), invoice.Id, tenantId)),
+            ContentBody = JsonSerializer.Serialize(invoice, new JsonSerializerOptions(JsonSerializerDefaults.Web))
+        });
+    }
+
+    public async Task<InvoiceContent?> GetAsync(string id, string? tenantId = null)
+    {
+        try
+        {
+            using var response = await Client.GetObjectAsync(InvoiceKeys.Bucket,
+                InvoiceKeys.For(new S3KeyContext(typeof(InvoiceContent), id, tenantId)));
+
+            using var reader = new StreamReader(response.ResponseStream);
+
+            return JsonSerializer.Deserialize<InvoiceContent>(await reader.ReadToEndAsync(),
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        }
+        catch (AmazonS3Exception e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public Task DeleteAsync(string id, string? tenantId = null)
+    {
+        return Client.DeleteObjectAsync(InvoiceKeys.Bucket,
+            InvoiceKeys.For(new S3KeyContext(typeof(InvoiceContent), id, tenantId)));
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/InvoiceDomain.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/InvoiceDomain.cs
@@ -1,0 +1,76 @@
+using IntegrationTests;
+using Wolverine.Persistence;
+
+namespace Wolverine.AmazonS3.Tests;
+
+public record InvoiceContent(string Id, string Body);
+
+public record ReadInvoice(string Id);
+
+public record TouchInvoice(string Id);
+
+public record ReadOptionalInvoice(string Id);
+
+public record WriteInvoice(string Id, string Body);
+
+public record DeleteInvoice(string Id);
+
+public record ReplaceInvoices(string Id, string Body, string OtherId);
+
+public static class InvoiceHandler
+{
+    /// <summary>
+    /// Records every invoice a handler actually saw, so a test can tell "the handler ran and the body
+    /// was X" apart from "the handler never ran because the object was missing".
+    /// </summary>
+    public static readonly List<string> Touched = [];
+
+    public static string Handle(ReadInvoice command, [Entity] InvoiceContent content)
+    {
+        return content.Body;
+    }
+
+    public static void Handle(TouchInvoice command, [Entity] InvoiceContent content)
+    {
+        Touched.Add(content.Body);
+    }
+
+    public static string? Handle(ReadOptionalInvoice command,
+        [Entity(Required = false)] InvoiceContent? content)
+    {
+        return content?.Body;
+    }
+
+    public static IStorageAction<InvoiceContent> Handle(WriteInvoice command)
+    {
+        return Storage.Store(new InvoiceContent(command.Id, command.Body));
+    }
+
+    public static IStorageAction<InvoiceContent> Handle(DeleteInvoice command, [Entity] InvoiceContent content)
+    {
+        return Storage.Delete(content);
+    }
+
+    public static UnitOfWork<InvoiceContent> Handle(ReplaceInvoices command)
+    {
+        return new UnitOfWork<InvoiceContent>()
+            .Store(new InvoiceContent(command.Id, command.Body))
+            .Delete(new InvoiceContent(command.OtherId, string.Empty));
+    }
+}
+
+/// <summary>
+/// The key layout these tests register: a generation prefix, the tenant when there is one, and the id.
+/// Deliberately not something Wolverine could have guessed.
+/// </summary>
+public static class InvoiceKeys
+{
+    public const string Bucket = "wolverine-s3-persistence-tests";
+
+    public static string For(S3KeyContext ctx)
+    {
+        return ctx.TenantId == null
+            ? $"invoices/v7/shared/{ctx.Id}.json"
+            : $"invoices/v7/{ctx.TenantId}/{ctx.Id}.json";
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/NoParallelization.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/NoParallelization.cs
@@ -1,0 +1,2 @@
+// Every test class here stands up a real Wolverine host against one LocalStack, so they run serially.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/Persistence/Wolverine.AmazonS3.Tests/Wolverine.AmazonS3.Tests.csproj
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/Wolverine.AmazonS3.Tests.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Wolverine.ClaimCheck.AmazonS3\Wolverine.ClaimCheck.AmazonS3.csproj" />
+      <ProjectReference Include="..\Wolverine.AmazonS3\Wolverine.AmazonS3.csproj" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/Persistence/Wolverine.AmazonS3.Tests/loading_entities_from_s3.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/loading_entities_from_s3.cs
@@ -1,0 +1,84 @@
+using IntegrationTests;
+using Shouldly;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// A plain <c>[Entity]</c> parameter resolving out of S3, with no other persistence registered in the
+/// host at all — which is the point of the package.
+/// </summary>
+public class loading_entities_from_s3 : IClassFixture<AmazonS3Fixture>
+{
+    private readonly AmazonS3Fixture _fixture;
+
+    public loading_entities_from_s3(AmazonS3Fixture fixture)
+    {
+        _fixture = fixture;
+        InvoiceHandler.Touched.Clear();
+    }
+
+    [LocalStackFact]
+    public async Task loads_an_object_written_outside_wolverine()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        await _fixture.PutAsync(new InvoiceContent(id, "one hundred euro"));
+
+        var body = await _fixture.Host.MessageBus().InvokeAsync<string>(new ReadInvoice(id));
+
+        body.ShouldBe("one hundred euro");
+    }
+
+    [LocalStackFact]
+    public async Task a_missing_required_object_stops_the_handler()
+    {
+        await _fixture.Host.MessageBus().InvokeAsync(new TouchInvoice(Guid.NewGuid().ToString("N")));
+
+        InvoiceHandler.Touched.ShouldBeEmpty();
+    }
+
+    [LocalStackFact]
+    public async Task a_present_required_object_lets_the_handler_run()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        await _fixture.PutAsync(new InvoiceContent(id, "it is here"));
+
+        await _fixture.Host.MessageBus().InvokeAsync(new TouchInvoice(id));
+
+        InvoiceHandler.Touched.ShouldBe(["it is here"]);
+    }
+
+    [LocalStackFact]
+    public async Task an_optional_object_arrives_as_null_when_it_is_not_there()
+    {
+        var body = await _fixture.Host.MessageBus()
+            .InvokeAsync<string>(new ReadOptionalInvoice(Guid.NewGuid().ToString("N")));
+
+        body.ShouldBeNull();
+    }
+
+    [LocalStackFact]
+    public async Task the_key_function_sees_the_tenant()
+    {
+        var id = Guid.NewGuid().ToString("N");
+
+        // Same id, different bodies, addressed only by the tenant segment of the key.
+        await _fixture.PutAsync(new InvoiceContent(id, "for aap"), "aap");
+        await _fixture.PutAsync(new InvoiceContent(id, "for noot"), "noot");
+
+        var bus = _fixture.Host.MessageBus();
+
+        (await bus.InvokeForTenantAsync<string>("aap", new ReadInvoice(id))).ShouldBe("for aap");
+        (await bus.InvokeForTenantAsync<string>("noot", new ReadInvoice(id))).ShouldBe("for noot");
+    }
+
+    [LocalStackFact]
+    public async Task a_tenanted_key_is_not_visible_without_the_tenant()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        await _fixture.PutAsync(new InvoiceContent(id, "for aap"), "aap");
+
+        var body = await _fixture.Host.MessageBus().InvokeAsync<string>(new ReadOptionalInvoice(id));
+
+        body.ShouldBeNull();
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/mixed_persistence_precedence.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/mixed_persistence_precedence.cs
@@ -1,0 +1,178 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.AmazonS3.Internals;
+using Wolverine.Configuration;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Sagas;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// One application using [Entity] against both a document store and S3. The S3 provider is selective,
+/// so it is consulted ahead of a catch-all store and claims only what was registered; everything else
+/// falls through. Whichever order the two integrations were registered in.
+/// </summary>
+/// <remarks>
+/// The catch-all here is a stub standing in for Marten rather than Marten itself: the question is
+/// purely about consultation order, and registering the real thing would put a Postgres dependency on
+/// a suite whose CI target only starts LocalStack. Real-store permutations of the same rule live in
+/// PersistenceTests/persistence_provider_precedence_permutations.cs, and the rule itself in
+/// CoreTests/Persistence/persistence_provider_precedence.cs.
+/// </remarks>
+public class mixed_persistence_precedence
+{
+    private record InS3(string Id);
+
+    private record InTheOtherStore(string Id);
+
+    private static IServiceContainer theContainer
+    {
+        get
+        {
+            var configuration = new AmazonS3Configuration();
+            configuration.Store<InS3>(x =>
+            {
+                x.BucketName = "some-bucket";
+                x.KeyFor = ctx => $"{ctx.Id}.json";
+            });
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configuration);
+            services.AddSingleton<IServiceCollection>(services);
+            services.AddSingleton<IServiceContainer, ServiceContainer>();
+
+            return services.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+        }
+    }
+
+    private static GenerationRules rulesWith(params IPersistenceFrameProvider[] providers)
+    {
+        var rules = new GenerationRules();
+        rules.Properties[GenerationRulesExtensions.PersistenceKey] = providers.ToList();
+        return rules;
+    }
+
+    [Fact]
+    public void s3_wins_for_a_registered_document_with_the_document_store_registered_first()
+    {
+        var s3 = new S3PersistenceFrameProvider();
+        var rules = rulesWith(new CatchAllStore(), s3);
+
+        rules.TryFindPersistenceFrameProvider(theContainer, typeof(InS3), out var provider).ShouldBeTrue();
+
+        provider.ShouldBeSameAs(s3);
+    }
+
+    [Fact]
+    public void s3_wins_for_a_registered_document_with_s3_registered_first()
+    {
+        var s3 = new S3PersistenceFrameProvider();
+        var rules = rulesWith(s3, new CatchAllStore());
+
+        rules.TryFindPersistenceFrameProvider(theContainer, typeof(InS3), out var provider).ShouldBeTrue();
+
+        provider.ShouldBeSameAs(s3);
+    }
+
+    [Fact]
+    public void everything_s3_did_not_claim_falls_through_to_the_document_store()
+    {
+        var other = new CatchAllStore();
+        var rules = rulesWith(new S3PersistenceFrameProvider(), other);
+
+        rules.TryFindPersistenceFrameProvider(theContainer, typeof(InTheOtherStore), out var provider)
+            .ShouldBeTrue();
+
+        provider.ShouldBeSameAs(other);
+    }
+
+    /// <summary>
+    /// Registering S3 without registering any document type leaves the rest of the application exactly
+    /// as it was.
+    /// </summary>
+    [Fact]
+    public void an_empty_s3_registration_claims_nothing_at_all()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new AmazonS3Configuration());
+        services.AddSingleton<IServiceCollection>(services);
+        services.AddSingleton<IServiceContainer, ServiceContainer>();
+        var container = services.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+
+        var other = new CatchAllStore();
+        var rules = rulesWith(new S3PersistenceFrameProvider(), other);
+
+        rules.TryFindPersistenceFrameProvider(container, typeof(InS3), out var provider).ShouldBeTrue();
+
+        provider.ShouldBeSameAs(other);
+    }
+
+    /// <summary>
+    /// Sagas resolve on CanApply rather than CanPersist, and the S3 provider claims no chains, so a
+    /// saga in a mixed application still belongs to the transactional store.
+    /// </summary>
+    [Fact]
+    public void sagas_still_belong_to_the_document_store()
+    {
+        var other = new CatchAllStore { AppliesToChains = true };
+        var rules = rulesWith(new S3PersistenceFrameProvider(), other);
+
+        rules.GetPersistenceProviders(null!, theContainer).ShouldBeSameAs(other);
+    }
+
+    // Claims every type it is asked about, like Marten.
+    private class CatchAllStore : IPersistenceFrameProvider
+    {
+        public bool AppliesToChains { get; init; }
+
+        public bool IsCatchAll => true;
+
+        public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
+        {
+            persistenceService = GetType();
+            return true;
+        }
+
+        public bool CanApply(IChain chain, IServiceContainer container) => AppliesToChains;
+
+        public void ApplyTransactionSupport(IChain chain, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType) =>
+            throw new NotSupportedException();
+
+        public Type DetermineSagaIdType(Type sagaType, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineInsertFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame CommitUnitOfWorkFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineUpdateFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineDeleteFrame(Variable sagaId, Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineStoreFrame(Variable saga, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineDeleteFrame(Variable variable, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame DetermineStorageActionFrame(Type entityType, Variable action, IServiceContainer container) =>
+            throw new NotSupportedException();
+
+        public Frame[] DetermineFrameToNullOutMaybeSoftDeleted(Variable entity) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/s3_document_mapping_validation.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/s3_document_mapping_validation.cs
@@ -1,0 +1,76 @@
+using Shouldly;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// A mapping is validated at its own Store call site, where the mistake is in front of the developer,
+/// rather than at code generation time.
+/// </summary>
+public class s3_document_mapping_validation
+{
+    private record Invoice(string Id, string Body);
+
+    private record NoIdentity(string Body);
+
+    private record struct AStruct(string Id);
+
+    [Fact]
+    public void a_bucket_name_is_required()
+    {
+        var ex = Should.Throw<InvalidS3DocumentMappingException>(() =>
+            new AmazonS3Configuration().Store<Invoice>(x => x.KeyFor = ctx => $"{ctx.Id}.json"));
+
+        ex.Message.ShouldContain("No bucket name was set");
+    }
+
+    [Fact]
+    public void a_key_function_is_required()
+    {
+        var ex = Should.Throw<InvalidS3DocumentMappingException>(() =>
+            new AmazonS3Configuration().Store<Invoice>(x => x.BucketName = "some-bucket"));
+
+        ex.Message.ShouldContain("No object key function was set");
+    }
+
+    [Fact]
+    public void an_identity_member_is_required_unless_the_type_is_named()
+    {
+        var ex = Should.Throw<InvalidS3DocumentMappingException>(() =>
+            new AmazonS3Configuration().Store<NoIdentity>(x =>
+            {
+                x.BucketName = "some-bucket";
+                x.KeyFor = ctx => $"{ctx.Id}.json";
+            }));
+
+        ex.Message.ShouldContain("No identity member could be found");
+    }
+
+    [Fact]
+    public void an_explicit_identity_type_covers_a_document_with_no_identity_member()
+    {
+        Should.NotThrow(() => new AmazonS3Configuration().Store<NoIdentity>(x =>
+        {
+            x.BucketName = "some-bucket";
+            x.KeyFor = ctx => $"{ctx.Id}.json";
+            x.IdentityType = typeof(string);
+        }));
+    }
+
+    [Fact]
+    public void only_reference_types_can_be_stored()
+    {
+        var ex = Should.Throw<InvalidS3DocumentMappingException>(() =>
+            new AmazonS3Configuration().Store(typeof(AStruct), _ => { }));
+
+        ex.Message.ShouldContain("Only reference types");
+    }
+
+    [Fact]
+    public void an_unregistered_type_says_where_to_register_it()
+    {
+        var ex = Should.Throw<InvalidS3DocumentMappingException>(() =>
+            new AmazonS3Configuration().MappingFor(typeof(Invoice)));
+
+        ex.Message.ShouldContain("UseAmazonS3Persistence()");
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/s3_document_serializer_tests.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/s3_document_serializer_tests.cs
@@ -1,0 +1,46 @@
+using Shouldly;
+
+namespace Wolverine.AmazonS3.Tests;
+
+public class s3_document_serializer_tests
+{
+    private record Invoice(string Id, string Body);
+
+    private static readonly Invoice theInvoice = new("ABC-123", "one hundred euro");
+
+    [Fact]
+    public void plain_json_round_trips_and_declares_no_encoding()
+    {
+        var serializer = new S3DocumentSerializer();
+
+        serializer.ContentType.ShouldBe("application/json");
+        serializer.ContentEncoding.ShouldBeNull();
+
+        serializer.Deserialize<Invoice>(serializer.Serialize(theInvoice)).ShouldBe(theInvoice);
+    }
+
+    [Theory]
+    [InlineData(S3Compression.Brotli, "br")]
+    [InlineData(S3Compression.GZip, "gzip")]
+    public void a_compressed_document_round_trips_and_declares_its_encoding(S3Compression compression,
+        string encoding)
+    {
+        var serializer = new S3DocumentSerializer(compression: compression);
+
+        serializer.ContentEncoding.ShouldBe(encoding);
+
+        serializer.Deserialize<Invoice>(serializer.Serialize(theInvoice)).ShouldBe(theInvoice);
+    }
+
+    [Fact]
+    public void compression_actually_compresses()
+    {
+        // A short document can come out larger, so use one with something to compress.
+        var repetitive = new Invoice("ABC-123", new string('a', 4096));
+
+        var plain = new S3DocumentSerializer().Serialize(repetitive).Length;
+        var compressed = new S3DocumentSerializer(compression: S3Compression.Brotli).Serialize(repetitive).Length;
+
+        compressed.ShouldBeLessThan(plain);
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/s3_persistence_frame_provider_tests.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/s3_persistence_frame_provider_tests.cs
@@ -1,0 +1,150 @@
+using Amazon.S3;
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.AmazonS3.Internals;
+using Wolverine.Persistence;
+
+namespace Wolverine.AmazonS3.Tests;
+
+public class s3_persistence_frame_provider_tests
+{
+    private record Registered(string Id, string Body);
+
+    private record NotRegistered(Guid Id);
+
+    private record GuidIdentified(Guid Id, string Body);
+
+    private static IServiceContainer containerFor(Action<AmazonS3Configuration> configure)
+    {
+        var configuration = new AmazonS3Configuration();
+        configure(configuration);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(configuration);
+        services.AddSingleton<IServiceCollection>(services);
+        services.AddSingleton<IServiceContainer, ServiceContainer>();
+
+        return services.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+    }
+
+    private static IServiceContainer theContainer => containerFor(s3 => s3.Store<Registered>(x =>
+    {
+        x.BucketName = "some-bucket";
+        x.KeyFor = ctx => $"{ctx.Id}.json";
+    }));
+
+    /// <summary>
+    /// Read through the interface deliberately, so a lost override reads the interface default of false
+    /// and fails here rather than quietly making this provider a catch-all that shadows Marten.
+    /// </summary>
+    [Fact]
+    public void is_not_a_catch_all()
+    {
+        IPersistenceFrameProvider provider = new S3PersistenceFrameProvider();
+        provider.IsCatchAll.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void claims_a_registered_document_type()
+    {
+        new S3PersistenceFrameProvider()
+            .CanPersist(typeof(Registered), theContainer, out var service)
+            .ShouldBeTrue();
+
+        service.ShouldBe(typeof(IS3DocumentSession));
+    }
+
+    [Fact]
+    public void does_not_claim_an_unregistered_document_type()
+    {
+        new S3PersistenceFrameProvider()
+            .CanPersist(typeof(NotRegistered), theContainer, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void does_not_claim_anything_when_wired_up_without_configuration()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IServiceCollection>(services);
+        services.AddSingleton<IServiceContainer, ServiceContainer>();
+        var container = services.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+
+        new S3PersistenceFrameProvider().CanPersist(typeof(Registered), container, out _).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// A message handler binds an [Entity] identity by exact CLR type, so this has to follow the
+    /// document rather than being a hardcoded string.
+    /// </summary>
+    [Fact]
+    public void takes_the_identity_type_from_the_document()
+    {
+        var container = containerFor(s3 =>
+        {
+            s3.Store<Registered>(x =>
+            {
+                x.BucketName = "some-bucket";
+                x.KeyFor = ctx => $"{ctx.Id}.json";
+            });
+
+            s3.Store<GuidIdentified>(x =>
+            {
+                x.BucketName = "some-bucket";
+                x.KeyFor = ctx => $"{ctx.Id}.json";
+            });
+        });
+
+        var provider = new S3PersistenceFrameProvider();
+
+        provider.DetermineSagaIdType(typeof(Registered), container).ShouldBe(typeof(string));
+        provider.DetermineSagaIdType(typeof(GuidIdentified), container).ShouldBe(typeof(Guid));
+    }
+
+    [Fact]
+    public void an_explicit_identity_type_wins()
+    {
+        var container = containerFor(s3 => s3.Store<GuidIdentified>(x =>
+        {
+            x.BucketName = "some-bucket";
+            x.KeyFor = ctx => $"{ctx.Id}.json";
+            x.IdentityType = typeof(string);
+        }));
+
+        new S3PersistenceFrameProvider()
+            .DetermineSagaIdType(typeof(GuidIdentified), container)
+            .ShouldBe(typeof(string));
+    }
+
+    /// <summary>
+    /// There is no transaction to apply, and claiming a chain would make AutoApplyTransactions
+    /// ambiguous in the normal case of S3 documents alongside a transactional store.
+    /// </summary>
+    [Fact]
+    public void claims_no_chains()
+    {
+        new S3PersistenceFrameProvider().CanApply(null!, theContainer).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void has_no_soft_delete_frames()
+    {
+        new S3PersistenceFrameProvider().DetermineFrameToNullOutMaybeSoftDeleted(null!).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// S3 has no query engine. Leaving these at the interface default is what makes [All],
+    /// [FirstOrDefault] and [Queryable] fail at bootstrapping naming this provider.
+    /// </summary>
+    [Fact]
+    public void does_not_pretend_to_be_queryable()
+    {
+        IPersistenceFrameProvider provider = new S3PersistenceFrameProvider();
+        var container = theContainer;
+
+        provider.TryBuildAllFrame(typeof(Registered), container, out _, out _).ShouldBeFalse();
+        provider.TryBuildFirstOrDefaultFrame(typeof(Registered), container, out _, out _).ShouldBeFalse();
+        provider.TryBuildQueryableFrame(typeof(Registered), container, out _, out _).ShouldBeFalse();
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/storage_actions_against_s3.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/storage_actions_against_s3.cs
@@ -1,0 +1,76 @@
+using IntegrationTests;
+using Shouldly;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// The declarative <c>Storage.Store()</c> / <c>Delete()</c> return values and <c>UnitOfWork&lt;T&gt;</c>
+/// against a bucket.
+/// </summary>
+public class storage_actions_against_s3 : IClassFixture<AmazonS3Fixture>
+{
+    private readonly AmazonS3Fixture _fixture;
+
+    public storage_actions_against_s3(AmazonS3Fixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [LocalStackFact]
+    public async Task store_writes_the_object()
+    {
+        var id = Guid.NewGuid().ToString("N");
+
+        await _fixture.Host.MessageBus().InvokeAsync(new WriteInvoice(id, "written by a handler"));
+
+        var stored = await _fixture.GetAsync(id);
+        stored.ShouldNotBeNull();
+        stored.Body.ShouldBe("written by a handler");
+    }
+
+    [LocalStackFact]
+    public async Task store_overwrites_what_is_already_there()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        await _fixture.PutAsync(new InvoiceContent(id, "first"));
+
+        await _fixture.Host.MessageBus().InvokeAsync(new WriteInvoice(id, "second"));
+
+        (await _fixture.GetAsync(id))!.Body.ShouldBe("second");
+    }
+
+    [LocalStackFact]
+    public async Task store_puts_the_object_at_the_tenant_key()
+    {
+        var id = Guid.NewGuid().ToString("N");
+
+        await _fixture.Host.MessageBus().InvokeForTenantAsync("aap", new WriteInvoice(id, "tenanted"));
+
+        (await _fixture.GetAsync(id, "aap"))!.Body.ShouldBe("tenanted");
+        (await _fixture.GetAsync(id)).ShouldBeNull();
+    }
+
+    [LocalStackFact]
+    public async Task delete_removes_the_object()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        await _fixture.PutAsync(new InvoiceContent(id, "about to go"));
+
+        await _fixture.Host.MessageBus().InvokeAsync(new DeleteInvoice(id));
+
+        (await _fixture.GetAsync(id)).ShouldBeNull();
+    }
+
+    [LocalStackFact]
+    public async Task a_unit_of_work_applies_every_action()
+    {
+        var kept = Guid.NewGuid().ToString("N");
+        var removed = Guid.NewGuid().ToString("N");
+        await _fixture.PutAsync(new InvoiceContent(removed, "about to go"));
+
+        await _fixture.Host.MessageBus().InvokeAsync(new ReplaceInvoices(kept, "kept", removed));
+
+        (await _fixture.GetAsync(kept))!.Body.ShouldBe("kept");
+        (await _fixture.GetAsync(removed)).ShouldBeNull();
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/AmazonS3Configuration.cs
+++ b/src/Persistence/Wolverine.AmazonS3/AmazonS3Configuration.cs
@@ -1,0 +1,64 @@
+using JasperFx.Core.Reflection;
+
+namespace Wolverine.AmazonS3;
+
+/// <summary>
+/// Declares which document types Wolverine may read and write in S3, and how each is addressed.
+/// </summary>
+/// <remarks>
+/// Registration is explicit, type by type, which is also what keeps the frame provider selective:
+/// Wolverine takes the first provider whose <c>CanPersist</c> claims a type, so a provider claiming
+/// everything an object store could theoretically hold would compete with Marten and EF Core for
+/// their own documents depending on registration order.
+/// </remarks>
+public class AmazonS3Configuration
+{
+    private readonly Dictionary<Type, S3DocumentMapping> _mappings = new();
+
+    /// <summary>
+    /// Store documents of type <typeparamref name="T" /> in S3.
+    /// </summary>
+    public AmazonS3Configuration Store<T>(Action<S3DocumentMapping> configure) where T : class
+    {
+        return Store(typeof(T), configure);
+    }
+
+    public AmazonS3Configuration Store(Type entityType, Action<S3DocumentMapping> configure)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (entityType.IsValueType)
+        {
+            throw new InvalidS3DocumentMappingException(entityType, "Only reference types can be stored as S3 objects.");
+        }
+
+        if (!_mappings.TryGetValue(entityType, out var mapping))
+        {
+            mapping = new S3DocumentMapping(entityType);
+            _mappings[entityType] = mapping;
+        }
+
+        configure(mapping);
+
+        // Fail at this call site rather than at codegen time, where the mistake is much harder to place.
+        mapping.Compile();
+
+        return this;
+    }
+
+    internal IReadOnlyCollection<S3DocumentMapping> Mappings => _mappings.Values;
+
+    internal bool TryFindMapping(Type entityType, out S3DocumentMapping mapping)
+    {
+        return _mappings.TryGetValue(entityType, out mapping!);
+    }
+
+    internal S3DocumentMapping MappingFor(Type entityType)
+    {
+        return _mappings.TryGetValue(entityType, out var mapping)
+            ? mapping
+            : throw new InvalidS3DocumentMappingException(entityType,
+                $"It was never registered. Add it with Store<{entityType.NameInCode()}>(...) inside UseAmazonS3Persistence().");
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/AssemblyAttributes.cs
+++ b/src/Persistence/Wolverine.AmazonS3/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wolverine.AmazonS3.Tests")]

--- a/src/Persistence/Wolverine.AmazonS3/IS3DocumentSerializer.cs
+++ b/src/Persistence/Wolverine.AmazonS3/IS3DocumentSerializer.cs
@@ -1,0 +1,118 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace Wolverine.AmazonS3;
+
+/// <summary>
+/// How a document's bytes are written to and read back from an S3 object. Supply your own on a
+/// <see cref="S3DocumentMapping" /> for a different format, an envelope around the payload, a
+/// checksum, or encryption.
+/// </summary>
+public interface IS3DocumentSerializer
+{
+    /// <summary>Written as the object's Content-Type.</summary>
+    string ContentType { get; }
+
+    /// <summary>Written as the object's Content-Encoding when non-null.</summary>
+    string? ContentEncoding { get; }
+
+    ReadOnlyMemory<byte> Serialize<T>(T document) where T : class;
+
+    T? Deserialize<T>(ReadOnlyMemory<byte> data) where T : class;
+}
+
+public enum S3Compression
+{
+    None,
+    Brotli,
+    GZip
+}
+
+/// <summary>
+/// The default serializer: System.Text.Json, optionally compressed.
+/// </summary>
+/// <remarks>
+/// Calls the reflection-based <see cref="JsonSerializer" /> overloads, as Wolverine's own default
+/// serializer does, so the trim and AOT warnings are suppressed at the leaf. An AOT-clean application
+/// should supply an <see cref="IS3DocumentSerializer" /> wrapping
+/// <c>JsonSerializer.Serialize&lt;T&gt;(value, JsonTypeInfo)</c> — see the AOT publishing guide.
+/// </remarks>
+public class S3DocumentSerializer : IS3DocumentSerializer
+{
+    private readonly S3Compression _compression;
+    private readonly JsonSerializerOptions _options;
+
+    public S3DocumentSerializer(JsonSerializerOptions? options = null,
+        S3Compression compression = S3Compression.None)
+    {
+        _options = options ?? new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        _compression = compression;
+    }
+
+    public static IS3DocumentSerializer Default { get; } = new S3DocumentSerializer();
+
+    public string ContentType => "application/json";
+
+    public string? ContentEncoding => _compression switch
+    {
+        S3Compression.Brotli => "br",
+        S3Compression.GZip => "gzip",
+        _ => null
+    };
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Default document serializer; AOT consumers supply an IS3DocumentSerializer wrapping JsonTypeInfo. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Default document serializer; AOT consumers supply an IS3DocumentSerializer wrapping JsonTypeInfo. See AOT guide.")]
+    public ReadOnlyMemory<byte> Serialize<T>(T document) where T : class
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(document, _options);
+
+        if (_compression == S3Compression.None)
+        {
+            return json;
+        }
+
+        using var output = new MemoryStream();
+        using (var compressor = compressing(output))
+        {
+            compressor.Write(json, 0, json.Length);
+        }
+
+        return output.ToArray();
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Default document serializer; AOT consumers supply an IS3DocumentSerializer wrapping JsonTypeInfo. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Default document serializer; AOT consumers supply an IS3DocumentSerializer wrapping JsonTypeInfo. See AOT guide.")]
+    public T? Deserialize<T>(ReadOnlyMemory<byte> data) where T : class
+    {
+        if (_compression == S3Compression.None)
+        {
+            return JsonSerializer.Deserialize<T>(data.Span, _options);
+        }
+
+        using var input = new MemoryStream(data.ToArray(), false);
+        using var decompressor = decompressing(input);
+        using var output = new MemoryStream();
+        decompressor.CopyTo(output);
+
+        return JsonSerializer.Deserialize<T>(output.ToArray(), _options);
+    }
+
+    private Stream compressing(Stream output)
+    {
+        return _compression == S3Compression.Brotli
+            ? new BrotliStream(output, CompressionMode.Compress, true)
+            : new GZipStream(output, CompressionMode.Compress, true);
+    }
+
+    private Stream decompressing(Stream input)
+    {
+        return _compression == S3Compression.Brotli
+            ? new BrotliStream(input, CompressionMode.Decompress, true)
+            : new GZipStream(input, CompressionMode.Decompress, true);
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/IS3DocumentSession.cs
+++ b/src/Persistence/Wolverine.AmazonS3/IS3DocumentSession.cs
@@ -1,0 +1,28 @@
+namespace Wolverine.AmazonS3;
+
+/// <summary>
+/// Reads and writes registered document types as S3 objects.
+/// </summary>
+/// <remarks>
+/// Not a unit of work. S3 has no transaction, so every method here takes effect immediately: a handler
+/// that writes two documents and then throws has written one of them.
+/// </remarks>
+public interface IS3DocumentSession
+{
+    /// <summary>
+    /// Load a document by its identity, or null when the object does not exist.
+    /// </summary>
+    Task<T?> LoadAsync<T>(object id, string? tenantId, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Write a document, overwriting whatever is at its key.
+    /// </summary>
+    Task StoreAsync<T>(T document, string? tenantId, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Delete the object a document lives at. Missing objects are not an error.
+    /// </summary>
+    Task DeleteAsync<T>(T document, string? tenantId, CancellationToken token = default) where T : class;
+
+    Task DeleteByIdAsync<T>(object id, string? tenantId, CancellationToken token = default) where T : class;
+}

--- a/src/Persistence/Wolverine.AmazonS3/Internals/AmazonS3StartupValidator.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/AmazonS3StartupValidator.cs
@@ -1,0 +1,50 @@
+using Amazon.S3;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.AmazonS3.Internals;
+
+/// <summary>
+/// Refuses to start an application whose S3 document registration cannot work, where the client is
+/// resolvable and the mappings are known, rather than letting a missing IAmazonS3 surface as a
+/// container failure inside the first handler that happens to touch a document.
+/// </summary>
+internal class AmazonS3StartupValidator : IHostedService
+{
+    private readonly AmazonS3Configuration _configuration;
+    private readonly ILogger<AmazonS3StartupValidator> _logger;
+    private readonly IServiceProvider _services;
+
+    public AmazonS3StartupValidator(AmazonS3Configuration configuration, IServiceProvider services,
+        ILogger<AmazonS3StartupValidator> logger)
+    {
+        _configuration = configuration;
+        _services = services;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_configuration.Mappings.Count == 0)
+        {
+            _logger.LogWarning(
+                "UseAmazonS3Persistence() was called but no document types were registered with Store<T>(), so nothing will resolve to S3");
+
+            return Task.CompletedTask;
+        }
+
+        if (_services.GetService<IAmazonS3>() == null)
+        {
+            throw new InvalidOperationException(
+                $"No IAmazonS3 is registered, but {_configuration.Mappings.Count} document type(s) are registered to be stored in S3. Register a client before UseAmazonS3Persistence() -- services.AddSingleton<IAmazonS3>(...) or AddAWSService<IAmazonS3>().");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/Internals/S3DocumentSession.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/S3DocumentSession.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace Wolverine.AmazonS3.Internals;
+
+/// <summary>
+/// Public because Wolverine generates code that constructs it directly; an internal type would force
+/// service location, which ServiceLocationPolicy.NotAllowed refuses.
+/// </summary>
+public class S3DocumentSession : IS3DocumentSession
+{
+    private readonly IAmazonS3 _client;
+    private readonly AmazonS3Configuration _configuration;
+
+    public S3DocumentSession(IAmazonS3 client, AmazonS3Configuration configuration)
+    {
+        _client = client;
+        _configuration = configuration;
+    }
+
+    public async Task<T?> LoadAsync<T>(object id, string? tenantId, CancellationToken token = default)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var mapping = _configuration.MappingFor(typeof(T));
+
+        try
+        {
+            using var response = await _client.GetObjectAsync(new GetObjectRequest
+            {
+                BucketName = mapping.BucketName,
+                Key = mapping.KeyForIdentity(id, tenantId)
+            }, token).ConfigureAwait(false);
+
+            using var buffer = new MemoryStream();
+            await response.ResponseStream.CopyToAsync(buffer, token).ConfigureAwait(false);
+
+            return mapping.Serializer.Deserialize<T>(buffer.ToArray());
+        }
+        catch (AmazonS3Exception e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            // Only 404. A 403 on a missing permission has to keep propagating, or a misconfigured
+            // bucket looks exactly like an empty one.
+            return null;
+        }
+    }
+
+    public Task StoreAsync<T>(T document, string? tenantId, CancellationToken token = default)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var mapping = _configuration.MappingFor(typeof(T));
+
+        return putAsync(mapping, mapping.KeyForEntity(document, tenantId), document, token);
+    }
+
+    public Task DeleteAsync<T>(T document, string? tenantId, CancellationToken token = default)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var mapping = _configuration.MappingFor(typeof(T));
+
+        return deleteAsync(mapping, mapping.KeyForEntity(document, tenantId), token);
+    }
+
+    public Task DeleteByIdAsync<T>(object id, string? tenantId, CancellationToken token = default)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var mapping = _configuration.MappingFor(typeof(T));
+
+        return deleteAsync(mapping, mapping.KeyForIdentity(id, tenantId), token);
+    }
+
+    private async Task putAsync<T>(S3DocumentMapping mapping, string key, T document, CancellationToken token)
+        where T : class
+    {
+        var body = mapping.Serializer.Serialize(document);
+        using var stream = new MemoryStream(body.ToArray(), false);
+
+        var request = new PutObjectRequest
+        {
+            BucketName = mapping.BucketName,
+            Key = key,
+            InputStream = stream,
+            ContentType = mapping.Serializer.ContentType
+        };
+
+        if (mapping.Serializer.ContentEncoding != null)
+        {
+            request.Headers.ContentEncoding = mapping.Serializer.ContentEncoding;
+        }
+
+        await _client.PutObjectAsync(request, token).ConfigureAwait(false);
+    }
+
+    private Task deleteAsync(S3DocumentMapping mapping, string key, CancellationToken token)
+    {
+        // S3 reports success for a key that was never there, so this is naturally idempotent.
+        return _client.DeleteObjectAsync(new DeleteObjectRequest
+        {
+            BucketName = mapping.BucketName,
+            Key = key
+        }, token);
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/Internals/S3Frames.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/S3Frames.cs
@@ -1,0 +1,130 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Wolverine.Persistence;
+using Wolverine.Runtime;
+
+namespace Wolverine.AmazonS3.Internals;
+
+/// <summary>
+/// Resolves the tenant to pass into <see cref="S3StorageActionApplier" />.
+/// </summary>
+/// <remarks>
+/// Same order the Marten, Polecat and Fisher session frames use — the chain's own <c>tenantId</c>
+/// variable first, then the active message context — so an S3 document and a Marten document in one
+/// handler resolve the same tenant.
+/// </remarks>
+internal class S3TenantSource
+{
+    private Variable? _context;
+    private Variable? _tenantId;
+
+    public IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        if (chain.TryFindVariableByName(typeof(string), PersistenceConstants.TenantIdVariableName, out var tenant))
+        {
+            _tenantId = tenant;
+            yield return _tenantId;
+            yield break;
+        }
+
+        _context = chain.TryFindVariable(typeof(IMessageContext), VariableSource.NotServices)
+                   ?? chain.TryFindVariable(typeof(IMessageBus), VariableSource.NotServices);
+
+        if (_context != null)
+        {
+            yield return _context;
+        }
+    }
+
+    public string Expression =>
+        _tenantId?.Usage ?? (_context == null ? "null" : $"{_context.Usage}.{nameof(IMessageBus.TenantId)}");
+}
+
+/// <summary>
+/// Loads a registered document out of S3, or null when the object is not there.
+/// </summary>
+internal class LoadS3DocumentFrame : AsyncFrame
+{
+    private readonly Variable _id;
+    private readonly S3TenantSource _tenant = new();
+    private Variable? _cancellation;
+    private Variable? _session;
+
+    public LoadS3DocumentFrame(Type documentType, Variable id)
+    {
+        _id = id;
+        Document = new Variable(documentType, this);
+    }
+
+    public Variable Document { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IS3DocumentSession));
+        yield return _session;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+
+        foreach (var variable in _tenant.FindVariables(chain))
+        {
+            yield return variable;
+        }
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteComment($"Load the {Document.VariableType.NameInCode()} from S3, or null if it is not there");
+        writer.Write(
+            $"var {Document.Usage} = await {typeof(S3StorageActionApplier).FullNameInCode()}.{nameof(S3StorageActionApplier.LoadAsync)}<{Document.VariableType.FullNameInCode()}>({_session!.Usage}, {_id.Usage}, {_tenant.Expression}, {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+/// Calls one of the <see cref="S3StorageActionApplier" /> write methods against a variable the handler
+/// already has — an <c>IStorageAction&lt;T&gt;</c>, or the document itself.
+/// </summary>
+internal class S3WriteFrame : AsyncFrame
+{
+    private readonly Type _documentType;
+    private readonly string _methodName;
+    private readonly S3TenantSource _tenant = new();
+    private readonly Variable _value;
+    private Variable? _cancellation;
+    private Variable? _session;
+
+    public S3WriteFrame(string methodName, Type documentType, Variable value)
+    {
+        _methodName = methodName;
+        _documentType = documentType;
+        _value = value;
+
+        uses.Add(value);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _session = chain.FindVariable(typeof(IS3DocumentSession));
+        yield return _session;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+
+        foreach (var variable in _tenant.FindVariables(chain))
+        {
+            yield return variable;
+        }
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"await {typeof(S3StorageActionApplier).FullNameInCode()}.{_methodName}<{_documentType.FullNameInCode()}>({_session!.Usage}, {_value.Usage}, {_tenant.Expression}, {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/Internals/S3PersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/S3PersistenceFrameProvider.cs
@@ -1,0 +1,118 @@
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Wolverine.Configuration;
+using Wolverine.Persistence;
+
+namespace Wolverine.AmazonS3.Internals;
+
+/// <summary>
+/// Reads and writes registered document types as S3 objects, so a plain <c>[Entity]</c> parameter and
+/// the declarative <c>Storage.Store()</c> / <c>Delete()</c> return values work against a bucket.
+/// </summary>
+/// <remarks>
+/// Built by <c>InsertFirstPersistenceStrategy&lt;T&gt;()</c>, which needs a parameterless constructor,
+/// so the configuration is read back out of the container at codegen time.
+/// </remarks>
+public class S3PersistenceFrameProvider : IPersistenceFrameProvider
+{
+    /// <summary>
+    /// Selective, not catch-all: this claims only the types the application registered, so it is
+    /// consulted ahead of catch-all stores like Marten and never competes with them for their own
+    /// documents.
+    /// </summary>
+    public bool IsCatchAll => false;
+
+    public bool CanPersist(Type entityType, IServiceContainer container, out Type persistenceService)
+    {
+        persistenceService = typeof(IS3DocumentSession);
+
+        return tryFindConfiguration(container, out var configuration) &&
+               configuration.TryFindMapping(entityType, out _);
+    }
+
+    /// <summary>
+    /// S3 has no transaction and no unit of work, so there is nothing to attach to a chain. Claiming
+    /// one would also make <c>AutoApplyTransactions</c> ambiguous for the normal case of S3 documents
+    /// alongside a real transactional store.
+    /// </summary>
+    public bool CanApply(IChain chain, IServiceContainer container)
+    {
+        return false;
+    }
+
+    public void ApplyTransactionSupport(IChain chain, IServiceContainer container)
+    {
+    }
+
+    public void ApplyTransactionSupport(IChain chain, IServiceContainer container, Type entityType)
+    {
+    }
+
+    /// <summary>
+    /// The identity type from the document registration. Deliberately not a hardcoded <c>string</c>: a
+    /// message handler binds the identity by exact CLR type, so hardcoding it would stop a
+    /// Guid-identified document binding at all.
+    /// </summary>
+    public Type DetermineSagaIdType(Type sagaType, IServiceContainer container)
+    {
+        return tryFindConfiguration(container, out var configuration) &&
+               configuration.TryFindMapping(sagaType, out var mapping)
+            ? mapping.ResolvedIdentityType
+            : typeof(string);
+    }
+
+    public Frame DetermineLoadFrame(IServiceContainer container, Type sagaType, Variable sagaId)
+    {
+        return new LoadS3DocumentFrame(sagaType, sagaId);
+    }
+
+    // Insert, update and store are one PutObject; S3 has no insert-versus-update.
+    public Frame DetermineInsertFrame(Variable saga, IServiceContainer container) => store(saga);
+
+    public Frame DetermineUpdateFrame(Variable saga, IServiceContainer container) => store(saga);
+
+    public Frame DetermineStoreFrame(Variable saga, IServiceContainer container) => store(saga);
+
+    public Frame DetermineDeleteFrame(Variable sagaId, Variable saga, IServiceContainer container) => delete(saga);
+
+    public Frame DetermineDeleteFrame(Variable variable, IServiceContainer container) => delete(variable);
+
+    public Frame CommitUnitOfWorkFrame(Variable saga, IServiceContainer container)
+    {
+        return new CommentFrame("S3 writes take effect immediately; there is no unit of work to commit");
+    }
+
+    public Frame DetermineStorageActionFrame(Type entityType, Variable action, IServiceContainer container)
+    {
+        return new S3WriteFrame(nameof(S3StorageActionApplier.ApplyAction), entityType, action);
+    }
+
+    /// <summary>
+    /// S3 has no soft delete; a mapping that wants one answers null from its own serializer.
+    /// </summary>
+    public Frame[] DetermineFrameToNullOutMaybeSoftDeleted(Variable entity) => [];
+
+    // TryBuildAllFrame, TryBuildFirstOrDefaultFrame, TryBuildQueryableFrame and
+    // TryBuildFetchSpecificationFrame stay at their defaults of false. ListObjectsV2 over a key prefix
+    // is a paged scan, not a query, so [All] / [Queryable] failing at bootstrapping and naming this
+    // provider beats a scan that looks like a query until the bucket grows.
+
+    private static Frame store(Variable document)
+    {
+        return new S3WriteFrame(nameof(S3StorageActionApplier.StoreAsync), document.VariableType, document);
+    }
+
+    private static Frame delete(Variable document)
+    {
+        return new S3WriteFrame(nameof(S3StorageActionApplier.DeleteAsync), document.VariableType, document);
+    }
+
+    // Absent for an application that wired this provider up by hand, which registered no documents either.
+    private static bool tryFindConfiguration(IServiceContainer container, out AmazonS3Configuration configuration)
+    {
+        configuration = container.Services.GetService<AmazonS3Configuration>()!;
+        return configuration != null;
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/Internals/S3StorageActionApplier.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/S3StorageActionApplier.cs
@@ -1,0 +1,52 @@
+using Wolverine.Persistence;
+
+namespace Wolverine.AmazonS3.Internals;
+
+/// <summary>
+/// What the generated code calls. Public because generated code lives in another assembly.
+/// </summary>
+public static class S3StorageActionApplier
+{
+    public static Task<T?> LoadAsync<T>(IS3DocumentSession session, object id, string? tenantId,
+        CancellationToken token) where T : class
+    {
+        return session.LoadAsync<T>(id, tenantId, token);
+    }
+
+    /// <summary>
+    /// Carry out one <see cref="IStorageAction{T}" /> — the <c>Storage.Store()</c> / <c>Insert()</c> /
+    /// <c>Update()</c> / <c>Delete()</c> return values, and every element of a <c>UnitOfWork&lt;T&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Insert, Update and Store all become the same write: a PutObject overwrites whatever is at the
+    /// key, so S3 has no insert-versus-update to honour. These are last-write-wins by design.
+    /// </remarks>
+    public static Task ApplyAction<T>(IS3DocumentSession session, IStorageAction<T> action, string? tenantId,
+        CancellationToken token) where T : class
+    {
+        if (action.Entity == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return action.Action switch
+        {
+            StorageAction.Delete => session.DeleteAsync(action.Entity, tenantId, token),
+            StorageAction.Insert or StorageAction.Store or StorageAction.Update =>
+                session.StoreAsync(action.Entity, tenantId, token),
+            _ => Task.CompletedTask
+        };
+    }
+
+    public static Task StoreAsync<T>(IS3DocumentSession session, T document, string? tenantId,
+        CancellationToken token) where T : class
+    {
+        return document == null ? Task.CompletedTask : session.StoreAsync(document, tenantId, token);
+    }
+
+    public static Task DeleteAsync<T>(IS3DocumentSession session, T document, string? tenantId,
+        CancellationToken token) where T : class
+    {
+        return document == null ? Task.CompletedTask : session.DeleteAsync(document, tenantId, token);
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/S3DocumentMapping.cs
+++ b/src/Persistence/Wolverine.AmazonS3/S3DocumentMapping.cs
@@ -1,0 +1,122 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.Persistence.Sagas;
+
+namespace Wolverine.AmazonS3;
+
+public class InvalidS3DocumentMappingException : Exception
+{
+    public InvalidS3DocumentMappingException(Type entityType, string reason)
+        : base($"{entityType.FullNameInCode()} cannot be stored in S3. {reason}")
+    {
+    }
+}
+
+/// <summary>
+/// How one document type is addressed in S3. Both <see cref="BucketName" /> and <see cref="KeyFor" />
+/// are required — Wolverine has no default key layout, because the identity-to-key mapping is the part
+/// only the application knows.
+/// </summary>
+public class S3DocumentMapping
+{
+    internal S3DocumentMapping(Type entityType)
+    {
+        EntityType = entityType;
+    }
+
+    public Type EntityType { get; }
+
+    /// <summary>
+    /// The bucket these documents live in. Wolverine never creates it.
+    /// </summary>
+    public string? BucketName { get; set; }
+
+    /// <summary>
+    /// The object key for a document. Called for every read and write of this type.
+    /// </summary>
+    /// <example>
+    /// <code>x.KeyFor = ctx => $"invoices/v7/{ctx.TenantId}/{ctx.Id}.json";</code>
+    /// </example>
+    public Func<S3KeyContext, string>? KeyFor { get; set; }
+
+    public IS3DocumentSerializer Serializer { get; set; } = S3DocumentSerializer.Default;
+
+    /// <summary>
+    /// The CLR type of this document's identity. Leave it unset to take the type of the document's own
+    /// identity member.
+    /// </summary>
+    /// <remarks>
+    /// A message handler binds an <c>[Entity]</c> parameter's identity by matching a message member on
+    /// exact CLR type, so getting this wrong means the parameter does not bind at all.
+    /// </remarks>
+    public Type? IdentityType { get; set; }
+
+    internal MemberInfo? IdentityMember { get; private set; }
+
+    internal Type ResolvedIdentityType { get; private set; } = typeof(string);
+
+    internal void Compile()
+    {
+        if (BucketName.IsEmpty())
+        {
+            throw new InvalidS3DocumentMappingException(EntityType,
+                $"No bucket name was set. Set it with Store<{EntityType.NameInCode()}>(x => x.BucketName = \"...\").");
+        }
+
+        if (KeyFor == null)
+        {
+            throw new InvalidS3DocumentMappingException(EntityType,
+                $"No object key function was set. Set it with Store<{EntityType.NameInCode()}>(x => x.KeyFor = ctx => ...).");
+        }
+
+        // Passing the type as both arguments is how the shared convention is asked what identifies the
+        // type itself, as InMemoryPersistenceFrameProvider does for [Entity].
+        IdentityMember = SagaChain.DetermineSagaIdMember(EntityType, EntityType);
+        ResolvedIdentityType = IdentityType ?? IdentityMember?.GetMemberType() ?? typeof(string);
+
+        if (IdentityMember == null && IdentityType == null)
+        {
+            throw new InvalidS3DocumentMappingException(EntityType,
+                "No identity member could be found. Add an Id member, or set IdentityType explicitly.");
+        }
+    }
+
+    internal string KeyForIdentity(object id, string? tenantId)
+    {
+        return KeyFor!(new S3KeyContext(EntityType, id, withoutDefaultTenant(tenantId)));
+    }
+
+    // Wolverine hands out StorageConstants.DefaultTenantId rather than null for a message with no
+    // tenant. A key function should not have to know that sentinel exists.
+    private static string? withoutDefaultTenant(string? tenantId)
+    {
+        return tenantId == null || tenantId == StorageConstants.DefaultTenantId ? null : tenantId;
+    }
+
+    internal string KeyForEntity(object entity, string? tenantId)
+    {
+        if (IdentityMember == null)
+        {
+            throw new InvalidS3DocumentMappingException(EntityType,
+                "It has no identity member, so Wolverine cannot work out the object key of an instance. Writes need one even when reads take their identity from the message or route.");
+        }
+
+        var id = readIdentity(IdentityMember, entity)
+                 ?? throw new InvalidOperationException(
+                     $"The {IdentityMember.Name} of this {EntityType.FullNameInCode()} is null, so it has no object key in bucket {BucketName}.");
+
+        return KeyForIdentity(id, tenantId);
+    }
+
+    private static object? readIdentity(MemberInfo member, object entity)
+    {
+        return member switch
+        {
+            PropertyInfo property => property.GetValue(entity),
+            FieldInfo field => field.GetValue(entity),
+            _ => null
+        };
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/S3KeyContext.cs
+++ b/src/Persistence/Wolverine.AmazonS3/S3KeyContext.cs
@@ -1,0 +1,34 @@
+namespace Wolverine.AmazonS3;
+
+/// <summary>
+/// What Wolverine knows about a document when it asks a mapping's <see cref="S3DocumentMapping.KeyFor" />
+/// for its object key.
+/// </summary>
+public readonly struct S3KeyContext
+{
+    public S3KeyContext(Type entityType, object id, string? tenantId)
+    {
+        EntityType = entityType;
+        Id = id;
+        TenantId = tenantId;
+    }
+
+    public Type EntityType { get; }
+
+    /// <summary>
+    /// The identity Wolverine resolved for the document. Never null.
+    /// </summary>
+    public object Id { get; }
+
+    /// <summary>
+    /// The tenant in play, or null when there is none. Wolverine hands out a default-tenant sentinel
+    /// rather than null for a message with no tenant; that is normalised away before a key function
+    /// ever sees it.
+    /// </summary>
+    public string? TenantId { get; }
+
+    public override string ToString()
+    {
+        return TenantId == null ? $"{EntityType.Name} {Id}" : $"{EntityType.Name} {Id} for tenant {TenantId}";
+    }
+}

--- a/src/Persistence/Wolverine.AmazonS3/Wolverine.AmazonS3.csproj
+++ b/src/Persistence/Wolverine.AmazonS3/Wolverine.AmazonS3.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Amazon S3 document and saga persistence for Wolverine applications</Description>
+        <PackageId>WolverineFx.AmazonS3</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Wolverine\Wolverine.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="AWSSDK.S3" />
+    </ItemGroup>
+
+</Project>

--- a/src/Persistence/Wolverine.AmazonS3/WolverineAmazonS3Extensions.cs
+++ b/src/Persistence/Wolverine.AmazonS3/WolverineAmazonS3Extensions.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.AmazonS3.Internals;
+using Wolverine.Persistence.Sagas;
+
+namespace Wolverine.AmazonS3;
+
+public static class WolverineAmazonS3Extensions
+{
+    /// <summary>
+    /// Store the named document types as objects in Amazon S3, so a plain <c>[Entity]</c> parameter and
+    /// the declarative <c>Storage.Store()</c> / <c>Storage.Delete()</c> return values resolve against a
+    /// bucket.
+    /// </summary>
+    /// <remarks>
+    /// Requires an <see cref="Amazon.S3.IAmazonS3" /> in the service container, left to the application
+    /// so it keeps its own credential chain, region and retry policy. This does not make S3 the message
+    /// store: the transactional inbox and outbox stay with whichever database the application uses.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// opts.UseAmazonS3Persistence(s3 =&gt;
+    /// {
+    ///     s3.Store&lt;InvoiceContent&gt;(x =&gt;
+    ///     {
+    ///         x.BucketName = "invoice-content";
+    ///         x.KeyFor = ctx =&gt; $"invoices/v7/{ctx.TenantId}/{ctx.Id}.json";
+    ///     });
+    /// });
+    /// </code>
+    /// </example>
+    public static WolverineOptions UseAmazonS3Persistence(this WolverineOptions options,
+        Action<AmazonS3Configuration> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var configuration = new AmazonS3Configuration();
+        configure(configuration);
+
+        // Read back by S3PersistenceFrameProvider when the frames are generated.
+        options.Services.AddSingleton(configuration);
+
+        options.Services.AddScoped<IS3DocumentSession, S3DocumentSession>();
+        options.Services.AddSingleton<IHostedService, AmazonS3StartupValidator>();
+
+        options.CodeGeneration.InsertFirstPersistenceStrategy<S3PersistenceFrameProvider>();
+
+        // Without this the generated code does not compile: it references S3StorageActionApplier.
+        options.CodeGeneration.ReferenceAssembly(typeof(WolverineAmazonS3Extensions).Assembly);
+
+        return options;
+    }
+}

--- a/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/AmazonS3ClaimCheckStoreTests.cs
+++ b/src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/AmazonS3ClaimCheckStoreTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Amazon.S3;
 using Amazon.S3.Model;
+using IntegrationTests;
 using Shouldly;
 using Wolverine.Persistence;
 

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -74,6 +74,10 @@
     <Project Path="src/Persistence/SharedPersistenceModels/SharedPersistenceModels.csproj" />
     <Project Path="src/Persistence/Wolverine.RDBMS/Wolverine.RDBMS.csproj" />
   </Folder>
+  <Folder Name="/Persistence/AmazonS3/">
+    <Project Path="src/Persistence/Wolverine.AmazonS3/Wolverine.AmazonS3.csproj" />
+    <Project Path="src/Persistence/Wolverine.AmazonS3.Tests/Wolverine.AmazonS3.Tests.csproj" />
+  </Folder>
   <Folder Name="/Persistence/ClaimCheck/">
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AmazonS3/Wolverine.ClaimCheck.AmazonS3.csproj" />
     <Project Path="src/Persistence/Wolverine.ClaimCheck.AmazonS3.Tests/Wolverine.ClaimCheck.AmazonS3.Tests.csproj" />


### PR DESCRIPTION
Anne's #4165, rebased onto `main` after #4164 merged. Her commit is unchanged and she remains its author; #4165 went `CONFLICTING` only because the squash of #4164 gave its commit a new sha, and the fork branch could not be rebased in place from here.

Review happened on #4165 — see that thread. The follow-up changes agreed there (StorageActionCompliance, the "documents and sagas" doc claims, the S3 claim check move out of `WolverineFx.ClaimCheck.AmazonS3`, and the saga question) land in a separate PR immediately after this one.