### PR TITLE
GH-4205: a generic message type's slice reads as source spells it

### DIFF
--- a/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
+++ b/src/Http/Wolverine.Http/Diagnostics/HttpEventModelSource.cs
@@ -96,7 +96,7 @@ internal sealed class HttpEventModelSource : IEventModelDefinitionSource
         var resourceType = chain.ResourceType is { } res && res != typeof(void) ? res : null;
 
         var seed = new EventModelSliceSeed(
-            requestType?.Name ?? $"{verb} {route}",
+            (requestType == null ? null : EventModelRoles.DisplayNameFor(requestType)) ?? $"{verb} {route}",
             TriggerKind.Http,
             new PublisherOrigin { HttpRoute = route, HttpMethod = verb, Label = $"{verb} {route}" },
             requestType,

--- a/src/Testing/CoreTests/Acceptance/generic_slice_display_names_4205.cs
+++ b/src/Testing/CoreTests/Acceptance/generic_slice_display_names_4205.cs
@@ -1,0 +1,81 @@
+using Shouldly;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel4205;
+
+/// <summary>
+/// GH-4205. A handler for a closed generic message minted a slice literally labelled
+/// <c>IEvent`1</c> — the CLR spelling of <see cref="System.Type.Name" />. Unreadable on the canvas,
+/// and identical for every closed form of the same open generic, so two relays of different payloads
+/// collided on one slice name. Slice names are the merge key across model sources (GH-3988), so
+/// every source that names a slice has to answer this the same way.
+/// </summary>
+public class generic_slice_display_names_4205
+{
+    private static HandlerChain chainFor<THandler>(System.Linq.Expressions.Expression<Action<THandler>> expression)
+        => HandlerChain.For(expression, new HandlerGraph());
+
+    [Fact]
+    public void a_closed_generic_message_reads_as_source_would_spell_it()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<ClaimReleasedRelayHandler>(x => ClaimReleasedRelayHandler.Handle(null!)));
+
+        slice.Name.ShouldBe("Relay<ClaimReleased>");
+    }
+
+    /// <summary>
+    /// The point of the previous test, stated the other way: two closed forms of one open generic are
+    /// two slices, and under Type.Name they were one.
+    /// </summary>
+    [Fact]
+    public void two_closed_forms_of_the_same_generic_are_two_slices()
+    {
+        var released = EventModelRoles.ForHandlerChain(
+            chainFor<ClaimReleasedRelayHandler>(x => ClaimReleasedRelayHandler.Handle(null!)));
+        var claimed = EventModelRoles.ForHandlerChain(
+            chainFor<ClaimTakenRelayHandler>(x => ClaimTakenRelayHandler.Handle(null!)));
+
+        released.Name.ShouldNotBe(claimed.Name);
+        claimed.Name.ShouldBe("Relay<ClaimTaken>");
+    }
+
+    /// <summary>
+    /// A slice name is also a merge key, and ShortNameInCode() prefixes a nested type with its
+    /// declaring type — so this stays on Type.Name for everything that is not generic, rather than
+    /// renaming every existing slice whose message happens to be a nested class.
+    /// </summary>
+    [Fact]
+    public void a_non_generic_message_is_named_exactly_as_before()
+    {
+        EventModelRoles.DisplayNameFor(typeof(ClaimReleased)).ShouldBe("ClaimReleased");
+        EventModelRoles.DisplayNameFor(typeof(NestedMessages.Inner)).ShouldBe("Inner");
+    }
+}
+
+public record ClaimReleased;
+
+public record ClaimTaken;
+
+public record Relay<T>(T Body);
+
+public static class NestedMessages
+{
+    public record Inner;
+}
+
+public class ClaimReleasedRelayHandler
+{
+    public static void Handle(Relay<ClaimReleased> message)
+    {
+    }
+}
+
+public class ClaimTakenRelayHandler
+{
+    public static void Handle(Relay<ClaimTaken> message)
+    {
+    }
+}

