### PR TITLE
Fix `{NodeId}`/`{NodeNumber}` placeholder mismatch in structured logs

### DIFF
--- a/src/Wolverine/Runtime/Agents/AssignAgent.cs
+++ b/src/Wolverine/Runtime/Agents/AssignAgent.cs
@@ -43,7 +43,7 @@ internal record AssignAgent(Uri AgentUri, NodeDestination Destination) : IAgentC
             }
         }
 
-        runtime.Logger.LogInformation("Successfully started agent {AgentUri} on node {NodeId}", AgentUri, runtime.Options.Durability.AssignedNodeNumber);
+        runtime.Logger.LogInformation("Successfully started agent {AgentUri} on node {NodeNumber}", AgentUri, runtime.Options.Durability.AssignedNodeNumber);
 
         return AgentCommands.Empty;
     }

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -179,7 +179,7 @@ public partial class WolverineRuntime
             }
             else
             {
-                Logger.LogInformation("Wolverine assigned node id for envelope persistence is {NodeId}", Options.Durability.AssignedNodeNumber);
+                Logger.LogInformation("Wolverine assigned node id for envelope persistence is {NodeNumber}", Options.Durability.AssignedNodeNumber);
             }
 
             switch (Options.Durability.Mode)


### PR DESCRIPTION
Fixes the structured-log inconsistency where `{NodeId}` carries an `int` (`AssignedNodeNumber`) in two messages, while the same placeholder is `Guid` (`UniqueNodeId`) elsewhere. ELK ends up indexing the same property name as two different types, which breaks field mappings.

Closes #4228 

# What changes

Two log calls rename the placeholder from `{NodeId}` to `{NodeNumber}`. The passed value (`Durability.AssignedNodeNumber`) is unchanged — it's the semantically correct thing to log in both spots.

```diff
- runtime.Logger.LogInformation("Successfully started agent {AgentUri} on node {NodeId}", AgentUri, runtime.Options.Durability.AssignedNodeNumber);
+ runtime.Logger.LogInformation("Successfully started agent {AgentUri} on node {NodeNumber}", AgentUri, runtime.Options.Durability.AssignedNodeNumber);

- Logger.LogInformation("Wolverine assigned node id for envelope persistence is {NodeId}", Options.Durability.AssignedNodeNumber);
+ Logger.LogInformation("Wolverine assigned node id for envelope persistence is {NodeNumber}", Options.Durability.AssignedNodeNumber);
```

# Convention now enforced

- `{NodeId}` → `Guid` (`Options.UniqueNodeId` / `Destination.NodeId`)
- `{NodeNumber}` → `int` (`Durability.AssignedNodeNumber`)

Already followed everywhere else in `NodeAgentController`, `StartAgents`, `ResponseHandler`, the heartbeat paths, and the XML doc on `WolverineHeartbeat.NodeNumber`.
