### PR TITLE
GH-4012 item 5: classify terminal settle failures on the block, not in a catch

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/terminal_ack_classification_4012.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/Internal/terminal_ack_classification_4012.cs
@@ -27,11 +27,16 @@ public class terminal_ack_classification_4012
     private static Task deleteAsync(IAmazonSQS client)
     {
         return SqsSettlement.DeleteAsync(client, "https://sqs.test/q", "receipt-handle",
-            NullLogger.Instance, CancellationToken.None);
+            CancellationToken.None);
     }
 
+    /// <summary>
+    /// GH-4012 item 5 moved the seam: the callback no longer swallows, so every failure propagates and the
+    /// block's <c>ShouldRetry</c> decides. What is classified as terminal is unchanged, and that is what
+    /// this pins -- <c>SqsListener</c> wires the predicate as <c>e => !SqsSettlement.IsTerminal(e)</c>.
+    /// </summary>
     [Fact]
-    public async Task terminal_failures_are_swallowed_so_the_retry_block_stops()
+    public async Task terminal_failures_are_classified_and_still_propagate_to_the_block()
     {
         Exception[] terminals =
         [
@@ -44,14 +49,14 @@ public class terminal_ack_classification_4012
         {
             SqsSettlement.IsTerminal(terminal).ShouldBeTrue($"{terminal.GetType().Name} should be terminal");
 
-            // Swallowing is what stops the RetryBlock. The message is simply not deleted; SQS makes it
-            // visible again on its own clock and redelivers it
-            await deleteAsync(clientThatThrows(terminal));
+            // The block stops on this rather than the callback hiding it. The message is simply not
+            // deleted; SQS makes it visible again on its own clock and redelivers it.
+            await Should.ThrowAsync<Exception>(() => deleteAsync(clientThatThrows(terminal)));
         }
     }
 
     [Fact]
-    public async Task transient_failures_still_propagate_so_the_retry_block_retries()
+    public async Task transient_failures_are_not_classified_as_terminal()
     {
         Exception[] transients =
         [

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -89,11 +89,20 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
 
         _reassembler = new SqsFragmentReassembler(queue.FragmentReassemblyTimeout, logger);
 
-        // GH-4012 item 3: a delete that can never succeed must not burn the retry budget
+        // GH-4012 items 3 and 5: a delete that can never succeed must not burn the retry budget, and the
+        // classification lives on the block rather than in a catch inside the callback.
         _singleDeleteBlock = new RetryBlock<Message>(
             (message, token) => SqsSettlement.DeleteAsync(_transport.Client!, _queue.QueueUrl!,
-                message.ReceiptHandle, logger, token),
-            logger, runtime.Cancellation);
+                message.ReceiptHandle, token),
+            logger, runtime.Cancellation)
+        {
+            ShouldRetry = e => !SqsSettlement.IsTerminal(e),
+            OnTerminalFailure = (_, e) =>
+            {
+                SqsSettlement.LogTerminalDelete(logger, _queue.QueueUrl!, e);
+                return Task.CompletedTask;
+            }
+        };
 
         if (_queue.DeleteMessageBatchSize > 1)
         {

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSettlement.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsSettlement.cs
@@ -8,7 +8,9 @@ namespace Wolverine.AmazonSqs.Internal;
 /// GH-4012 item 3. Terminal-failure classification for the SQS delete -- the settle on this transport.
 /// </summary>
 /// <remarks>
-/// <para>Without it a permanent failure burns the whole retry budget before being dropped. The same
+/// <para>GH-4012 item 5 moved the classification itself onto the block as <c>ShouldRetry</c>; this type now
+/// owns the predicate and the give-up log rather than a try/catch. Without classification a permanent
+/// failure burns the whole retry budget before being dropped. The same
 /// reasoning as <c>sendOrDiscardAsync</c> (GH-3926) applies in the other direction: a <see cref="RetryBlock{T}" />
 /// retries until it succeeds, so an operation that can never succeed spins the block for nothing.</para>
 ///
@@ -32,21 +34,24 @@ namespace Wolverine.AmazonSqs.Internal;
 /// </remarks>
 internal static class SqsSettlement
 {
-    internal static async Task DeleteAsync(IAmazonSQS client, string queueUrl, string receiptHandle,
-        ILogger logger, CancellationToken token)
+    internal static Task DeleteAsync(IAmazonSQS client, string queueUrl, string receiptHandle,
+        CancellationToken token)
     {
-        try
-        {
-            await client.DeleteMessageAsync(queueUrl, receiptHandle, token);
-        }
-        catch (Exception e) when (IsTerminal(e))
-        {
-            // Swallowing is what stops the RetryBlock. The delivery is simply not deleted; SQS makes it
-            // visible again on its own clock and redelivers it.
-            logger.LogInformation(
-                "Discarding a terminal SQS delete failure ({Failure}) on {QueueUrl}; the message will be redelivered when its visibility window lapses",
-                e.GetType().Name, queueUrl);
-        }
+        // GH-4012 item 5: no catch here any more. The block's ShouldRetry does the classification and its
+        // OnTerminalFailure does the reporting, so this is just the settle.
+        return client.DeleteMessageAsync(queueUrl, receiptHandle, token);
+    }
+
+    /// <summary>
+    /// GH-4012 item 5. Reports a give-up, which the swallow-in-the-callback shape could not: an exception
+    /// caught inside the callback is indistinguishable from success at the block's boundary, so the block
+    /// could never log it differently.
+    /// </summary>
+    internal static void LogTerminalDelete(ILogger logger, string queueUrl, Exception e)
+    {
+        logger.LogInformation(
+            "Discarding a terminal SQS delete failure ({Failure}) on {QueueUrl}; the message will be redelivered when its visibility window lapses",
+            e.GetType().Name, queueUrl);
     }
 
     internal static bool IsTerminal(Exception e)

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Internal/terminal_ack_classification_4012.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/Internal/terminal_ack_classification_4012.cs
@@ -24,8 +24,13 @@ public class terminal_ack_classification_4012
         return new AzureServiceBusEnvelope(message, receiver);
     }
 
+    /// <summary>
+    /// GH-4012 item 5 moved the seam: <c>CompleteAsync</c> no longer swallows, so the failure propagates and
+    /// the block's <c>ShouldRetry</c> decides. What counts as terminal is unchanged, and all four listeners
+    /// now wire it -- including the two session listeners, which had no classification at all.
+    /// </summary>
     [Fact]
-    public async Task a_terminal_failure_is_swallowed_so_the_retry_block_stops()
+    public async Task a_terminal_failure_is_classified_and_propagates_to_the_block()
     {
         var receiver = Substitute.For<ServiceBusReceiver>();
         receiver.CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>())
@@ -33,13 +38,16 @@ public class terminal_ack_classification_4012
 
         var envelope = envelopeFor(receiver);
 
-        // Swallowing is what stops the RetryBlock. The delivery is left unsettled, its lock lapses,
-        // and the broker redelivers -- the same recovery Rabbit's unknown-delivery-tag branch relies on
-        await AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None);
+        // The block stops on this rather than the callback hiding it. The delivery is left unsettled, its
+        // lock lapses, and the broker redelivers -- the same recovery Rabbit's unknown-tag branch relies on.
+        var terminal = await Should.ThrowAsync<ServiceBusException>(() =>
+            AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None));
+
+        AzureServiceBusSettlement.IsTerminal(terminal).ShouldBeTrue();
     }
 
     [Fact]
