### PR TITLE
Explicit per-provider entity attributes: [FromMarten] and [FromEfCore]

### DIFF
--- a/docs/guide/handlers/persistence.md
+++ b/docs/guide/handlers/persistence.md
@@ -14,6 +14,7 @@ These all speak one vocabulary, and none of it names your database:
 | You want | Use |
 |---|---|
 | A document or entity loaded for you | `[Entity]` |
+| The same, but from a store you name | [`[FromMarten]` / `[FromEfCore]`](#naming-the-store-explicitly) |
 | An event sourced model loaded for **writing**, with concurrency protection | `[WriteModel]` |
 | An event sourced model's current state, read only | `[ReadModel]` |
 | The whole method to be an event sourced command handler | `[DeciderFunction]` |
@@ -228,6 +229,104 @@ public enum ValueSource
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Wolverine/Attributes/ModifyChainAttribute.cs#L18-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_valuesource' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Naming the Store Explicitly <Badge type="tip" text="6.32" />
+
+`[Entity]` is deliberately store-agnostic: it asks every registered persistence provider which of them
+claims the entity type, and the first one that says yes builds the load. That is the right default, and it
+is what lets the same handler compile against Marten, EF Core, or anything else you have configured.
+
+Sometimes you want the store named in the code instead. For those cases there is an explicit attribute
+per provider:
+
+```cs
+public static OrderSummary Handle(
+    ReadOrder command,
+    [FromMarten] Order order)
+    => new(order.Id, order.Total);
+```
+
+There are two reasons to reach for one.
+
+**Explicitness.** Some teams simply prefer a parameter to say where it comes from, especially in a codebase
+where more than one persistence tool is in play and a reader cannot tell from the entity type alone.
+
+**Disambiguation.** More substantially, two registered stores can both be able to claim the same type.
+Marten's provider claims *every* document type, because Marten genuinely can persist any document, so
+Wolverine consults selective providers first — an entity mapped in an EF Core `DbContext` resolves to EF
+Core no matter which integration was registered first. That precedence rule is correct as a default, but if
+the type also lives in Marten and *that* is the copy you wanted, `[Entity]` has no way to know:
+
+```cs
+public static Report Handle(
+    BuildReport command,
+    // Mapped in a DbContext AND stored in Marten. A plain [Entity] would resolve to EF Core;
+    // this says which one was meant.
+    [FromMarten] Coupon coupon)
+    => Report.For(coupon);
+```
+
+These attributes are `[Entity]` in every other respect. They inherit its implementation outright rather
+than reimplementing it, so `Required`, `OnMissing`, `MissingMessage`, `MaybeSoftDeleted`, the identity
+conventions, the explicit argument name constructor, the `ValueSource` options, and availability in
+`Before` / `Validate` methods all behave identically. The one thing that changes is which provider builds
+the load.
+
+### When the Store Cannot Deliver
+
+Because you named the store, Wolverine can tell you exactly what went wrong at code generation time
+instead of quietly falling through to a different provider. There are two distinct failures, and they have
+different remedies:
+
+* **The store is not integrated at all.** `[FromMarten]` in an application that never called
+  `IntegrateWithWolverine()` fails naming the parameter, its declaring method, and the bootstrapping call
+  you are missing.
+* **The store is integrated but does not know the type.** `[FromEfCore]` on a class that no registered
+  `DbContext` maps fails saying exactly that, rather than reporting a generic "could not determine a
+  matching persistence service".
+
+Both are thrown while the handler or endpoint is being compiled, so a mistake surfaces at startup rather
+than on the first message.
+
+### The EF Core Extras <Badge type="tip" text="6.32" />
+
+`[FromEfCore]` adds two loading options that only mean something to EF Core:
+
+```cs
+public static OrderSummary Handle(
+    ReadOrder command,
+    [FromEfCore(AsNoTracking = true, Include = "Lines.Product")] Order order)
+    => OrderSummary.For(order);
+```
+
+`AsNoTracking` loads the entity detached from EF Core's change tracker. It is cheaper for a read-only
+handler or endpoint — but note that mutating a detached entity will **not** be picked up by the
+transactional middleware's `SaveChangesAsync`, which is the entire point of asking for it.
+
+`Include` eagerly loads a navigation property, and `Includes` takes several at once (they combine rather
+than replace each other). A dotted path chains, so `Include = "Lines.Product"` is EF Core's
+`Include(x => x.Lines).ThenInclude(x => x.Product)`. These are strings rather than lambdas because
+attribute arguments have to be compile-time constants; they map onto EF Core's own string `Include`
+overload, which is what makes a `ThenInclude` chain expressible at all.
+
+::: tip What the extras change about the generated code
+With neither option set, `[FromEfCore]` emits the same `DbContext.FindAsync` load that `[Entity]` does,
+which can answer straight from the change tracker without touching the database. `FindAsync` supports
+neither `Include` nor `AsNoTracking`, so asking for either one switches the generated load to a
+`Set<T>()` query terminated by `FirstOrDefaultAsync` on the primary key. That is a real behavioral
+difference, and it is why the attribute only makes the switch when you actually ask for it.
+:::
+
+Every include path is walked against the EF Core model while the chain is being compiled, so a typo is a
+startup error that names the bad segment and lists the navigations that *do* exist on that type — not a
+runtime failure on the first message handled. Nothing is ever silently dropped: a request Wolverine cannot
+honor (an unknown navigation, or a composite primary key, which the query form cannot express) is a
+codegen error rather than a load that quietly ignores half of what you asked for.
+
+### The Rest of the Family
+
+`[FromMarten]` and `[FromEfCore]` ship first, and the family is being extended to the other persistence
+providers on exactly the same shape — same inherited `[Entity]` behavior, same two failure diagnostics.
 
 ## Reading the First of a Type <Badge type="tip" text="6.28" />
 

--- a/src/Persistence/EfCoreTests/from_ef_core_attribute_usage.cs
+++ b/src/Persistence/EfCoreTests/from_ef_core_attribute_usage.cs
@@ -1,0 +1,442 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace EfCoreTests;
+
+/// <summary>
+///     <c>[FromEfCore]</c> is <c>[Entity]</c> pinned to EF Core, plus the two loading options that only EF Core has.
+///     The inherited half is covered by the <c>[FromMarten]</c> suite and the existing <c>[Entity]</c> suites; what
+///     is proved here is the EF-specific half.
+/// </summary>
+/// <remarks>
+///     Each extra is asserted on the GENERATED SOURCE as well as at runtime. That is not belt-and-braces: the whole
+///     failure mode this feature guards against is an <c>Include</c> or an <c>AsNoTracking</c> being silently dropped
+///     on the floor, and a results-only assertion cannot always see the difference — a navigation can be populated by
+///     change-tracker fixup rather than by the query, and a no-tracking read looks exactly like a tracked one until
+///     something writes.
+/// </remarks>
+[Collection("sqlserver")]
+public class from_ef_core_attribute_usage : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(DepotHandler));
+
+                opts.Services.AddDbContextWithWolverineIntegration<LogisticsDbContext>(o =>
+                {
+                    o.UseSqlServer(Servers.SqlServerConnectionString);
+                });
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "from_ef_core");
+                opts.UseEntityFrameworkCoreTransactions();
+                opts.UseEntityFrameworkCoreWolverineManagedMigrations();
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LogisticsDbContext>();
+        db.ShipmentLines.RemoveRange(db.ShipmentLines);
+        db.Shipments.RemoveRange(db.Shipments);
+        db.Depots.RemoveRange(db.Depots);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task<Guid> seedDepot()
+    {
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LogisticsDbContext>();
+
+        var depot = new Depot { Id = Guid.NewGuid(), Name = "Topeka" };
+        var shipment = new Shipment { Id = Guid.NewGuid(), DepotId = depot.Id, Tracking = "TRK-1" };
+        var line = new ShipmentLine { Id = Guid.NewGuid(), ShipmentId = shipment.Id, Sku = "SKU-1" };
+
+        db.Depots.Add(depot);
+        db.Shipments.Add(shipment);
+        db.ShipmentLines.Add(line);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return depot.Id;
+    }
+
+    private async Task<string?> nameOf(Guid id)
+    {
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LogisticsDbContext>();
+        var depot = await db.Depots.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id, TestContext.Current.CancellationToken);
+        return depot?.Name;
+    }
+
+    private string sourceFor<T>()
+    {
+        _host.GetRuntime().Handlers.HandlerFor<T>();
+        var chain = _host.GetRuntime().Handlers.ChainFor<T>();
+        chain.ShouldNotBeNull();
+
+        var code = chain.SourceCode;
+        code.ShouldNotBeNull();
+        return code;
+    }
+
+    [Fact]
+    public async Task a_plain_from_ef_core_behaves_like_entity()
+    {
+        var id = await seedDepot();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadDepot(id));
+
+        tracked.Sent.SingleMessage<DepotRead>().Name.ShouldBe("Topeka");
+    }
+
+    [Fact]
+    public void a_plain_from_ef_core_still_uses_the_cheaper_find_async()
+    {
+        // No Include, no AsNoTracking, so nothing about the load should change from what [Entity] emits
+        var code = sourceFor<ReadDepot>();
+
+        code.ShouldContain("FindAsync<EfCoreTests.Depot>");
+        code.ShouldNotContain("AsNoTracking");
+    }
+
+    [Fact]
+    public async Task required_and_missing_still_stops_the_handler()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadDepot(Guid.NewGuid()));
+
+        tracked.Sent.AllMessages().Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void as_no_tracking_switches_to_a_set_query_and_emits_as_no_tracking()
+    {
+        var code = sourceFor<RenameDepotWithoutTracking>();
+
+        code.ShouldContain("AsNoTracking<EfCoreTests.Depot>");
+        code.ShouldContain("FirstOrDefaultAsync<EfCoreTests.Depot>");
+        code.ShouldContain("Property<System.Guid>(__entity, \"Id\")");
+
+        // FindAsync cannot express either extra, so it must be gone
+        code.ShouldNotContain("FindAsync<EfCoreTests.Depot>");
+    }
+
+    [Fact]
+    public async Task as_no_tracking_really_does_detach_the_entity()
+    {
+        var id = await seedDepot();
+
+        // The control: loaded the normal way, the entity is tracked, so a mutation is written
+        await _host.InvokeAsync(new RenameDepot(id));
+        DepotHandler.TrackedState.ShouldBe(EntityState.Unchanged);
+        (await nameOf(id)).ShouldBe("renamed");
+
+        // ...and with AsNoTracking the same handler shape leaves the entity detached, so the identical
+        // mutation and SaveChangesAsync write nothing
+        await _host.InvokeAsync(new RenameDepotWithoutTracking(id));
+        DepotHandler.TrackedState.ShouldBe(EntityState.Detached);
+        (await nameOf(id)).ShouldBe("renamed");
+    }
+
+    [Fact]
+    public void a_single_include_is_emitted_as_a_string_include()
+    {
+        var code = sourceFor<ReadDepotWithShipments>();
+
+        code.ShouldContain("Include<EfCoreTests.Depot>");
+        code.ShouldContain("\"Shipments\"");
+        code.ShouldContain("FirstOrDefaultAsync<EfCoreTests.Depot>");
+    }
+
+    [Fact]
+    public async Task a_single_include_really_populates_the_navigation()
+    {
+        var id = await seedDepot();
+
+        // The control: with no Include at all the collection comes back empty
+        var without = await _host.InvokeMessageAndWaitAsync(new ReadDepot(id));
+        without.Sent.SingleMessage<DepotRead>().ShipmentCount.ShouldBe(0);
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadDepotWithShipments(id));
+        var read = tracked.Sent.SingleMessage<DepotRead>();
+
+        read.ShipmentCount.ShouldBe(1);
+        read.LineCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_dotted_include_path_chains_like_then_include()
+    {
+        var id = await seedDepot();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadDepotWithLines(id));
+        var read = tracked.Sent.SingleMessage<DepotRead>();
+
+        read.ShipmentCount.ShouldBe(1);
+        read.LineCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task include_and_includes_combine_and_coexist_with_as_no_tracking()
+    {
+        var id = await seedDepot();
+
+        var code = sourceFor<ReadDepotEverything>();
+        code.ShouldContain("\"Shipments\"");
+        code.ShouldContain("\"Shipments.Lines\"");
+        code.ShouldContain("AsNoTracking<EfCoreTests.Depot>");
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadDepotEverything(id));
+        var read = tracked.Sent.SingleMessage<DepotRead>();
+
+        read.ShipmentCount.ShouldBe(1);
+        read.LineCount.ShouldBe(1);
+    }
+}
+
+/// <summary>
+///     The refusals. Every one of these would otherwise be a handler that compiles, runs, and quietly returns an
+///     entity that is not what the developer asked for.
+/// </summary>
+[Collection("sqlserver")]
+public class from_ef_core_refuses_what_it_cannot_honor
+{
+    private static async Task compile<T>(Type handlerType)
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType);
+
+                opts.Services.AddDbContextWithWolverineIntegration<LogisticsDbContext>(o =>
+                {
+                    o.UseSqlServer(Servers.SqlServerConnectionString);
+                });
+
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "from_ef_core");
+                opts.UseEntityFrameworkCoreTransactions();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        host.GetRuntime().Handlers.HandlerFor<T>();
+    }
+
+    [Fact]
+    public async Task an_include_path_that_names_no_navigation_fails_at_codegen()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            compile<ReadDepotWithBadInclude>(typeof(BadIncludeHandler)));
+
+        ex.Message.ShouldContain("[FromEfCore]");
+        ex.Message.ShouldContain("'depot'");
+        ex.Message.ShouldContain("Cargo");
+        ex.Message.ShouldContain("Known navigations there are: Shipments");
+    }
+
+    [Fact]
+    public async Task a_broken_second_segment_of_a_dotted_path_fails_at_codegen()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            compile<ReadDepotWithBadThenInclude>(typeof(BadThenIncludeHandler)));
+
+        ex.Message.ShouldContain("Shipments.Crates");
+        ex.Message.ShouldContain("\"Crates\" is not a navigation property on EfCoreTests.Shipment");
+    }
+
+    /// <summary>
+    ///     The second failure mode an explicit attribute can have: the store is registered, but it does not know
+    ///     this type. A plain <c>[Entity]</c> would have fallen through to some other provider — which is exactly
+    ///     the accident these attributes exist to prevent.
+    /// </summary>
+    [Fact]
+    public async Task an_unmapped_entity_type_fails_naming_ef_core_and_the_type()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            compile<ReadUnmapped>(typeof(UnmappedHandler)));
+
+        ex.Message.ShouldContain("[FromEfCore]");
+        ex.Message.ShouldContain("EF Core is registered with this application, but it does not persist");
+        ex.Message.ShouldContain("EfCoreTests.NotMappedAnywhere");
+        ex.Message.ShouldContain("No registered DbContext maps");
+    }
+}
+
+public class Depot
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public List<Shipment> Shipments { get; set; } = [];
+}
+
+public class Shipment
+{
+    public Guid Id { get; set; }
+    public Guid DepotId { get; set; }
+    public string Tracking { get; set; } = null!;
+    public List<ShipmentLine> Lines { get; set; } = [];
+}
+
+public class ShipmentLine
+{
+    public Guid Id { get; set; }
+    public Guid ShipmentId { get; set; }
+    public string Sku { get; set; } = null!;
+}
+
+public class NotMappedAnywhere
+{
+    public Guid Id { get; set; }
+}
+
+public class LogisticsDbContext : DbContext
+{
+    public LogisticsDbContext(DbContextOptions<LogisticsDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Depot> Depots { get; set; } = null!;
+    public DbSet<Shipment> Shipments { get; set; } = null!;
+    public DbSet<ShipmentLine> ShipmentLines { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.MapWolverineEnvelopeStorage();
+
+        modelBuilder.Entity<Depot>(map =>
+        {
+            map.ToTable("depots");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Name);
+            map.HasMany(x => x.Shipments).WithOne().HasForeignKey(x => x.DepotId);
+        });
+
+        modelBuilder.Entity<Shipment>(map =>
+        {
+            map.ToTable("shipments");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Tracking);
+            map.HasMany(x => x.Lines).WithOne().HasForeignKey(x => x.ShipmentId);
+        });
+
+        modelBuilder.Entity<ShipmentLine>(map =>
+        {
+            map.ToTable("shipment_lines");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Sku);
+        });
+    }
+}
+
+public record ReadDepot(Guid Id);
+
+public record ReadDepotWithShipments(Guid Id);
+
+public record ReadDepotWithLines(Guid Id);
+
+public record ReadDepotEverything(Guid Id);
+
+public record RenameDepot(Guid Id);
+
+public record RenameDepotWithoutTracking(Guid Id);
+
+public record DepotRead(string Name, int ShipmentCount, int LineCount);
+
+[WolverineIgnore]
+public static class DepotHandler
+{
+    public static EntityState? TrackedState { get; set; }
+
+    public static DepotRead Handle(ReadDepot command, [FromEfCore] Depot depot)
+        => read(depot);
+
+    public static DepotRead Handle(ReadDepotWithShipments command,
+        [FromEfCore(Include = "Shipments")] Depot depot)
+        => read(depot);
+
+    public static DepotRead Handle(ReadDepotWithLines command,
+        [FromEfCore(Include = "Shipments.Lines")] Depot depot)
+        => read(depot);
+
+    public static DepotRead Handle(ReadDepotEverything command,
+        [FromEfCore(AsNoTracking = true, Include = "Shipments", Includes = new[] { "Shipments.Lines" })]
+        Depot depot)
+        => read(depot);
+
+    // Both of these are deliberately identical apart from the AsNoTracking flag: same mutation, same
+    // explicit SaveChangesAsync, same DbContext. Only the tracking state differs, and only one of them
+    // writes anything.
+    public static async Task Handle(RenameDepot command, [FromEfCore] Depot depot, LogisticsDbContext db,
+        CancellationToken token)
+    {
+        TrackedState = db.Entry(depot).State;
+        depot.Name = "renamed";
+        await db.SaveChangesAsync(token);
+    }
+
+    public static async Task Handle(RenameDepotWithoutTracking command,
+        [FromEfCore(AsNoTracking = true)] Depot depot, LogisticsDbContext db, CancellationToken token)
+    {
+        TrackedState = db.Entry(depot).State;
+        depot.Name = "never persisted";
+        await db.SaveChangesAsync(token);
+    }
+
+    public static void Handle(DepotRead read)
+    {
+    }
+
+    private static DepotRead read(Depot depot)
+        => new(depot.Name, depot.Shipments.Count, depot.Shipments.Sum(x => x.Lines.Count));
+}
+
+public record ReadDepotWithBadInclude(Guid Id);
+
+[WolverineIgnore]
+public static class BadIncludeHandler
+{
+    public static void Handle(ReadDepotWithBadInclude command, [FromEfCore(Include = "Cargo")] Depot depot)
+    {
+    }
+}
+
+public record ReadDepotWithBadThenInclude(Guid Id);
+
+[WolverineIgnore]
+public static class BadThenIncludeHandler
+{
+    public static void Handle(ReadDepotWithBadThenInclude command,
+        [FromEfCore(Include = "Shipments.Crates")] Depot depot)
+    {
+    }
+}
+
+public record ReadUnmapped(Guid Id);
+
+[WolverineIgnore]
+public static class UnmappedHandler
+{
+    public static void Handle(ReadUnmapped command, [FromEfCore] NotMappedAnywhere thing)
+    {
+    }
+}

