### PR TITLE
fix(postgresql): survive a duplicated scheduled identity with a partitioned inbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,31 @@
   `IPagedList<Order>` unwraps too; maps, strings, types that enumerate as two things, and scalar
   elements (a `byte[]` download is not a view over `byte`) are left alone.
 
+### WolverineFx.PostgreSQL
+
+- **A duplicated scheduled identity no longer wedges the scheduled message poller under
+  `EnableInboxPartitioning`.** (closes
+  [#4202](https://github.com/JasperFx/wolverine/issues/4202)) Partitioning puts `status` in the inbox
+  primary key, so uniqueness is only enforced *within* a partition and one identity can legally sit in
+  both the scheduled and the incoming partition — a broker redelivery arriving while the previous
+  attempt is parked as a scheduled retry produces exactly that pair. Promoting the scheduled row then
+  moved it onto an identity the incoming partition already held, and PostgreSQL raised a 23505 unique
+  violation. Because the promotion is one statement covering the whole due batch inside the polling
+  transaction, that single row rolled back every *other* due scheduled message with it, on every poll,
+  indefinitely: scheduled delivery stopped for the whole database until someone deleted the row by
+  hand. The poller now discards the superseded scheduled copy — the same identity has since been
+  received, or already handled, in another partition — logs a warning naming it, and
+  promotes the rest of the batch. Discarding it rather than promoting past a handled row also stops the
+  retry re-executing a completed message into a row that could never be marked handled, because marking
+  it handled is itself a cross-partition move onto the key the retained row still holds.
+
+- **The scheduled-message promotion is qualified by status and by the configured message identity.**
+  This half applies with or without partitioning. The statement previously matched on `id` alone, so it
+  could touch rows the poller's own `SELECT` had not produced — including, under
+  `MessageIdentity.IdAndDestination`, rows belonging to a different destination that merely shared an
+  envelope id. It now matches the key the incoming table was actually built with and promotes only rows
+  still in `Scheduled`.
+
 ### Dependencies
 
 - JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator and JasperFx.SourceGenerator to

--- a/docs/guide/durability/idempotency.md
+++ b/docs/guide/durability/idempotency.md
@@ -5,6 +5,16 @@ There is nothing you need to do to opt into idempotent, no more than once messag
 on any Wolverine listening endpoint where you want this behavior. 
 :::
 
+::: warning
+This guarantee is weaker under `Durability.EnableInboxPartitioning` on PostgreSQL. The inbox primary key
+gains the `status` column, so uniqueness is only enforced *within* a status partition. A message still
+inside the `KeepAfterMessageHandling` retention window sits in the `handled` partition, where it no longer
+blocks an insert of the same `Envelope.Id` as `Incoming`. On a durable listening endpoint deduplication is
+that insert failing, so a redelivery is stored and handled again rather than discarded, and then cannot be
+marked handled itself. See
+[PostgreSQL](/guide/durability/postgresql) for the full statement.
+:::
+
 When applying the [durable inbox](/guide/durability/#using-the-inbox-for-incoming-messages) to [message listeners](/guide/messaging/listeners), you also get a no more than once, 
 [idempotent](https://en.wikipedia.org/wiki/Idempotence) message delivery guarantee. This means that Wolverine will discard
 any received message that it can detect has been previously handled. Wolverine does this with its durable inbox storage to check on receipt of a 

--- a/docs/guide/durability/postgresql.md
+++ b/docs/guide/durability/postgresql.md
@@ -65,6 +65,38 @@ var host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Persistence/PostgresqlTests/compliance_using_table_partitioning.cs#L26-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_inbox_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: warning
+Partitioning also weakens the inbox's uniqueness guarantee. The primary key gains the `status` column,
+so PostgreSQL only enforces uniqueness *within* a status partition and one message identity can legally
+exist as both `Incoming` and `Scheduled` at the same time -- for example when a broker redelivers a
+message while the previous attempt is parked as a scheduled retry. When the scheduled message poller
+finds such a pair it discards the scheduled copy in favor of the row that supersedes it -- in the
+`incoming` partition or in the `handled` one -- and logs a warning naming the envelope. Where the
+superseding row is a handled one the pending retry is dropped and never executed, deliberately:
+promoting past it would re-execute a message that already completed, into a row that could never be
+marked handled because that too is a cross-partition move onto the key the retained row still holds.
+
+Where the superseding row is an incoming one it is executed in the retry's place. The discarded copy carries the retry state of the earlier attempt,
+so the surviving row is executed with the attempt count it was stored with rather than the one the
+retry had reached, so the retry budget restarts and the message can be attempted more times than the
+endpoint's error policy nominally allows. Under `MessageIdentity.IdOnly` the identity is the envelope id
+alone, so such a pair is resolved across listening endpoints rather than within one. This is the same
+weakened uniqueness that keeps deduplication claims in their own table; see
+[Idempotency](./idempotency).
+
+The `Incoming`/`Handled` pair is weakened the same way, and it never reaches the poller. A
+message retained after handling by `KeepAfterMessageHandling` -- the setting whose purpose is to absorb
+a broker redelivery -- sits in the `handled` partition, where it no longer blocks an insert of the same
+identity as `Incoming`. On a durable listening endpoint duplicate detection is that insert failing, so a
+redelivery arriving inside that retention window is stored and handled again rather than discarded --
+and then cannot be marked handled at all, because that too is a cross-partition move onto the key the
+retained row still holds. The redelivery is left sitting in the `incoming` partition owned by the node
+that processed it. Neither pair raises `DuplicateIncomingEnvelopeException`, which is
+the only path to `MaximumBrokerRedeliveries` -- that setting dead-letters a delivery the inbox rejected as
+a duplicate and the listener could not settle, rather than bounding duplicate execution, so it bounds
+neither pair.
+:::
+
 ## Connection Stability for Leader Election
 
 ::: tip

--- a/docs/tutorials/idempotency.md
+++ b/docs/tutorials/idempotency.md
@@ -40,6 +40,14 @@ Means that the uniqueness is the message id + the endpoint destination, which Wo
 various envelope storage databases. In all cases, Wolverine simply detects a [primary key](https://en.wikipedia.org/wiki/Primary_key) violation on the incoming envelope
 storage to "know" that the message has already been handled. 
 
+::: warning
+That is not true under `Durability.EnableInboxPartitioning` on PostgreSQL, where the primary key includes
+`status`. Re-inserting the identity of a row sitting in the `handled` partition raises no violation at all,
+so step 3 below is never reached and the message is handled a second time -- and then cannot be marked
+handled itself. See
+[PostgreSQL](/guide/durability/postgresql).
+:::
+
 ::: info
 There are built in error policies in Wolverine (introduced in 5.3) to automatically [discard](/guide/handlers/error-handling.html#discarding-messages) any message that is determined to be a duplicate.
 This is done through exception filters and matching based on exceptions thrown by the underlying message storage database, and there's

--- a/src/Persistence/PostgresqlTests/Bugs/Bug_partitioned_inbox_scheduled_promotion.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_partitioned_inbox_scheduled_promotion.cs
@@ -1,0 +1,462 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+using Wolverine.Transports.Tcp;
+using Wolverine.Util;
+
+namespace PostgresqlTests.Bugs;
+
+// GH-4202: with EnableInboxPartitioning the incoming table is PARTITION BY LIST (status) and status is
+// part of the primary key, so one identity can legally hold both a Scheduled row (a retry) and an Incoming
+// row (a redelivery). Promoting the scheduled row by id alone moved it across partitions onto an identity
+// the incoming partition already held, and the resulting 23505 rolled back the whole polling transaction --
+// wedging every other due scheduled message, forever.
+//
+// The two _is_accepted_by_the_partitioned_key tests characterize duplicate states this fix does not close.
+// They pin one mechanism only: Inbox.StoreIncomingAsync is a plain insert whose sole dedup is the
+// per-partition unique constraint. Eager idempotency (MessageContext.AssertEagerIdempotencyAsync ->
+// Inbox.ExistsAsync) is a separate path with no status predicate, and it is not exercised here.
+//
+// The patched promotion statement carries two predicates and only the identity match is pinned on its own:
+// a_scheduled_sibling_at_another_destination_is_left_alone fails when the match is widened to the id alone.
+// The status predicate is defensive. Nothing here can distinguish it from a no-op, because the discard step
+// runs first and leaves no promotable row whose identity still holds an Incoming or a Handled sibling; it
+// guards the window between those two statements, which these tests cannot force open.
+//
+// The raw SQL in the_unqualified_promotion_statement_raises_a_unique_violation is a deliberate verbatim
+// copy of the pre-fix statement. It must stay unqualified: rewriting it to match the patched statement
+// would silently remove the evidence that the constraint fires at all.
+public abstract class PartitionedInboxScheduledPromotionContext : IAsyncLifetime
+{
+    private const int RetryAttempts = 3;
+    private const int RedeliveryAttempts = 2;
+
+    private readonly int thePort = PortFinder.GetAvailablePort();
+
+    private IHost? theHost;
+
+    protected IMessageStore thePersistence = null!;
+
+    protected abstract MessageIdentity identityStyle { get; }
+    protected abstract string schemaName { get; }
+
+    protected abstract Uri redeliveryDestinationFor(Envelope original);
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.EnableInboxPartitioning = true;
+                opts.Durability.MessageIdentity = identityStyle;
+
+                // MessageDatabase.StartScheduledJobs pumps this same poller on any non-tenant store whatever
+                // DurabilityAgentEnabled says, and every row built here is already due, so the timer has to be
+                // pushed past the test rather than switched off.
+                opts.Durability.ScheduledJobFirstExecution = TimeSpan.FromHours(1);
+                opts.Durability.ScheduledJobPollingTime = TimeSpan.FromHours(1);
+
+                opts.Services.AddMarten(x =>
+                {
+                    x.Connection(Servers.PostgresConnectionString);
+                    x.DatabaseSchemaName = schemaName;
+                }).IntegrateWithWolverine();
+
+                opts.ListenAtPort(thePort).UseDurableInbox();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        thePersistence = theHost.Services.GetRequiredService<IMessageStore>();
+
+        await theHost.ResetResourceState();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (theHost is null) return;
+
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    protected static Envelope dueScheduledEnvelope()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+        envelope.ScheduledTime = DateTimeOffset.UtcNow.AddMinutes(-1);
+        return envelope;
+    }
+
+    [Fact]
+    public async Task redelivery_while_scheduled_for_retry_is_accepted_by_the_partitioned_key()
+    {
+        var envelope = await createDuplicatedIdentityAsync();
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        counts.Incoming.ShouldBe(1, "The partitioned key does not reject the redelivery: it lands in a different partition than the scheduled retry.");
+        counts.Scheduled.ShouldBe(1, "The store leaves both rows in place. Reconciliation happens in the poller -- see promotion_converges_on_a_single_row.");
+
+        (await statusesForAsync(envelope.Id)).ShouldBe(["Incoming", "Scheduled"]);
+    }
+
+    [Fact]
+    public async Task redelivery_alongside_a_handled_row_is_accepted_by_the_partitioned_key()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(envelope);
+        await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(envelope);
+
+        var redelivered = ObjectMother.Envelope();
+        redelivered.Id = envelope.Id;
+        redelivered.Destination = redeliveryDestinationFor(envelope);
+        redelivered.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(redelivered);
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        counts.Handled.ShouldBe(1, "Guard: the handled row is still there, so the insert above was a genuine same-identity redelivery.");
+        counts.Incoming.ShouldBe(1, "The partitioned key does not reject the redelivery: the handled row sits in another partition.");
+
+        (await statusesForAsync(envelope.Id)).ShouldBe(["Handled", "Incoming"]);
+    }
+
+    [Fact]
+    public async Task the_unqualified_promotion_statement_raises_a_unique_violation()
+    {
+        var envelope = await createDuplicatedIdentityAsync();
+
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            $"update {schemaName}.{DatabaseConstants.IncomingTable} set owner_id = @owner, status = 'Incoming' where id = ANY(@ids)";
+        command.Parameters.AddWithValue("owner", 1);
+        command.Parameters.AddWithValue("ids", new[] { envelope.Id });
+
+        var exception = await Should.ThrowAsync<PostgresException>(async () =>
+            await command.ExecuteNonQueryAsync(cancellation));
+
+        exception.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
+    }
+
+    [Fact]
+    public async Task one_duplicated_row_does_not_block_unrelated_scheduled_messages()
+    {
+        var duplicated = await createDuplicatedIdentityAsync();
+
+        var valid = dueScheduledEnvelope();
+        valid.Destination = new Uri("stub://valid");
+        await thePersistence.Inbox.StoreIncomingAsync(valid);
+        await thePersistence.Inbox.ScheduleExecutionAsync(valid);
+
+        var captured = await pollAsync();
+
+        captured.ShouldNotBeEmpty("The poll must have won the scheduled-job advisory lock and actually run.");
+
+        captured.ShouldContain(x => x.Id == valid.Id,
+            "An unrelated valid scheduled message must still be dispatched.");
+
+        captured.ShouldNotContain(x => x.Id == duplicated.Id,
+            "The superseded scheduled copy must not be dispatched alongside the incoming row it duplicates.");
+    }
+
+    [Fact]
+    public async Task several_duplicated_rows_are_discarded_in_one_poll()
+    {
+        var first = await createDuplicatedIdentityAsync();
+        var second = await createDuplicatedIdentityAsync();
+
+        var valid = dueScheduledEnvelope();
+        valid.Destination = new Uri("stub://valid");
+        await thePersistence.Inbox.StoreIncomingAsync(valid);
+        await thePersistence.Inbox.ScheduleExecutionAsync(valid);
+
+        var captured = await pollAsync();
+
+        captured.ShouldContain(x => x.Id == valid.Id,
+            "The unrelated valid scheduled message must still be dispatched.");
+
+        captured.ShouldNotContain(x => x.Id == first.Id || x.Id == second.Id,
+            "Every superseded scheduled copy in the batch must be dropped, not just the first one found.");
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        counts.Scheduled.ShouldBe(0, "Both superseded rows must be discarded in the same poll.");
+        counts.Incoming.ShouldBe(3, "The two surviving redeliveries and the promoted valid message remain.");
+
+        (await statusesForAsync(first.Id)).ShouldBe(["Incoming"]);
+        (await statusesForAsync(second.Id)).ShouldBe(["Incoming"]);
+    }
+
+    [Fact]
+    public async Task promotion_converges_on_a_single_row()
+    {
+        var envelope = await createDuplicatedIdentityAsync();
+
+        var captured = await pollAsync();
+
+        captured.ShouldBeEmpty("Nothing was promotable, so the superseded row must not reach dispatch either.");
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        counts.Scheduled.ShouldBe(0, "The superseded scheduled row must be discarded rather than left to poison every later poll.");
+        counts.Incoming.ShouldBe(1, "The surviving incoming row must be the only copy of the identity left.");
+
+        (await statusesForAsync(envelope.Id)).ShouldBe(["Incoming"]);
+
+        (await survivingAttemptsAsync(envelope.Id)).ShouldBe(RedeliveryAttempts,
+            "The surviving row must keep the attempt count it was stored with rather than the one the discarded retry had reached.");
+    }
+
+    [Fact]
+    public async Task a_scheduled_retry_is_discarded_when_the_identity_is_already_handled()
+    {
+        var handled = ObjectMother.Envelope();
+        handled.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(handled);
+        await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(handled);
+
+        var scheduled = dueScheduledEnvelope();
+        scheduled.Id = handled.Id;
+        scheduled.Destination = redeliveryDestinationFor(handled);
+
+        await thePersistence.Inbox.StoreIncomingAsync(scheduled);
+
+        // ScheduleExecutionAsync cannot build this pair under IdAndDestination, where the retry shares the
+        // handled row's received_at: it matches the identity without a status predicate, so under partitioning
+        // it drags the handled row into the scheduled partition too and hits 23505. Under IdOnly the two
+        // destinations differ and the real call would work; the helper is shared so both fixtures reach the
+        // same state. That is a sibling of the defect fixed here, reported on GH-4202; when it is fixed this
+        // helper should be replaced by the real call so the precondition stays one production can reach.
+        await moveToScheduledAsync(scheduled);
+
+        var captured = await pollAsync();
+
+        captured.ShouldNotContain(x => x.Id == handled.Id,
+            "The identity was already handled, so its pending retry must not be executed a second time.");
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        counts.Handled.ShouldBe(1, "The discard is scoped to the scheduled partition, so the handled row stays where it is.");
+        counts.Incoming.ShouldBe(0, "Promoting past the handled row would leave a row that can never be marked handled.");
+        counts.Scheduled.ShouldBe(0, "The superseded retry is discarded rather than left to re-fail on every later poll.");
+
+        (await statusesForAsync(handled.Id)).ShouldBe(["Handled"]);
+    }
+
+    private async Task moveToScheduledAsync(Envelope envelope)
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            $"update {schemaName}.{DatabaseConstants.IncomingTable} " +
+            $"set status = '{EnvelopeStatus.Scheduled}', {DatabaseConstants.ExecutionTime} = @time " +
+            $"where id = @id and status = '{EnvelopeStatus.Incoming}'";
+        command.Parameters.AddWithValue("time", envelope.ScheduledTime!.Value);
+        command.Parameters.AddWithValue("id", envelope.Id);
+
+        (await command.ExecuteNonQueryAsync(cancellation))
+            .ShouldBe(1, "The precondition must move exactly the one incoming row it was given.");
+    }
+
+    protected async Task<int> ownerOfAsync(Guid id, Uri destination)
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            $"select {DatabaseConstants.OwnerId} from {schemaName}.{DatabaseConstants.IncomingTable} " +
+            $"where id = @id and {DatabaseConstants.ReceivedAt} = @destination";
+        command.Parameters.AddWithValue("id", id);
+        command.Parameters.AddWithValue("destination", destination.ToString());
+
+        var value = await command.ExecuteScalarAsync(cancellation);
+
+        value.ShouldNotBeNull("The row under test must still exist.");
+
+        return (int)value;
+    }
+
+    protected async Task<List<string>> statusesForAsync(Guid id)
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            $"select status from {schemaName}.{DatabaseConstants.IncomingTable} where id = @id order by status";
+        command.Parameters.AddWithValue("id", id);
+
+        var statuses = new List<string>();
+
+        await using var reader = await command.ExecuteReaderAsync(cancellation);
+        while (await reader.ReadAsync(cancellation))
+        {
+            statuses.Add(reader.GetString(0));
+        }
+
+        return statuses;
+    }
+
+    private async Task<int> survivingAttemptsAsync(Guid id)
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            $"select {DatabaseConstants.Attempts} from {schemaName}.{DatabaseConstants.IncomingTable} where id = @id and status = '{EnvelopeStatus.Incoming}'";
+        command.Parameters.AddWithValue("id", id);
+
+        var value = await command.ExecuteScalarAsync(cancellation);
+
+        value.ShouldNotBeNull("An incoming row must survive for the identity under test.");
+
+        return (int)value;
+    }
+
+    private async Task<Envelope> createDuplicatedIdentityAsync()
+    {
+        var envelope = dueScheduledEnvelope();
+        await thePersistence.Inbox.StoreIncomingAsync(envelope);
+
+        envelope.Attempts = RetryAttempts;
+        await thePersistence.Inbox.RescheduleExistingEnvelopeForRetryAsync(envelope);
+
+        var redelivered = ObjectMother.Envelope();
+        redelivered.Id = envelope.Id;
+        redelivered.Destination = redeliveryDestinationFor(envelope);
+        redelivered.Status = EnvelopeStatus.Incoming;
+        redelivered.Attempts = RedeliveryAttempts;
+
+        await thePersistence.Inbox.StoreIncomingAsync(redelivered);
+
+        return envelope;
+    }
+
+    protected async Task<List<Envelope>> pollAsync()
+    {
+        var captured = new List<Envelope>();
+        var spyRuntime = Substitute.For<IWolverineRuntime>();
+        spyRuntime
+            .EnqueueDirectlyAsync(Arg.Do<IReadOnlyList<Envelope>>(es => captured.AddRange(es)))
+            .Returns(ValueTask.CompletedTask);
+
+        var durabilitySettings = theHost!.Services.GetRequiredService<DurabilitySettings>();
+
+        await ((IMessageDatabase)thePersistence).PollForScheduledMessagesAsync(
+            spyRuntime, NullLogger.Instance, durabilitySettings, CancellationToken.None);
+
+        return captured;
+    }
+}
+
+[Collection("marten")]
+public class Bug_partitioned_inbox_scheduled_promotion_by_id_and_destination
+    : PartitionedInboxScheduledPromotionContext
+{
+    protected override MessageIdentity identityStyle => MessageIdentity.IdAndDestination;
+    protected override string schemaName => "partitioned_promotion_id_and_destination";
+
+    protected override Uri redeliveryDestinationFor(Envelope original) => original.Destination!;
+
+    [Fact]
+    public async Task a_shared_id_at_another_destination_is_a_different_identity()
+    {
+        var scheduled = dueScheduledEnvelope();
+        await thePersistence.Inbox.StoreIncomingAsync(scheduled);
+        await thePersistence.Inbox.ScheduleExecutionAsync(scheduled);
+
+        var elsewhere = ObjectMother.Envelope();
+        elsewhere.Id = scheduled.Id;
+        elsewhere.Destination = new Uri("stub://elsewhere");
+        elsewhere.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(elsewhere);
+
+        var ownerBefore = await ownerOfAsync(elsewhere.Id, elsewhere.Destination);
+
+        var captured = await pollAsync();
+
+        captured.ShouldContain(x => x.Id == scheduled.Id && x.Destination == scheduled.Destination,
+            "Under IdAndDestination the incoming row at another destination is a different identity, so it must not supersede the scheduled message.");
+
+        var counts = await thePersistence.Admin.FetchCountsAsync();
+
+        counts.Scheduled.ShouldBe(0, "The scheduled row was promoted rather than discarded as superseded.");
+        counts.Incoming.ShouldBe(2, "Both identities survive: the promoted one and the unrelated row sharing its id.");
+
+        (await ownerOfAsync(elsewhere.Id, elsewhere.Destination)).ShouldBe(ownerBefore,
+            "Matching on the id alone would let the promotion claim ownership of a row the poller never selected.");
+    }
+
+    [Fact]
+    public async Task a_scheduled_sibling_at_another_destination_is_left_alone()
+    {
+        var due = dueScheduledEnvelope();
+        await thePersistence.Inbox.StoreIncomingAsync(due);
+        await thePersistence.Inbox.ScheduleExecutionAsync(due);
+
+        var later = ObjectMother.Envelope();
+        later.Id = due.Id;
+        later.Destination = new Uri("stub://elsewhere");
+        later.Status = EnvelopeStatus.Incoming;
+        later.ScheduledTime = DateTimeOffset.UtcNow.AddHours(1);
+
+        await thePersistence.Inbox.StoreIncomingAsync(later);
+        await thePersistence.Inbox.ScheduleExecutionAsync(later);
+
+        var captured = await pollAsync();
+
+        captured.ShouldContain(x => x.Destination == due.Destination,
+            "The due scheduled message must still be promoted and dispatched.");
+
+        captured.ShouldNotContain(x => x.Destination == later.Destination,
+            "The sibling is not due yet, so the poller must not have selected it.");
+
+        (await statusesForAsync(due.Id)).ShouldBe(["Incoming", "Scheduled"],
+            "Both rows sit in the scheduled partition, so only the identity clause can keep the promotion off the sibling.");
+    }
+}
+
+[Collection("marten")]
+public class Bug_partitioned_inbox_scheduled_promotion_by_id_only
+    : PartitionedInboxScheduledPromotionContext
+{
+    protected override MessageIdentity identityStyle => MessageIdentity.IdOnly;
+    protected override string schemaName => "partitioned_promotion_id_only";
+
+    protected override Uri redeliveryDestinationFor(Envelope original) => new("stub://redelivered");
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx;
@@ -52,6 +52,7 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConn
     private readonly string _discardAndReassignOutgoingSql;
     private readonly string _findAtLargeEnvelopesSql;
     private readonly string _reassignIncomingSql;
+    private readonly string _discardSupersededScheduledSql;
     private DatabaseServerId? _serverId;
 
     private readonly List<ISchemaObject> _externalTables = new();
@@ -91,8 +92,46 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConn
         ILogger<PostgresqlMessageStore> logger, IEnumerable<SagaTableDefinition> sagaTypes) : base(databaseSettings, dataSource,
         settings, logger, new PostgresqlMigrator(), PostgresqlProvider.Instance)
     {
+        // The incoming table's key shape follows MessageIdentity: received_at joins the primary key only
+        // under IdAndDestination (see IncomingEnvelopeTable), and EnableInboxPartitioning then adds status
+        // on top. Match the identity the same way ExistsAsync does, so both statements below agree with
+        // whichever key the table was actually built with.
+        string identityMatchClause(string alias, string other) => matchesIncomingById
+            ? $"{alias}.id = {other}.id"
+            : $"{alias}.id = {other}.id and {alias}.{DatabaseConstants.ReceivedAt} = {other}.{DatabaseConstants.ReceivedAt}";
+
+        // With partitioning the same identity can also hold a Handled row, which the identity match on its
+        // own would sweep into the incoming partition alongside the scheduled row.
         _reassignIncomingSql =
-            $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' where id = ANY(@ids)";
+            $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} target " +
+            $"set owner_id = @owner, status = '{EnvelopeStatus.Incoming}' " +
+            $"from unnest(@ids, @uris) as due(id, {DatabaseConstants.ReceivedAt}) " +
+            $"where {identityMatchClause("target", "due")} " +
+            $"and target.status = '{EnvelopeStatus.Scheduled}'";
+
+        // With EnableInboxPartitioning the incoming table is PARTITION BY LIST (status) and status is part
+        // of the primary key, so uniqueness is only enforced within a partition and one identity can legally
+        // sit in the scheduled partition and in the incoming or handled partition at once. Promoting the
+        // scheduled row moves it across partitions onto an identity another partition already holds, and
+        // Postgres raises 23505 for the whole polling transaction. Either way the identity is already live in
+        // another partition, so discard the scheduled copy and let the surviving row stand. Typically that copy
+        // is a parked retry, since a locally scheduled send carries a fresh envelope id and cannot collide when
+        // it is written, but the statement matches on the state rather than on how the row got there. Handled
+        // supersedes for a second reason: promoting past it re-executes a message that already completed, and
+        // marking that promotion handled would then collide on the handled partition's own key with nothing
+        // left to try. The DELETE and the promotion are separate statements, so a row another connection commits
+        // in between can still collide with the promotion. That costs one poll rather than every later one,
+        // because the next poll sees the pair and discards it.
+        _discardSupersededScheduledSql =
+            $"delete from {QuotedSchemaName}.{DatabaseConstants.IncomingTable} scheduled " +
+            $"using unnest(@ids, @uris) as due(id, {DatabaseConstants.ReceivedAt}) " +
+            $"where {identityMatchClause("scheduled", "due")} " +
+            $"and scheduled.status = '{EnvelopeStatus.Scheduled}' " +
+            $"and exists (select 1 from {QuotedSchemaName}.{DatabaseConstants.IncomingTable} superseding " +
+            $"where {identityMatchClause("superseding", "scheduled")} " +
+            $"and superseding.status in ('{EnvelopeStatus.Incoming}', '{EnvelopeStatus.Handled}')) " +
+            $"returning scheduled.id, scheduled.{DatabaseConstants.ReceivedAt}";
+
         _deleteOutgoingEnvelopesSql =
             $"delete from {QuotedSchemaName}.{DatabaseConstants.OutgoingTable} WHERE id = ANY(@ids);";
 
