### PR TITLE
GH-4215: heal a listener whose broker entity was deleted underneath it

### DIFF
--- a/src/Testing/CoreTests/Transports/receive_loop_entity_missing_4215.cs
+++ b/src/Testing/CoreTests/Transports/receive_loop_entity_missing_4215.cs
@@ -1,0 +1,141 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine.Transports;
+using Xunit;
+
+namespace CoreTests.Transports;
+
+/// <summary>
+/// GH-4215. A broker entity deleted underneath a running listener -- an emulator or LocalStack restarting
+/// empty, an operator or IaC teardown -- used to kill that listener permanently. Every iteration exception was
+/// treated the same: log at Error, back off (capped at one second), retry the same receive forever. Two
+/// consequences, both observed on a real fleet: the listener never consumed again until the host restarted,
+/// and the tight retry emitted ~23 error lines a second, drowning out everything else the host logged.
+/// </summary>
+public class receive_loop_entity_missing_4215
+{
+    private sealed class EntityGoneException : Exception;
+
+    private static BackgroundReceiveLoop loop(Func<CancellationToken, Task<bool>> body,
+        Func<CancellationToken, Task>? redeclare = null)
+    {
+        return new BackgroundReceiveLoop(new Uri("test://loop-4215"), NullLogger.Instance, body,
+            CancellationToken.None, 20.Milliseconds())
+        {
+            IsEntityMissing = e => e is EntityGoneException,
+            RedeclareAsync = redeclare
+        };
+    }
+
+    [Fact]
+    public async Task a_missing_entity_is_reported_as_such_rather_than_as_running()
+    {
+        var theLoop = loop(_ => throw new EntityGoneException());
+        theLoop.Start();
+
+        // Before this, a listener whose queue had been deleted reported Running forever -- an operator had
+        // nothing to distinguish it from a healthy quiet one.
+        await waitUntil(() => theLoop.ReceiveLoopStatus == ReceiveLoopStatus.EntityMissing);
+
+        // Still alive and still trying: this is NOT Faulted, which means "stopped, needs a rebuild".
+        theLoop.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.EntityMissing);
+
+        await theLoop.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task the_redeclare_hook_runs_so_a_wiped_broker_can_heal()
+    {
+        var declared = 0;
+        var entityExists = false;
+
+        var theLoop = loop(
+            _ => entityExists ? Task.FromResult(false) : throw new EntityGoneException(),
+            _ =>
+            {
+                Interlocked.Increment(ref declared);
+                entityExists = true;
+                return Task.CompletedTask;
+            });
+
+        theLoop.Start();
+
+        await waitUntil(() => declared > 0);
+
+        // The whole point: the application already knew how to declare the entity, because AutoProvision did
+        // it at startup. Nothing simply re-ran that afterwards.
+        await waitUntil(() => theLoop.ReceiveLoopStatus == ReceiveLoopStatus.Running);
+
+        await theLoop.DisposeAsync();
+    }
+
+    /// <summary>
+    /// A healed loop must stop reporting the diagnosis that got it there, or a recovered listener looks
+    /// permanently broken to whatever is watching it.
+    /// </summary>
+    [Fact]
+    public async Task recovering_clears_the_entity_missing_status()
+    {
+        var fail = true;
+        var theLoop = loop(_ => fail ? throw new EntityGoneException() : Task.FromResult(false));
+
+        theLoop.Start();
+        await waitUntil(() => theLoop.ReceiveLoopStatus == ReceiveLoopStatus.EntityMissing);
+
+        fail = false;
+        await waitUntil(() => theLoop.ReceiveLoopStatus == ReceiveLoopStatus.Running);
+
+        await theLoop.DisposeAsync();
+    }
+
+    /// <summary>
+    /// A failure the transport does not recognize keeps the old behaviour exactly. Widening the new path to
+    /// every exception would turn an ordinary transient blip into a five-second stall.
+    /// </summary>
+    [Fact]
+    public async Task an_unclassified_failure_is_still_an_ordinary_retry()
+    {
+        var theLoop = loop(_ => throw new InvalidOperationException("a transient blip"));
+        theLoop.Start();
+
+        await waitUntil(() => theLoop.ConsecutiveFailures > 1);
+
+        theLoop.ReceiveLoopStatus.ShouldBe(ReceiveLoopStatus.Running);
+
+        await theLoop.DisposeAsync();
+    }
+
+    /// <summary>
+    /// A transport that classifies but cannot re-declare -- AutoProvision off, so re-creating an entity the
+    /// application never created is not Wolverine's call -- still gets the visibility and the backoff.
+    /// </summary>
+    [Fact]
+    public async Task classification_without_a_redeclare_hook_still_reports_and_backs_off()
+    {
+        var theLoop = loop(_ => throw new EntityGoneException());
+        theLoop.Start();
+
+        await waitUntil(() => theLoop.ReceiveLoopStatus == ReceiveLoopStatus.EntityMissing);
+
+        var failures = theLoop.ConsecutiveFailures;
+        await Task.Delay(400.Milliseconds(), TestContext.Current.CancellationToken);
+
+        // The 5s floor, not the 1s cap: a handful of retries in 400ms would mean the old cadence.
+        theLoop.ConsecutiveFailures.ShouldBe(failures);
+
+        await theLoop.DisposeAsync();
+    }
+
+    private static async Task waitUntil(Func<bool> condition)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException("Condition never became true");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -121,7 +121,22 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         // catch -> log -> exponential-backoff -> continue policy, the idle delay when a poll returns nothing, the
         // heartbeat, and safe teardown. The listener just provides one poll-and-process iteration and reports the
         // loop's health through IReportReceiveLoopHealth.
-        _loop = new BackgroundReceiveLoop(_queue.Uri, logger, pollOnceAsync, runtime.Cancellation);
+        _loop = new BackgroundReceiveLoop(_queue.Uri, logger, pollOnceAsync, runtime.Cancellation)
+        {
+            // GH-4215: a wiped broker -- LocalStack or an emulator restarting empty, an operator or IaC
+            // teardown -- used to kill this listener permanently. The queue was declared by AutoProvision at
+            // startup, so the application knows how to declare it; nothing simply re-ran that afterwards.
+            IsEntityMissing = e => e is QueueDoesNotExistException,
+
+            // Gated on AutoProvision: re-creating a queue the application never created is not Wolverine's
+            // call. Without it the loop still reports EntityMissing and backs off, which is the visibility
+            // half of the fix.
+            // SetupAsync re-creates the queue AND reassigns QueueUrl, so the next poll uses the new one --
+            // which matters because a recreated queue is a different entity even when the name is identical.
+            RedeclareAsync = _transport.AutoProvision
+                ? _ => _queue.SetupAsync(_transport.Client!)
+                : null
+        };
         _loop.Start();
     }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/BatchedAzureServiceBusListener.cs
