### PR TITLE
GH-4216: retire a redelivered inbox row, and correct the MaximumBrokerRedeliveries docs

### DIFF
--- a/src/Persistence/PostgresqlTests/Bugs/Bug_partitioned_inbox_scheduled_promotion.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_partitioned_inbox_scheduled_promotion.cs
@@ -137,6 +137,64 @@ public abstract class PartitionedInboxScheduledPromotionContext : IAsyncLifetime
         (await statusesForAsync(envelope.Id)).ShouldBe(["Handled", "Incoming"]);
     }
 
+    /// <summary>
+    /// GH-4216. The worst of the three sibling statements GH-4209 reproduced and deliberately left alone.
+    /// <c>_markEnvelopeAsHandledById</c> matched the identity with no status predicate and SET status, so
+    /// retiring a redelivered row was itself a cross-partition move onto the key the retained handled row
+    /// already held. The row could not be retired AT ALL: it stayed Incoming, owned by the node that had
+    /// already processed it, with nothing left to try.
+    /// </summary>
+    [Fact]
+    public async Task a_redelivered_row_can_be_retired_when_the_identity_is_already_handled()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(envelope);
+        await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(envelope);
+
+        var redelivered = ObjectMother.Envelope();
+        redelivered.Id = envelope.Id;
+        redelivered.Destination = redeliveryDestinationFor(envelope);
+        redelivered.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(redelivered);
+
+        // Guard: the pair the partitioned key permits, which is the state this statement has to survive.
+        (await statusesForAsync(envelope.Id)).ShouldBe(["Handled", "Incoming"]);
+
+        await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(redelivered);
+
+        // The incoming copy is gone rather than stranded. The retained handled row is what serves the
+        // KeepAfterMessageHandling dedup window, and it was already there.
+        (await statusesForAsync(envelope.Id)).ShouldBe(["Handled"]);
+    }
+
+    /// <summary>
+    /// The batched mark-as-handled coalesces completions into one statement, so it has to carry the same
+    /// shape -- otherwise a coalesced retire strands exactly the rows the single-envelope path now retires.
+    /// </summary>
+    [Fact]
+    public async Task the_batched_retire_survives_the_same_pair()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(envelope);
+        await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync(envelope);
+
+        var redelivered = ObjectMother.Envelope();
+        redelivered.Id = envelope.Id;
+        redelivered.Destination = redeliveryDestinationFor(envelope);
+        redelivered.Status = EnvelopeStatus.Incoming;
+
+        await thePersistence.Inbox.StoreIncomingAsync(redelivered);
+
+        await thePersistence.Inbox.MarkIncomingEnvelopeAsHandledAsync([redelivered]);
+
+        (await statusesForAsync(envelope.Id)).ShouldBe(["Handled"]);
+    }
+
     [Fact]
     public async Task the_unqualified_promotion_statement_raises_a_unique_violation()
     {

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -64,6 +64,12 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConn
     /// </summary>
     protected override string QuotedSchemaName => SchemaName.QuoteIdentifier();
 
+    /// <summary>
+    /// GH-4216. PostgreSQL needs its schema name quoted; everything else about the mark-as-handled statement
+    /// is shared, including the partition-aware form that inbox partitioning requires.
+    /// </summary>
+    protected override string MarkAsHandledTableName => $"{QuotedSchemaName}.{DatabaseConstants.IncomingTable}";
+
 
     public PostgresqlMessageStore(DatabaseSettings databaseSettings, DurabilitySettings settings, NpgsqlDataSource dataSource,
         ILogger<PostgresqlMessageStore> logger) : this(databaseSettings, settings, GetPrimaryNpgsqlNodeIfPossible(dataSource), logger, Array.Empty<SagaTableDefinition>())
@@ -141,9 +147,10 @@ internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConn
         _discardAndReassignOutgoingSql = _deleteOutgoingEnvelopesSql +
                                          $";update {QuotedSchemaName}.{DatabaseConstants.OutgoingTable} set owner_id = @node where id = ANY(@rids)";
 
-        // Rebuild base class SQL strings with properly quoted schema name for PostgreSQL
-        _markEnvelopeAsHandledById =
-            $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
+        // GH-4216: _markEnvelopeAsHandledById is no longer rebuilt here. It carries partition-aware logic now,
+        // and rebuilding it in this constructor both dropped that logic and did so in the one provider that
+        // supports inbox partitioning. Only the quoted table name differs, so that is what is overridden --
+        // see MarkAsHandledTableName below.
         _incrementIncomingEnvelopeAttempts =
             $"update {QuotedSchemaName}.{DatabaseConstants.IncomingTable} set attempts = @attempts where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
@@ -9,7 +9,7 @@ namespace Wolverine.RDBMS;
 
 public abstract partial class MessageDatabase<T>
 {
-    protected string _markEnvelopeAsHandledById;
+    protected string? _markEnvelopeAsHandledById;
     protected string _incrementIncomingEnvelopeAttempts;
 
     public abstract Task<IReadOnlyList<Envelope>> LoadPageOfGloballyOwnedIncomingAsync(Uri listenerAddress, int limit);
@@ -80,10 +80,68 @@ public abstract partial class MessageDatabase<T>
         }
     }
 
