### PR TITLE
GH-4213: a shutting-down node must not dead-letter work it never ran

### DIFF
--- a/src/Testing/CoreTests/Bugs/Bug_4213_shutdown_does_not_dead_letter_an_unbuilt_executor.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_4213_shutdown_does_not_dead_letter_an_unbuilt_executor.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+// GH-4213. Building the executor for a message type resolves services, so a node that is shutting down can
+// hit it after the IServiceProvider is already disposed: IHost.Dispose() flags the provider *before* it
+// disposes WolverineRuntime, whose DisposeAsync then drains whatever the receiver still holds. Every envelope
+// caught in that window threw ObjectDisposedException out of HandlerChain.AttachTypesSynchronously and landed
+// in the GH-4151 catch, which classifies an unbuildable executor as a permanent configuration error and
+// dead-letters the envelope.
+//
+// Found through the Redis NativeAck suite, where a draining node dead-lettered five entries whose handlers
+// never ran and the pending entries list went to zero -- the exact loss the mode exists to prevent. It is not
+// a Redis defect: the classification is the pipeline's, and every transport reaches it.
+//
+// Shutdown is not a configuration error. The envelope has to be left unsettled so the broker (or the inbox)
+// redelivers it to a live node, which is what InvokeAsync's own ObjectDisposedException guard already does --
+// the GH-4151 catch was simply intercepting first.
+public class Bug_4213_shutdown_does_not_dead_letter_an_unbuilt_executor
+{
+    private readonly Envelope theEnvelope = new() { Id = Guid.NewGuid(), Message = new Bug4213Ping() };
+
+    [Fact]
+    public async Task a_disposed_container_leaves_the_envelope_unsettled()
+    {
+        var channel = new RecordingChannel();
+
+        await invokeAsync(channel, new ObjectDisposedException("IServiceProvider"));
+
+        // Neither terminal: not acked away, and not dead-lettered. The broker still owns it.
+        channel.CompleteCalls.ShouldBe(0);
+        channel.DeadLetterCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task any_other_executor_build_failure_is_still_dead_lettered()
+    {
+        // GH-4151 unchanged: a chain that will never build is permanent, and the DLQ is where it belongs.
+        var channel = new RecordingChannel();
+
+        await invokeAsync(channel, new InvalidOperationException("this chain will never compile"));
+
+        channel.DeadLetterCalls.ShouldBe(1);
+    }
+
+    private async Task invokeAsync(RecordingChannel channel, Exception buildFailure)
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.DisableConventionalDiscovery().IncludeType<Bug4213PingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        // A live runtime with a live cancellation token -- the point is the *container* being gone, not the
+        // runtime having been asked to stop. A cancelled runtime short-circuits InvokeAsync before any of
+        // this and would make the test vacuous.
+        var runtime = (WolverineRuntime)host.Services.GetRequiredService<IWolverineRuntime>();
+        var pipeline = new HandlerPipeline(runtime, new ThrowingExecutorFactory(buildFailure));
+
+        // Nothing may escape the pipeline either way: an exception out of InvokeAsync faults the receiver
+        // loop and stops the listener.
+        await Should.NotThrowAsync(() => pipeline.InvokeAsync(theEnvelope, channel));
+    }
+
+    private sealed class ThrowingExecutorFactory(Exception failure) : IExecutorFactory
+    {
+        public IExecutor BuildFor(Type messageType) => throw failure;
+        public IExecutor BuildFor(Type messageType, Endpoint endpoint) => throw failure;
+    }
+
+    private sealed class RecordingChannel : IChannelCallback, ISupportDeadLetterQueue
+    {
+        public int CompleteCalls { get; private set; }
+        public int DeadLetterCalls { get; private set; }
+
+        public IHandlerPipeline? Pipeline => null;
+        public bool NativeDeadLetterQueueEnabled => true;
+
+        public ValueTask CompleteAsync(Envelope envelope)
+        {
+            CompleteCalls++;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DeferAsync(Envelope envelope) => ValueTask.CompletedTask;
+
+        public Task MoveToErrorsAsync(Envelope envelope, Exception exception)
+        {
+            DeadLetterCalls++;
+            return Task.CompletedTask;
+        }
+    }
+}
+
+public record Bug4213Ping;
+
+public class Bug4213PingHandler
+{
+    public static void Handle(Bug4213Ping ping)
+    {
+    }
+}

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -377,6 +377,16 @@ public class HandlerPipeline : IHandlerPipeline
         {
             executor = _executors[envelope.Message!.GetType()];
         }
+        catch (ObjectDisposedException)
+        {
+            // GH-4213: the container is already disposed, which means the node is shutting down rather than
+            // misconfigured -- building the executor resolves services, and IHost.Dispose() flags the
+            // IServiceProvider before it disposes WolverineRuntime and drains. Rethrowing hands this to
+            // InvokeAsync's ObjectDisposedException guard, which leaves the envelope unsettled so the broker
+            // or the inbox redelivers it to a live node. Dead-lettering it here instead would discard work
+            // whose handler never ran, on a shutdown that succeeds everywhere else.
+            throw;
+        }
         catch (Exception e)
         {
             // GH-4151: building the executor happens *before* any HandlerChain instance exists, so there


### PR DESCRIPTION
Closes #4213.

## What the failure actually was

Neither of the two candidates in the issue. Not a load-sensitive test, and not "the drain path acks" — the drain path **dead-letters**, through a core classification that has nothing to do with Redis.

Instrumenting the shutdown showed all five entries leaving the PEL as dead letters:

```
Moved envelope ... to dead letter queue ...:dead-letter with message ID ...
  Exception: ObjectDisposedException: Cannot access a disposed object. Object name: 'IServiceProvider'.
```

The throw site:

```
HandlerPipeline.executeAsync            -> _executors[messageType]
WolverineRuntime.IExecutorFactory.BuildFor
HandlerGraph.HandlerFor
HandlerChain.AttachTypesSynchronously   -> services.GetRequiredService<T>()  ** disposed **
```

Building the executor for a message type resolves services. `IHost.Dispose()` flags the `IServiceProvider` as disposed *before* it disposes `WolverineRuntime`, whose `DisposeAsync` then calls `StopAsync` and drains whatever the receiver still holds. Any envelope in that window whose executor has not been built yet throws `ObjectDisposedException` and lands in the **GH-4151** catch, which classifies an unbuildable executor as a permanent configuration error and returns `MoveToErrorQueue`. XACK plus a DLQ row, for a handler that never ran.

`InvokeAsync` twenty lines up already has the correct guard — `catch (ObjectDisposedException) { // It's shutting down, get out of here }` — which leaves the envelope unsettled so the broker or the inbox redelivers it to a live node. The GH-4151 catch was simply intercepting first.

## The fix

Rethrow that one exception type out of the GH-4151 catch so it reaches the guard that already exists. GH-4151's own behaviour is unchanged for every other cause: a missing pre-built type, a chain that will not compile, a sticky-handler misconfiguration are all still permanent, and still dead-lettered.

## Why CI was green and a loaded machine was not

Timing decides only whether the five handlers get in before dispose, not what happens to them if they do not. On CI the executor is built and the handlers park, so the entries stay pending and the test passes. On a loaded machine the executor is still being built at dispose, and every queued envelope is dead-lettered instead. The classification is the pipeline's, so this reaches **every transport** — Redis just has a test that watches the pending entries list directly.

## Verification

- `Bug_4213_shutdown_does_not_dead_letter_an_unbuilt_executor` — new, in CoreTests. Fails without the fix, passes with it. Its second case pins GH-4151's behaviour for any other exception, and passes either way.
- `native_ack_mode.nothing_is_acked_until_the_handler_succeeds_so_a_draining_node_loses_nothing` — failed 3/3 before, passes 3/3 after, on the same loaded machine, and for the right reason: entries stay pending, node-2's XAUTOCLAIM picks up all five.
- CoreTests: 2736 passed, 0 failed.
- Wolverine.Redis.Tests: 246 passed, 0 failed.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)