--- a/src/Persistence/MartenTests/from_marten_attribute_usage.cs
+++ b/src/Persistence/MartenTests/from_marten_attribute_usage.cs
@@ -1,0 +1,288 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace MartenTests;
+
+/// <summary>
+///     <c>[FromMarten]</c> is <c>[Entity]</c> that always resolves through Marten. It inherits
+///     <c>EntityAttribute.Modify</c> outright and overrides only the provider selection, so this suite does NOT
+///     re-run the whole <c>[Entity]</c> matrix — see <see cref="missing_data_handling_with_entity_attributes" /> for
+///     that. It proves the inheritance is real by exercising one representative of each inherited behavior, and then
+///     covers what is genuinely new: the two ways naming a provider explicitly can fail.
+/// </summary>
+public class from_marten_attribute_usage : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(TicketHandler))
+                    .IncludeType(typeof(InspectTicketHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "from_marten";
+                    m.Schema.For<Ticket>().SoftDeleted();
+                }).IntegrateWithWolverine().UseLightweightSessions();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        await _host.DocumentStore().Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Ticket));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task<Ticket> storeTicket(Action<Ticket>? configure = null)
+    {
+        var ticket = new Ticket { Subject = "printer on fire" };
+        configure?.Invoke(ticket);
+
+        await using var session = _host.DocumentStore().LightweightSession();
+        session.Store(ticket);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return ticket;
+    }
+
+    [Fact]
+    public async Task loads_the_document_by_the_conventional_id_member()
+    {
+        var ticket = await storeTicket();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadTicket(ticket.Id));
+
+        tracked.Sent.SingleMessage<TicketRead>().Subject.ShouldBe("printer on fire");
+    }
+
+    [Fact]
+    public async Task loads_the_document_by_the_type_name_id_convention()
+    {
+        var ticket = await storeTicket();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new EscalateTicket(ticket.Id));
+
+        tracked.Sent.SingleMessage<TicketRead>().Subject.ShouldBe("printer on fire");
+    }
+
+    [Fact]
+    public async Task loads_the_document_by_an_explicitly_named_argument()
+    {
+        var ticket = await storeTicket();
+
+        var tracked = await _host.InvokeMessageAndWaitAsync(new AuditTicket(ticket.Id));
+
+        tracked.Sent.SingleMessage<TicketRead>().Subject.ShouldBe("printer on fire");
+    }
+
+    [Fact]
+    public async Task required_and_missing_stops_the_handler()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadTicket(Guid.NewGuid()));
+
+        tracked.Sent.AllMessages().Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task on_missing_throw_exception_with_a_custom_message()
+    {
+        var ex = await Should.ThrowAsync<RequiredDataMissingException>(async () =>
+        {
+            await _host.InvokeAsync(new DemandTicket(Guid.NewGuid()));
+        });
+
+        ex.Message.ShouldContain("No ticket like that");
+    }
+
+    [Fact]
+    public async Task on_missing_empty_content_with_204_just_stops_in_a_handler()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new PeekAtTicket(Guid.NewGuid()));
+
+        tracked.Sent.AllMessages().Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task not_required_hands_the_handler_a_null()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new MaybeReadTicket(Guid.NewGuid()));
+
+        tracked.Sent.SingleMessage<TicketRead>().Subject.ShouldBe("(none)");
+    }
+
+    [Fact]
+    public async Task maybe_soft_deleted_false_treats_a_deleted_document_as_missing()
+    {
+        var ticket = await storeTicket();
+
+        await using (var session = _host.DocumentStore().LightweightSession())
+        {
+            session.Delete(ticket);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The default MaybeSoftDeleted = true still hands the handler the document...
+        var stillVisible = await _host.InvokeMessageAndWaitAsync(new ReadTicket(ticket.Id));
+        stillVisible.Sent.SingleMessage<TicketRead>().Subject.ShouldBe("printer on fire");
+
+        // ...while MaybeSoftDeleted = false nulls it out, and Required = true then stops the handler
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadLiveTicket(ticket.Id));
+        tracked.Sent.AllMessages().Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task the_entity_is_available_to_a_before_method()
+    {
+        var open = await storeTicket();
+        var closed = await storeTicket(x => x.Closed = true);
+
+        InspectTicketHandler.Inspected.Clear();
+
+        await _host.InvokeAsync(new InspectTicket(open.Id));
+        await _host.InvokeAsync(new InspectTicket(closed.Id));
+
+        // The Before method got the same loaded document the handler would have, and used it to stop
+        // the closed one short of the handler
+        InspectTicketHandler.Inspected.ShouldBe([open.Id]);
+    }
+
+    [Fact]
+    public void the_load_really_does_go_through_marten()
+    {
+        // Forces the chain to compile so SourceCode is populated
+        _host.GetRuntime().Handlers.HandlerFor<ReadTicket>();
+
+        var chain = _host.GetRuntime().Handlers.ChainFor<ReadTicket>();
+        chain.ShouldNotBeNull();
+
+        var code = chain.SourceCode;
+        code.ShouldNotBeNull();
+
+        // The Marten frame provider's own session and its LoadAsync -- not a generic "some provider
+        // claimed it" load
+        code.ShouldContain("Wolverine.Marten.Publishing.OutboxedSessionFactory");
+        code.ShouldContain("documentSession.LoadAsync<MartenTests.Ticket>");
+    }
+}
+
+/// <summary>
+///     The first of the two failure modes that only an explicit attribute can have: the store it names is not part
+///     of the application at all. A plain <c>[Entity]</c> would have fallen through to whatever else was registered
+///     — or to the generic "could not determine a matching persistence service" — and neither says the useful thing.
+/// </summary>
+public class from_marten_without_marten_registered
+{
+    [Fact]
+    public async Task names_the_parameter_the_tool_and_the_bootstrapping_call()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Solo;
+                    opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(NoMartenHandler));
+                }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+            host.GetRuntime().Handlers.HandlerFor<ReadTicketWithoutMarten>();
+        });
+
+        ex.Message.ShouldContain("[FromMarten]");
+        ex.Message.ShouldContain("'ticket'");
+        ex.Message.ShouldContain(nameof(NoMartenHandler));
+        ex.Message.ShouldContain("Marten is not integrated with this Wolverine application");
+        ex.Message.ShouldContain("IntegrateWithWolverine()");
+    }
+}
+
+public class Ticket
+{
+    public Guid Id { get; set; }
+    public string Subject { get; set; } = null!;
+    public bool Closed { get; set; }
+}
+
+public record ReadTicket(Guid Id);
+
+public record EscalateTicket(Guid TicketId);
+
+public record AuditTicket(Guid Reference);
+
+public record DemandTicket(Guid Id);
+
+public record PeekAtTicket(Guid Id);
+
+public record MaybeReadTicket(Guid Id);
+
+public record ReadLiveTicket(Guid Id);
+
+public record TicketRead(string Subject);
+
+public static class TicketHandler
+{
+    public static TicketRead Handle(ReadTicket command, [FromMarten] Ticket ticket)
+        => new(ticket.Subject);
+
+    public static TicketRead Handle(EscalateTicket command, [FromMarten] Ticket ticket)
+        => new(ticket.Subject);
+
+    public static TicketRead Handle(AuditTicket command, [FromMarten(nameof(AuditTicket.Reference))] Ticket ticket)
+        => new(ticket.Subject);
+
+    public static TicketRead Handle(DemandTicket command,
+        [FromMarten(OnMissing = OnMissing.ThrowException, MissingMessage = "No ticket like that")] Ticket ticket)
+        => new(ticket.Subject);
+
+    public static TicketRead Handle(PeekAtTicket command,
+        [FromMarten(OnMissing = OnMissing.EmptyContentWith204)] Ticket ticket)
+        => new(ticket.Subject);
+
+    public static TicketRead Handle(MaybeReadTicket command, [FromMarten(Required = false)] Ticket? ticket)
+        => new(ticket?.Subject ?? "(none)");
+
+    public static TicketRead Handle(ReadLiveTicket command, [FromMarten(MaybeSoftDeleted = false)] Ticket ticket)
+        => new(ticket.Subject);
+
+    public static void Handle(TicketRead read)
+    {
+    }
+}
+
+public record InspectTicket(Guid Id);
+
+public static class InspectTicketHandler
+{
+    public static List<Guid> Inspected { get; } = [];
+
+    public static HandlerContinuation Before([FromMarten] Ticket ticket)
+        => ticket.Closed ? HandlerContinuation.Stop : HandlerContinuation.Continue;
+
+    public static void Handle(InspectTicket command, Ticket ticket) => Inspected.Add(ticket.Id);
+}
+
+public record ReadTicketWithoutMarten(Guid Id);
+
+public static class NoMartenHandler
+{
+    public static void Handle(ReadTicketWithoutMarten command, [FromMarten] Ticket ticket)
+    {
+    }
+}

--- a/src/Persistence/PersistenceTests/explicit_provider_entity_attributes.cs
+++ b/src/Persistence/PersistenceTests/explicit_provider_entity_attributes.cs
@@ -1,0 +1,222 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Marten;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PersistenceTests;
+
+/// <summary>
+///     The point of the explicit per-provider entity attributes, in one application: <c>[FromMarten]</c> and
+///     <c>[FromEfCore]</c> resolve to the store they name, not to whichever registered provider would have claimed
+///     the type first.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The discriminating case is <see cref="Coupon" />, which lives in BOTH stores. A plain <c>[Entity]</c>
+///         resolves it to EF Core, because the selective provider outranks Marten's catch-all
+///         <c>CanPersist</c> (GH-3359). So a <c>[FromMarten] Coupon</c> that comes back holding the EF Core row is
+///         precisely the failure a broken provider hook would produce, and it is the only shape of test that can
+///         see it — a Marten-only document would resolve to Marten with or without the attribute.
+///     </para>
+///     <para>
+///         Both attributes are also exercised on the SAME handler method, since nothing else in the codebase
+///         proves that two different persistence providers can each contribute a load frame to one chain.
+///     </para>
+/// </remarks>
+public class explicit_provider_entity_attributes : IAsyncLifetime
+{
+    private static readonly Guid TheCouponId = Guid.NewGuid();
+
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.DurabilityAgentEnabled = false;
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(MixedStoreHandler));
+
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DatabaseSchemaName = "explicit_providers";
+                }).IntegrateWithWolverine(x => x.MessageStorageSchemaName = "explicit_providers")
+                    .UseLightweightSessions();
+
+                opts.Services.AddDbContext<CouponDbContext>(x => x.UseSqlServer(Servers.SqlServerConnectionString));
+                opts.UseEntityFrameworkCoreTransactions();
+
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        await seedSqlServer();
+        await seedMarten();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private async Task seedSqlServer()
+    {
+        using var scope = _host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<CouponDbContext>();
+
+        // Deterministic DDL rather than EnsureCreated, which is a no-op against a database that already exists
+        await db.Database.ExecuteSqlRawAsync(
+            "if object_id('dbo.explicit_provider_coupons') is not null drop table dbo.explicit_provider_coupons;",
+            TestContext.Current.CancellationToken);
+        await db.Database.ExecuteSqlRawAsync(
+            "create table dbo.explicit_provider_coupons (Id uniqueidentifier not null primary key, Source nvarchar(100) not null);",
+            TestContext.Current.CancellationToken);
+
+        db.Coupons.Add(new Coupon { Id = TheCouponId, Source = "sql server" });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task seedMarten()
+    {
+        var store = _host.DocumentStore();
+        await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Coupon));
+        await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(PromoNote));
+
+        await using var session = store.LightweightSession();
+        session.Store(new Coupon { Id = TheCouponId, Source = "marten" });
+        session.Store(new PromoNote { Id = TheCouponId, Text = "spring sale" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task plain_entity_resolves_a_shared_type_to_the_selective_provider()
+    {
+        // The baseline this feature exists to override. Not a bug -- just not always what you meant.
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadCouponImplicitly(TheCouponId));
+
+        tracked.Sent.SingleMessage<CouponSource>().Source.ShouldBe("sql server");
+    }
+
+    [Fact]
+    public async Task from_marten_overrides_that_and_reads_the_marten_copy()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadCouponFromMarten(TheCouponId));
+
+        tracked.Sent.SingleMessage<CouponSource>().Source.ShouldBe("marten");
+    }
+
+    [Fact]
+    public async Task from_ef_core_names_the_store_it_would_have_got_anyway()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadCouponFromEfCore(TheCouponId));
+
+        tracked.Sent.SingleMessage<CouponSource>().Source.ShouldBe("sql server");
+    }
+
+    [Fact]
+    public async Task one_handler_can_load_from_both_stores_at_once()
+    {
+        var tracked = await _host.InvokeMessageAndWaitAsync(new ReadFromBothStores(TheCouponId));
+
+        var read = tracked.Sent.SingleMessage<BothStoresRead>();
+
+        // Same type, same identity, one handler, two stores, two answers
+        read.MartenSource.ShouldBe("marten");
+        read.EfCoreSource.ShouldBe("sql server");
+
+        // ...and a Marten-only document alongside them, to prove the two load frames coexist rather than
+        // one of them quietly winning the whole chain
+        read.NoteText.ShouldBe("spring sale");
+    }
+}
+
+/// <summary>
+///     Lives in Marten AND in the EF Core DbContext below. That overlap is what makes this suite meaningful.
+/// </summary>
+public class Coupon
+{
+    public Guid Id { get; set; }
+    public string Source { get; set; } = null!;
+}
+
+/// <summary>
+///     Deliberately NOT mapped in any DbContext, so only Marten can claim it.
+/// </summary>
+public class PromoNote
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = null!;
+}
+
+public class CouponDbContext : DbContext
+{
+    public CouponDbContext(DbContextOptions<CouponDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Coupon> Coupons { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Coupon>(map =>
+        {
+            map.ToTable("explicit_provider_coupons");
+            map.HasKey(x => x.Id);
+            map.Property(x => x.Source);
+        });
+    }
+}
+
+public record ReadCouponImplicitly(Guid Id);
+
+public record ReadCouponFromMarten(Guid Id);
+
+public record ReadCouponFromEfCore(Guid Id);
+
+public record ReadFromBothStores(Guid Id);
+
+public record CouponSource(string Source);
+
+public record BothStoresRead(string MartenSource, string EfCoreSource, string NoteText);
+
+[WolverineIgnore]
+public static class MixedStoreHandler
+{
+    public static CouponSource Handle(ReadCouponImplicitly command, [Entity] Coupon coupon)
+        => new(coupon.Source);
+
+    public static CouponSource Handle(ReadCouponFromMarten command, [FromMarten] Coupon coupon)
+        => new(coupon.Source);
+
+    public static CouponSource Handle(ReadCouponFromEfCore command, [FromEfCore] Coupon coupon)
+        => new(coupon.Source);
+
+    public static BothStoresRead Handle(ReadFromBothStores command,
+        [FromMarten] Coupon martenCoupon,
+        [FromEfCore] Coupon efCoreCoupon,
+        [FromMarten] PromoNote note)
+        => new(martenCoupon.Source, efCoreCoupon.Source, note.Text);
+
+    public static void Handle(CouponSource message)
+    {
+    }
+
+    public static void Handle(BothStoresRead message)
+    {
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EFCorePersistenceFrameProvider.cs
@@ -165,6 +165,103 @@ internal class EFCorePersistenceFrameProvider : IPersistenceFrameProvider
         return new LoadEntityFrame(dbContextType, sagaType, sagaId);
     }
 
+    /// <summary>
+    ///     The <c>[FromEfCore]</c> load frame for a parameter that asked for <c>AsNoTracking</c> or eager
+    ///     <c>Include</c> paths. Validates every request against the EF Core model at CODEGEN time and throws if
+    ///     any of it cannot be honored, because the alternative — quietly emitting the plain
+    ///     <c>FindAsync</c> load and dropping the request — produces a handler that looks correct, compiles, runs,
+    ///     and hands back an entity with unpopulated navigations.
+    /// </summary>
+    /// <param name="usage">
+    ///     How to name the offending declaration in an exception, supplied by the attribute because only it knows
+    ///     which parameter and method are involved.
+    /// </param>
+    internal Frame DetermineLoadFrameWithQueryOptions(IServiceContainer container, Type entityType, Variable id,
+        string[] includes, bool asNoTracking, string usage)
+    {
+        var dbContextType = DetermineDbContextType(entityType, container);
+
+        using var nested = container.Services.CreateScope();
+        var context = resolveDbContext(nested, dbContextType);
+
+        var efEntityType = context.Model.FindEntityType(entityType);
+        if (efEntityType == null)
+        {
+            throw new InvalidOperationException(
+                $"{usage} cannot be honored. {entityType.FullNameInCode()} is not mapped in DbContext {dbContextType.FullNameInCode()}.");
+        }
+
+        var key = efEntityType.FindPrimaryKey();
+        if (key == null)
+        {
+            throw new InvalidOperationException(
+                $"{usage} cannot be honored. {entityType.FullNameInCode()} has no primary key in DbContext {dbContextType.FullNameInCode()}.");
+        }
+
+        // FindAsync takes params object[] and copes with a composite key; the FirstOrDefaultAsync form that
+        // Include and AsNoTracking require needs a single-valued identity to compare against, and [Entity]
+        // only ever discovers one identity variable anyway.
+        if (key.Properties.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"{usage} cannot be honored. {entityType.FullNameInCode()} has a composite primary key ({key.Properties.Select(x => x.Name).Join(", ")}), and eager loading or no-tracking requires a single-valued key to query on.");
+        }
+
+        foreach (var include in includes)
+        {
+            validateIncludePath(efEntityType, include, usage);
+        }
+
+        var keyProperty = key.Properties[0];
+        return new LoadEntityWithQueryOptionsFrame(dbContextType, entityType, id, keyProperty.Name,
+            keyProperty.ClrType, includes, asNoTracking);
+    }
+
+    private static DbContext resolveDbContext(IServiceScope scope, Type dbContextType)
+    {
+        var service = scope.ServiceProvider.GetRequiredService(dbContextType);
+
+        // Multi-tenanted registrations resolve through a builder rather than the DbContext itself
+        return service is IDbContextBuilder builder ? builder.BuildForMain() : (DbContext)service;
+    }
+
+    /// <summary>
+    ///     Walks a dotted <c>Include</c> path against the EF Core model. EF's string overload is what makes a
+    ///     <c>ThenInclude</c> chain expressible in an attribute argument at all, but it also means a typo is a
+    ///     runtime <c>InvalidOperationException</c> on the first message handled rather than a compile error. This
+    ///     moves that failure back to codegen and names the alternatives.
+    /// </summary>
+    private static void validateIncludePath(Microsoft.EntityFrameworkCore.Metadata.IEntityType root, string path,
+        string usage)
+    {
+        if (path.IsEmpty() || path.Trim().Length == 0)
+        {
+            throw new InvalidOperationException($"{usage} declares an empty Include path.");
+        }
+
+        var current = root;
+        foreach (var segment in path.Split('.'))
+        {
+            Microsoft.EntityFrameworkCore.Metadata.INavigationBase? navigation = current.FindNavigation(segment);
+            navigation ??= current.FindSkipNavigation(segment);
+
+            if (navigation == null)
+            {
+                var available = current.GetNavigations().Select(x => x.Name)
+                    .Concat(current.GetSkipNavigations().Select(x => x.Name)).ToArray();
+
+                var choices = available.Any()
+                    ? "Known navigations there are: " + available.Join(", ") + "."
+                    : "That type has no navigation properties at all.";
+
+                throw new InvalidOperationException(
+                    $"{usage} asks to Include \"{path}\", but \"{segment}\" is not a navigation property on {current.ClrType.FullNameInCode()}. {choices}");
+            }
+
+            current = navigation.TargetEntityType;
+        }
+    }
+
     public Frame DetermineInsertFrame(Variable saga, IServiceContainer container)
     {
         var dbContextType = DetermineDbContextType(saga.VariableType, container);

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/LoadEntityWithQueryOptionsFrame.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/LoadEntityWithQueryOptionsFrame.cs
@@ -1,0 +1,119 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore.Codegen;
+
+/// <summary>
+///     The load frame for a <c>[FromEfCore]</c> parameter that asked for eager loading or no-tracking. Emits
+///     <c>dbContext.Set&lt;T&gt;()</c> composed with <c>AsNoTracking()</c> and the requested string
+///     <c>Include(...)</c> paths, terminated by <c>FirstOrDefaultAsync(...)</c> on the primary key.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The plain <see cref="LoadEntityFrame" /> uses <c>DbContext.FindAsync</c>, which is the better read for a
+///         bare load — it can answer from the change tracker without touching the database. But <c>FindAsync</c>
+///         accepts neither <c>Include</c> nor <c>AsNoTracking</c>, so honoring either one means changing the query
+///         shape entirely. <c>[FromEfCore]</c> switches to this frame only when one of them is actually requested,
+///         so an attribute with no extras still gets the cheaper <c>FindAsync</c>.
+///     </para>
+///     <para>
+///         The key predicate goes through <c>EF.Property&lt;T&gt;(entity, "Name")</c> rather than a member access so
+///         that a shadow primary key — one with no CLR property to write a lambda against — works identically to a
+///         mapped one.
+///     </para>
+///     <para>
+///         Extension classes and methods are referenced through <c>typeof</c> / <c>nameof</c> rather than string
+///         literals so a rename in EF Core breaks this build, matching <see cref="AllFrame" /> and
+///         <see cref="FirstOrDefaultFrame" />.
+///     </para>
+/// </remarks>
+internal class LoadEntityWithQueryOptionsFrame : AsyncFrame
+{
+    // Deliberately obscure: a lambda parameter may not shadow a local in the enclosing method, and the
+    // generated method is full of user-named locals.
+    private const string LambdaParameter = "__entity";
+
+    private readonly Type _dbContextType;
+    private readonly Type _entityType;
+    private readonly Variable _id;
+    private readonly string _keyPropertyName;
+    private readonly Type _keyType;
+    private readonly string[] _includes;
+    private readonly bool _asNoTracking;
+    private Variable? _context;
+    private Variable? _cancellation;
+
+    public LoadEntityWithQueryOptionsFrame(Type dbContextType, Type entityType, Variable id, string keyPropertyName,
+        Type keyType, string[] includes, bool asNoTracking)
+    {
+        _dbContextType = dbContextType;
+        _entityType = entityType;
+        _id = id;
+        _keyPropertyName = keyPropertyName;
+        _keyType = keyType;
+        _includes = includes;
+        _asNoTracking = asNoTracking;
+
+        Entity = new Variable(entityType, this);
+    }
+
+    public Variable Entity { get; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        _context = chain.FindVariable(_dbContextType);
+        yield return _context;
+
+        _cancellation = chain.FindVariable(typeof(CancellationToken));
+        yield return _cancellation;
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        var entityTypeName = _entityType.FullNameInCode();
+        var extensions = typeof(EntityFrameworkQueryableExtensions).FullNameInCode();
+
+        var query = $"{_context!.Usage}.{nameof(DbContext.Set)}<{entityTypeName}>()";
+
+        if (_asNoTracking)
+        {
+            query =
+                $"{extensions}.{nameof(EntityFrameworkQueryableExtensions.AsNoTracking)}<{entityTypeName}>({query})";
+        }
+
+        foreach (var include in _includes)
+        {
+            query =
+                $"{extensions}.{nameof(EntityFrameworkQueryableExtensions.Include)}<{entityTypeName}>({query}, \"{include}\")";
+        }
+
+        var predicate =
+            $"{LambdaParameter} => {typeof(EF).FullNameInCode()}.{nameof(EF.Property)}<{_keyType.FullNameInCode()}>({LambdaParameter}, \"{_keyPropertyName}\") == {_id.Usage}";
+
+        writer.WriteLine("");
+        writer.WriteComment(describe());
+        writer.Write(
+            $"var {Entity.Usage} = await {extensions}.{nameof(EntityFrameworkQueryableExtensions.FirstOrDefaultAsync)}<{entityTypeName}>({query}, {predicate}, {_cancellation!.Usage}).ConfigureAwait(false);");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    private string describe()
+    {
+        var text = $"Loading {_entityType.NameInCode()} by its primary key";
+        if (_asNoTracking)
+        {
+            text += ", without change tracking";
+        }
+
+        if (_includes.Length > 0)
+        {
+            text += ", eagerly loading " + string.Join(", ", _includes.Select(x => "\"" + x + "\""));
+        }
+
+        return text;
+    }
+}

--- a/src/Persistence/Wolverine.EntityFrameworkCore/FromEfCoreAttribute.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/FromEfCoreAttribute.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.Persistence;
+
+namespace Wolverine.EntityFrameworkCore;
+
+/// <summary>
+///     Load this parameter through EF Core by its primary key, exactly as <see cref="EntityAttribute" /> does, but
+///     always through EF Core rather than through whichever registered persistence provider happens to claim the
+///     type first — plus the two loading options that only mean something to EF Core.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Every <see cref="EntityAttribute" /> option applies unchanged —
+///         <see cref="EntityAttribute.Required" />, <see cref="EntityAttribute.OnMissing" />,
+///         <see cref="EntityAttribute.MissingMessage" />, the <c>ArgumentName</c> constructor and the
+///         <c>FromRoute</c> / <c>FromHeader</c> / <c>FromClaim</c> / <c>FromMethod</c> value sources — because this
+///         attribute inherits the one implementation of them all.
+///     </para>
+///     <para>
+///         With neither <see cref="AsNoTracking" /> nor an include path set, the emitted load is the same
+///         <c>DbContext.FindAsync</c> that <c>[Entity]</c> emits, which can answer straight from the change tracker.
+///         Setting either one switches to a <c>Set&lt;T&gt;()</c> query, because <c>FindAsync</c> supports neither.
+///     </para>
+/// </remarks>
+public class FromEfCoreAttribute : ExplicitEntityAttribute
+{
+    public FromEfCoreAttribute()
+    {
+    }
+
+    /// <param name="argumentName">
+    ///     The name of the member on the incoming message, route argument, header, or claim that carries the
+    ///     entity's identity, when it is not <c>Id</c> or <c>{EntityType}Id</c>.
+    /// </param>
+    public FromEfCoreAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    /// <summary>
+    ///     Load the entity without EF Core change tracking. Faster and cheaper for a read-only handler or endpoint,
+    ///     but be aware that mutating a no-tracking entity will NOT be picked up by the transactional middleware's
+    ///     <c>SaveChangesAsync</c>.
+    /// </summary>
+    public bool AsNoTracking { get; set; }
+
+    /// <summary>
+    ///     A single navigation path to eagerly load with the entity. Dotted paths chain, so
+    ///     <c>Include = "Orders.Items"</c> is EF Core's <c>Include(x =&gt; x.Orders).ThenInclude(x =&gt; x.Items)</c>.
+    /// </summary>
+    /// <remarks>
+    ///     A string rather than a lambda because attribute arguments must be compile-time constants. Every path is
+    ///     walked against the EF Core model during code generation, so a typo is a bootstrapping error naming the
+    ///     valid alternatives rather than a runtime failure on the first message handled.
+    /// </remarks>
+    public string? Include { get; set; }
+
+    /// <summary>
+    ///     Several navigation paths to eagerly load with the entity, each with the same dotted semantics as
+    ///     <see cref="Include" />. Combines with <see cref="Include" /> rather than replacing it.
+    /// </summary>
+    public string[] Includes { get; set; } = [];
+
+    protected override Type providerType => typeof(EFCorePersistenceFrameProvider);
+
+    protected override string toolName => "EF Core";
+
+    protected override string integrationCall =>
+        "services.AddDbContextWithWolverineIntegration<YourDbContext>(/* ... */)";
+
+    protected override string cannotPersistRemedy(Type entityType)
+    {
+        return $"No registered DbContext maps {entityType.FullNameInCode()}. Map it in a DbContext's OnModelCreating (or expose it as a DbSet), or use the attribute for the store that really holds it.";
+    }
+
+    /// <summary>
+    ///     Every include path this attribute asked for, in declaration order, with <see cref="Include" /> first.
+    /// </summary>
+    internal string[] AllIncludes()
+    {
+        var all = new List<string>();
+        if (Include.IsNotEmpty())
+        {
+            all.Add(Include!);
+        }
+
+        all.AddRange(Includes.Where(x => x.IsNotEmpty()));
+
+        return all.ToArray();
+    }
+
+    protected override Frame determineLoadFrame(IPersistenceFrameProvider provider, IServiceContainer container,
+        ParameterInfo parameter, Variable identity)
+    {
+        var includes = AllIncludes();
+        if (!AsNoTracking && includes.Length == 0)
+        {
+            // Nothing EF-specific was asked for, so keep the cheaper FindAsync load
+            return base.determineLoadFrame(provider, container, parameter, identity);
+        }
+
+        // tryFindProvider is sealed on ExplicitEntityAttribute and matched this on providerType, so the cast
+        // cannot fail
+        var efCore = (EFCorePersistenceFrameProvider)provider;
+
+        return efCore.DetermineLoadFrameWithQueryOptions(container, parameter.ParameterType, identity, includes,
+            AsNoTracking, describeUsage(parameter));
+    }
+}

--- a/src/Persistence/Wolverine.Marten/FromMartenAttribute.cs
+++ b/src/Persistence/Wolverine.Marten/FromMartenAttribute.cs
@@ -1,0 +1,49 @@
+using Wolverine.Marten.Persistence.Sagas;
+using Wolverine.Persistence;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+///     Load this parameter as a Marten document by its identity, exactly as <see cref="EntityAttribute" /> does,
+///     but always through Marten rather than through whichever registered persistence provider happens to claim
+///     the type first.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Every <see cref="EntityAttribute" /> option applies unchanged —
+///         <see cref="EntityAttribute.Required" />, <see cref="EntityAttribute.OnMissing" />,
+///         <see cref="EntityAttribute.MissingMessage" />, <see cref="EntityAttribute.MaybeSoftDeleted" />, the
+///         <c>ArgumentName</c> constructor and the <c>FromRoute</c> / <c>FromHeader</c> / <c>FromClaim</c> /
+///         <c>FromMethod</c> value sources — because this attribute inherits the one implementation of them all.
+///     </para>
+///     <para>
+///         Reach for it when you want the store named in the code rather than inferred, and especially when a type
+///         could plausibly be claimed by two registered stores: Marten's provider claims every document type, so in
+///         an application that also maps a type in an EF Core <c>DbContext</c>, a plain <c>[Entity]</c> resolves to
+///         EF Core. <c>[FromMarten]</c> says which one you meant, and fails loudly if Marten cannot deliver.
+///     </para>
+/// </remarks>
+public class FromMartenAttribute : ExplicitEntityAttribute
+{
+    public FromMartenAttribute()
+    {
+    }
+
+    /// <param name="argumentName">
+    ///     The name of the member on the incoming message, route argument, header, or claim that carries the
+    ///     document's identity, when it is not <c>Id</c> or <c>{DocumentType}Id</c>.
+    /// </param>
+    public FromMartenAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    protected override Type providerType => typeof(MartenPersistenceFrameProvider);
+
+    protected override string toolName => "Marten";
+
+    protected override string integrationCall => "services.AddMarten(/* ... */).IntegrateWithWolverine()";
+
+    // Marten's CanPersist claims every type -- it genuinely can persist any document -- so
+    // ProviderCannotPersistType is unreachable here. The base message is kept anyway rather than
+    // suppressed: if that ever stops being true, the diagnostic should still read correctly.
+}

--- a/src/Wolverine/Persistence/EntityAttribute.cs
+++ b/src/Wolverine/Persistence/EntityAttribute.cs
@@ -142,7 +142,7 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
         _onMissing ??= entityDefaults.OnMissing;
         _maybeSoftDeleted ??= entityDefaults.MaybeSoftDeleted;
 
-        if (!rules.TryFindPersistenceFrameProvider(container, parameter.ParameterType, out var provider))
+        if (!tryFindProvider(rules, container, parameter, out var provider))
         {
             throw new InvalidOperationException("Could not determine a matching persistence service for entity " +
                                                 parameter.ParameterType.FullNameInCode());
@@ -162,7 +162,7 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
             chain.Middleware.Add(identity.Creator);
         }
 
-        var frame = provider.DetermineLoadFrame(container, parameter.ParameterType, identity);
+        var frame = determineLoadFrame(provider, container, parameter, identity);
 
         var entity = frame.Creates.First(x => x.VariableType == parameter.ParameterType);
         entity.OverrideName(parameter.Name!);
@@ -193,6 +193,40 @@ public class EntityAttribute : WolverineParameterAttribute, IDataRequirement
         StoreDeferredMiddlewareVariable(chain, parameter.Name!, returnVariable);
 
         return returnVariable;
+    }
+
+    /// <summary>
+    ///     Chooses the <see cref="IPersistenceFrameProvider" /> that will build this parameter's load frame.
+    ///     This is the <b>only</b> provider-specific decision in <see cref="Modify" />, which is exactly why it is a
+    ///     hook rather than something a subclass reimplements: the explicit per-provider attributes
+    ///     (<c>[FromMarten]</c>, <c>[FromEfCore]</c>, ...) inherit every other behavior — identity discovery,
+    ///     <see cref="Required" />, <see cref="OnMissing" />, <see cref="MissingMessage" />,
+    ///     <see cref="MaybeSoftDeleted" />, the stop-condition frames and the deferred middleware variable — by
+    ///     construction rather than by copying <see cref="Modify" /> and keeping the copies in step.
+    /// </summary>
+    /// <remarks>
+    ///     Takes the whole <see cref="ParameterInfo" /> rather than just the entity type so an overriding attribute
+    ///     can name the offending parameter and its declaring method in the exception it throws — see
+    ///     <see cref="WolverineParameterAttribute.DescribeMember" />. An override is free to throw with a specific
+    ///     diagnostic instead of returning false; returning false yields the generic "no matching persistence
+    ///     service" message from <see cref="Modify" />.
+    /// </remarks>
+    protected virtual bool tryFindProvider(GenerationRules rules, IServiceContainer container,
+        ParameterInfo parameter, out IPersistenceFrameProvider provider)
+    {
+        return rules.TryFindPersistenceFrameProvider(container, parameter.ParameterType, out provider);
+    }
+
+    /// <summary>
+    ///     Builds the frame that actually reads the entity. Overridden by provider-specific subclasses that expose
+    ///     extra loading options their provider alone understands — <c>[FromEfCore(AsNoTracking = true)]</c> and its
+    ///     <c>Include</c> paths, for instance, cannot be expressed through <c>DbContext.FindAsync</c> and need a
+    ///     different query shape.
+    /// </summary>
+    protected virtual Frame determineLoadFrame(IPersistenceFrameProvider provider, IServiceContainer container,
+        ParameterInfo parameter, Variable identity)
+    {
+        return provider.DetermineLoadFrame(container, parameter.ParameterType, identity);
     }
 
     internal static void StoreDeferredMiddlewareVariable(IChain chain, string parameterName, Variable variable)

--- a/src/Wolverine/Persistence/ExplicitEntityAttribute.cs
+++ b/src/Wolverine/Persistence/ExplicitEntityAttribute.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core.Reflection;
+using Wolverine.Attributes;
+using Wolverine.Persistence.Sagas;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+///     Base class for the explicit, provider-specific entity loading attributes — <c>[FromMarten]</c>,
+///     <c>[FromEfCore]</c> and the rest of that family. Behaves exactly like <see cref="EntityAttribute" /> in every
+///     respect except one: instead of asking every registered provider which of them claims the entity type, it
+///     demands the single provider it names.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Everything an <see cref="EntityAttribute" /> does — identity discovery from the message, route, header,
+///         claim or method; <see cref="EntityAttribute.Required" />; the whole <see cref="OnMissing" /> matrix;
+///         <see cref="EntityAttribute.MissingMessage" />; <see cref="EntityAttribute.MaybeSoftDeleted" />; the
+///         deferred variable that lets <c>Before</c>/<c>After</c> middleware take the same parameter — is inherited
+///         rather than reimplemented. That is deliberate: these attributes promise "the same thing as
+///         <c>[Entity]</c>, but always against this store", and inheriting the one <c>Modify</c> implementation is
+///         what makes that promise true by construction instead of by diligence.
+///     </para>
+///     <para>
+///         A subclass supplies three things — which provider type to demand, what to call it in an error message,
+///         and how the reader would have registered it. Everything else, including both failure diagnostics, is
+///         here.
+///     </para>
+/// </remarks>
+public abstract class ExplicitEntityAttribute : EntityAttribute
+{
+    protected ExplicitEntityAttribute()
+    {
+    }
+
+    protected ExplicitEntityAttribute(string argumentName) : base(argumentName)
+    {
+    }
+
+    /// <summary>
+    ///     The <see cref="IPersistenceFrameProvider" /> implementation type this attribute demands. Matched with
+    ///     <see cref="Type.IsInstanceOfType" />, so a subclassed provider still satisfies it.
+    /// </summary>
+    protected abstract Type providerType { get; }
+
+    /// <summary>
+    ///     Human readable name of the persistence tool for error messages, e.g. "Marten" or "EF Core".
+    /// </summary>
+    protected abstract string toolName { get; }
+
+    /// <summary>
+    ///     How the reader would have integrated this tool with Wolverine, quoted verbatim into the
+    ///     "not registered" diagnostic.
+    /// </summary>
+    protected abstract string integrationCall { get; }
+
+    /// <summary>
+    ///     Why <paramref name="entityType" /> might be unknown to an otherwise-registered provider, and what to do
+    ///     about it. Override for a selective provider that requires each type to be enrolled by hand — an
+    ///     <c>[Entity]</c> would simply have fallen through to another provider, so this is the only place the real
+    ///     cause gets said out loud.
+    /// </summary>
+    protected virtual string cannotPersistRemedy(Type entityType)
+    {
+        return $"Map {entityType.FullNameInCode()} in {toolName} to load it this way, or use a different attribute.";
+    }
+
+    protected sealed override bool tryFindProvider(GenerationRules rules, IServiceContainer container,
+        ParameterInfo parameter, out IPersistenceFrameProvider provider)
+    {
+        var entityType = parameter.ParameterType;
+        var resolution =
+            rules.TryFindPersistenceFrameProviderOfType(container, providerType, entityType, out provider);
+
+        switch (resolution)
+        {
+            case PersistenceProviderResolution.Found:
+                return true;
+
+            case PersistenceProviderResolution.ProviderNotRegistered:
+                throw new InvalidOperationException(
+                    $"{describeUsage(parameter)} explicitly requires {toolName}, but {toolName} is not integrated with this Wolverine application. Add it during bootstrapping with {integrationCall}, or use [Entity] to let Wolverine choose among the persistence providers that are registered.");
+
+            default:
+                throw new InvalidOperationException(
+                    $"{describeUsage(parameter)} explicitly requires {toolName}. {toolName} is registered with this application, but it does not persist {entityType.FullNameInCode()}. {cannotPersistRemedy(entityType)}");
+        }
+    }
+
+    /// <summary>
+    ///     "[FromMarten] on parameter 'invoice' of My.Namespace.InvoiceHandler.Handle()" — enough for the reader to
+    ///     find the declaration, which matters because these attributes fail at CODEGEN and can surface on a chain
+    ///     the developer did not know was being compiled. Protected so that a provider-specific refusal in another
+    ///     assembly (an <c>Include</c> path that names no navigation, say) can be reported with the same prefix as
+    ///     the two failures handled here.
+    /// </summary>
+    protected string describeUsage(ParameterInfo parameter)
+    {
+        var name = GetType().Name;
+        if (name.EndsWith("Attribute", StringComparison.Ordinal))
+        {
+            name = name.Substring(0, name.Length - "Attribute".Length);
+        }
+
+        return $"[{name}] on parameter '{parameter.Name}' of {DescribeMember(parameter)}";
+    }
+}

--- a/src/Wolverine/Persistence/Sagas/GenerationRulesExtensions.cs
+++ b/src/Wolverine/Persistence/Sagas/GenerationRulesExtensions.cs
@@ -5,6 +5,30 @@ using Wolverine.Runtime;
 
 namespace Wolverine.Persistence.Sagas;
 
+/// <summary>
+///     The outcome of looking a persistence frame provider up by its implementation type with
+///     <see cref="GenerationRulesExtensions.TryFindPersistenceFrameProviderOfType" />.
+/// </summary>
+public enum PersistenceProviderResolution
+{
+    /// <summary>
+    ///     The named provider is registered and claims the entity type.
+    /// </summary>
+    Found,
+
+    /// <summary>
+    ///     No provider of the named type is registered with this application at all — the integration was never
+    ///     added.
+    /// </summary>
+    ProviderNotRegistered,
+
+    /// <summary>
+    ///     The named provider is registered, but its <see cref="IPersistenceFrameProvider.CanPersist" /> declines
+    ///     this entity type.
+    /// </summary>
+    ProviderCannotPersistType
+}
+
 public static class GenerationRulesExtensions
 {
     public static readonly string PersistenceKey = "PERSISTENCE";
@@ -75,6 +99,40 @@ public static class GenerationRulesExtensions
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///     Finds the registered <see cref="IPersistenceFrameProvider" /> of a <b>named implementation type</b>, as the
+    ///     explicit per-provider entity attributes (<c>[FromMarten]</c>, <c>[FromEfCore]</c>, ...) do, and reports
+    ///     which of the two possible failures happened.
+    /// </summary>
+    /// <remarks>
+    ///     The distinction between the two failures is the whole point of naming a provider explicitly.
+    ///     <see cref="PersistenceProviderResolution.ProviderNotRegistered" /> means the integration is missing from
+    ///     the application altogether and the remedy is a bootstrapping call; the entity type is irrelevant.
+    ///     <see cref="PersistenceProviderResolution.ProviderCannotPersistType" /> means the integration is there but
+    ///     its <see cref="IPersistenceFrameProvider.CanPersist" /> declines this type — for a selective provider
+    ///     that usually means the type was never mapped or registered with it. Collapsing the two into one
+    ///     "couldn't find a provider" message sends the reader looking in the wrong place.
+    /// </remarks>
+    public static PersistenceProviderResolution TryFindPersistenceFrameProviderOfType(this GenerationRules rules,
+        IServiceContainer container, Type providerType, Type entityType, out IPersistenceFrameProvider provider)
+    {
+        provider = default!;
+
+        var candidate = rules.PersistenceProviders().FirstOrDefault(providerType.IsInstanceOfType);
+        if (candidate == null)
+        {
+            return PersistenceProviderResolution.ProviderNotRegistered;
+        }
+
+        if (!candidate.CanPersist(entityType, container, out _))
+        {
+            return PersistenceProviderResolution.ProviderCannotPersistType;
+        }
+
+        provider = candidate;
+        return PersistenceProviderResolution.Found;
     }
 
     /// <summary>


### PR DESCRIPTION
`[Entity]` is deliberately store-agnostic. This adds an explicit alternative per provider — `[FromMarten]` and `[FromEfCore]` ship here, the rest of the family follows on the same shape.

Two reasons to want one:

- **Explicitness.** Some teams want the parameter to say where it comes from.
- **Disambiguation.** Marten's `CanPersist` claims *every* document type, so an entity also mapped in a `DbContext` resolves to EF Core by the `IsCatchAll` precedence rule (GH-3359). Correct as a default — but if the Marten copy is the one you wanted, `[Entity]` has no way to hear that.

## The hook lives on `EntityAttribute`

`EntityAttribute.Modify` does identity discovery, the load frame, soft-delete frames, `AddStopConditionIfNull`, `Required`/`OnMissing`/`MissingMessage`/`MaybeSoftDeleted`, and the deferred middleware variable. Exactly one line of it is provider-specific. So the whole family is one `protected virtual` hook that subclasses override:

```csharp
protected virtual bool tryFindProvider(GenerationRules rules, IServiceContainer container,
    ParameterInfo parameter, out IPersistenceFrameProvider provider)
```

`Modify` is inherited outright, not copied — which is what makes "same functionality in all ways as `[Entity]`" true by construction. A second hook, `determineLoadFrame`, exists only because `[FromEfCore]`'s extras genuinely need a different query shape.

`ExplicitEntityAttribute` in core carries both failure diagnostics, so each remaining provider is a ~20-line subclass supplying three strings (`providerType`, `toolName`, `integrationCall`) and optionally overriding `cannotPersistRemedy`.

## Two failures, not one

New in `GenerationRulesExtensions`:

```csharp
public static PersistenceProviderResolution TryFindPersistenceFrameProviderOfType(
    this GenerationRules rules, IServiceContainer container, Type providerType, Type entityType,
    out IPersistenceFrameProvider provider)
```

`ProviderNotRegistered` and `ProviderCannotPersistType` have nothing in common as remedies, and `[Entity]`'s existing "Could not determine a matching persistence service for entity Foo" points at neither. Both throw at codegen naming the attribute, the parameter, and its declaring method (GH-3937 — a chain may be compiled that the developer did not know was in discovery).

## The EF Core extras

`AsNoTracking`, plus `Include` and `Includes` using EF's **string** overload (attribute arguments must be compile-time constants; a dotted path is a `ThenInclude` chain).

`FindAsync` supports neither, so asking for either switches the emitted load to a `Set<T>()` query terminated by `FirstOrDefaultAsync` on the primary key — and only then, so a plain `[FromEfCore]` keeps the cheaper change-tracker read. The key predicate goes through `EF.Property<T>(x, "Name")` so a shadow primary key works identically to a mapped one.

**Nothing is silently dropped.** Every include path is walked against the EF Core model at codegen; a bad segment throws naming the navigations that *do* exist on that type. A composite primary key, which the `FirstOrDefaultAsync` form cannot express, throws rather than falling back to `FindAsync` with the include quietly discarded.

## Tests

- `MartenTests/from_marten_attribute_usage.cs` — inherited behavior (identity by convention, by `{Type}Id`, by explicit argument name; `Required`; all `OnMissing` arms; `MissingMessage`; `MaybeSoftDeleted`; a `Before` method), a generated-source check that the load really goes through Marten, and the provider-not-registered diagnostic.
- `EfCoreTests/from_ef_core_attribute_usage.cs` — `AsNoTracking` and `Include` verified against SQL Server both in the generated source and at runtime, plus three codegen refusals.
- `PersistenceTests/explicit_provider_entity_attributes.cs` — the load-bearing one. A `Coupon` that lives in **both** Postgres/Marten and SQL Server/EF Core, where `[Entity]` resolves to EF Core and `[FromMarten]` must not, and one handler loading from both stores at once.

Assertions are on generated source *as well as* results because an `Include` that never engaged and one that did return the same shaped object, and a no-tracking read looks exactly like a tracked one until something writes.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors
- MartenTests 631/631, EfCoreTests 220/220, PersistenceTests 109/109, CoreTests 2730/2732 (2 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