+    /// <summary>
+    /// GH-4216. The mark-as-handled statement for one identity. Unchanged without inbox partitioning: a single
+    /// UPDATE flipping status to Handled.
+    ///
+    /// <para>
+    /// With <c>EnableInboxPartitioning</c> the incoming table is PARTITION BY LIST (status) and status is part
+    /// of the primary key, so uniqueness is only enforced per partition and one identity can legally sit in
+    /// the incoming partition and the handled partition at once. Flipping status is then a cross-partition
+    /// move -- DELETE + INSERT -- straight onto a key the handled partition already holds, and it fails. The
+    /// consequence is worse than a failed update: a promoted or redelivered row could not be retired AT ALL,
+    /// so it stayed Incoming, owned by the node that had already processed it, with no way forward.
+    /// </para>
+    ///
+    /// <para>
+    /// So when a Handled row already exists for the identity, the incoming row is DELETED rather than flipped.
+    /// The retained Handled row is what serves <c>KeepAfterMessageHandling</c>'s dedup window, and it already
+    /// exists -- keeping the second copy would add nothing and re-create the collision on the next attempt.
+    /// The UPDATE that follows carries the same <c>status &lt;&gt; 'Handled'</c> predicate, so it affects zero
+    /// rows when the DELETE handled it.
+    /// </para>
+    /// </summary>
+    /// <summary>
+    /// GH-4216. The incoming table as this provider spells it. Overridable because PostgreSQL quotes its
+    /// schema name differently and used to rebuild the whole statement in its constructor to get it -- which
+    /// meant the ONE provider that supports inbox partitioning was also the one bypassing the partition-aware
+    /// statement entirely, and doing it in a constructor where EnableInboxPartitioning is not yet settled.
+    /// Overriding just the name keeps the SQL in one place and lets it be built lazily, at call time.
+    /// </summary>
+    protected virtual string MarkAsHandledTableName => QuotedTableNameFor(DatabaseConstants.IncomingTable);
+
+    protected string MarkAsHandledSql(string idExpression, string uriExpression)
+    {
+        var table = MarkAsHandledTableName;
+
+        var update =
+            $"update {table} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = {idExpression} and {DatabaseConstants.ReceivedAt} = {uriExpression}";
+
+        if (!Durability.EnableInboxPartitioning)
+        {
+            return update;
+        }
+
+        // The existence check has to use whichever identity the TABLE was keyed with, not the row-matching
+        // clause above. Under IdOnly a redelivery at a different destination is the SAME identity -- the key is
+        // (id, status) and received_at is not part of it -- so an existence check that also matched received_at
+        // would miss the handled row it is looking for and let the collision through anyway.
+        var handledExists = Durability.MessageIdentity == MessageIdentity.IdOnly
+            ? $"select 1 from {table} h where h.id = {idExpression} and h.{DatabaseConstants.Status} = '{EnvelopeStatus.Handled}'"
+            : $"select 1 from {table} h where h.id = {idExpression} and h.{DatabaseConstants.ReceivedAt} = {uriExpression} and h.{DatabaseConstants.Status} = '{EnvelopeStatus.Handled}'";
+
+        return
+            $"delete from {table} where id = {idExpression} and {DatabaseConstants.ReceivedAt} = {uriExpression} and {DatabaseConstants.Status} <> '{EnvelopeStatus.Handled}' " +
+            $"and exists ({handledExists});" +
+            $"{update} and {DatabaseConstants.Status} <> '{EnvelopeStatus.Handled}'";
+    }
+
     public Task MarkIncomingEnvelopeAsHandledAsync(Envelope envelope)
     {
         if (HasDisposed) return Task.CompletedTask;
         var keepUntil = DateTimeOffset.UtcNow.Add(Durability.KeepAfterMessageHandling);
+        _markEnvelopeAsHandledById ??= MarkAsHandledSql("@id", "@uri");
+
         return CreateCommand(_markEnvelopeAsHandledById)
             .With("id", envelope.Id)
             .With("keepUntil", keepUntil)
@@ -99,14 +157,49 @@ public abstract partial class MessageDatabase<T>
         var builder = ToCommandBuilder();
         builder.AddNamedParameter("keepUntil", keepUntil);
 
+        // GH-4216: the batch has to carry the same partition-aware shape as the single-envelope path, or a
+        // coalesced mark-as-handled strands exactly the rows the single one now retires. Each identity's
+        // parameters are appended per occurrence, which is why the same value goes in more than once.
+        var partitioned = Durability.EnableInboxPartitioning;
+        var table = MarkAsHandledTableName;
+
         foreach (var envelope in envelopes)
         {
-            builder.Append($"update {QuotedTableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = ");
+            var uri = envelope.Destination!.ToString();
+
+            if (partitioned)
+            {
+                builder.Append($"delete from {table} where id = ");
+                builder.AppendParameter(envelope.Id);
+                builder.Append($" and {DatabaseConstants.ReceivedAt} = ");
+                builder.AppendParameter(uri);
+                builder.Append(
+                    $" and {DatabaseConstants.Status} <> '{EnvelopeStatus.Handled}' and exists (select 1 from {table} h where h.id = ");
+                builder.AppendParameter(envelope.Id);
+
+                // Same identity rule as MarkAsHandledSql: under IdOnly a redelivery at another destination is
+                // the same identity, so matching received_at here would miss the handled row it looks for.
+                if (Durability.MessageIdentity != MessageIdentity.IdOnly)
+                {
+                    builder.Append($" and h.{DatabaseConstants.ReceivedAt} = ");
+                    builder.AppendParameter(uri);
+                }
+
+                builder.Append($" and h.{DatabaseConstants.Status} = '{EnvelopeStatus.Handled}');");
+            }
+
+            builder.Append($"update {table} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = ");
             builder.AppendParameter(envelope.Id);
             builder.Append(" and ");
             builder.Append(DatabaseConstants.ReceivedAt);
             builder.Append( " = ");
-            builder.AppendParameter(envelope.Destination!.ToString());
+            builder.AppendParameter(uri);
+
+            if (partitioned)
+            {
+                builder.Append($" and {DatabaseConstants.Status} <> '{EnvelopeStatus.Handled}'");
+            }
+
             builder.Append(";");
         }
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -51,8 +51,11 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
         Durability = settings;
         _cancellation = settings.Cancellation;
 
-        _markEnvelopeAsHandledById =
-            $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set {DatabaseConstants.Status} = '{EnvelopeStatus.Handled}', {DatabaseConstants.KeepUntil} = @keepUntil where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
+        // GH-4216: deliberately NOT built here. Durability.EnableInboxPartitioning is not reliably set at
+        // construction time -- the batched path reads it per call and got the partitioned shape while this
+        // one, built in the constructor, silently kept the unpartitioned statement. Built lazily on first
+        // use instead, where the setting is settled.
+
         _incrementIncomingEnvelopeAttempts =
             $"update {this.TableNameFor(DatabaseConstants.IncomingTable)} set attempts = @attempts where id = @id and {DatabaseConstants.ReceivedAt} = @uri";
 

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -132,9 +132,17 @@ public class DurabilitySettings : IDescribeMyself
     public int MaximumAckAttempts { get; set; } = 3;
 
     /// <summary>
-    /// GH-4012 item 4. The most times a broker may redeliver one message before Wolverine stops trying to
+    /// GH-4012 item 4. The most times a broker may <b>deliver</b> one message before Wolverine stops trying to
     /// process it and moves it to the dead letter queue instead. Zero — the default — leaves the broker's
     /// own limit in charge and changes nothing.
+    ///
+    /// <para>
+    /// GH-4216: <b>this is a delivery count, not a redelivery count, despite the property name.</b> The first
+    /// delivery is <c>1</c> on both Azure Service Bus and SQS, and the check is <c>count &gt; limit</c>, so
+    /// <c>MaximumBrokerRedeliveries = 3</c> permits three deliveries and dead-letters on the fourth. A message
+    /// delivered exactly the permitted number of times still gets to run. This summary previously said
+    /// "redeliver", which describes a limit one delivery more generous than the one implemented.
+    /// </para>
     /// </summary>
     /// <remarks>
     /// This is the counterpart to <see cref="MaximumAckAttempts" /> for the failure that one cannot reach.


### PR DESCRIPTION
Addresses two of #4216's remaining items. **Deliberately does not close it** — see below.

## 1. A redelivered inbox row can be retired when its identity is already handled

The worst of the three sibling statements #4209 reproduced and left alone, and the one that is a defect rather than a design call.

`_markEnvelopeAsHandledById` matched the identity with no status predicate and *set* status. With `EnableInboxPartitioning` the incoming table is partitioned by status and status is part of the key, so one identity can legally sit in the incoming partition and the handled partition at once. Retiring the incoming row was therefore itself a cross-partition move onto a key the handled partition already held — so **the row could not be retired at all**: it stayed `Incoming`, owned by the node that had already processed it, with nothing left to try.

When a handled row already exists for the identity, the incoming row is now **deleted** rather than flipped. The retained handled row is what serves the `KeepAfterMessageHandling` dedup window and it already exists; keeping the second copy would add nothing and re-create the collision on the next attempt. Gated on `EnableInboxPartitioning`, so every non-partitioned provider is byte-for-byte unchanged.

Two things this took that are worth knowing:

- **The existence check uses whichever identity the table was keyed with**, not the row-matching clause. Under `IdOnly` a redelivery at another destination is the *same* identity — the key is `(id, status)` and `received_at` is not part of it — so an existence check that also matched `received_at` would miss the handled row it is looking for and let the collision through anyway. Same distinction #4209's promotion fix had to make; my first cut got it wrong.
- **`PostgresqlMessageStore` rebuilt `_markEnvelopeAsHandledById` in its own constructor** to quote the schema name. So the one provider that supports inbox partitioning was also the one bypassing the partition-aware statement — in a constructor where `EnableInboxPartitioning` is not yet settled. The batched path read the flag per call and worked while the single path did not, and that asymmetry is what gave it away. Only the table name differs now, through a virtual, and the statement is built lazily at call time.

The batched mark-as-handled carries the same shape; without it a coalesced retire strands exactly the rows the single-envelope path now retires.

## 2. `MaximumBrokerRedeliveries` is documented as the delivery count it is

Three surfaces described this setting and two agreed. The implementation is `count > limit` with `BrokerDeliveryCount` starting at `1`, so `= 3` permits three deliveries and dead-letters the fourth. The durability guide says exactly that and even flags that the property name is misleading. The XML summary said "the most times a broker may **redeliver** one message" — a limit one delivery more generous than the one implemented.

The docs were right, so this corrects the XML doc rather than the behaviour. **No new test:** the arithmetic is already pinned by `a_delivery_count_past_the_limit_is_exhausted` and `the_limit_itself_is_not_past_it`, the latter with an off-by-one comment. The behaviour was never wrong — only one of the three descriptions of it was.

## Still open on #4216

This is why the PR says *addresses* rather than *closes*, and **#4216 should move to the 6.33 milestone**:

- `ScheduleExecutionAsync` and `RescheduleExistingEnvelopeForRetryAsync` — the other two sibling statements. The issue's own note stands: adding a status predicate to the reschedule makes it stop updating a `Handled` row, fall into its `rowsAffected == 0` branch, and hit a PK violation on the insert. That is a decision, not a predicate.
- The `Incoming`/`Handled` partitioning pair.
- 1a for CosmosDb — the CI budget question from #4219.

## Verification

- Partitioned inbox suite: **20/20**, both identity shapes, including two new tests for the single and batched retire paths.
- PostgreSQL **538/540** — the one failure is `Bug_1942 … inline_rabbitmq_listener_replay_does_not_loop`, which fails identically on a stashed baseline because RabbitMQ is not running locally.
- SQL Server **409/411**, SQLite **217/218**, zero failures on both. Those two matter most here: the whole claim of the gate is that non-partitioned providers are unchanged, and this touches `MessageDatabase.Incoming.cs`, which every relational provider shares.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

MySQL and Oracle were not re-run for this change; they take the same unchanged non-partitioned path, and `CIMySql` / `CIOracle` cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)