@@ -586,13 +625,32 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
                     return;
                 }
 
-                await conn.CreateCommand(_reassignIncomingSql)
+                var (promotable, superseded) =
+                    await discardSupersededScheduledEnvelopesAsync(conn, tx, envelopes, cancellationToken);
+
+                if (!promotable.Any())
+                {
+                    await tx.CommitAsync(cancellationToken);
+                    announceSupersededScheduledEnvelopes(logger, superseded);
+                    return;
+                }
+
+                envelopes = promotable;
+
+                var (promotableIds, promotableUris) = toIdAndUriArrays(envelopes);
+
+                await using var reassign = conn.CreateCommand(_reassignIncomingSql);
+                reassign.Transaction = tx;
+                await reassign
                     .With("owner", durabilitySettings.AssignedNodeNumber)
-                    .With("ids", envelopes.Select(x => x.Id).ToArray())
+                    .With("ids", promotableIds)
+                    .With("uris", promotableUris)
                     .ExecuteNonQueryAsync(_cancellation);
 
 
                 await tx.CommitAsync(cancellationToken);
+
+                announceSupersededScheduledEnvelopes(logger, superseded);
 
                 // Stamp the envelope's owning store on each row so the rest of the
                 // pipeline (DelegatingMessageInbox, FlushOutgoingMessagesOnCommit,
