### PR TITLE
GH-4160: S3 saga persistence, with conditional writes and the compliance specs

### DIFF
--- a/docs/guide/durability/amazon-s3.md
+++ b/docs/guide/durability/amazon-s3.md
@@ -12,8 +12,7 @@
 
 The two share nothing but a package and an `IAmazonS3`. Use either, or both.
 
-Sagas are **not** persisted to S3. A saga belongs to whichever transactional store owns its chain —
-see [alongside another store](#alongside-another-store).
+Sagas are supported too, through their own registration — see [sagas](#sagas).
 :::
 
 ::: warning Moved in 6.31
@@ -122,6 +121,37 @@ key, so S3 has no insert-versus-update to honour and these are last-write-wins.
 
 You can also take `IS3DocumentSession` directly for the same key mapping outside a handler.
 
+## Sagas <Badge type="tip" text="6.31" />
+
+A saga is registered separately from a document, and the difference is not bookkeeping:
+
+```csharp
+opts.UseAmazonS3Persistence(s3 =>
+{
+    s3.Saga<OrderSaga>(x =>
+    {
+        x.BucketName = "order-sagas";
+        x.KeyFor = ctx => $"sagas/{ctx.TenantId}/{ctx.Id}.json";
+    });
+});
+```
+
+**Saga writes are conditional; document writes are not.** A document is last-write-wins, because
+`PutObject` overwrites whatever is at the key. A saga is a read-modify-write, so two messages for the
+same saga arriving at once would silently lose one update. Wolverine writes a saga with S3's
+conditional put instead — `If-None-Match: *` when starting one, `If-Match` against the ETag it read
+when updating one — and turns a `412 Precondition Failed` into `SagaConcurrencyException`, which is the
+same exception Marten, EF Core and CosmosDB raise for the same situation. A single
+`OnException<ConcurrencyException>().RetryTimes(...)` policy covers all of them.
+
+`Store<T>()` **refuses** a type deriving from `Saga`, and `Saga<T>()` refuses one that does not. The
+two are not interchangeable: a saga registered as a document would be claimed for its *type* and not
+for its *chain*, so Wolverine would keep it in the in-memory saga persistor while the bucket and key
+function sat unused.
+
+Everything else about sagas is unchanged — `[SagaIdentity]`, `MarkCompleted()`, timeout messages, and
+identities of `string`, `Guid`, `int` or `long` all behave exactly as they do on any other store.
+
 ## Alongside another store
 
 S3 documents and Marten (or Polecat, Fisher, EF Core, RavenDb, CosmosDb) documents coexist in one
@@ -145,9 +175,10 @@ integrations were registered in.
 
 Two consequences worth knowing:
 
-- **Sagas stay with the transactional store.** Saga chains resolve on a different question -- which
-  provider owns this *chain* rather than which owns this *type* -- and this provider claims no chains,
-  so a saga in a mixed application is persisted by Marten or your database exactly as before.
+- **Sagas belong to whoever was asked for them.** Saga chains resolve on a different question — which
+  provider owns this *chain* rather than which owns this *type* — and this provider claims a chain only
+  for a saga you registered with `Saga<T>()`. A saga you did not register that way is persisted by
+  Marten or your database exactly as before.
 - **There is no atomicity across the two.** The Marten write commits in its transaction; the S3 write
   already happened. A handler that writes both and then throws has written the S3 object and not the
   Marten document. If that matters, write the S3 object from a projection or a follow-on message
@@ -166,12 +197,6 @@ there is nothing to commit and nothing to roll back.
 **No querying.** `[All]`, `[FirstOrDefault]` and `[Queryable]` are not supported and fail at
 bootstrapping naming this provider. `ListObjectsV2` over a key prefix is a paged scan, not a query,
 and a scan that looks like a query is worse than an honest refusal.
-
-**No sagas.** `Store<T>()` refuses a type deriving from `Saga`. It would otherwise be silently useless
-*and* dangerous: a saga chain picks its persistence on which provider owns the chain, this one owns
-none, and the fallback is the **in-memory** saga persistor -- so the bucket and key function would be
-ignored and the saga would live in process memory, gone on the next restart and invisible to every
-other node. Keep sagas with a transactional store.
 
 **No soft delete.** `MaybeSoftDeleted` does not apply. Only your serializer knows what deleted means
 for its payload; answer `null` for anything that should count as missing.

--- a/docs/guide/durability/amazon-s3.md
+++ b/docs/guide/durability/amazon-s3.md
@@ -1,4 +1,4 @@
-# Amazon S3 Integration <Badge type="tip" text="6.31" />
+# Amazon S3 Integration <Badge type="tip" text="6.32" />
 
 ::: tip
 `WolverineFx.AmazonS3` does two independent things, and this page is about the first.
@@ -15,7 +15,7 @@ The two share nothing but a package and an `IAmazonS3`. Use either, or both.
 Sagas are supported too, through their own registration — see [sagas](#sagas).
 :::
 
-::: warning Moved in 6.31
+::: warning Moved in 6.32
 The claim check half used to ship as `WolverineFx.ClaimCheck.AmazonS3`, which is now deprecated.
 The types and their namespace are unchanged, so swapping the package reference is the whole migration.
 :::
@@ -121,7 +121,7 @@ key, so S3 has no insert-versus-update to honour and these are last-write-wins.
 
 You can also take `IS3DocumentSession` directly for the same key mapping outside a handler.
 
-## Sagas <Badge type="tip" text="6.31" />
+## Sagas <Badge type="tip" text="6.32" />
 
 A saga is registered separately from a document, and the difference is not bookkeeping:
 

--- a/docs/guide/durability/claim-checks.md
+++ b/docs/guide/durability/claim-checks.md
@@ -154,7 +154,7 @@ The store maps each `ClaimCheckToken.Id` directly to a blob name, and sets `Blob
 dotnet add package WolverineFx.AmazonS3
 ```
 
-::: warning Moved in 6.31
+::: warning Moved in 6.32
 The S3 claim check store now ships in `WolverineFx.AmazonS3`, alongside the
 [S3 document persistence](/guide/durability/amazon-s3). **`WolverineFx.ClaimCheck.AmazonS3` is deprecated**
 and will not be published again.

--- a/src/Persistence/Wolverine.AmazonS3.Tests/s3_refuses_what_it_cannot_actually_do.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/s3_refuses_what_it_cannot_actually_do.cs
@@ -19,13 +19,14 @@ public class s3_refuses_what_it_cannot_actually_do : IClassFixture<AmazonS3Fixtu
 
     /// <summary>
     /// A saga chain picks its persistence provider on <c>CanApply</c>, not <c>CanPersist</c>, and this
-    /// provider claims no chains. The fallback in <c>GenerationRulesExtensions</c> is the IN-MEMORY
-    /// saga persistor, so a saga registered here would start cleanly, ignore its bucket and key
-    /// function entirely, and keep its state in process memory. Refusing at the registration is the
-    /// difference between an error and silent data loss on the next restart.
+    /// provider claims a chain only for a type registered through <c>Saga&lt;T&gt;()</c>. Through
+    /// <c>Store&lt;T&gt;()</c> the fallback is the IN-MEMORY saga persistor, so the saga would start
+    /// cleanly, ignore its bucket and key function entirely, and keep its state in process memory.
+    /// Refusing at the registration is the difference between an error and silent data loss on the
+    /// next restart.
     /// </summary>
     [Fact]
-    public void refuses_to_register_a_saga_type()
+    public void refuses_to_register_a_saga_type_as_an_ordinary_document()
     {
         var configuration = new AmazonS3Configuration();
 
@@ -35,8 +36,25 @@ public class s3_refuses_what_it_cannot_actually_do : IClassFixture<AmazonS3Fixtu
             x.KeyFor = ctx => $"sagas/{ctx.Id}.json";
         }));
 
-        ex.Message.ShouldContain("not supported yet");
+        ex.Message.ShouldContain("Saga<AnS3Saga>(...)");
         ex.Message.ShouldContain("in-memory saga persistor");
+    }
+
+    /// <summary>
+    /// ...and the mirror, so neither registration silently accepts the other's type.
+    /// </summary>
+    [Fact]
+    public void refuses_to_register_a_non_saga_as_a_saga()
+    {
+        var configuration = new AmazonS3Configuration();
+
+        var ex = Should.Throw<InvalidS3DocumentMappingException>(() => configuration.Saga(typeof(NotASaga), x =>
+        {
+            x.BucketName = "does-not-matter";
+            x.KeyFor = ctx => $"nope/{ctx.Id}.json";
+        }));
+
+        ex.Message.ShouldContain("does not derive from Saga");
     }
 
     /// <summary>