@@ -306,9 +306,37 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
                                    ?? TransportConnectionState.Reconnecting;
 
                 failedCount++;
-                var pauseTime = failedCount > 5 ? 1.Seconds() : (failedCount * 100).Milliseconds();
 
-                if (_endpoint.Role == EndpointRole.Application)
+                // GH-4215. A missing entity is not a transient blip: the emulator restarting empty, an operator
+                // or IaC teardown, a broker wipe. Retrying the receive cannot bring it back, so the old
+                // one-second cadence bought nothing and cost ~23 error lines a second across a fleet. The
+                // entity was declared by AutoProvision at startup, so the application knows how to declare it --
+                // nothing simply re-ran that afterwards.
+                var entityMissing = e is ServiceBusException
+                {
+                    Reason: ServiceBusFailureReason.MessagingEntityNotFound
+                };
+
+                var pauseTime = entityMissing
+                    ? 5.Seconds()
+                    : failedCount > 5
+                        ? 1.Seconds()
+                        : (failedCount * 100).Milliseconds();
+
+                if (entityMissing)
+                {
+                    // First of a streak and then every 60th, rather than every iteration -- the log storm was
+                    // its own outage on top of the one being reported.
+                    if (failedCount == 1 || failedCount % 60 == 0)
+                    {
+                        _logger.LogWarning(e,
+                            "The Azure Service Bus entity for {Uri} does not exist (consecutive failures: {Count}). Retrying the receive cannot succeed until it is re-declared.",
+                            _endpoint.Uri, failedCount);
+                    }
+
+                    await tryRedeclareAsync();
+                }
+                else if (_endpoint.Role == EndpointRole.Application)
                 {
                     _logger.LogError(e, "Error while trying to retrieve messages from Azure Service Bus {Uri}",
                         _endpoint.Uri);
@@ -322,6 +350,28 @@ public class BatchedAzureServiceBusListener : IListener, ISupportDeadLetterQueue
 
                 await Task.Delay(pauseTime);
             }