@@ -613,6 +671,83 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
         finally
         {
             await conn.CloseAsync();
+        }
+    }
+
+    private bool matchesIncomingById => Durability.MessageIdentity == MessageIdentity.IdOnly;
+
+    private static (Guid[] Ids, string[] Uris) toIdAndUriArrays(IReadOnlyList<Envelope> envelopes)
+    {
+        var ids = new Guid[envelopes.Count];
+        var uris = new string[envelopes.Count];
+
+        for (var i = 0; i < envelopes.Count; i++)
+        {
+            ids[i] = envelopes[i].Id;
+            uris[i] = envelopes[i].Destination!.ToString();
+        }
+
+        return (ids, uris);
+    }
+
+    private async Task<(IReadOnlyList<Envelope> Promotable, IReadOnlyList<Envelope> Superseded)>
+        discardSupersededScheduledEnvelopesAsync(NpgsqlConnection conn, NpgsqlTransaction tx,
+            IReadOnlyList<Envelope> envelopes, CancellationToken cancellationToken)
+    {
+        if (!Durability.EnableInboxPartitioning) return (envelopes, []);
+
+        var (ids, uris) = toIdAndUriArrays(envelopes);
+
+        await using var command = conn.CreateCommand(_discardSupersededScheduledSql);
+        command.Transaction = tx;
+        command.With("ids", ids).With("uris", uris);
+
+        var discarded = new HashSet<(Guid, string)>();
+
+        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+        {
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                discarded.Add(discardKey(await reader.GetFieldValueAsync<Guid>(0, cancellationToken),
+                    await reader.GetFieldValueAsync<string>(1, cancellationToken)));
+            }
+        }
+
+        if (discarded.Count == 0) return (envelopes, []);
+
+        var promotable = new List<Envelope>(envelopes.Count);
+        var superseded = new List<Envelope>();
+
+        foreach (var envelope in envelopes)
+        {
+            if (discarded.Contains(discardKey(envelope.Id, envelope.Destination!.ToString())))
+            {
+                superseded.Add(envelope);
+            }
+            else
+            {
+                promotable.Add(envelope);
+            }
+        }
+
+        return (promotable, superseded);
+    }
+
+    // Keyed the way the DELETE keys its rows: under IdOnly the statement matches on id alone, so folding
+    // received_at into the set would let the in-memory partition disagree with the rows actually removed.
+    private (Guid, string) discardKey(Guid id, string receivedAt)
+        => matchesIncomingById ? (id, string.Empty) : (id, receivedAt);
+
+    // Logged only after the enclosing transaction commits. The DELETE is not durable until then, and a
+    // failure in the promotion that follows it rolls the discard back, so reporting earlier would tell an
+    // operator a row was dropped when it is still there.
+    private static void announceSupersededScheduledEnvelopes(ILogger logger, IReadOnlyList<Envelope> superseded)
+    {
+        foreach (var envelope in superseded)
+        {
+            logger.LogWarning(
+                "Discarded scheduled envelope {EnvelopeId} of type {MessageType} for destination {Destination} after {Attempts} attempts because the same identity is already present in the incoming or handled partition.",
+                envelope.Id, envelope.MessageType, envelope.Destination, envelope.Attempts);
         }
     }
 

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -176,7 +176,39 @@ public class DurabilitySettings : IDescribeMyself
     /// <summary>
     /// For persistence mechanisms that support this (PostgreSQL), this directs Wolverine to use partitioning
     /// based on the envelope status for the transactional inbox storage. This can be a performance optimization,
-    /// but does require a database migration if enabled
+    /// but does require a database migration if enabled.
+    ///
+    /// Note that partitioning also weakens the inbox's uniqueness guarantee, because the primary key gains the
+    /// status column and PostgreSQL can only enforce uniqueness within a single partition. One message identity
+    /// can therefore exist as both Incoming and Scheduled at the same time, for example when a broker redelivers
+    /// a message while the previous attempt is parked as a scheduled retry. The scheduled message poller resolves
+    /// such a pair by discarding the scheduled copy in favor of the row that supersedes it, whether that row sits
+    /// in the incoming or in the handled partition.
+    ///
+    /// When the superseding row is a handled one the pending retry is dropped and never executed. That is
+    /// deliberate: promoting past it would re-execute a message that already completed, into a row that could
+    /// never be marked handled because marking it handled is itself a cross-partition move onto the key the
+    /// retained row still holds.
+    ///
+    /// When the superseding row is an incoming one it is executed in the retry's place. The discarded
+    /// copy carries the retry state of the earlier attempt, so the surviving row is executed with the attempt count
+    /// it was stored with rather than the one the retry had reached. The retry budget therefore restarts, and
+    /// the message can be attempted more times than the endpoint's error policy nominally allows.
+    ///
+    /// Under <see cref="MessageIdentity.IdOnly"/> the identity is the envelope id alone, so a pair
+    /// like this is resolved across listening endpoints rather than within one.
+    ///
+    /// The Incoming/Handled pair is weakened in the same way, and the poller never sees it. A message
+    /// retained after handling by <see cref="KeepAfterMessageHandling"/> sits in the handled partition, where it no
+    /// longer blocks an insert of the same identity as Incoming. On a durable listening endpoint duplicate
+    /// detection is that insert failing, so a redelivery arriving inside that retention window is stored and
+    /// handled again rather than discarded, and then cannot be marked handled itself because that is another
+    /// cross-partition move onto the key the retained row still holds.
+    ///
+    /// Neither pair raises <see cref="Persistence.Durability.DuplicateIncomingEnvelopeException"/>, which is the
+    /// only path to <see cref="MaximumBrokerRedeliveries"/>. That setting dead-letters a delivery the inbox
+    /// rejected as a duplicate and the listener could not settle; it does not bound duplicate execution, and
+    /// neither pair reaches it.
     /// </summary>
     public bool EnableInboxPartitioning { get; set; }
 