@@ -86,6 +104,11 @@ public class s3_refuses_what_it_cannot_actually_do : IClassFixture<AmazonS3Fixtu
 }
 
 public class AnS3Saga : Saga
+{
+    public string Id { get; set; } = null!;
+}
+
+public class NotASaga
 {
     public string Id { get; set; } = null!;
 }

--- a/src/Persistence/Wolverine.AmazonS3.Tests/saga_optimistic_concurrency.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/saga_optimistic_concurrency.cs
@@ -1,0 +1,128 @@
+using Amazon.S3;
+using IntegrationTests;
+using Shouldly;
+using Wolverine.AmazonS3.Internals;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// GH-4160. The shipped saga compliance specs are entirely sequential, so every one of them passes
+/// against a plain PutObject that silently loses concurrent updates. A saga is a read-modify-write by
+/// definition, so this is the property that actually makes S3 saga storage safe, and it needs its own
+/// test or it is a guarantee nobody checked.
+/// </summary>
+/// <remarks>
+/// Two <see cref="S3DocumentSession" /> instances, because generated code builds one session per
+/// handler invocation — so two sessions is exactly two concurrent messages for one saga, without
+/// having to race real threads to observe it.
+/// </remarks>
+public class saga_optimistic_concurrency : IAsyncLifetime
+{
+    private const string Bucket = "wolverine-s3-saga-concurrency";
+
+    private AmazonS3Client _client = null!;
+    private AmazonS3Configuration _configuration = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        Assert.SkipUnless(LocalStack.IsRunning, LocalStack.SkipReason);
+
+        _client = LocalStack.CreateClient();
+
+        try
+        {
+            await _client.PutBucketAsync(Bucket);
+        }
+        catch (AmazonS3Exception e) when (e.ErrorCode is "BucketAlreadyOwnedByYou" or "BucketAlreadyExists")
+        {
+        }
+
+        _configuration = new AmazonS3Configuration();
+        _configuration.Saga<ConcurrentSaga>(x =>
+        {
+            x.BucketName = Bucket;
+            x.KeyFor = ctx => $"concurrency/{ctx.Id}.json";
+        });
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private S3DocumentSession session() => new(_client, _configuration);
+
+    [LocalStackFact]
+    public async Task the_second_of_two_concurrent_updates_is_refused()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var ct = TestContext.Current.CancellationToken;
+
+        await session().StoreAsync(new ConcurrentSaga { Id = id, Count = 0 }, null, ct);
+
+        // Two messages for one saga, each with its own session, both reading the same version
+        var first = session();
+        var second = session();
+
+        var readByFirst = await first.LoadAsync<ConcurrentSaga>(id, null, ct);
+        var readBySecond = await second.LoadAsync<ConcurrentSaga>(id, null, ct);
+
+        readByFirst!.Count = 1;
+        await first.StoreAsync(readByFirst, null, ct);
+
+        // ...and the second one is now working from a version that no longer exists
+        readBySecond!.Count = 2;
+
+        var ex = await Should.ThrowAsync<SagaConcurrencyException>(async () =>
+            await second.StoreAsync(readBySecond, null, ct));
+
+        ex.Message.ShouldContain("changed by another message");
+
+        // The first write stands: the loser did not overwrite it, which is the whole point
+        var survivor = await session().LoadAsync<ConcurrentSaga>(id, null, ct);
+        survivor!.Count.ShouldBe(1);
+    }
+
+    [LocalStackFact]
+    public async Task two_sessions_that_both_believe_they_are_starting_the_saga_do_not_both_win()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var ct = TestContext.Current.CancellationToken;
+
+        // Neither has read anything, so both write with If-None-Match: *
+        await session().StoreAsync(new ConcurrentSaga { Id = id, Count = 10 }, null, ct);
+
+        await Should.ThrowAsync<SagaConcurrencyException>(async () =>
+            await session().StoreAsync(new ConcurrentSaga { Id = id, Count = 20 }, null, ct));
+
+        (await session().LoadAsync<ConcurrentSaga>(id, null, ct))!.Count.ShouldBe(10);
+    }
+
+    [LocalStackFact]
+    public async Task one_session_may_write_the_same_saga_twice()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var ct = TestContext.Current.CancellationToken;
+
+        // A handler that saves, mutates and saves again compares against what it last wrote rather
+        // than against what it first read -- otherwise the second write refuses itself.
+        var only = session();
+        await only.StoreAsync(new ConcurrentSaga { Id = id, Count = 1 }, null, ct);
+
+        var loaded = await only.LoadAsync<ConcurrentSaga>(id, null, ct);
+        loaded!.Count = 2;
+        await only.StoreAsync(loaded, null, ct);
+
+        loaded.Count = 3;
+        await only.StoreAsync(loaded, null, ct);
+
+        (await session().LoadAsync<ConcurrentSaga>(id, null, ct))!.Count.ShouldBe(3);
+    }
+}
+
+public class ConcurrentSaga : Saga
+{
+    public string Id { get; set; } = null!;
+    public int Count { get; set; }
+}