--- a/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
@@ -74,6 +74,28 @@ public sealed record EventModelSliceSeed(
 public static class EventModelRoles
 {
     /// <summary>
+    ///     How a message or request type is named on the Event Model canvas. GH-4205.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="Type.Name" /> spells a generic in CLR notation, so an <c>IEvent&lt;ClaimReleased&gt;</c>
+    ///         relay handler minted a slice labelled <c>IEvent`1</c> — unreadable, and identical for every
+    ///         closed form of the same open generic. <c>ShortNameInCode()</c> renders it as source would.
+    ///     </para>
+    ///     <para>
+    ///         Deliberately only for generics. A slice name is also the <b>merge key</b> across model
+    ///         sources (GH-3988), and <c>ShortNameInCode()</c> prefixes a nested type with its declaring
+    ///         type — so applying it everywhere would rename every slice whose message is a nested class,
+    ///         for no gain. Every source that names a slice has to agree on this, or the same message
+    ///         reached through a handler and through HTTP would stop merging into one slice.
+    ///     </para>
+    /// </remarks>
+    public static string DisplayNameFor(Type type)
+    {
+        return type.IsGenericType ? type.ShortNameInCode() : type.Name;
+    }
+
+    /// <summary>
     ///     Describe a message handler chain. The slice is named for the message type, triggered by a
     ///     message handler — or by the job scheduler for a <see cref="TimeoutMessage" /> — and the
     ///     command is the message type itself.
@@ -87,7 +109,7 @@ public static class EventModelRoles
         var handlerType = chain.Handlers.FirstOrDefault()?.HandlerType;
 
         return Describe(chain, new EventModelSliceSeed(
-            chain.MessageType.Name,
+            DisplayNameFor(chain.MessageType),
             triggerKind,
             null,
             chain.MessageType,

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -336,7 +336,7 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
 
     private static EventModelSliceDescriptor grpcTriggerOnlySlice(GrpcEndpointDescriptor endpoint, PublisherOrigin origin)
         => new(
-            endpoint.RequestType.Name,
+            EventModelRoles.DisplayNameFor(endpoint.RequestType),
             // GH-4181: TriggerLabel unclaimed, for the same reason EventModelRoles.Describe leaves it
             // unclaimed -- this slice sets the origin two lines down, so claiming the label as well only
             // duplicated the origin onto the Derived rung and beat any label an overlay declared


### PR DESCRIPTION
Closes #4205.

An `IEvent<ClaimReleased>` relay handler minted a slice labelled **`` IEvent`1 ``**. `EventModelRoles.ForHandlerChain` named slices with `chain.MessageType.Name`, which is the CLR spelling.

Unreadable on the canvas, and there is a second problem underneath the cosmetic one: `Type.Name` is **identical for every closed form of the same open generic**, and a slice name is the merge key across model sources (GH-3988). Two relays carrying different payloads collided on one slice.

## The change

Generic type names destined for display go through `ShortNameInCode()`, so `IEvent<ClaimReleased>` reads as source spells it.

**Only generics.** `ShortNameInCode()` prefixes a nested type with its declaring type, so applying it to every type would rename every existing slice whose message happens to be a nested class — churn on a merge key, for no gain. The rule lives in one place, `EventModelRoles.DisplayNameFor`, and **all three sources that name a slice call it** — the handler chain, the HTTP source, and the gRPC-only slice in `WolverineEventModelSource`. They have to agree, or a message reached through both a handler and an HTTP endpoint stops merging into one slice.

## Two notes on the issue text

- `ShortNameInCode()` renders an **open** generic as `IEvent<>`, not the `IEvent<T>` the issue imagines. That is the helper's spelling; naming it here rather than quietly delivering something different from what was asked for.
- `TypeDescriptor.For` (JasperFx) also carries `type.Name`, so the type names *inside* a slice — commands, events, read models — still read `` IEvent`1 ``. I left it alone deliberately: `TypeDescriptor.Name` is not display-only, it is matched against `subscription.Match` for `RoutingScope.Type` in `WolverineEventModelSource`, so changing it in JasperFx would change routing-scope matching too. If you want those rendered as well, the safe shape is an additive display field on the descriptor rather than a redefinition of `Name` — say the word and I'll open it against jasperfx.

The separable half of the issue — whether an open-generic relay handler should mint a slice at all — is untouched.

## Tests

`CoreTests.Acceptance.EventModel4205`: a closed generic reads `Relay<ClaimReleased>`; two closed forms of one open generic are two distinct slices (the collision, stated directly); and a non-generic message, nested one included, is named exactly as before.

Existing coverage green: 38 core event-model tests (`event_model_roles_3988`, `event_model_per_rpc_4000`, `event_model_publish_url_4146`, `event_model_provenance_ladder_4147`, `external_system_3989`) and 11 HTTP event-model tests.