-    public async Task a_transient_failure_still_propagates_so_the_retry_block_retries()
+    public async Task a_transient_failure_is_not_classified_as_terminal()
     {
         var receiver = Substitute.For<ServiceBusReceiver>();
         receiver.CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>())
@@ -47,10 +55,37 @@ public class terminal_ack_classification_4012
 
         var envelope = envelopeFor(receiver);
 
-        // The whole point of classifying: a transient failure must NOT be swallowed, or the retry
-        // budget this change exists to protect would never be spent on the cases that deserve it
-        await Should.ThrowAsync<ServiceBusException>(() =>
+        // The whole point of classifying: a transient failure must keep its retries, or the budget this
+        // change exists to protect would never be spent on the cases that deserve it.
+        var transient = await Should.ThrowAsync<ServiceBusException>(() =>
             AzureServiceBusSettlement.CompleteAsync(envelope, 3, NullLogger.Instance, CancellationToken.None));
+
+        AzureServiceBusSettlement.IsTerminal(transient).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// GH-4012 item 5. The classification is only worth anything if the block it guards is actually built
+    /// with it, and that wiring is precisely what went missing before: item 3 applied it by routing through
+    /// a helper that two of the four listeners never called. Every listener now builds its settle block
+    /// through <c>CompleteBlock</c>, so this pins the factory once instead of four copies of an initializer.
+    /// </summary>
+    [Fact]
+    public void the_settle_block_factory_carries_the_classification()
+    {
+        var block = AzureServiceBusSettlement.CompleteBlock((_, _) => Task.CompletedTask,
+            NullLogger.Instance, CancellationToken.None);
+
+        block.ShouldRetry.ShouldNotBeNull("Without this the block retries every failure, which is the pre-GH-4012 behaviour.");
+
+        block.ShouldRetry!(new ServiceBusException("lock is gone", ServiceBusFailureReason.MessageLockLost))
+            .ShouldBeFalse("A non-transient failure must end the attempt sequence immediately.");
+
+        block.ShouldRetry(new ServiceBusException("busy", ServiceBusFailureReason.ServiceBusy))
+            .ShouldBeTrue("A transient failure is exactly what the retry budget exists for.");
+
+        // The capability the swallow-in-the-callback shape could not provide: the block gets to report a
+        // give-up rather than having it look identical to a success.
+        block.OnTerminalFailure.ShouldNotBeNull();
     }
 
     [Fact]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSettlement.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusSettlement.cs
@@ -1,4 +1,5 @@
 using Azure.Messaging.ServiceBus;
+using JasperFx.Blocks;
 using Microsoft.Extensions.Logging;
 
 namespace Wolverine.AzureServiceBus.Internal;
@@ -15,9 +16,10 @@ namespace Wolverine.AzureServiceBus.Internal;
 /// wrong for a long time precisely because it was a string, and nothing failed loudly when it stopped
 /// matching.</para>
 ///
-/// <para>Both give-up paths deliberately swallow rather than rethrow. Swallowing is what stops the
-/// <c>RetryBlock</c>; the delivery is simply left unsettled, its lock lapses, and the broker
-/// redelivers -- the same recovery the RabbitMQ unknown-delivery-tag branch relies on.</para>
+/// <para>The give-up leaves the delivery unsettled: its lock lapses and the broker redelivers -- the same
+/// recovery the RabbitMQ unknown-delivery-tag branch relies on. GH-4012 item 5 moved the classification off
+/// a <c>catch</c> in this method and onto the block itself as <c>ShouldRetry</c>, so the block can tell a
+/// terminal give-up from a success and report it through <c>OnTerminalFailure</c>.</para>
 /// </remarks>
 internal static class AzureServiceBusSettlement
 {
@@ -32,18 +34,55 @@ internal static class AzureServiceBusSettlement
             return;
         }
 
-        try
+        // GH-4012 item 5: no catch here any more. The block's ShouldRetry classifies and its
+        // OnTerminalFailure reports, so this is the budget check plus the settle.
+        await envelope.CompleteAsync(token);
+    }
+
+    /// <summary>
+    /// GH-4012 item 5. The one place a settle block is built, so the classification cannot be left off one.
+    ///
+    /// <para>
+    /// That is not hypothetical. Item 3 applied the classification by routing callbacks through
+    /// <see cref="CompleteAsync"/>, and two of the four listeners -- both session listeners -- never called
+    /// it, so they kept burning the full retry budget on failures that could never succeed. A factory can be
+    /// used wrongly only by not using it, which is visible at the call site; a helper can be forgotten
+    /// silently.
+    /// </para>
+    /// </summary>
+    internal static RetryBlock<AzureServiceBusEnvelope> CompleteBlock(
+        Func<AzureServiceBusEnvelope, CancellationToken, Task> settle, ILogger logger, CancellationToken token)
+    {
+        return new RetryBlock<AzureServiceBusEnvelope>((e, c) => settle(e, c), logger, token)
         {
-            await envelope.CompleteAsync(token);
-        }
-        catch (ServiceBusException e) when (!e.IsTransient)
-        {
-            // Terminal. MessageLockLost is the common one: the lock is gone, so no later attempt on
-            // any receiver can settle this delivery. Retrying only delays the redelivery that is
-            // already coming.
-            logger.LogInformation(
-                "Discarding a terminal Azure Service Bus settle failure ({Reason}) for envelope {EnvelopeId}; the broker will redeliver it",
-                e.Reason, envelope.Id);
-        }
+            ShouldRetry = e => !IsTerminal(e),
+            OnTerminalFailure = (envelope, e) =>
+            {
+                LogTerminalSettle(logger, envelope, e);
+                return Task.CompletedTask;
+            }
+        };
+    }
+
+    /// <summary>
+    /// GH-4012 item 5. Azure Service Bus makes the distinction first class, so unlike RabbitMQ there is no
+    /// broker text to string-match. <c>MessageLockLost</c> is the common terminal case: the lock is gone, so
+    /// no later attempt on any receiver can settle this delivery, and retrying only delays the redelivery
+    /// that is already coming.
+    /// </summary>
+    internal static bool IsTerminal(Exception e)
+    {
+        return e is ServiceBusException { IsTransient: false };
+    }
+
+    /// <summary>
+    /// GH-4012 item 5. Reports a give-up, which the swallow-in-the-callback shape could not: an exception
+    /// caught inside the callback is indistinguishable from success at the block's boundary.
+    /// </summary>
+    internal static void LogTerminalSettle(ILogger logger, Envelope envelope, Exception e)
+    {
+        logger.LogInformation(
+            "Discarding a terminal Azure Service Bus settle failure ({Reason}) for envelope {EnvelopeId}; the broker will redeliver it",
+            (e as ServiceBusException)?.Reason.ToString() ?? e.GetType().Name, envelope.Id);
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -43,7 +43,7 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
         _task = Task.Run(listenForMessages, _cancellation.Token);
 
         // GH-4012 item 3: ack budget + terminal-failure classification, shared with the inline listener
-        _complete = new RetryBlock<AzureServiceBusEnvelope>(
+        _complete = AzureServiceBusSettlement.CompleteBlock(
             (e, _) => AzureServiceBusSettlement.CompleteAsync(e, maximumAckAttempts, _logger, _cancellation.Token),
             _logger, _cancellation.Token);
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusListener.cs
@@ -41,7 +41,7 @@ public class InlineAzureServiceBusListener : IListener, ISupportDeadLetterQueue,
         _requeue = requeue;
 
         // GH-4012 item 3: ack budget + terminal-failure classification, shared with the batched listener
-        _complete = new RetryBlock<AzureServiceBusEnvelope>(
+        _complete = AzureServiceBusSettlement.CompleteBlock(
             (e, _) => AzureServiceBusSettlement.CompleteAsync(e, maximumAckAttempts, _logger, _cancellation.Token),
             _logger, _cancellation.Token);
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusSessionListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/InlineAzureServiceBusSessionListener.cs
@@ -47,7 +47,9 @@ public class InlineAzureServiceBusSessionListener : IListener, ISupportDeadLette
         _mapper = mapper;
         _requeue = requeue;
 
-        _complete = new RetryBlock<AzureServiceBusEnvelope>((e, _) => { return e.CompleteAsync(_cancellation.Token); },
+        // GH-4012 item 5 -- see the note on SessionSpecificListener: neither session listener had terminal
+        // classification, because item 3 applied it by routing through a helper these two never called.
+        _complete = AzureServiceBusSettlement.CompleteBlock((e, _) => e.CompleteAsync(_cancellation.Token),
             _logger, _cancellation.Token);
 
         _defer = new RetryBlock<AzureServiceBusEnvelope>(async (envelope, _) =>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/SessionSpecificListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/SessionSpecificListener.cs
@@ -152,8 +152,13 @@ internal class SessionSpecificListener : IListener, ISupportDeadLetterQueue
         _mapper = mapper;
         _logger = logger;
 
-        _complete = new RetryBlock<AzureServiceBusEnvelope>((e, _) => e.CompleteAsync(_cancellation.Token), _logger,
-            _cancellation.Token);
+        // GH-4012 item 5. This settle had no terminal classification at all: item 3 landed it in
+        // AzureServiceBusSettlement and routed the two non-session listeners through the helper, but both
+        // session listeners call CompleteAsync directly and so kept burning the full retry budget on a
+        // failure that can never succeed. Declaring the predicate ON THE BLOCK is what makes that hard to
+        // forget again -- "remember to call the helper" is exactly what was forgotten here.
+        _complete = AzureServiceBusSettlement.CompleteBlock((e, _) => e.CompleteAsync(_cancellation.Token),
+            _logger, _cancellation.Token);
 
         _defer = new RetryBlock<AzureServiceBusEnvelope>(async (envelope, _) =>
         {

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/terminal_ack_classification_4012.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/terminal_ack_classification_4012.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Exceptions;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests;
+
+/// <summary>
+/// GH-4012 item 5. RabbitMQ was the one transport that already classified a terminal settle failure, but it
+/// did so with a <c>catch</c> inside the block's own callback -- which works, and hides the give-up from the
+/// block: a swallowed exception is indistinguishable from success at the block's boundary, so the block can
+/// neither log it differently nor hand it to <c>OnTerminalFailure</c>.
+///
+/// <para>
+/// The classification itself is unchanged, and that is the point of these assertions. The previous catch
+/// swallowed <b>every</b> <see cref="AlreadyClosedException"/> and made only the log and the GH-3950 quiesce
+/// conditional on the delivery tag, so treating just the unknown-tag case as terminal would have been a
+/// behaviour change wearing a refactor's clothes.
+/// </para>
+/// </summary>
+public class terminal_ack_classification_4012
+{
+    private static RabbitMqChannelCallback theCallback()
+    {
+        return new RabbitMqChannelCallback(NullLogger.Instance, CancellationToken.None, 3);
+    }
+
+    [Fact]
+    public void the_settle_block_classifies_a_closed_channel_as_terminal()
+    {
+        using var callback = theCallback();
+
+        callback.Complete.ShouldRetry.ShouldNotBeNull(
+            "Without this the block retries every failure, which is what burned the budget before GH-4012.");
+
+        callback.Complete.ShouldRetry!(
+                new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Peer, 406,
+                    "PRECONDITION_FAILED - unknown delivery tag 1")))
+            .ShouldBeFalse("The tag belongs to a channel that is gone; no retry on a later channel can succeed.");
+    }
+
+    /// <summary>
+    /// The half that is easy to get wrong on a refactor: the old catch was on the exception TYPE, not on the
+    /// message, so a closed channel is terminal whatever closed it. Narrowing this to the unknown-tag text
+    /// would silently start retrying failures that used to stop immediately.
+    /// </summary>
+    [Fact]
+    public void any_closed_channel_is_terminal_not_just_an_unknown_tag()
+    {
+        using var callback = theCallback();
+
+        callback.Complete.ShouldRetry!(
+                new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Peer, 320,
+                    "CONNECTION_FORCED - broker forced connection closure")))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_ordinary_failure_is_still_retried()
+    {
+        using var callback = theCallback();
+
+        callback.Complete.ShouldRetry!(new TimeoutException("the broker was slow"))
+            .ShouldBeTrue("A transient failure is exactly what the retry budget exists for.");
+    }
+
+    [Fact]
+    public void the_give_up_is_reportable_rather_than_swallowed()
+    {
+        using var callback = theCallback();
+
+        // The capability the catch-in-the-callback shape could not provide.
+        callback.Complete.OnTerminalFailure.ShouldNotBeNull();
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqChannelCallback.cs
@@ -36,33 +36,39 @@ internal class RabbitMqChannelCallback : IChannelCallback, IDisposable, ISupport
             // broker round trips for one delivery, with neither block able to see the other's count.
             if (!e.TryRecordAckAttempt(maximumAckAttempts))
             {
-                // Swallowing stops the retry loop. The delivery stays unsettled, the broker
-                // redelivers it, and the durable inbox deduplicates -- the same recovery the
-                // unknown-delivery-tag branch below relies on.
+                // Returning without settling stops the retry loop. The delivery stays unsettled, the
+                // broker redelivers it, and the durable inbox deduplicates -- the same recovery the
+                // unknown-delivery-tag classification below relies on.
                 logger.LogWarning(
                     "Giving up on acking Rabbit MQ delivery for envelope {EnvelopeId} after {AckAttempts} attempts; leaving it for broker redelivery",
                     e.Id, e.AckAttempts);
                 return;
             }
 
-            try
+            // GH-4012 item 5: the classification and the give-up handling moved onto the block below, so
+            // this is the budget check plus the settle.
+            await e.CompleteAsync();
+        }, logger, cancellationToken)
+        {
+            // A closed channel is terminal for this delivery whatever closed it -- the tag belongs to that
+            // channel and no retry on a later one can succeed. This deliberately matches the previous
+            // behaviour exactly: the old catch swallowed EVERY AlreadyClosedException and only made the log
+            // and the quiesce conditional on the delivery tag, so widening or narrowing here would be a
+            // behaviour change rather than the refactor this is.
+            ShouldRetry = e => e is not AlreadyClosedException,
+            OnTerminalFailure = (envelope, exception) =>
             {
-                await e.CompleteAsync();
-            }
-            catch (AlreadyClosedException exception)
-            {
-                // An unknown delivery tag is terminal -- the tag's channel is gone and no retry on any
-                // later channel can succeed. Swallowing it here stops the RetryBlock from burning its
-                // budget; the broker will redeliver and the durable inbox will deduplicate.
-                if (isUnknownDeliveryTag(exception))
+                if (exception is AlreadyClosedException closed && isUnknownDeliveryTag(closed))
                 {
                     logger.LogInformation("Encountered an unknown delivery tag, discarding the envelope");
 
                     // GH-3950: the broker has already closed that channel. Stop feeding it.
-                    e.RabbitMqListener.QuiesceAfterRejectedSettle(e);
+                    envelope.RabbitMqListener.QuiesceAfterRejectedSettle(envelope);
                 }
+
+                return Task.CompletedTask;
             }
-        }, logger, cancellationToken);
+        };
 
         Defer = new RetryBlock<RabbitMqEnvelope>((e, _) => e.DeferAsync().AsTask(), logger, cancellationToken);
         _deadLetterQueue = new RetryBlock<RabbitMqEnvelope>(moveToErrorQueueAsync, logger, cancellationToken);


### PR DESCRIPTION
Closes #4012 — item 5, the last one open.

**It is unblocked.** `RetryBlock.ShouldRetry` and `OnTerminalFailure` (jasperfx#701) are both in **JasperFx 2.59.0**, which Wolverine already pins, so the "cannot consume until JasperFx ships a release" note on the issue is stale. Items 1–4 were verified shipped before starting: #4014, #4106, #4112.

## The refactor

All three transports that classify a terminal settle failure did it by swallowing inside the block's own callback. That works, and it hides the give-up from the block — a swallowed exception is indistinguishable from success at the block's boundary, so the block can neither log it differently nor report it. All three now let the failure propagate and declare the classification as `ShouldRetry`, with `OnTerminalFailure` doing the reporting.

**The classification is unchanged everywhere.** RabbitMQ's is worth spelling out, because it is easy to get wrong: the old catch swallowed **every** `AlreadyClosedException` and made only the log and the GH-3950 quiesce conditional on the delivery tag. So the faithful predicate is `e is not AlreadyClosedException`, *not* the unknown-tag text. Narrowing it would be a behaviour change wearing a refactor's clothes, and there is a test named for exactly that.

## A real gap this closed along the way

Item 3 applied Azure Service Bus classification by routing callbacks through `AzureServiceBusSettlement.CompleteAsync`. **Only two of the four listeners ever called it:**

| ASB listener | before |
|---|---|
| `BatchedAzureServiceBusListener` | classified, budgeted |
| `InlineAzureServiceBusListener` | classified, budgeted |
| `SessionSpecificListener` | `e.CompleteAsync(...)` **direct** — no classification |
| `InlineAzureServiceBusSessionListener` | same |

So on a session queue a non-transient settle failure still burned the full retry budget — precisely what item 3 existed to stop.

The fix is deliberately **not** four copies of an initializer, because "remember to route through the helper" is what was forgotten in the first place. All four listeners now build their settle block through one `AzureServiceBusSettlement.CompleteBlock` factory carrying the classification. A factory can be misused only by not calling it, which is visible at the call site; a helper can be skipped silently.

That also makes the wiring **testable**, which the old shape was not — the previous tests could only assert the predicate, so deleting the wiring would have left them green. There is now a test on the factory itself and four on the RabbitMQ callback.

## Deliberately out of scope

- **`_defer` and `_deadLetter` are untouched.** That is where GH-4068's double-settle logic lives, and `SessionLockLost` semantics there are their own decision — #4085 explicitly chose not to tolerate it in `CompleteAsync`, reasoning that a genuinely lost lock means redelivery is coming.
- **The session listeners still lack the ack budget.** That is item 1's reach rather than item 5's, and adding it is a behaviour change rather than a refactor.

## Verification

- Azure Service Bus `terminal_ack_classification_4012` — 4 passed (3 updated for the moved seam, 1 new factory-wiring test)
- Amazon SQS `terminal_ack_classification_4012` — 3 passed, updated for the moved seam
- RabbitMQ `terminal_ack_classification_4012` — 4 passed, new
- `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings

The updated tests are updated rather than deleted: what they asserted (terminal failures stop the retry loop) is still true, but it is now true at the block rather than inside the callback, so they assert the classification and the propagation instead of the swallow.

**Not run locally:** the ASB and RabbitMQ integration suites, which need the emulator and a broker. `CIAzureServiceBus` and `CIRabbitMQ` are their first real exercise.

## Housekeeping

#4012 is still on the **6.31.0** milestone, which has shipped. Worth moving to 6.32 or clearing when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)