--- a/src/Persistence/Wolverine.AmazonS3.Tests/saga_storage_compliance.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/saga_storage_compliance.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using Amazon.S3;
+using Amazon.S3.Model;
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.ComplianceTests.Sagas;
+
+namespace Wolverine.AmazonS3.Tests;
+
+/// <summary>
+/// The shared saga compliance specs, run against a bucket. GH-4160.
+/// </summary>
+/// <remarks>
+/// All four identity flavours, unlike CosmosDb's implementation of the same specs, which supports only
+/// the string one because a Cosmos id is a string. An S3 object key is a string too, but the key
+/// function is handed the identity as an <c>object</c>, so a Guid, an int and a long each address a
+/// key just as well.
+/// </remarks>
+public class AmazonS3SagaHost : ISagaHost
+{
+    public const string Bucket = "wolverine-s3-sagas";
+
+    private readonly AmazonS3Client _client = LocalStack.CreateClient();
+
+    public AmazonS3SagaHost()
+    {
+        if (!LocalStack.IsRunning) return;
+
+        try
+        {
+#pragma warning disable VSTHRD002 // ISagaHost is constructed synchronously by the compliance specs
+            _client.PutBucketAsync(new PutBucketRequest { BucketName = Bucket }).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+        }
+        catch (AmazonS3Exception e) when (e.ErrorCode is "BucketAlreadyOwnedByYou" or "BucketAlreadyExists")
+        {
+        }
+    }
+
+    public static string KeyFor(S3KeyContext ctx) => $"sagas/{ctx.EntityType.Name}/{ctx.Id}.json";
+
+    public Task<IHost> BuildHostAsync<TSaga>()
+    {
+        return Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                // Only the saga under test. CosmosDb's implementation of these specs includes the whole
+                // compliance assembly, which it can afford because it claims every type; this provider is
+                // selective, so pulling in TodoHandler -- which returns Store<Todo> -- would fail codegen
+                // with NoMatchingPersistenceProviderException before a single saga test ran.
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<TSaga>();
+
+                opts.Services.AddSingleton<IAmazonS3>(LocalStack.CreateClient());
+
+                opts.UseAmazonS3Persistence(s3 => s3.Saga(typeof(TSaga), x =>
+                {
+                    x.BucketName = Bucket;
+                    x.KeyFor = KeyFor;
+                }));
+            }).StartAsync();
+    }
+
+    public Task<T?> LoadState<T>(Guid id) where T : Saga => load<T>(id);
+
+    public Task<T?> LoadState<T>(int id) where T : Saga => load<T>(id);
+
+    public Task<T?> LoadState<T>(long id) where T : Saga => load<T>(id);
+
+    public Task<T?> LoadState<T>(string id) where T : Saga => load<T>(id);
+
+    // Read straight through the AWS client rather than through Wolverine, so a green test means the
+    // object really is in the bucket rather than that Wolverine can read back its own writes.
+    private async Task<T?> load<T>(object id) where T : Saga
+    {
+        try
+        {
+            using var response = await _client.GetObjectAsync(Bucket,
+                KeyFor(new S3KeyContext(typeof(T), id, null)));
+            using var reader = new StreamReader(response.ResponseStream);
+
+            return JsonSerializer.Deserialize<T>(await reader.ReadToEndAsync(),
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        }
+        catch (AmazonS3Exception e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return default;
+        }
+    }
+}
+
+public class string_identified_saga_compliance : StringIdentifiedSagaComplianceSpecs<AmazonS3SagaHost>;
+
+public class guid_identified_saga_compliance : GuidIdentifiedSagaComplianceSpecs<AmazonS3SagaHost>;
+
+public class int_identified_saga_compliance : IntIdentifiedSagaComplianceSpecs<AmazonS3SagaHost>;
+
+public class long_identified_saga_compliance : LongIdentifiedSagaComplianceSpecs<AmazonS3SagaHost>;