+        }
+    }
+
+    /// <summary>
+    /// GH-4215. Re-declare the entity so a wiped broker heals the way a startup does. Gated on AutoProvision:
+    /// re-creating an entity the application never created is not Wolverine's call to make, and without it the
+    /// loop still backs off and reports rather than retrying once a second forever.
+    /// </summary>
+    private async Task tryRedeclareAsync()
+    {
+        if (!_endpoint.Parent.AutoProvision) return;
+
+        try
+        {
+            await _endpoint.SetupAsync(_logger);
+        }
+        catch (Exception redeclare)
+        {
+            // Best-effort by nature: the broker being unreachable is exactly when this fails, and it must
+            // never take the receive loop down with it.
+            _logger.LogWarning(redeclare, "Could not re-declare the Azure Service Bus entity for {Uri}",
+                _endpoint.Uri);
         }
     }
 

--- a/src/Wolverine/Transports/BackgroundReceiveLoop.cs
+++ b/src/Wolverine/Transports/BackgroundReceiveLoop.cs
@@ -26,6 +26,28 @@ public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoop
     private long _lastActivityTicks;
     private volatile ReceiveLoopStatus _status = ReceiveLoopStatus.NotStarted;
 
+    /// <summary>
+    /// GH-4215. Optional classification of a failure as "the broker entity this loop reads from does not exist".
+    /// Null by default, which keeps the pre-existing behaviour: every failure is a transient one worth retrying
+    /// at the same cadence.
+    ///
+    /// <para>
+    /// A missing entity is not transient in the way a socket blip is. Retrying the receive cannot bring the
+    /// queue back, so before this the loop retried once a second forever -- ~23 error lines per second across a
+    /// fleet, 180MB of stdout in 45 minutes, and a listener that never consumed again until the host restarted.
+    /// </para>
+    /// </summary>
+    public Func<Exception, bool>? IsEntityMissing { get; init; }
+
+    /// <summary>
+    /// GH-4215. Optional re-declare step, run when <see cref="IsEntityMissing"/> classifies a failure. This is
+    /// what actually heals the loop: the application already knows how to declare the entity, because
+    /// AutoProvision declared it at startup -- nothing simply re-ran that after startup. Transports should wire
+    /// this to the endpoint's own <c>SetupAsync</c>, and only when the endpoint was auto-provisioned: re-creating
+    /// an entity the application did not create is not Wolverine's call to make.
+    /// </summary>
+    public Func<CancellationToken, Task>? RedeclareAsync { get; init; }
+
     public BackgroundReceiveLoop(Uri uri, ILogger logger, Func<CancellationToken, Task<bool>> iteration,
         CancellationToken parentToken, TimeSpan? idleDelay = null)
     {
@@ -78,6 +100,14 @@ public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoop
                     var didWork = await _iteration(_cancellation.Token).ConfigureAwait(false);
                     _consecutiveFailures = 0;
 
+                    // GH-4215: a successful iteration clears an EntityMissing streak, so a loop that healed
+                    // reports Running again rather than staying stuck on the diagnosis that got it there.
+                    if (_status == ReceiveLoopStatus.EntityMissing)
+                    {
+                        _status = ReceiveLoopStatus.Running;
+                        _logger.LogInformation("The receive loop for {Uri} is consuming again", _uri);
+                    }
+
                     if (!didWork)
                     {
                         await Task.Delay(_idleDelay, _cancellation.Token).ConfigureAwait(false);
@@ -90,13 +120,35 @@ public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoop
                 catch (Exception e)
                 {
                     var failures = Interlocked.Increment(ref _consecutiveFailures);
-                    _logger.LogError(e,
-                        "Error in the receive loop for {Uri} (consecutive failures: {Count}); backing off and retrying",
-                        _uri, failures);
+                    var entityMissing = IsEntityMissing?.Invoke(e) ?? false;
+
+                    if (entityMissing)
+                    {
+                        _status = ReceiveLoopStatus.EntityMissing;
+
+                        // GH-4215: logged on the first failure of a streak and then every 60th, rather than every
+                        // iteration. The old behaviour drowned out everything else the host logged, which is its
+                        // own outage on top of the one being reported.
+                        if (failures == 1 || failures % 60 == 0)
+                        {
+                            _logger.LogWarning(e,
+                                "The broker entity for {Uri} does not exist (consecutive failures: {Count}). Retrying the receive cannot succeed until it is re-declared.",
+                                _uri, failures);
+                        }
+
+                        await tryRedeclareAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _logger.LogError(e,
+                            "Error in the receive loop for {Uri} (consecutive failures: {Count}); backing off and retrying",
+                            _uri, failures);
+                    }
 
                     try
                     {
-                        await Task.Delay(backoffFor(failures), _cancellation.Token).ConfigureAwait(false);
+                        await Task.Delay(backoffFor(failures, entityMissing), _cancellation.Token)
+                            .ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -120,8 +172,30 @@ public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoop
     }
 
     // Mirrors the historical SQS backoff curve: a gentle ramp, capped at one second.
-    private static TimeSpan backoffFor(int failures)
-        => failures > 5 ? 1.Seconds() : (failures * 100).Milliseconds();
+    // GH-4215: a missing entity gets a far longer floor than a transient blip. Retrying the receive cannot
+    // succeed until something re-declares, so a one-second cadence buys nothing and costs a log storm.
+    private static TimeSpan backoffFor(int failures, bool entityMissing)
+    {
+        if (entityMissing) return 5.Seconds();
+
+        return failures > 5 ? 1.Seconds() : (failures * 100).Milliseconds();
+    }
+
+    private async Task tryRedeclareAsync()
+    {
+        if (RedeclareAsync == null) return;
+
+        try
+        {
+            await RedeclareAsync(_cancellation.Token).ConfigureAwait(false);
+        }
+        catch (Exception redeclare)
+        {
+            // Never let the healing attempt take the loop down -- it is best-effort by nature, and the broker
+            // being unreachable is exactly when it will fail.
+            _logger.LogWarning(redeclare, "Could not re-declare the broker entity for {Uri}", _uri);
+        }
+    }
 
     /// <summary>
     /// Cancel the loop and await its completion, up to <paramref name="timeout"/>. Safe to call from background

--- a/src/Wolverine/Transports/ReceiveLoopHealth.cs
+++ b/src/Wolverine/Transports/ReceiveLoopHealth.cs
@@ -32,7 +32,21 @@ public enum ReceiveLoopStatus
     /// The receive loop terminated on an unexpected exception and is no longer consuming. The listener is silently
     /// dead even though its <c>ListeningStatus</c> may still read <c>Accepting</c>.
     /// </summary>
-    Faulted
+    Faulted,
+
+    /// <summary>
+    /// GH-4215. The broker entity this loop reads from does not exist -- it was deleted, or the broker was wiped
+    /// and came back empty, which is what an emulator or LocalStack restart does. The loop is still alive and
+    /// still retrying, but no retry of the receive itself can succeed until the entity exists again.
+    ///
+    /// <para>
+    /// Distinct from <see cref="Faulted"/> on purpose: a faulted loop has stopped and needs a rebuild, while this
+    /// one is running and will heal on its own if the endpoint can be re-declared. It is also distinct from
+    /// <see cref="Running"/>, which is what this used to report -- an operator watching a healthy-looking loop
+    /// retrying once a second forever had nothing to tell them the entity was simply gone.
+    /// </para>
+    /// </summary>
+    EntityMissing
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #4215. Both halves of the issue's ask, because they compose — the classification is what the healing hangs off.

## The failure

A wiped broker — LocalStack or the ASB emulator restarting empty, an operator or IaC teardown — permanently killed every listener on it. `BackgroundReceiveLoop` treated every iteration exception identically: log at `Error`, back off (capped at **one second**), retry the same receive forever. The entities were declared by `AutoProvision` at startup, so the application knows how to declare them; **nothing re-ran that afterwards.**

Two consequences, both observed on the fleet: the listener never consumed again until the host restarted, and the tight retry emitted ~23 error lines per second across the two dead transports — 180MB of stdout in 45 minutes, which is its own outage on top of the one being reported.

Premise verified before building: `backoffFor` is `failures > 5 ? 1.Seconds() : ...` with no failure categories and no hook for a transport to re-declare.

## The fix

`BackgroundReceiveLoop` gains two optional members, **both null by default**, so every existing loop behaves exactly as before:

- `IsEntityMissing` — the transport's classifier.
- `RedeclareAsync` — the transport's declare step.

A classified failure now:
- reports the new **`ReceiveLoopStatus.EntityMissing`**,
- logs at `Warning` on the first of a streak and then every 60th, rather than every iteration,
- backs off on a **5 second floor** instead of the 1 second cap,
- and runs the re-declare.

A successful iteration clears the status back to `Running`, so a healed loop stops reporting the diagnosis that got it there.

`EntityMissing` is deliberately distinct from both neighbours: `Faulted` means stopped and needing a rebuild, while this loop is alive and heals itself; `Running` is what a listener with a deleted queue reported forever, which is what left an operator with nothing to look at.

Per transport:

- **SQS** classifies `QueueDoesNotExistException` and re-declares through the queue's own `SetupAsync`, which reassigns `QueueUrl` — a recreated queue is a different entity even when the name matches. (The settlement side already documented this exception as "the queue is gone; retrying cannot bring it back", exactly as the issue noted — the receive loop just had no equivalent.)
- **Azure Service Bus** classifies `MessagingEntityNotFound`. Its batched listener has its **own hand-rolled loop** rather than a `BackgroundReceiveLoop`, complete with its own copy of the same 1-second policy, so it gets the same treatment inline.

**Both re-declares are gated on `AutoProvision`.** Re-creating an entity the application never created is not Wolverine's call to make — and without it the loop still reports `EntityMissing` and backs off, so option 2 from the issue stands on its own for those users.

## Verification

11 tests — 5 new, plus the 6 existing GH-3236 loop tests still green, which is the regression check that matters for this file. The new ones cover: the status is reported rather than `Running`; the re-declare hook heals a wiped broker; recovery clears the status; classification without a re-declare hook still reports and backs off.

One is a deliberate control — `an_unclassified_failure_is_still_an_ordinary_retry` — because widening the new path to every exception would turn an ordinary transient blip into a five-second stall.

CoreTests **2756/2758** (2 pre-existing skips). `dotnet build wolverine.slnx -c Release -f net9.0` clean.

**Not verified locally:** the end-to-end broker-wipe recovery. The core loop behaviour is unit-tested with a fake, but actually restarting LocalStack / the ASB emulator under a live host is the repro the issue offers and I have not run it. `CIAWSSqs` and `CIAzureServiceBus` exercise the wiring but not the wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)