### PR TITLE
GH-4199: make the NativeAck / partitioned listener observability surface readable

### DIFF
--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -293,6 +293,19 @@ a lost message. Only a delivery that reached a terminal the broker will not undo
 native dead-letter move) is recorded. Duplicate drops are logged at `Debug`, not `Error`: in a mode that
 never settles at receipt, redelivery is expected operational noise rather than a sign that something is wrong.
 
+Both are also metered <Badge type="tip" text="6.32" />, tagged by endpoint:
+
+| Meter | Answers |
+| --- | --- |
+| `wolverine-duplicates-suppressed` | "Is my redelivery rate normal?" — how many duplicate deliveries this guard has dropped |
+| `wolverine-idempotency-early-rotation` | "Is my window big enough?" — how often the `maxTracked` ceiling forced a rotation *before* the window elapsed |
+
+The second is the one to alert on. A non-zero and rising count means the early-rotation row in the table
+above is firing, so the effective suppression window is **shorter than the `window` you configured** — the
+guard is still bounded and still correct, but it is forgetting ids sooner than you asked it to. A deployment
+doing that was previously indistinguishable from one that was not. Rotations the clock caused are deliberately
+not counted, or every long-lived endpoint would report a shrinkage it does not have.
+
 ### Prefer broker-side deduplication where it exists
 
 Some transports can deduplicate at the broker, which is strictly better than anything an in-process guard can