--- a/src/Persistence/Wolverine.AmazonS3.Tests/saga_storage_compliance.cs
+++ b/src/Persistence/Wolverine.AmazonS3.Tests/saga_storage_compliance.cs
@@ -25,7 +25,11 @@ public class AmazonS3SagaHost : ISagaHost
 
     public AmazonS3SagaHost()
     {
-        if (!LocalStack.IsRunning) return;
+        // The skip is taken HERE rather than in BuildHostAsync, and that is not a style choice:
+        // several of the shipped saga specs wrap their body in Should.ThrowAsync, which swallows the
+        // SkipException and reports it as "expected IndeterminateSagaStateIdException, got
+        // SkipException". From the constructor it skips cleanly.
+        Assert.SkipUnless(LocalStack.IsRunning, LocalStack.SkipReason);
 
         try
         {

--- a/src/Persistence/Wolverine.AmazonS3/AmazonS3Configuration.cs
+++ b/src/Persistence/Wolverine.AmazonS3/AmazonS3Configuration.cs
@@ -33,15 +33,15 @@ public class AmazonS3Configuration
             throw new InvalidS3DocumentMappingException(entityType, "Only reference types can be stored as S3 objects.");
         }
 
-        // GH-4160. Registering a saga here would be silently useless and worse than useless: a saga
-        // chain picks its persistence on CanApply rather than CanPersist, this provider claims no
-        // chains, and the fallback is the IN-MEMORY saga persistor. The host would start, the bucket
-        // and key function would be ignored, and the saga would live in process memory -- gone on
-        // restart and invisible to every other node. Refuse it where the mistake is made.
+        // GH-4160. A saga registered through Store<T>() would be silently useless and worse than
+        // useless: a saga chain picks its persistence on CanApply rather than CanPersist, and this
+        // provider claims a chain only for a type registered through Saga<T>(). Through Store<T>() the
+        // fallback is the IN-MEMORY saga persistor -- host starts, bucket and key function ignored,
+        // saga state in process memory. Refuse it where the mistake is made.
         if (entityType.CanBeCastTo<Saga>())
         {
             throw new InvalidS3DocumentMappingException(entityType,
-                "Saga persistence in S3 is not supported yet. A saga registered here would silently be kept by the in-memory saga persistor instead, so this refuses rather than pretending. Keep the saga with a transactional store.");
+                $"Register a saga with Saga<{entityType.NameInCode()}>(...) instead. Store<T>() does not claim saga CHAINS, so a saga registered through it would silently be kept by the in-memory saga persistor -- bucket and key function ignored -- rather than in S3.");
         }
 
         if (!_mappings.TryGetValue(entityType, out var mapping))