### PR DESCRIPTION
Fixes #4202.

## Problem

With `Durability.EnableInboxPartitioning = true`, promotion of scheduled messages back to
`Incoming` can fail permanently with a PostgreSQL unique violation (`23505`), and once it
does **every** scheduled message in that database stops being delivered. The failure
repeats at each `ScheduledJobPollingTime` interval and does not self-heal; the only
recovery is to delete the offending row by hand.

Three things combine:

**1. Under partitioning, inbox uniqueness is only per-partition.**
`IncomingEnvelopeTable` adds `status` to the primary key when partitioning is enabled:

```csharp
if (durability.EnableInboxPartitioning)
{
    ModifyColumn(DatabaseConstants.Status).AsPrimaryKey();
    PartitionByList(DatabaseConstants.Status)
        .AddPartition("incoming", EnvelopeStatus.Incoming.ToString())
        .AddPartition("scheduled", EnvelopeStatus.Scheduled.ToString())
        .AddPartition("handled", EnvelopeStatus.Handled.ToString());
}
```

so the key becomes `(id, status)` under the default `MessageIdentity.IdOnly` and
`(id, received_at, status)` under `IdAndDestination`. Either way the same identity can
legally exist once in the `scheduled` partition and once in the `incoming` partition at the
same time — nothing rejects the second insert, because it lands in a different partition.
The duplicate-detection path that raises `DuplicateIncomingEnvelopeException` never fires.

This is reachable through the public API alone: schedule a message for local retry, then
receive the same message again (broker redelivery, competing consumer, at-least-once
transport). The added `redelivery_while_scheduled_for_retry_is_accepted_by_the_partitioned_key`
demonstrates it — after the second `StoreIncomingAsync`, `counts.Incoming == 1` **and**
`counts.Scheduled == 1` for one identity.

**2. The promotion statement then collides.** `PollForScheduledMessagesAsync` promoted with:

```sql
update <schema>.wolverine_incoming_envelopes
set owner_id = @owner, status = 'Incoming'
where id = ANY(@ids)
```

It matches on `id` alone and has no `status` predicate, so it also rewrites rows that are
already `Incoming` (and rows sitting in the `handled` partition). Flipping `status` moves a
row across partitions, which Postgres implements as `DELETE` + `INSERT` — straight onto the
identity the `incoming` partition already holds. `23505`.

**3. One bad row stops everything.** The promotion is a single statement for the whole
batch, inside the advisory-locked polling transaction. The unique violation rolls the
transaction back, so every other due scheduled message in the batch is left behind as well,
and the same batch is retried — and fails identically — on every subsequent poll.

## Fix

Two changes in `PostgresqlMessageStore`, both scoped to the polling path:

* **Scope the promotion correctly.** Match the identity the same way `ExistsAsync` already
  does — `id` alone under `IdOnly`, `(id, received_at)` under `IdAndDestination` — and
  require `status = 'Scheduled'`. Mutation-probed, so the coverage claim is precise rather than
  hopeful. Widening the match back to `id` alone — keeping the status clause — fails
  `a_scheduled_sibling_at_another_destination_is_left_alone`, where both rows sit in the
  `Scheduled` partition so the status clause cannot mask a broken identity match. A **full**
  revert to the pre-fix statement additionally fails
  `a_shared_id_at_another_destination_is_a_different_identity`, which asserts the foreign row's
  `owner_id` is untouched — the regression the old statement actually caused, the poller claiming
  ownership of a row it never selected.

  The `status` clause is honestly weaker: it is **not** independently pinned, and removing it
  alone leaves all 16 runs green. It cannot be, because the discard step runs first and leaves no
  promotable row whose identity still holds an `Incoming` or `Handled` sibling. It is there to
  guard the window between the poller's own `SELECT` and this `UPDATE`, which the tests cannot
  force open. Drop it if you would rather not carry an unpinned predicate — the fix does not
  depend on it.

* **Discard the superseded scheduled copy.** When partitioning is on, before promoting,
  delete any selected scheduled row whose identity is already present in the `incoming` **or
  `handled`** partition, and drop those envelopes from the dispatch batch. In both cases the
  scheduled row is a retry of a message that has since been received, or already completed,
  under the same identity, so the surviving row stands and the message is not processed twice.
  Each discard is logged at warning level with the envelope's id, message type, destination and
  attempt count — *after* the transaction commits, so a rollback never reports a drop that did
  not happen.

  `Handled` is in that guard for a second reason, and it is the one that matters most.
  Promoting a scheduled retry past a retained `Handled` row re-executes a message that already
  completed, and then `MarkIncomingEnvelopeAsHandledAsync` on the promoted row is *itself* a
  cross-partition move onto the key the retained row still holds:
  `23505 ... "wolverine_incoming_envelopes_handled_pkey"`, in both key shapes. That end state
  has no way forward — the row is stranded `Incoming`, owned by the node that processed it. An
  earlier revision of this PR promoted in that case and asserted the stranded state as correct;
  it was wrong, and the test now pins the discard instead.

  Deliberately **not** routed through `IMessageTracker.DiscardedEnvelope`: `EnvelopeHistory`
  is keyed by envelope id and treats `MessageEventType.Discarded` as terminal, marking every
  record for that id complete. The superseded copy shares its id with the surviving incoming
  row by construction, so reporting it there would mark a still-live message complete in any
  `TrackedSession`.