@@ -334,6 +347,56 @@ or `executing` (duplication realized); `wolverine-leases-renewed` and `wolverine
 out the picture. A rising `executing` count means lane depth has outgrown the configured lease — raise the
 lease, raise the slot count, or lower the prefetch.
 :::
+
+## Monitoring a Native Ack or Partitioned Listener <Badge type="tip" text="6.32" />
+
+`EndpointHealthSnapshot` is what a monitoring console reads, and three of its fields exist because the
+ordinary ones are the wrong numbers on these two modes.
+
+### The depth needs the right ceiling
+
+`QueueCount` is real for `Inline` and `NativeAck` — but `BufferLimit` is **null** on both, and that is
+deliberate rather than missing. Neither mode builds a `BackPressureAgent`, so nothing enforces
+`BufferingLimits` there even if you set it; reporting it would render as `234 of 1,000` and offer headroom
+that does not exist.
+
+The ceiling that *does* bound these modes is the broker's prefetch window, reported as `InFlightLimit`:
+
+| Transport | `InFlightLimit` |
+| --- | --- |
+| RabbitMQ | `PreFetchCount` — a genuine cap on unacknowledged deliveries, applied with `BasicQosAsync` |
+| Azure Service Bus | `PrefetchCount`, or null when prefetch is disabled |
+| Everything else | null |
+
+Null means *this transport has no such ceiling*, which is a real answer. Render the depth without a
+denominator rather than inventing one. Redis Streams reports null on purpose: its read batch is a per-read
+size and not a cap on unacked entries, so publishing it would recreate exactly the false headroom this
+avoids.
+
+### On a partitioned listener, the total is the wrong number
+
+`PartitionProcessingByGroupId()` gives you one sequential lane per slot, and the sum across those lanes
+cannot see the failure the lanes exist to bound. 100 messages spread evenly over 10 lanes and 100 messages
+piled into a single lane report the **identical** `QueueCount` — and the second is a stalled listener while
+the first is perfectly healthy. That is the "one dominant group id serializes everything behind it" case.
+
+Three more fields make it visible:
+
+| Field | Meaning |
+| --- | --- |
+| `LaneCount` | Number of partition slots, or null when the listener is not partitioned at all |
+| `BusiestLaneCount` | Depth of the deepest single slot |
+| `ExemptLaneCount` | Depth of the [exempt lane](/guide/messaging/partitioning.html#exempting-message-types-from-partitioned-processing), or null when there are no exemptions |
+
+Compare `BusiestLaneCount` against `QueueCount / LaneCount`. Roughly even is a healthy listener; a busiest
+lane holding most of the total is a hot group id, and the fix is a better group id rather than more slots.
+
+`ExemptLaneCount` is reported separately and is **not** folded into `BusiestLaneCount`, because the exempt
+lane runs at the endpoint's full parallelism rather than as a sequential slot. A healthy exempt lane holding
+plenty of messages is not a hot partition, and folding the two together would report it as one.
+
+A null `LaneCount` means the listener is not partitioned — which is a different state from a listener
+partitioned into a single lane.
 
 ## Buffered Endpoints
 

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/duplicate_suppression_metrics_4199.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/duplicate_suppression_metrics_4199.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4199, item 3. The plain counters on the guard prove the arithmetic; this proves the number actually
+/// leaves the process. A monitoring consumer reads the OTel instrument, not an internal property, and the
+/// guard is only ever handed a Meter from <see cref="Endpoint.Compile"/> -- so without this the wiring could
+/// be silently absent while every unit test still passed.
+/// </summary>
+public class duplicate_suppression_metrics_4199 : IAsyncLifetime
+{
+    private const string TheServiceName = "dup-metrics-4199";
+
+    private IHost _host = null!;
+    private MeterListener _listener = null!;
+    private readonly ConcurrentDictionary<string, ConcurrentBag<Dictionary<string, object?>>> _measurements = new();
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = TheServiceName;
+                opts.Discovery.DisableConventionalDiscovery();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "Wolverine:" + TheServiceName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<int>((inst, _, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var tag in tags)
+            {
+                dict[tag.Key] = tag.Value;
+            }
+
+            _measurements.GetOrAdd(inst.Name, _ => new ConcurrentBag<Dictionary<string, object?>>()).Add(dict);
+        });
+
+        _listener.Start();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _listener.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public void the_suppression_counter_reaches_the_meter_tagged_by_endpoint()
+    {
+        var runtime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+
+        var endpoint = new NativeAckStubEndpoint("dup-4199", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.InMemoryIdempotency = new InMemoryIdempotencySettings();
+        endpoint.Compile(runtime);
+
+        var guard = endpoint.IdempotencyGuard.ShouldNotBeNull();
+
+        var envelope = new Envelope { Id = Guid.NewGuid(), Destination = endpoint.Uri };
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.TryBeginProcessing(envelope).ShouldBeFalse();
+
+        _measurements.TryGetValue(MetricsConstants.DuplicatesSuppressed, out var recorded).ShouldBeTrue(
+            "The duplicate-suppression counter never reached the meter, so a monitoring consumer cannot see it at all.");
+
+        recorded!.Count.ShouldBe(1);
+
+        // Tagged by endpoint, so a fleet-wide redelivery rate can be broken down per listener rather than
+        // arriving as one undifferentiated number.
+        recorded.Single()[MetricsConstants.MessageDestinationKey].ShouldBe(endpoint.Uri.ToString());
+    }
+}

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/endpoint_health_ceilings_4199.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/endpoint_health_ceilings_4199.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4199, item 1. GH-4186 made <c>QueueCount</c> real for Inline and NativeAck, and in doing so turned a
+/// dormant mis-render into a live one: EndpointCollection filled in <c>BufferLimit</c> for every listener
+/// regardless of mode, but <see cref="Endpoint.ShouldEnforceBackPressure"/> is false for exactly those two
+/// modes, so no BackPressureAgent is built and nothing ever reads that limit there. Before 6.31.0 the pair
+/// read <c>(0, 1000)</c> and looked merely idle; afterwards it reads <c>234 of 1,000</c> and offers an
+/// operator headroom that does not exist.
+///
+/// The fix is both halves: stop reporting the ceiling that is not enforced, and start reporting the one that
+/// is -- the broker's prefetch window, via <see cref="Endpoint.InFlightLimit"/>.
+/// </summary>
+public class endpoint_health_ceilings_4199 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private WolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts => opts.Discovery.IncludeType<NativeAckPingHandler>())
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task a_native_ack_listener_reports_no_buffer_ceiling()
+    {
+        var endpoint = new NativeAckStubEndpoint("na-4199", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        // Deliberately set: the point is that a configured value is NOT reported, because nothing enforces it.
+        endpoint.BufferingLimits = new BufferingLimits(1000, 500);
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+
+        var snapshot = snapshotFor(endpoint.Uri);
+
+        endpoint.ShouldEnforceBackPressure().ShouldBeFalse();
+        snapshot.BufferLimit.ShouldBeNull(
+            "A NativeAck listener builds no BackPressureAgent, so reporting a buffering ceiling offers headroom that does not exist.");
+    }
+
+    [Fact]
+    public async Task an_inline_listener_reports_no_buffer_ceiling_either()
+    {
+        var endpoint = new StubEndpoint("inline-4199", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.Inline;
+        endpoint.BufferingLimits = new BufferingLimits(1000, 500);
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+
+        snapshotFor(endpoint.Uri).BufferLimit.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// The other half of the guard: the modes that DO enforce back pressure must keep reporting the ceiling,
+    /// or this fix would have traded a mis-render for a blind spot.
+    /// </summary>
+    [Fact]
+    public async Task a_buffered_listener_still_reports_its_buffer_ceiling()
+    {
+        var endpoint = new StubEndpoint("buffered-4199", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.BufferedInMemory;
+        endpoint.BufferingLimits = new BufferingLimits(1000, 500);
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+
+        endpoint.ShouldEnforceBackPressure().ShouldBeTrue();
+        snapshotFor(endpoint.Uri).BufferLimit.ShouldBe(1000);
+    }
+
+    /// <summary>
+    /// A transport with no prefetch window reports null rather than inventing a denominator. The stub is that
+    /// transport; RabbitMQ and Azure Service Bus override <see cref="Endpoint.InFlightLimit"/> and are covered
+    /// in their own suites, where a real broker applies the window.
+    /// </summary>
+    [Fact]
+    public async Task no_in_flight_ceiling_is_reported_when_the_transport_has_none()
+    {
+        var endpoint = new NativeAckStubEndpoint("na-4199-noceiling", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+
+        endpoint.InFlightLimit.ShouldBeNull();
+        snapshotFor(endpoint.Uri).InFlightLimit.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task the_transport_prefetch_window_reaches_the_snapshot()
+    {
+        var endpoint = new PrefetchingStubEndpoint("na-4199-prefetch", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+
+        var snapshot = snapshotFor(endpoint.Uri);
+
+        // The number an operator should read QueueCount against on this mode -- and the one that was
+        // unreachable from outside Wolverine entirely before GH-4199.
+        snapshot.InFlightLimit.ShouldBe(64);
+        snapshot.BufferLimit.ShouldBeNull();
+    }
+
+    private EndpointHealthSnapshot snapshotFor(Uri uri)
+    {
+        return theRuntime.Endpoints.CollectEndpointHealth()
+            .Single(x => x.Uri == uri && x.Direction == EndpointDirection.Listening);
+    }
+}
+
+/// <summary>Stands in for a transport whose broker applies a prefetch window, as RabbitMQ's BasicQosAsync does.</summary>
+internal class PrefetchingStubEndpoint : StubEndpoint
+{
+    public PrefetchingStubEndpoint(string queueName, StubTransport transport) : base(queueName, transport)
+    {
+    }
+
+    protected override bool supportsNativeAck => true;
+
+    public override int? InFlightLimit => 64;
+}

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/generational_idempotency_guard.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/generational_idempotency_guard.cs
@@ -249,4 +249,100 @@ public class generational_idempotency_guard
     {
         Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryIdempotencySettings { MaxTracked = 1 });
     }
+
+    #region GH-4199 -- the suppression is countable
+
+    /// <summary>
+    /// GH-4199. The drop used to be a LogDebug and nothing else, so "is my redelivery rate normal" had no
+    /// answer. NativeAckReceiver's own comment pointed at GH-3713 for the number, and GH-3713 closed as a
+    /// flood reproduction rather than as a metric, so it was never actually produced.
+    /// </summary>
+    [Fact]
+    public void counts_every_duplicate_it_drops()
+    {
+        var guard = guardFor();
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.DuplicatesSuppressed.ShouldBe(0, "The first delivery is not a duplicate.");
+
+        guard.TryBeginProcessing(envelope).ShouldBeFalse();
+        guard.TryBeginProcessing(envelope).ShouldBeFalse();
+
+        guard.DuplicatesSuppressed.ShouldBe(2);
+    }
+
+    [Fact]
+    public void an_in_flight_duplicate_counts_as_well_as_a_processed_one()
+    {
+        var guard = guardFor();
+        var envelope = envelopeFor();
+
+        guard.TryBeginProcessing(envelope).ShouldBeTrue();
+        guard.TryBeginProcessing(envelope).ShouldBeFalse();   // still in flight
+        guard.MarkProcessed(envelope);
+        guard.TryBeginProcessing(envelope).ShouldBeFalse();   // now processed
+
+        guard.DuplicatesSuppressed.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Unique traffic must not register as suppression. Without this the counter would climb on a perfectly
+    /// healthy endpoint and be useless as a redelivery-rate signal.
+    /// </summary>
+    [Fact]
+    public void distinct_messages_never_count_as_suppressed()
+    {
+        var guard = guardFor();
+
+        for (var i = 0; i < 50; i++)
+        {
+            guard.TryBeginProcessing(envelopeFor()).ShouldBeTrue();
+        }
+
+        guard.DuplicatesSuppressed.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// GH-4199, the second question: "is the guard's window big enough?" A rotation forced by MaxTracked
+    /// means ids are being forgotten sooner than the configured window, and a deployment doing that was
+    /// indistinguishable from one that is not.
+    /// </summary>
+    [Fact]
+    public void a_size_forced_rotation_is_reported_as_early()
+    {
+        // Rotation happens at MaxTracked / 2, so this rotates every 5 tracked ids with the clock standing still.
+        var guard = guardFor(window: 10.Minutes(), maxTracked: 10);
+
+        guard.EarlyRotations.ShouldBe(0);
+
+        for (var i = 0; i < 20; i++)
+        {
+            guard.TryBeginProcessing(envelopeFor());
+        }
+
+        guard.EarlyRotations.ShouldBeGreaterThan(0,
+            "The ceiling forced rotation while the window had not elapsed, so the effective window is shorter than configured.");
+    }
+
+    /// <summary>
+    /// The control: a rotation the clock caused is NOT early, and must not be reported as one. Otherwise
+    /// every long-lived endpoint reports a shrinking window it does not have.
+    /// </summary>
+    [Fact]
+    public void a_clock_driven_rotation_is_not_early()
+    {
+        var guard = guardFor(window: 10.Minutes(), maxTracked: 100_000);
+
+        guard.TryBeginProcessing(envelopeFor()).ShouldBeTrue();
+
+        // Past half the window, which is where rotation is due.
+        theTime = theTime.Add(6.Minutes());
+
+        guard.TryBeginProcessing(envelopeFor()).ShouldBeTrue();
+
+        guard.EarlyRotations.ShouldBe(0);
+    }
+
+    #endregion
 }

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/partitioned_lane_depth_4199.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/partitioned_lane_depth_4199.cs
@@ -1,0 +1,221 @@
+using System.Reflection;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4199, item 2. A partitioned listener's whole point is its slots -- one single-worker lane per slot, so
+/// same-group messages serialize while different groups run in parallel -- and the only depth it exposed was
+/// the sum. 100 messages spread evenly over 10 lanes and 100 messages piled into one lane reported the
+/// identical number, so the failure the structure exists to bound ("one dominant GroupId serializes
+/// everything behind it", the one GH-3899's exempt lane mitigates) was invisible from outside the process.
+/// </summary>
+public class partitioned_lane_depth_4199 : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private WolverineRuntime theRuntime = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<LaneDepthPingHandler>();
+                opts.MessagePartitioning.ByMessage<LaneDepthPing>(x => x.Group);
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        theRuntime = (WolverineRuntime)_host.Services.GetRequiredService<IWolverineRuntime>();
+        LaneDepthPingHandler.Gate = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        LaneDepthPingHandler.Gate?.TrySetResult();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task a_hot_lane_is_distinguishable_from_an_evenly_loaded_one()
+    {
+        var agent = await startPartitionedListenerAsync("lanes-4199");
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        LaneDepthPingHandler.Gate = gate;
+
+        try
+        {
+            // Every message carries the SAME group id, so the partitioner routes all of them to one slot.
+            var flood = Task.Run(() => agent.EnqueueDirectlyAsync(
+                    Enumerable.Range(0, 60).Select(_ => pingFor("one-hot-group")).ToArray()),
+                TestContext.Current.CancellationToken);
+
+            await waitUntil(() => snapshotFor(agent.Uri).BusiestLaneCount > 1,
+                "the partitioned listener never reported a busiest-lane depth");
+
+            var snapshot = snapshotFor(agent.Uri);
+
+            snapshot.LaneCount.ShouldBe(5);
+
+            // The assertion the aggregate could never make: nearly everything is in ONE lane.
+            snapshot.BusiestLaneCount.ShouldNotBeNull();
+            snapshot.BusiestLaneCount.Value.ShouldBeGreaterThan(1);
+            snapshot.BusiestLaneCount!.Value.ShouldBeGreaterThan(snapshot.QueueCount / 5,
+                "All of these messages share a group id, so the busiest lane must hold far more than an even share.");
+
+            gate.SetResult();
+            await flood;
+        }
+        finally
+        {
+            gate.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// The control. Without this the busiest-lane number could be the aggregate under another name and the
+    /// test above would still pass.
+    /// </summary>
+    [Fact]
+    public async Task spread_traffic_does_not_report_a_hot_lane()
+    {
+        var agent = await startPartitionedListenerAsync("lanes-4199-spread");
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        LaneDepthPingHandler.Gate = gate;
+
+        try
+        {
+            var flood = Task.Run(() => agent.EnqueueDirectlyAsync(
+                    Enumerable.Range(0, 60).Select(i => pingFor("group-" + i)).ToArray()),
+                TestContext.Current.CancellationToken);
+
+            await waitUntil(() => snapshotFor(agent.Uri).QueueCount > 5,
+                "the partitioned listener never took on any depth");
+
+            var snapshot = snapshotFor(agent.Uri);
+
+            // Distinct group ids hash across the slots, so no single lane holds the whole load.
+            snapshot.BusiestLaneCount.ShouldNotBeNull();
+            snapshot.BusiestLaneCount.Value.ShouldBeLessThan(snapshot.QueueCount,
+                "With 60 distinct group ids no single lane should hold everything -- if it does, this is the aggregate wearing a different name.");
+
+            gate.SetResult();
+            await flood;
+        }
+        finally
+        {
+            gate.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task an_unpartitioned_listener_reports_no_lanes_at_all()
+    {
+        var endpoint = new NativeAckStubEndpoint("nolanes-4199", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+
+        var snapshot = snapshotFor(endpoint.Uri);
+
+        // Null rather than 1, because "not partitioned" and "partitioned into one lane" are different states.
+        snapshot.LaneCount.ShouldBeNull();
+        snapshot.BusiestLaneCount.ShouldBeNull();
+        snapshot.ExemptLaneCount.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// The trap this design had to survive: ReceiverWithRules is installed by something as ordinary as an
+    /// endpoint-level MessageType, and GlobalPartitionedInterceptor can nest on top of it. A default
+    /// interface member on IHasQueueDepth would silently report "not partitioned" through either one.
+    /// </summary>
+    [Fact]
+    public async Task lane_depth_survives_a_receiver_wrapper()
+    {
+        var endpoint = new NativeAckStubEndpoint("lanes-4199-wrapped", new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.GroupShardingSlotNumber = PartitionSlots.Five;
+
+        // This alone installs ReceiverWithRules in front of the NativeAckReceiver.
+        endpoint.MessageType = typeof(LaneDepthPing);
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+        var agent = theRuntime.Endpoints.FindListeningAgent(endpoint.Uri).ShouldNotBeNull();
+
+        // Guard against a vacuous pass: if no wrapper is installed this proves nothing about delegation.
+        receiverOf(agent).ShouldBeOfType<ReceiverWithRules>();
+
+        snapshotFor(endpoint.Uri).LaneCount.ShouldBe(5,
+            "The wrapper has to delegate LaneDepth, or a partitioned endpoint reads as unpartitioned for most real configurations.");
+    }
+
+    private async Task<IListeningAgent> startPartitionedListenerAsync(string name)
+    {
+        var endpoint = new NativeAckStubEndpoint(name, new StubTransport()) { IsListener = true };
+        endpoint.Mode = EndpointMode.NativeAck;
+        endpoint.GroupShardingSlotNumber = PartitionSlots.Five;
+
+        await theRuntime.Endpoints.StartListenerAsync(endpoint, CancellationToken.None);
+        return theRuntime.Endpoints.FindListeningAgent(endpoint.Uri).ShouldNotBeNull();
+    }
+
+    private EndpointHealthSnapshot snapshotFor(Uri uri)
+    {
+        return theRuntime.Endpoints.CollectEndpointHealth()
+            .Single(x => x.Uri == uri && x.Direction == EndpointDirection.Listening);
+    }
+
+    private static Envelope pingFor(string group)
+    {
+        return new Envelope(new LaneDepthPing(group))
+        {
+            MessageType = typeof(LaneDepthPing).ToMessageTypeName()
+        };
+    }
+
+    private static async Task waitUntil(Func<bool> condition, string failure)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(25);
+        }
+
+        throw new TimeoutException(failure);
+    }
+
+    private static IReceiver receiverOf(IListeningAgent agent)
+    {
+        var field = typeof(ListeningAgent).GetField("_receiver", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (IReceiver)field.GetValue(agent)!;
+    }
+}
+
+public record LaneDepthPing(string Group);
+
+public class LaneDepthPingHandler
+{
+    public static TaskCompletionSource? Gate { get; set; }
+
+    public static async Task Handle(LaneDepthPing ping)
+    {
+        var gate = Gate;
+        if (gate != null)
+        {
+            await gate.Task;
+        }
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -69,6 +69,14 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
     ///     buffer, so an oversized prefetch combined with slow handlers leads to lock-lost
     ///     redeliveries.
     /// </summary>
+    /// <summary>
+    /// GH-4199. Azure Service Bus prefetch is a client-side buffer rather than a hard cap on unsettled
+    /// deliveries, but it is still the bound an operator tunes and the one that governs how many messages can
+    /// be sitting on this endpoint ahead of the handlers. Zero means prefetch is disabled, which is no ceiling
+    /// at all, so report null rather than a denominator of nothing.
+    /// </summary>
+    public override int? InFlightLimit => PrefetchCount > 0 ? PrefetchCount : null;
+
     public int PrefetchCount
     {
         get

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqQueue.cs
@@ -90,6 +90,14 @@ public partial class RabbitMqQueue : RabbitMqEndpoint, IBrokerQueue, IRabbitMqQu
     protected override bool supportsNativeAck => true;
 
     /// <summary>
+    /// GH-4199. On RabbitMQ the prefetch window IS the ceiling on unacknowledged deliveries -- it is applied
+    /// with <c>BasicQosAsync</c> and the broker stops delivering once it is reached -- so it is the number a
+    /// monitoring consumer should read <see cref="Wolverine.Configuration.EndpointHealthSnapshot.QueueCount"/>
+    /// against on the modes that build no BackPressureAgent.
+    /// </summary>
+    public override int? InFlightLimit => PreFetchCount;
+
+    /// <summary>
     ///     The number of unacknowledged messages that can be processed concurrently
     /// </summary>
     public ushort PreFetchCount

--- a/src/Wolverine/Configuration/Endpoint.cs
+++ b/src/Wolverine/Configuration/Endpoint.cs
@@ -714,8 +714,10 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
         if (InMemoryIdempotency != null && IdempotencyGuard == null && Mode != EndpointMode.Durable &&
             this is not Transports.Local.LocalQueue)
         {
-            IdempotencyGuard =
-                new GenerationalIdempotencyGuard(InMemoryIdempotency, runtime.DurabilitySettings.MessageIdentity);
+            // GH-4199: the meter and the endpoint tag come in here so the suppression counters are reported
+            // per endpoint, alongside the GH-4048 lease instruments.
+            IdempotencyGuard = new GenerationalIdempotencyGuard(InMemoryIdempotency,
+                runtime.DurabilitySettings.MessageIdentity, () => DateTimeOffset.UtcNow, runtime.Meter, Uri);
         }
 
         _hasCompiled = true;
@@ -937,6 +939,23 @@ public abstract class Endpoint : ICircuitParameters, IDescribesProperties
         // the broker stops delivering -- which makes an in-process BackPressureAgent redundant, same as Inline.
         return Mode is not (EndpointMode.Inline or EndpointMode.NativeAck);
     }
+
+    /// <summary>
+    /// GH-4199. The ceiling that actually bounds how many deliveries this endpoint can be holding when
+    /// <see cref="ShouldEnforceBackPressure"/> is false -- normally the broker's prefetch window, which is what
+    /// stands in for a <c>BackPressureAgent</c> on <see cref="EndpointMode.Inline"/> and
+    /// <see cref="EndpointMode.NativeAck"/>. Reported on <see cref="EndpointHealthSnapshot.InFlightLimit"/> so a
+    /// monitoring consumer has something to read the depth against.
+    ///
+    /// <para>
+    /// Null means "this transport has no such ceiling", which is a meaningful answer rather than a missing one:
+    /// a consumer should render the depth with no denominator rather than invent one. Do NOT override this with
+    /// a number that does not bound the unsettled window -- Redis Streams' read batch, for instance, is a
+    /// per-read size and not a cap on unacked entries, so reporting it would recreate exactly the false headroom
+    /// this exists to remove.
+    /// </para>
+    /// </summary>
+    public virtual int? InFlightLimit => null;
 
     /// <summary>
     ///     One time initialization of this endpoint

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -177,10 +177,19 @@ public class EndpointCollection : IEndpointCollection
                 LastQueueActivityAt: listener.LastQueueActivityAt,
                 LastMessageSentAt: null,
                 SenderLatched: false,
-                BufferLimit: listener.Endpoint.BufferingLimits?.Maximum,
+                // GH-4199: only report the buffering ceiling on the modes that actually enforce it. Inline and
+                // NativeAck build no BackPressureAgent, so filling this in there hands an operator headroom
+                // that does not exist -- invisible until GH-4186 made QueueCount real for those two modes.
+                BufferLimit: listener.Endpoint.ShouldEnforceBackPressure()
+                    ? listener.Endpoint.BufferingLimits?.Maximum
+                    : null,
                 ConnectionState: connectionStateOf(listener),
                 ReceiveLoopStatus: loopHealth?.ReceiveLoopStatus ?? ReceiveLoopStatus.Unknown,
-                LastReceiveLoopActivityAt: loopHealth?.LastReceiveLoopActivityAt));
+                LastReceiveLoopActivityAt: loopHealth?.LastReceiveLoopActivityAt,
+                InFlightLimit: listener.Endpoint.InFlightLimit,
+                LaneCount: listener.LaneDepth?.LaneCount,
+                BusiestLaneCount: listener.LaneDepth?.BusiestLaneCount,
+                ExemptLaneCount: listener.LaneDepth?.ExemptLaneCount));
         }
 
         foreach (var sender in _senders.Enumerate().Select(x => x.Value))

--- a/src/Wolverine/Configuration/EndpointHealthSnapshot.cs
+++ b/src/Wolverine/Configuration/EndpointHealthSnapshot.cs
@@ -5,6 +5,35 @@ namespace Wolverine.Configuration;
 /// <summary>
 /// A point-in-time snapshot of health state for a single messaging endpoint.
 /// </summary>
+/// <param name="BufferLimit">
+/// The local buffering ceiling, and <b>only</b> populated when the endpoint actually enforces it. GH-4199:
+/// this used to be filled in for every listener regardless of mode, but
+/// <see cref="Endpoint.ShouldEnforceBackPressure"/> is false on <see cref="EndpointMode.Inline"/> and
+/// <see cref="EndpointMode.NativeAck"/>, so no BackPressureAgent is built and nothing ever reads it there.
+/// Once GH-4186 made <see cref="QueueCount"/> real for those two modes the pair started rendering as
+/// "234 of 1,000" and offering headroom that does not exist. Null now means "this endpoint has no local
+/// buffering ceiling", and a consumer should look to <see cref="InFlightLimit"/> instead of reimplementing
+/// <c>ShouldEnforceBackPressure</c> from a serialized mode name.
+/// </param>
+/// <param name="LaneCount">
+/// GH-4199. Number of partition slots when this listener is group-partitioned, otherwise null.
+/// </param>
+/// <param name="BusiestLaneCount">
+/// GH-4199. The deepest single partition slot. <see cref="QueueCount"/> is the SUM across lanes, and the sum
+/// cannot see the failure the partitioning exists to bound: 100 messages spread over 10 lanes and 100
+/// messages piled into one lane report the identical depth, and the second is a stalled listener. Compare
+/// this against <see cref="QueueCount"/> and <see cref="LaneCount"/> to tell them apart.
+/// </param>
+/// <param name="ExemptLaneCount">
+/// GH-4199. Depth of the GH-3899 exempt lane, or null when the endpoint has no exemptions. Reported apart
+/// from <see cref="BusiestLaneCount"/> on purpose: the exempt lane has its own parallelism, so folding it in
+/// would misreport a healthy multi-worker lane as a hot partition.
+/// </param>
+/// <param name="InFlightLimit">
+/// GH-4199. The ceiling that does bound the endpoint when back pressure is not enforced -- normally the
+/// broker's prefetch window. Null when the transport has no such ceiling, which is a real answer rather than
+/// a missing one: render the depth with no denominator rather than inventing one.
+/// </param>
 public record EndpointHealthSnapshot(
     Uri Uri,
     string EndpointName,
@@ -18,7 +47,11 @@ public record EndpointHealthSnapshot(
     long? BrokerQueueDepth = null,
     TransportConnectionState ConnectionState = TransportConnectionState.Unknown,
     ReceiveLoopStatus ReceiveLoopStatus = ReceiveLoopStatus.Unknown,
-    DateTimeOffset? LastReceiveLoopActivityAt = null);
+    DateTimeOffset? LastReceiveLoopActivityAt = null,
+    int? InFlightLimit = null,
+    int? LaneCount = null,
+    int? BusiestLaneCount = null,
+    int? ExemptLaneCount = null);
 
 public enum EndpointDirection
 {

--- a/src/Wolverine/MetricsConstants.cs
+++ b/src/Wolverine/MetricsConstants.cs
@@ -32,6 +32,14 @@ public class MetricsConstants
     public const string LeaseCeilingReached = "wolverine-lease-ceiling-reached";
     public const string LeaseLossStageKey = "lease.loss.stage";
 
+    // GH-4199. Opt-in in-memory duplicate suppression (GH-3710) dropped duplicates with nothing but a
+    // LogDebug, so neither question an operator actually asks was answerable: "is my redelivery rate normal"
+    // and "is the guard's window big enough". EarlyRotation is the second one -- a rotation forced by the
+    // MaxTracked ceiling rather than by the clock means the effective window is SHORTER than the configured
+    // one, which is otherwise indistinguishable from a healthy deployment.
+    public const string DuplicatesSuppressed = "wolverine-duplicates-suppressed";
+    public const string IdempotencyEarlyRotation = "wolverine-idempotency-early-rotation";
+
     public const string MessageTypeKey = "message.type";
     public const string MessageDestinationKey = "message.destination";
     public const string TenantIdKey = "tenant.id";

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedInterceptor.cs
@@ -40,6 +40,10 @@ internal class GlobalPartitionedInterceptor : IReceiver, IHasQueueDepth, IReceiv
 
     public DateTimeOffset? LastReceivedAt => (_inner as IHasQueueDepth)?.LastReceivedAt;
 
+    // GH-4199: delegated for the same reason as QueueCount -- these wrappers NEST, so a partitioned receiver
+    // behind both this and ReceiverWithRules needs every layer to pass the lane depths through.
+    public PartitionedLaneDepth? LaneDepth => (_inner as IHasQueueDepth)?.LaneDepth;
+
     public async ValueTask ReceivedAsync(IListener listener, Envelope[] messages)
     {
         var passThrough = new List<Envelope>();

--- a/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
+++ b/src/Wolverine/Runtime/Partitioning/ShardedExecutionBlock.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using JasperFx.Blocks;
 using Wolverine.Transports;
 
+using Wolverine.Runtime.WorkerQueues;
+
 namespace Wolverine.Runtime.Partitioning;
 
 internal class ShardedExecutionBlock : BlockBase<Envelope>
@@ -238,6 +240,17 @@ internal class ShardedExecutionBlock : BlockBase<Envelope>
     }
 
     public override uint Count => (uint)allBlocks().Sum(x => x.Count);
+
+    /// <summary>
+    /// GH-4199. The lane distribution behind <see cref="Count"/>. The sum on its own cannot distinguish an
+    /// evenly loaded listener from one where a single dominant group id has everything queued behind it,
+    /// which is the exact failure the slots exist to bound -- and the exempt lane is reported separately
+    /// because it runs with its own parallelism and would misread as a hot partition if folded in.
+    /// </summary>
+    public PartitionedLaneDepth LaneDepth =>
+        new(_numberOfSlots,
+            _slots.Length == 0 ? 0 : (int)_slots.Max(x => x.Count),
+            _exemptLane == null ? null : (int)_exemptLane.Count);
 
     /// <summary>
     /// Propagates to every slot block. Without this, a slot's escaping exception falls to the

--- a/src/Wolverine/Runtime/WorkerQueues/GenerationalIdempotencyGuard.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/GenerationalIdempotencyGuard.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.Metrics;
+
 namespace Wolverine.Runtime.WorkerQueues;
 
 /// <summary>
@@ -44,6 +46,12 @@ internal class GenerationalIdempotencyGuard : IIncomingIdempotencyGuard
     private HashSet<IdempotencyKey> _previousInFlight = new();
     private HashSet<IdempotencyKey> _previousProcessed = new();
 
+    // GH-4199. Instruments alongside plain counters, matching LeaseRenewalTracker: tests and a debugger read
+    // the properties, OTel reads the instruments, and neither has to stand up the other.
+    private readonly Counter<int>? _suppressedCounter;
+    private readonly Counter<int>? _earlyRotationCounter;
+    private readonly KeyValuePair<string, object?>[] _tags;
+
     public GenerationalIdempotencyGuard(InMemoryIdempotencySettings settings, MessageIdentity identity)
         : this(settings, identity, () => DateTimeOffset.UtcNow)
     {
@@ -51,11 +59,25 @@ internal class GenerationalIdempotencyGuard : IIncomingIdempotencyGuard
 
     /// <param name="now">Seam for deterministic tests of the rotation policy. Production uses the system clock.</param>
     internal GenerationalIdempotencyGuard(InMemoryIdempotencySettings settings, MessageIdentity identity,
-        Func<DateTimeOffset> now)
+        Func<DateTimeOffset> now, Meter? meter = null, Uri? endpoint = null)
     {
         Settings = settings;
         _identity = identity;
         _now = now;
+
+        _tags = endpoint == null
+            ? []
+            : [new KeyValuePair<string, object?>(MetricsConstants.MessageDestinationKey, endpoint.ToString())];
+
+        if (meter != null)
+        {
+            _suppressedCounter = meter.CreateCounter<int>(MetricsConstants.DuplicatesSuppressed,
+                MetricsConstants.Messages,
+                "Number of duplicate deliveries dropped by the in-memory idempotency guard");
+            _earlyRotationCounter = meter.CreateCounter<int>(MetricsConstants.IdempotencyEarlyRotation,
+                MetricsConstants.Messages,
+                "Number of generation rotations forced by the MaxTracked ceiling rather than by the window elapsing");
+        }
 
         // Half the window, because an id has to survive BOTH generations to be forgotten -- rotating on the
         // full window would remember every id for up to twice as long as advertised.
@@ -65,6 +87,21 @@ internal class GenerationalIdempotencyGuard : IIncomingIdempotencyGuard
     }
 
     public InMemoryIdempotencySettings Settings { get; }
+
+    /// <summary>
+    /// GH-4199. How many duplicate deliveries this guard has dropped. The answer to "is my redelivery rate
+    /// normal" -- NativeAckReceiver's own comment pointed at GH-3713 for this number, and GH-3713 closed as a
+    /// flood reproduction rather than as a metric, so it was never actually produced.
+    /// </summary>
+    internal int DuplicatesSuppressed { get; private set; }
+
+    /// <summary>
+    /// GH-4199. How many times a generation rotated because the tracked count hit the ceiling rather than
+    /// because the window elapsed. Non-zero means the effective suppression window is SHORTER than the
+    /// configured one, which is the only way to tell a deployment that is silently evicting early from one
+    /// that is not.
+    /// </summary>
+    internal int EarlyRotations { get; private set; }
 
     /// <summary>Number of ids currently remembered as processed, across both generations. Test seam.</summary>
     internal int TrackedCount
@@ -102,6 +139,10 @@ internal class GenerationalIdempotencyGuard : IIncomingIdempotencyGuard
                                                || _currentProcessed.Contains(key) ||
                                                _previousProcessed.Contains(key))
             {
+                // GH-4199: counted here rather than at each caller's drop site so every receiver that uses a
+                // guard -- NativeAck, Inline, Buffered -- reports without having to remember to.
+                DuplicatesSuppressed++;
+                _suppressedCounter?.Add(1, _tags);
                 return false;
             }
 
@@ -150,6 +191,14 @@ internal class GenerationalIdempotencyGuard : IIncomingIdempotencyGuard
         if (!byTime && !bySize)
         {
             return;
+        }
+
+        // GH-4199. Only a size-forced rotation is "early": the window did not elapse, so ids are being
+        // forgotten sooner than configured. A rotation that is both is not early -- the clock got there too.
+        if (bySize && !byTime)
+        {
+            EarlyRotations++;
+            _earlyRotationCounter?.Add(1, _tags);
         }
 
         _previousProcessed = _currentProcessed;

--- a/src/Wolverine/Runtime/WorkerQueues/IHasQueueDepth.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/IHasQueueDepth.cs
@@ -31,4 +31,36 @@ public interface IHasQueueDepth
     /// nothing else ever would.
     /// </summary>
     DateTimeOffset? LastReceivedAt => null;
+
+    /// <summary>
+    /// GH-4199. Per-lane depth for a receiver whose execution block is partitioned by group id, or null when it
+    /// is not partitioned at all. <see cref="QueueCount"/> alone is the SUM across lanes, and the sum is
+    /// precisely the number that cannot see the failure the partitioning exists to bound: 100 messages spread
+    /// evenly over 10 lanes and 100 messages piled into one lane report the identical depth, and the second is
+    /// a stalled listener while the first is a healthy one.
+    ///
+    /// <para>
+    /// <b>Implementers behind a wrapper must delegate this.</b> <c>ReceiverWithRules</c> is installed for
+    /// something as ordinary as an endpoint-level <c>MessageType</c>, so leaving the default in place there
+    /// would report "not partitioned" for most real endpoints. See <c>ReceiverWithRules</c> and
+    /// <c>GlobalPartitionedInterceptor</c>, which delegate <see cref="QueueCount"/> for the same reason.
+    /// </para>
+    /// </summary>
+    PartitionedLaneDepth? LaneDepth => null;
 }
+
+/// <summary>
+/// GH-4199. A point-in-time read of how work is distributed across a partitioned receiver's lanes.
+/// </summary>
+/// <param name="LaneCount">How many partition slots the block was built with.</param>
+/// <param name="BusiestLaneCount">
+/// The deepest single partition slot. Read against <see cref="LaneCount"/> and the endpoint's total depth,
+/// this is what makes "one dominant GroupId is serializing everything behind it" -- the failure GH-3899's
+/// exempt lane exists to mitigate -- visible from outside the process.
+/// </param>
+/// <param name="ExemptLaneCount">
+/// Depth of the GH-3899 exempt lane, or null when the endpoint has no exemptions. Deliberately NOT folded
+/// into <paramref name="BusiestLaneCount"/>: the exempt lane runs with its own parallelism, so a healthy
+/// multi-worker lane holding plenty of messages would otherwise be misread as a hot partition.
+/// </param>
+public record PartitionedLaneDepth(int LaneCount, int BusiestLaneCount, int? ExemptLaneCount);

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -43,6 +43,10 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
     private readonly Endpoint _endpoint;
     private readonly ILogger _logger;
     private readonly IBlock<Envelope> _receivingBlock;
+
+    // GH-4199. Held separately from _receivingBlock because DeserializeFirst wraps the sharded block in an
+    // upstream deserialization stage, so the lane depths are not reachable through _receivingBlock at all.
+    private readonly ShardedExecutionBlock? _sharded;
     private readonly DurabilitySettings _settings;
 
     /// <summary>
@@ -103,6 +107,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
             // because each delivery settles against the listener that delivered it. Binding a single
             // IChannelCallback for the whole block -- which is all BufferedReceiver ever needed, since its
             // completions are no-ops -- would ack the wrong delivery under ListenerCount > 1.
+            _sharded = sharded;
             _receivingBlock = sharded.DeserializeFirst(pipeline, runtime, channelFor);
         }
 
@@ -118,6 +123,12 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
     // brought it -- but its lane depth is exactly the saturation signal an operator wants from this mode, and
     // it used to contribute a constant 0 to EndpointHealthSnapshot.
     public int QueueCount => (int)_receivingBlock.Count;
+
+    /// <summary>
+    /// GH-4199. Null unless this endpoint opted into group partitioning, in which case the sum reported by
+    /// <see cref="QueueCount"/> is the wrong number to judge the listener by on its own.
+    /// </summary>
+    public PartitionedLaneDepth? LaneDepth => _sharded?.LaneDepth;
 
     /// <summary>
     /// GH-4186. Stamped on receipt rather than derived from a depth change, because this mode runs no

--- a/src/Wolverine/Transports/IReceiver.cs
+++ b/src/Wolverine/Transports/IReceiver.cs
@@ -123,5 +123,10 @@ internal class ReceiverWithRules : IReceiver, ILocalQueue, IReceiverWrapper
 
     public DateTimeOffset? LastReceivedAt => (Inner as IHasQueueDepth)?.LastReceivedAt;
 
+    // GH-4199: delegated for the same reason as QueueCount. This wrapper is installed by something as
+    // ordinary as an endpoint-level MessageType, so taking the interface default here would report
+    // "not partitioned" for most real partitioned endpoints.
+    public PartitionedLaneDepth? LaneDepth => (Inner as IHasQueueDepth)?.LaneDepth;
+
     public Uri Uri => Inner is ILocalQueue q ? q.Uri : new Uri("none://none");
 }

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -59,6 +59,13 @@ public interface IListeningAgent : IListenerCircuit
     ValueTask LatchPermanently();
 
     /// <summary>
+    /// GH-4199. Per-lane depth when this listener's receiver is group-partitioned, otherwise null. The
+    /// aggregate <see cref="IListenerCircuit.QueueCount"/> cannot distinguish an evenly loaded partitioned
+    /// listener from one where a single dominant group id has everything serialized behind it.
+    /// </summary>
+    PartitionedLaneDepth? LaneDepth => null;
+
+    /// <summary>
     /// CritterWatch#942 — true when this listener's receiver execution block has faulted terminally
     /// (jasperfx#506). A faulted receiver can never make progress: its QueueCount freezes and every
     /// post from the receive loop throws, so the listener looks alive while dropping everything it
@@ -175,6 +182,13 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
     // both contributed a constant 0, so a saturated NativeAck listener was indistinguishable from an idle one.
     public int QueueCount => (_receiver is IHasQueueDepth q ? q.QueueCount : 0)
                              + _runtime.BatchingPendingCounts.PendingFor(Endpoint.Uri);
+
+    /// <summary>
+    /// GH-4199. Per-lane depth when this listener's receiver is group-partitioned, otherwise null. Read off
+    /// the OUTER receiver deliberately: both wrappers delegate it, and the outer one is what
+    /// <see cref="QueueCount"/> reads too, so the sum and its breakdown can never come from different layers.
+    /// </summary>
+    public PartitionedLaneDepth? LaneDepth => (_receiver as IHasQueueDepth)?.LaneDepth;
 
     /// <summary>
     /// Approximate timestamp of the last time a message was received on this listener. Receivers that stamp


### PR DESCRIPTION
Closes #4199. All three items, together — each is half an answer on its own, which is the argument the issue makes and it holds up.

The issue was explicit that it was a source read rather than a reproduction. **All three premises verified** against the code before anything was built.

---

## 1. The ceiling that was not there, and the one that was wrong

`EndpointCollection` filled in `BufferLimit` for every listener regardless of mode, but `Endpoint.ShouldEnforceBackPressure()` is false for exactly `Inline` and `NativeAck`, so no `BackPressureAgent` is built and nothing ever reads it there. Dormant while the pair read `(0, 1000)` and looked merely idle; **live** once GH-4186 made the depth real and it started reading `234 of 1,000`, offering an operator headroom that does not exist.

- `BufferLimit` is now null on the modes that do not enforce it.
- New `Endpoint.InFlightLimit` carries the ceiling that does — the broker's prefetch window — through to `EndpointHealthSnapshot.InFlightLimit`.

RabbitMQ reports `PreFetchCount`, which genuinely caps unacknowledged deliveries via `BasicQosAsync`. Azure Service Bus reports `PrefetchCount` when non-zero (zero is prefetch disabled, i.e. no ceiling, so null rather than a denominator of nothing).

**Redis Streams deliberately reports nothing.** Its read batch is a per-read size, not a cap on unacked entries — the endpoint's own source says so. Publishing it would recreate exactly the false headroom this change removes. That reasoning is in the `InFlightLimit` doc comment so the next transport author does not "fill in the gap".

A consumer no longer has to reimplement `ShouldEnforceBackPressure()` from a serialized mode name to know whether the number it was handed means anything.

## 2. A partitioned listener now reports where the work actually is

`ShardedExecutionBlock`'s slots are the whole point of partitioning, and the only depth it exposed was their sum. 100 messages spread over 10 lanes and 100 messages piled into one lane reported the identical number — and the second is a stalled listener while the first is healthy. That is the "one dominant `GroupId` serializes everything behind it" failure GH-3899's exempt lane exists to mitigate, invisible from outside the process.

`PartitionedLaneDepth(LaneCount, BusiestLaneCount, ExemptLaneCount)` flows from the block through the receiver and `ListeningAgent` to three nullable ints on the snapshot.

The **exempt lane is reported separately, not folded into the busiest reading** — it runs with its own parallelism, so a healthy multi-worker lane holding plenty of messages would otherwise misread as a hot partition. The issue called this out and it was right to. Null `LaneCount` means "not partitioned", which is a different state from a lane count of 1.

**Both receiver wrappers delegate `LaneDepth` explicitly.** A default interface member would have compiled, passed a naive test, and silently reported "not partitioned" for most real endpoints — `ReceiverWithRules` is installed by something as ordinary as an endpoint-level `MessageType`, and `GlobalPartitionedInterceptor` nests on top of it. There is a test that installs the wrapper that way and asserts the lane count still arrives.

`NativeAckReceiver` also holds the `ShardedExecutionBlock` separately: `DeserializeFirst` wraps it in an upstream deserialization stage, so the lanes are not reachable through `_receivingBlock` at all.

## 3. The suppression is countable

The GH-3710 guard dropped duplicates with a `LogDebug` and nothing else, so neither question an operator actually asks was answerable.

- **`wolverine-duplicates-suppressed`** — "is my redelivery rate normal". This is the number `NativeAckReceiver`'s own comment deferred to GH-3713, and GH-3713 closed as a flood *reproduction* rather than as a metric, so it was never produced.
- **`wolverine-idempotency-early-rotation`** — "is the window big enough". Counts only rotations forced by the `MaxTracked` ceiling **while the clock had not elapsed**, which is precisely "the effective window is shorter than you configured". Counting clock-driven rotations too would make every long-lived endpoint report a shrinkage it does not have; there is a control test for that.

Both are counted **inside the guard** rather than at each receiver's drop site, so NativeAck, Inline and Buffered all report without having to remember to. Both follow `LeaseRenewalTracker`: OTel instruments tagged by endpoint alongside plain properties, so tests read the arithmetic without standing up a `MeterListener`.

---

## Verification

15 new tests. Each was checked for vacuity rather than assumed:

- 3 of the 5 ceiling tests fail without the fix; the other 2 are controls (a Buffered listener must still report its ceiling, a transport with no prefetch must still report null) and pass either way.
- The wrapper-delegation test fails on its own when the delegation is removed, while the other three lane tests keep passing — so it tests the delegation specifically, not the feature generally.
- The suppression metric has an end-to-end `MeterListener` test, because the plain properties would pass even with the meter left unwired.

CoreTests **2751/2753** (2 pre-existing skips). `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings.

## Two things to know

- **The RabbitMQ and ASB `InFlightLimit` overrides are unverified locally** — no broker on this machine. They are one-line property overrides, but `CIRabbitMQ` and `CIAzureServiceBus` are their first real exercise.
- **No docs change.** The observability surface is documented in the guide and this adds three snapshot fields and two meters to it; happy to write that up here or separately, whichever you prefer.

`EndpointHealthSnapshot` gained four optional positional parameters at the end, so existing construction sites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)