@@ -58,7 +58,51 @@ public class AmazonS3Configuration
         return this;
     }
 
+    /// <summary>
+    ///     Persist the saga type <typeparamref name="T" /> in S3, using conditional writes for optimistic
+    ///     concurrency.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately a separate call from <see cref="Store{T}" />, for two reasons. It makes "this saga
+    ///     lives in this bucket" something the application said rather than something it got by accident;
+    ///     and it is what lets <c>CanApply</c> claim saga chains <em>only</em>, so <c>[Transactional]</c>
+    ///     and <c>AutoApplyTransactions</c> can never pick this provider as the transaction owner of an
+    ///     ordinary chain that happens to touch an S3 document. See GH-4160.
+    /// </remarks>
+    public AmazonS3Configuration Saga<T>(Action<S3DocumentMapping> configure) where T : Saga
+    {
+        return Saga(typeof(T), configure);
+    }
+
+    public AmazonS3Configuration Saga(Type sagaType, Action<S3DocumentMapping> configure)
+    {
+        ArgumentNullException.ThrowIfNull(sagaType);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (!sagaType.CanBeCastTo<Saga>())
+        {
+            throw new InvalidS3DocumentMappingException(sagaType,
+                $"It does not derive from Saga. Register an ordinary document with Store<{sagaType.NameInCode()}>(...) instead.");
+        }
+
+        if (!_mappings.TryGetValue(sagaType, out var mapping))
+        {
+            mapping = new S3DocumentMapping(sagaType) { IsSaga = true };
+            _mappings[sagaType] = mapping;
+        }
+
+        configure(mapping);
+        mapping.Compile();
+
+        return this;
+    }
+
     internal IReadOnlyCollection<S3DocumentMapping> Mappings => _mappings.Values;
+
+    internal bool TryFindSagaMapping(Type sagaType, out S3DocumentMapping mapping)
+    {
+        return _mappings.TryGetValue(sagaType, out mapping!) && mapping.IsSaga;
+    }
 
     internal bool TryFindMapping(Type entityType, out S3DocumentMapping mapping)
     {

--- a/src/Persistence/Wolverine.AmazonS3/Internals/S3DocumentSession.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/S3DocumentSession.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using Amazon.S3;
 using Amazon.S3.Model;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
 
 namespace Wolverine.AmazonS3.Internals;
 
@@ -12,6 +14,11 @@ public class S3DocumentSession : IS3DocumentSession
 {
     private readonly IAmazonS3 _client;
     private readonly AmazonS3Configuration _configuration;
+
+    // GH-4160. The ETag of every saga object this session read, so the matching write can be a
+    // compare-and-swap. Generated code builds one session per handler invocation, so the lifetime of
+    // this is exactly one message -- load, mutate, save -- which is the window a saga needs guarded.
+    private readonly Dictionary<string, string> _etags = new();
 
     public S3DocumentSession(IAmazonS3 client, AmazonS3Configuration configuration)
     {
@@ -28,14 +35,21 @@ public class S3DocumentSession : IS3DocumentSession
 
         try
         {
+            var key = mapping.KeyForIdentity(id, tenantId);
+
             using var response = await _client.GetObjectAsync(new GetObjectRequest
             {
                 BucketName = mapping.BucketName,
-                Key = mapping.KeyForIdentity(id, tenantId)
+                Key = key
             }, token).ConfigureAwait(false);
 
             using var buffer = new MemoryStream();
             await response.ResponseStream.CopyToAsync(buffer, token).ConfigureAwait(false);
+
+            if (mapping.IsSaga && response.ETag.IsNotEmpty())
+            {
+                _etags[key] = response.ETag;
+            }
 
             return mapping.Serializer.Deserialize<T>(buffer.ToArray());
         }
@@ -98,7 +112,39 @@ public class S3DocumentSession : IS3DocumentSession
             request.Headers.ContentEncoding = mapping.Serializer.ContentEncoding;
         }
 
-        await _client.PutObjectAsync(request, token).ConfigureAwait(false);
+        // A saga is a read-modify-write, so its put is a compare-and-swap: If-Match against the ETag
+        // this session read, or If-None-Match: * when it read nothing and believes it is creating one.
+        // An ordinary document stays last-write-wins -- S3 has no insert-versus-update and callers are
+        // told so. See GH-4160.
+        if (mapping.IsSaga)
+        {
+            if (_etags.TryGetValue(key, out var etag))
+            {
+                request.IfMatch = etag;
+            }
+            else
+            {
+                request.IfNoneMatch = "*";
+            }
+        }
+
+        try
+        {
+            var response = await _client.PutObjectAsync(request, token).ConfigureAwait(false);
+
+            // Keep the session's view current: a handler that writes the same saga twice in one message
+            // must compare against what it just wrote, not against what it originally read.
+            if (mapping.IsSaga && response.ETag.IsNotEmpty())
+            {
+                _etags[key] = response.ETag;
+            }
+        }
+        catch (AmazonS3Exception e) when (mapping.IsSaga && e.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            throw new SagaConcurrencyException(
+                $"Saga of type {mapping.EntityType.FullNameInCode()} at {mapping.BucketName}/{key} was changed by another message since it was read",
+                e);
+        }
     }
 
     private Task deleteAsync(S3DocumentMapping mapping, string key, CancellationToken token)

--- a/src/Persistence/Wolverine.AmazonS3/Internals/S3PersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.AmazonS3/Internals/S3PersistenceFrameProvider.cs
@@ -4,6 +4,7 @@ using JasperFx.CodeGeneration.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Configuration;
 using Wolverine.Persistence;
+using Wolverine.Persistence.Sagas;
 
 namespace Wolverine.AmazonS3.Internals;
 
@@ -33,13 +34,26 @@ public class S3PersistenceFrameProvider : IPersistenceFrameProvider
     }
 
     /// <summary>