The discard is guarded by `Durability.EnableInboxPartitioning`, so non-partitioned
deployments pay nothing — no extra round trip. The corrected promotion SQL applies
unconditionally; it is strictly narrower than what it replaced.

## What this deliberately does not change

The **insert** side is left alone. Closing the hole there means teaching the shared
`DatabasePersistence` insert builder a partition-aware conflict target, which changes
behaviour for every RDBMS provider that shares that builder — a much wider blast radius
than the incident warrants. `redelivery_while_scheduled_for_retry_is_accepted_by_the_partitioned_key`
is written as characterization of the current behaviour, so it documents the hole rather than
pretending it is gone.

The existing upsert added for #2823 (`MessageDatabase.Scheduled.cs`) does not cover this
case: it dedupes the scheduled write against an existing *scheduled* row, not against a row
sitting in a different partition.

**The same shape exists in three sibling statements, and I reproduced two of them.** All
three sit in the shared `MessageDatabase<T>` base, match the identity with no `status`
predicate, and *set* `status` — so under partitioning each can sweep a row across partitions
onto an identity another partition already holds:

| Statement | Location | Status |
|---|---|---|
| `ScheduleExecutionAsync` | `MessageDatabase.Scheduled.cs:14` | **reproduced**, both key shapes |
| `_markEnvelopeAsHandledById` | `MessageDatabase.cs:55` | **reproduced**, both key shapes |
| `RescheduleExistingEnvelopeForRetryAsync` | `MessageDatabase.Scheduled.cs:35` | same shape, not separately reproduced |

(`_incrementIncomingEnvelopeAttempts`, `MessageDatabase.cs:57`, has the same match shape but
does not set `status`, so it cannot move a row between partitions.)

Out of scope but worth naming: SQL Server's equivalent promotion, `uspMarkIncomingOwnership`
(`Schema/uspMarkIncomingOwnership.sql`, called from `Persistence/SqlServerMessageStore.cs:464`),
is `where id in (select id from @IDLIST)` — an id list only — so under `IdAndDestination` it still
claims a row at another destination the way the Postgres statement used to. Partitioning is a
PostgreSQL-only feature, so no `23505` follows there — but the ownership clobber that
`a_shared_id_at_another_destination_is_a_different_identity` pins does exist on that path.

`ScheduleExecutionAsync` — I hit it writing
`a_scheduled_retry_is_discarded_when_the_identity_is_already_handled`. Store an envelope, mark it
`Handled`, then store and schedule the same identity, and it raises
`23505 ... "wolverine_incoming_envelopes_scheduled_pkey"`: the update matched both the `Handled`
row and the new `Incoming` row and tried to move both into the `scheduled` partition. That test
therefore seeds its `Scheduled`/`Handled` pair with a status-qualified `UPDATE` of its own, with
a comment saying why, so a later reader does not "simplify" it back.

`_markEnvelopeAsHandledById` — from the state
`redelivery_alongside_a_handled_row_is_accepted_by_the_partitioned_key` already builds, calling
`MarkIncomingEnvelopeAsHandledAsync` on the redelivery raises
`23505 ... "wolverine_incoming_envelopes_handled_pkey"` in both fixtures: the promoted or
redelivered row cannot be retired because the retained handled row still holds that key. I ran
this as a probe and did not ship it as a test — a test that pins a defect somebody is going to
fix is a maintenance trap — but it is what the `Handled` arm of the discard guard is defending
against, and it is reported on the issue.

They are deliberately not fixed here. That is the base class for every RDBMS provider, and
adding a `status` predicate changes non-partitioned behaviour too —
`RescheduleExistingEnvelopeForRetryAsync` would stop updating a `Handled` row, fall through to
its `rowsAffected == 0` branch, and hit a primary-key violation on the insert. Which way that
should go is a design call for you rather than something to fold into an incident fix.

**Residual race.** The `DELETE` and the promotion are separate statements in the same
transaction, so an `Incoming` row committed by another connection in between can still raise
`23505`. That is a bounded regression of one poll rather than the permanent wedge this fixes
— the next poll sees the pair and discards it. Closing it fully would mean `SERIALIZABLE` or
a savepoint around the promotion, which seemed a poor trade against a self-healing window;
happy to add it if you would rather.

**Documented, not fixed: the `Incoming`/`Handled` pair.** The same partition-local uniqueness
also lets an identity exist as `Handled` and `Incoming` at once, which defeats the retention
window `KeepAfterMessageHandling` exists to provide. On a durable listening endpoint duplicate
detection *is* that insert failing, so a redelivery inside the window is stored and handled a
second time rather than discarded — and then cannot be marked handled at all, because that too
is a cross-partition move onto the key the retained row still holds, leaving the redelivery
stranded `Incoming`. Neither pair raises
`DuplicateIncomingEnvelopeException`, so `MaximumBrokerRedeliveries` never bounds them
(`HasExhaustedBrokerRedeliveries` has exactly one production caller, in `DurableReceiver`'s
duplicate path). That is out of scope here — the poller cannot see it — but it was undocumented,
so the `EnableInboxPartitioning` XML doc and the PostgreSQL guide now state it.

This is not a new claim so much as one you have already made. `guide/durability/idempotency.md`'s
"Why a separate table" gives as its *first* reason for keeping deduplication claims out of
`wolverine_incoming_envelopes` that "a `(deduplication_id, status)` index would let the same logical
id exist once as `Incoming` and once as `Handled`, silently, and only for users who enabled
partitioning." The built-in inbox deduplication is keyed exactly that way — `(id, status)` — so the
shape rejected for the opt-in feature is live in the path that runs by default.

Two idempotency pages promise the opposite in unqualified terms — `guide/durability/idempotency.md`
("There is nothing you need to do to opt into idempotent, no more than once message deduplication")
and `tutorials/idempotency.md` (which names the primary-key violation as the mechanism). Both now
carry a short warning scoped to `EnableInboxPartitioning`, pointing at the PostgreSQL guide. Shipping
a guide that says "this breaks" next to a tutorial that says "this cannot break" seemed worse than
either alone; happy to drop the tutorial one if you would rather keep this PR narrower.

**Residual window, disclosed rather than closed.** The promotion `UPDATE` used to match every
selected row unconditionally; now that it carries predicates it can affect fewer rows than the
batch. Its affected-row count is discarded and the whole batch is still dispatched, so a row that
left `Scheduled` between the poller's `SELECT` and the `UPDATE` would be executed without having
been claimed. Reaching that needs one of the sibling statements above to move the row from another
connection — the poller itself is serialised by the transaction-scoped advisory lock. I left it
alone: reconciling the `UPDATE` the way the `DELETE` is reconciled is a real behaviour change, and
I have no way to force the window open in a test, so it would ship unpinned. Say the word if you
would rather have the count checked and logged.

