### PR TITLE
GH-4204: a stream-appending handler's return value is a reply, not an event

### DIFF
--- a/src/Testing/CoreTests/Acceptance/stream_appends_are_not_replies_4204.cs
+++ b/src/Testing/CoreTests/Acceptance/stream_appends_are_not_replies_4204.cs
@@ -1,0 +1,113 @@
+using JasperFx.Events;
+using Shouldly;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel4204;
+
+/// <summary>
+/// GH-4204. A handler holding an <see cref="IEventStream{T}"/> appends imperatively INTO the stream, so
+/// what it RETURNS is a reply or a cascaded message. The classifier only knew the chain was "event
+/// sourced" and read every return value as an emitted event, so a slice reported its reply DTO as one of
+/// its events — and, because imperative appends are invisible to a static read, reported nothing else.
+/// </summary>
+/// <remarks>
+/// The half this does NOT fix, by design and as the issue says: the events actually appended through the
+/// stream stay invisible. <see cref="EventModelRoles"/> reads declarative returns only — that limit is
+/// stated on the class and is what CritterWatch's Roslyn source generator exists for. Reporting nothing
+/// is honest; reporting the reply DTO was not.
+/// </remarks>
+public class stream_appends_are_not_replies_4204
+{
+    private static HandlerChain chainFor<THandler>(System.Linq.Expressions.Expression<Action<THandler>> expression)
+        => HandlerChain.For(expression, new HandlerGraph());
+
+    [Fact]
+    public void a_reply_dto_from_a_stream_appending_handler_is_not_an_emitted_event()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<ClaimHandler>(x => ClaimHandler.Handle(null!, null!)));
+
+        slice.EmittedEvents.ShouldBeEmpty();
+        slice.PublishedMessages.Select(x => x.Name).ShouldContain(nameof(ClaimResult));
+    }
+
+    /// <summary>
+    /// The stream still establishes the write model — this is not achieved by forgetting the chain is
+    /// event sourced.
+    /// </summary>
+    [Fact]
+    public void the_stream_still_names_the_write_model()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<ClaimHandler>(x => ClaimHandler.Handle(null!, null!)));
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldContain(nameof(NodeClaim));
+    }
+
+    /// <summary>
+    /// The opposite case keeps the old reading: a chain returning an untyped event collection cannot have
+    /// its element types read off the collection, so its other return values ARE the events. Regression
+    /// guard for the condition this fix added.
+    /// </summary>
+    [Fact]
+    public void a_returned_event_collection_still_makes_the_other_returns_events()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<StreamAndCollectionHandler>(x => StreamAndCollectionHandler.Handle(null!, null!)));
+
+        slice.EmittedEvents.Select(x => x.Name).ShouldContain(nameof(NodeClaimed));
+    }
+
+    /// <summary>
+    /// And a declarative aggregate handler — no stream, events returned directly — is untouched. This is
+    /// the mainstream Critter Stack shape and the one that must not regress.
+    /// </summary>
+    [Fact]
+    public void a_declarative_write_model_handler_still_reports_its_returned_event()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<DeclarativeClaimHandler>(x => DeclarativeClaimHandler.Handle(null!, null!)));
+
+        slice.EmittedEvents.Select(x => x.Name).ShouldContain(nameof(NodeClaimed));
+        slice.PublishedMessages.ShouldBeEmpty();
+    }
+}
+
+public record ClaimNode(string NodeId);
+
+public record NodeClaimed(string NodeId);
+
+public record ClaimResult(string NodeId, bool Conflict);
+
+public class NodeClaim
+{
+    public string Id { get; set; } = null!;
+}
+
+public class ClaimHandler
+{
+    // The shape from the issue: appends through the stream, returns the InvokeAsync<T> reply
+    public static ClaimResult Handle(ClaimNode command, [WriteModel(Required = false)] IEventStream<NodeClaim> stream)
+    {
+        stream.AppendOne(new NodeClaimed(command.NodeId));
+        return new ClaimResult(command.NodeId, false);
+    }
+}
+
+public class StreamAndCollectionHandler
+{
+    public static (IEnumerable<object>, NodeClaimed) Handle(ClaimNode command,
+        [WriteModel(Required = false)] IEventStream<NodeClaim> stream)
+    {
+        return ([], new NodeClaimed(command.NodeId));
+    }
+}
+
+public class DeclarativeClaimHandler
+{
+    public static NodeClaimed Handle(ClaimNode command, [WriteModel] NodeClaim claim)
+    {
+        return new NodeClaimed(command.NodeId);
+    }
+}

--- a/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
@@ -141,7 +141,8 @@ public static class EventModelRoles
         // IEnumerable<object> — says "this handler appends events" even though the element types
         // cannot be read off it. That is enough to classify the chain, so the other return values
         // are read as events rather than as cascaded messages.