-    /// S3 has no transaction and no unit of work, so there is nothing to attach to a chain. Claiming
-    /// one would also make <c>AutoApplyTransactions</c> ambiguous for the normal case of S3 documents
-    /// alongside a real transactional store.
+    /// Saga chains only, and only for a type registered through <c>Saga&lt;T&gt;()</c>.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is the question a saga chain asks -- "which provider owns this CHAIN" -- and the
+    ///         answer has to be yes for an S3-persisted saga, or <c>SagaChain</c> falls through to the
+    ///         default in <c>GenerationRulesExtensions</c>, which is the IN-MEMORY saga persistor.
+    ///     </para>
+    ///     <para>
+    ///         It stays false for everything else on purpose. <c>[Transactional]</c> and
+    ///         <c>AutoApplyTransactions</c> ask the same question, and S3 has no transaction and no unit
+    ///         of work -- so an ordinary chain that merely touches an S3 document must never resolve to
+    ///         this provider as its transaction owner. See GH-4160.
+    ///     </para>
+    /// </remarks>
     public bool CanApply(IChain chain, IServiceContainer container)
     {
-        return false;
+        return chain is SagaChain saga
+               && tryFindConfiguration(container, out var configuration)
+               && configuration.TryFindSagaMapping(saga.SagaType, out _);
     }
 
     public void ApplyTransactionSupport(IChain chain, IServiceContainer container)
@@ -79,6 +93,10 @@ public class S3PersistenceFrameProvider : IPersistenceFrameProvider
 
     public Frame DetermineDeleteFrame(Variable variable, IServiceContainer container) => delete(variable);
 
+    /// <summary>
+    /// Nothing to commit: every write already happened, and for a saga it happened as a conditional put
+    /// that either took effect or threw <c>SagaConcurrencyException</c>.
+    /// </summary>
     public Frame CommitUnitOfWorkFrame(Variable saga, IServiceContainer container)
     {
         return new CommentFrame("S3 writes take effect immediately; there is no unit of work to commit");

--- a/src/Persistence/Wolverine.AmazonS3/S3DocumentMapping.cs
+++ b/src/Persistence/Wolverine.AmazonS3/S3DocumentMapping.cs
@@ -44,6 +44,14 @@ public class S3DocumentMapping
     public IS3DocumentSerializer Serializer { get; set; } = S3DocumentSerializer.Default;
 
     /// <summary>
+    /// True when this type was registered through <c>Saga&lt;T&gt;()</c>. A saga is written with a
+    /// conditional put -- If-None-Match on create, If-Match on update -- because a saga is a
+    /// read-modify-write and two messages for one saga would otherwise silently lose an update.
+    /// Ordinary documents stay last-write-wins. See GH-4160.
+    /// </summary>
+    internal bool IsSaga { get; init; }
+
+    /// <summary>
     /// The CLR type of this document's identity. Leave it unset to take the type of the document's own
     /// identity member.
     /// </summary>

--- a/src/Persistence/Wolverine.AmazonS3/Wolverine.AmazonS3.csproj
+++ b/src/Persistence/Wolverine.AmazonS3/Wolverine.AmazonS3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Description>Amazon S3 document persistence and claim check storage for Wolverine applications</Description>
+        <Description>Amazon S3 document and saga persistence, and claim check storage, for Wolverine applications</Description>
         <PackageId>WolverineFx.AmazonS3</PackageId>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
         <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>


### PR DESCRIPTION
The last piece of #4160, on top of #4207.

Sagas were the half of #4165 that was implemented in *shape* and unreachable in *fact*: the provider carried every saga-shaped member of `IPersistenceFrameProvider`, and none of them could be called, because a saga chain picks its provider on `CanApply` and that one claimed no chains. #4207 closed the trap by refusing the registration outright. This opens it properly.

## `s3.Saga<T>()` is a separate registration

```csharp
opts.UseAmazonS3Persistence(s3 =>
{
    s3.Saga<OrderSaga>(x =>
    {
        x.BucketName = "order-sagas";
        x.KeyFor = ctx => $"sagas/{ctx.TenantId}/{ctx.Id}.json";
    });
});
```

`Store<T>()` refuses a `Saga`-derived type and `Saga<T>()` refuses one that is not — the two are not interchangeable.

It is a separate call rather than a flag for two reasons. It makes "this saga lives in this bucket" something the application **said** rather than something it got. And it is what lets `CanApply` claim saga chains *only*: `[Transactional]` and `AutoApplyTransactions` ask that same question, and S3 has no transaction, so an ordinary chain that merely touches an S3 document must never resolve to this provider as its transaction owner.

## Saga writes are conditional; document writes are not

A document is last-write-wins, because `PutObject` overwrites whatever is at the key, and callers are told so. A saga is a **read-modify-write**, so two messages for one saga would silently lose an update.

A saga is written with `If-None-Match: *` when starting and `If-Match` against the ETag this session read when updating. A `412 Precondition Failed` becomes `SagaConcurrencyException` — the same exception Marten, EF Core and CosmosDB raise, so one `OnException<ConcurrencyException>` policy still covers every store.

The ETag cache lives on `S3DocumentSession`, whose lifetime is exactly one handler invocation — which is precisely the window a saga needs guarded. It is refreshed on write, so a handler that saves the same saga twice compares against what it last wrote rather than refusing itself.

CosmosDB does the same translation from *generated* code, because its call is emitted inline. Every S3 write already funnels through our own `IS3DocumentSession`, so it belongs there and needs no codegen.

## All four identity flavours pass the shared compliance specs

**37 tests** — `String`, `Guid`, `Int` and `Long` `IdentifiedSagaComplianceSpecs`. CosmosDb's implementation of the same specs supports only the string flavour, because a Cosmos id *is* a string; an S3 key function is handed the identity as `object`, so every flavour addresses a key just as well.

One difference from CosmosDb's host worth knowing if you copy it: this one narrows discovery to the saga under test. CosmosDb includes the whole compliance assembly, which it can afford by claiming every type — a *selective* provider fails codegen on `TodoHandler`'s `Store<Todo>` with `NoMatchingPersistenceProviderException` before a single saga test runs.

## ...and a concurrency suite the shipped specs cannot replace

Every compliance spec is **sequential**, so all 37 pass just as happily against a plain `PutObject` that loses concurrent writes. Three tests cover what they cannot see:

- a stale update is refused, and the winner's value survives — the loser did not overwrite it
- two sessions that both believe they are *starting* the saga do not both win
- one session may legitimately write the same saga twice

Two `S3DocumentSession` instances is exactly two concurrent messages for one saga, since generated code builds one session per handler invocation — no thread racing needed to observe it.

LocalStack implements all three conditional-write semantics (`If-None-Match: *` → 412, stale `If-Match` → 412, fresh `If-Match` → OK). I verified that *before* writing any of this rather than assuming it, since the whole design hinged on the guarantee being testable rather than merely asserted.

## Verification

- `Wolverine.AmazonS3.Tests` **100/100**, 0 skipped, against LocalStack
- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors
- Docs: the S3 page gains a **Sagas** section; the "No sagas" entry it replaced came in with #4207 one PR ago and is now false