**Open question — retry budget.** Discarding the scheduled row discards the `attempts`
count it carried; the surviving incoming row keeps its own. Carrying `greatest(attempts)`
forward is a one-statement change (the `DELETE` and the `UPDATE` touch disjoint rows), but
it changes retry semantics, so it is raised here rather than slipped in.

## Tests

New `src/Persistence/PostgresqlTests/Bugs/Bug_partitioned_inbox_scheduled_promotion.cs` — a
shared context run twice, once per `MessageIdentity`, because the key shape (and therefore
the identity predicate) differs between them:

| Test | What it pins |
|---|---|
| `redelivery_while_scheduled_for_retry_is_accepted_by_the_partitioned_key` | The duplicate state is reachable through the public API — characterization of the unfixed insert hole |
| `redelivery_alongside_a_handled_row_is_accepted_by_the_partitioned_key` | The sibling `Incoming`/`Handled` pair, characterized not fixed: a redelivery alongside a retained handled row is stored rather than rejected |
| `the_unqualified_promotion_statement_raises_a_unique_violation` | Evidence: the original statement, issued verbatim against that state, throws `23505` |
| `one_duplicated_row_does_not_block_unrelated_scheduled_messages` | The batch-poisoning behaviour is gone — unrelated due messages are still dispatched, and the superseded copy is not dispatched alongside the row it duplicates |
| `several_duplicated_rows_are_discarded_in_one_poll` | Two superseded identities plus one valid message in the same batch: both duplicates are discarded in a single poll and the valid one still promotes |
| `promotion_converges_on_a_single_row` | After the poll, one row remains for the identity, so repeated polls do not re-fail |
| `a_scheduled_retry_is_discarded_when_the_identity_is_already_handled` | A retry whose identity is already `Handled` is discarded, not promoted: nothing is dispatched, the retained handled row is untouched, and no row is left stranded `Incoming` |

The `IdAndDestination` fixture adds two more, both of which only mean anything under that key shape:

| test | what it pins |
|---|---|
| `a_shared_id_at_another_destination_is_a_different_identity` | An `Incoming` row sharing the id at a different destination must not supersede the scheduled message, and must not have its `owner_id` reassigned by the promotion either |
| `a_scheduled_sibling_at_another_destination_is_left_alone` | Two `Scheduled` rows share an id at different destinations, one due and one an hour out. Both sit in the same partition, so only the identity clause can keep the promotion off the sibling — this is what pins that clause on its own |

16 runs in total.

The `IdOnly` fixture uses a *different* destination for the redelivery, so it discriminates
the key-shape handling specifically: hard-coding the `IdAndDestination` predicate fails 4 of
its 7 tests (`one_duplicated_row_does_not_block_unrelated_scheduled_messages`,
`several_duplicated_rows_are_discarded_in_one_poll`, `promotion_converges_on_a_single_row` and
`a_scheduled_retry_is_discarded_when_the_identity_is_already_handled`), measured.

## Verification

Full `PostgresqlTests` project, interleaved against a control run of untouched `main`
(`c20cc555a`) built in a separate worktree:

| | total | succeeded | skipped | failed |
|---|---|---|---|---|
| `main` (control) | 512 | 510 | 1 | 1 |
| this branch | 528 | 526 | 1 | 1 |

The one failure is identical on both sides — `Bug_1942_replay_dlq_to_buffered_or_inline.inline_rabbitmq_listener_replay_does_not_loop`,
which needs a RabbitMQ broker that was not running locally (it fails the same way in isolation,
and `docker ps` shows only the Postgres container up). The delta in totals is the sixteen
added test runs.

One earlier full run on this branch also failed
`Transport.inbox_outbox_usage.cascaded_response_with_outbox` on a `TrackedSession` timeout; it
passed on the re-run and passes in isolation, and did not recur. That test schedules nothing and
runs without partitioning, so the changed promotion never fires for it and the discard returns
before touching the database (`if (!Durability.EnableInboxPartitioning) return (envelopes, []);`);
it also takes the default 5s tracking timeout where its own scheduling sibling needed 30s. I read
it as load sensitivity in a suite that starts many hosts in parallel, but it is recorded here
rather than dropped. The added tests were run in isolation on every edit round.

`dotnet build wolverine.slnx -c Release -f net9.0` is green, 0 warnings.

Both fixtures carry `[Collection("marten")]`, matching the other Postgres/Marten host
classes in the project, so they serialize with them rather than adding concurrent hosts.
Without it, the extra parallel load pushed
`PostgresqlMessageStoreTests.mark_several_envelopes_as_handled` past the fixed 5s wait it
uses for the deferred `DatabaseBatcher` flush.

The identity predicates added under `IdAndDestination` compare the stored `received_at` against
`new Uri(stored).ToString()`, so they depend on `Uri.ToString()` being idempotent. Rather than
assume it, I probed it over the destination shapes Wolverine persists (`local://`, `tcp://`,
`stub://`, `rabbitmq://`, tenant-qualified, spaces, `%20`, `%2520`, non-ASCII): idempotent in
every case. The assumption is in any event pre-existing — `ExistsAsync` and
`MarkIncomingEnvelopeAsHandledAsync` already rely on it — so no new test asserts BCL behaviour.

Branched off `main` at `c20cc555a` (6.31.0). The behaviour was originally observed on 6.24.4
and re-verified as still present on current `main` before any code was written.


## Note for reviewers

Spotted while checking the `<see cref>` targets, **not** fixed here because it is pre-existing and on
an unrelated axis: `DurabilitySettings.MaximumBrokerRedeliveries`' XML summary reads "the most times a
broker may *redeliver* one message", while `guide/durability/index.md:287` warns that it "is a delivery
count, not a redelivery count, despite the property name... `MaximumBrokerRedeliveries = 3` permits
three deliveries and dead-letters on the fourth" — which is what `HasExhaustedBrokerRedeliveries`
implements (`count > limit`). The two surfaces give a reader different arithmetic. Happy to fix it in a
separate PR if you want it.

`semgrep --config auto` flags four interpolated-SQL sites in
`Bugs/Bug_partitioned_inbox_scheduled_promotion.cs` (`csharp-sqli`) at ERROR severity — the
evidence statement and the test helpers that read or seed rows. False positive: `schemaName` is a
bare string literal on each fixture, `DatabaseConstants.IncomingTable` is a `const`, and every
value is a bound parameter. One of the flagged sites is in particular the *deliberately unsafe
original statement* the evidence test issues verbatim to demonstrate the `23505`, so it is not
rewritten to please the scanner.