-        if (returnTypes.Any(isUntypedEventCollection))
+        var returnsEventCollection = returnTypes.Any(isUntypedEventCollection);
+        if (returnsEventCollection)
         {
             roles.IsEventSourced = true;
         }
@@ -159,7 +160,13 @@ public static class EventModelRoles
 
             if (!isEventOrMessageCandidate(type)) continue;
 
-            if (roles.IsEventSourced)
+            // GH-4204. "This chain is event sourced" does not mean "everything it returns is an event".
+            // A handler holding an IEventStream<T> appends imperatively INTO the stream, so its return
+            // value is a reply or a cascaded message -- Stoat's ClaimResult, for one, was being reported
+            // as an emitted event of the slice. A chain that returns an untyped event collection is the
+            // opposite case and keeps the old reading: the element types cannot be read off the
+            // collection, so the other return values are the events.
+            if (roles.IsEventSourced && (returnsEventCollection || !roles.AppendsThroughStream))
             {
                 roles.EmittedEvents.Add(type);
             }
@@ -307,6 +314,10 @@ public static class EventModelRoles
 
             if (parameterType.Closes(typeof(IEventStream<>)))
             {
+                // GH-4204: remember that the appends go through the STREAM. Without this the chain is
+                // only known to be event sourced, and everything it returns reads as an emitted event --
+                // including the reply DTO of an InvokeAsync<T>, which is not an event at all.
+                roles.AppendsThroughStream = true;
                 roles.AddWrite(parameterType.GetGenericArguments()[0], false);
                 continue;
             }
@@ -477,6 +488,12 @@ public static class EventModelRoles
     private sealed class RoleSet
     {
         public bool IsEventSourced { get; set; }
+
+        /// <summary>
+        /// The chain appends through an <see cref="IEventStream{T}" /> parameter, so its events go into
+        /// the stream and never appear as return values. GH-4204.
+        /// </summary>
+        public bool AppendsThroughStream { get; set; }
         public List<Type> Aggregates { get; } = new();
         public Dictionary<Type, AggregateKind> AggregateKinds { get; } = new();
         public OrderedTypeSet EmittedEvents { get; } = new();


### PR DESCRIPTION
Closes #4204 (the half that is fixable — see below).

## The bug

Stoat's claim handler takes an `IEventStream<NodeClaim>`, appends through it, and returns a `ClaimResult` for `InvokeAsync<ClaimResult>`. The derived slice reported:

```
emittedEvents: [ClaimResult]
```

The reply DTO, as an event of the slice.

## Why

`"this chain is event sourced"` was being read as `"everything this chain returns is an event"`. Those are different claims, and the second one does not follow.

`readSignature` already detects the `IEventStream<>` parameter — it just discarded the fact that it *was* a stream and called `AddWrite`, after which the chain was known only to be event sourced. Then every return candidate fell into `roles.EmittedEvents`.

A handler holding an `IEventStream<T>` appends **imperatively, into the stream**. Nothing it returns is an event; the return is a reply or a cascaded message.

## The fix

The stream branch now records `AppendsThroughStream`, and such a chain classifies its returns as published messages instead — which is exactly how a non-event-sourced handler's return is already treated, so the reply lands somewhere meaningful rather than nowhere.

Deliberately narrow. A chain that returns an **untyped event collection** keeps the old reading:

```csharp
if (roles.IsEventSourced && (returnsEventCollection || !roles.AppendsThroughStream))
```

because the element types cannot be read off the collection, so its other return values really are the events. That is the reasoning already recorded in the comment above that block, and it still holds.

## The half this does not fix

The events appended through the stream **stay invisible**, exactly as the issue says. `EventModelRoles` reads declarative returns only; that limit is stated on the class and is what CritterWatch's Roslyn source generator exists for. Reporting nothing there is honest — reporting the reply DTO as an event was not.

## Tests

`CoreTests.Acceptance.EventModel4204`, 4 tests:

| test | what it pins |
|---|---|
| `a_reply_dto_from_a_stream_appending_handler_is_not_an_emitted_event` | the issue's exact shape — **fails without the fix**, `EmittedEvents` had 1 |
| `the_stream_still_names_the_write_model` | not achieved by forgetting the chain is event sourced |
| `a_returned_event_collection_still_makes_the_other_returns_events` | the condition's other arm |
| `a_declarative_write_model_handler_still_reports_its_returned_event` | the mainstream `[WriteModel]` aggregate shape, which must not regress |

No infrastructure needed — these build a bare `HandlerChain` and read the roles off the signature, like the `event_model_roles_3988` suite.

All 42 existing event-model tests green (`event_model_roles_3988`, `event_model_per_rpc_4000`, `event_model_publish_url_4146`, `event_model_provenance_ladder_4147`, `external_system_3989`, plus #4208's). `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors.