### PR TITLE
GH-4227: WolverineFx.AI, LLM callouts as durable messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 ## Unreleased
 
+### WolverineFx.AI (new package)
+
+- **LLM callouts as durable messages.** (closes
+  [#4227](https://github.com/JasperFx/wolverine/issues/4227)) A handler that awaits a language model
+  inline holds a transaction and an envelope open for seconds against a remote service that is slow,
+  rate limited, and occasionally down. Every one of those problems already has an answer in Wolverine;
+  it just needed the model call to be a message.
+
+  `LlmCallout.Ask<IncidentTriage>(prompt, context)` produces an ordinary Wolverine message. Returned
+  from a handler next to a storage action it is enrolled in the same outbox as the write, so a callout
+  cannot fire for a transaction that did not commit. It executes on a dedicated durable local queue
+  (`llm-callouts`) against the `IChatClient` the application registered, and the model's answer is
+  deserialized into the requested type and published as an ordinary, strongly typed message with its
+  own handler and its own retry policy. Retries, back pressure, scheduling, dead lettering, and the
+  correlation chain are all inherited rather than rebuilt. Turn it on with `opts.AddLlmCallouts(...)`.
+
+  Because the vocabulary is messages, event store integration needed nothing new: `RaiseSideEffects`
+  on the JasperFx.Events projection base already publishes messages atomically with a projection
+  update, so one integration serves Marten, Polecat, and Fisher. Side effects stay suppressed during
+  rebuilds, which is what stops a projection rebuild from re-triaging — and re-billing — two years of
+  history.
+
+  The package references only the **Microsoft.Extensions.AI abstractions**, never a vendor SDK — the
+  same bargain as `ILogger`. Registering the `IChatClient` stays with the application, so the provider
+  and any middleware over it (`UseOpenTelemetry`, `UseDistributedCache`) remain its choice.
+
+- **Spend guardrails as middleware on the callout queue.** `LlmBudget.MaximumPromptCharacters` refuses
+  a callout before the provider is called, so a context accidentally assembled from an unbounded
+  collection costs nothing. `LlmBudget.MaximumTokensPerWindow` refuses callouts once the node has
+  burned through its allowance, counted from the usage the provider actually reported. Both dead letter
+  rather than retry, and so does an answer that cannot be parsed into the requested response type: a
+  callout that is over budget is over budget on every attempt, and a prompt the model cannot answer in
+  the requested shape produces the identical unusable answer every time. Retrying either is precisely
+  the runaway spend the guardrails exist to stop. Token counters are published on a `Wolverine.AI`
+  meter, tagged by the callout's `Tag` and the responding model.
+
+- **A scripted `IChatClient` ships with the package.** `StubChatClient` exercises a callout's whole
+  round trip — outbox, queue, handler, published answer — with no key, no network, and no model. An
+  exhausted script is an error rather than a repeat, because a test that quietly reuses the last answer
+  for a callout it did not know it was making is a test that passes for the wrong reason. And a handler
+  that returns a callout is a pure function, so the most valuable test needs no host at all.
+
+- **The callout message is deliberately not generic.** `Ask<TResponse>` is generic; `LlmCallout` is not,
+  and the response type rides on the message as data. A closed `LlmCallout<T>` recovered from a durable
+  inbox on a cold start has no route back to a `Type` — the message type registry is a flat name lookup,
+  and the recovery sweep runs before the application has published a callout of its own — so a generic
+  wire type would require every response type to be enumerated at bootstrap. One message type also means
+  one handler chain, one dead letter identity, and one place for the budget middleware. See
+  [#4227](https://github.com/JasperFx/wolverine/issues/4227) for the full reasoning.
+
+  `WolverineFx.AI` is not trim or AOT compatible: the response type is named on the message at runtime
+  and its JSON schema is built reflectively.
+
 ### WolverineFx (core)
 
 - **Logical message deduplication, opt-in, on its own table.** (closes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,6 +72,7 @@
          (conflicting with Workspaces.MSBuild 4.14.0). WolverineFx.EntityFrameworkCore
          references this directly so the unification flows to all EF sample/test projects. -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.5" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="3.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/build/build.cs
+++ b/build/build.cs
@@ -95,7 +95,16 @@ partial class Build : NukeBuild
         });
 
     Target TestExtensions => _ => _
-        .DependsOn(FluentValidationTests, DataAnnotationsValidationTests, MemoryPackTests, MessagePackTests);
+        .DependsOn(FluentValidationTests, DataAnnotationsValidationTests, MemoryPackTests, MessagePackTests,
+            AiTests);
+
+    Target AiTests => _ => _
+        .DependsOn(Compile)
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            RunTestProject(Solution.Extensions.Wolverine_AI_Tests);
+        });
     
     Target FluentValidationTests => _ => _
         .DependsOn(Compile)    
@@ -325,6 +334,7 @@ partial class Build : NukeBuild
                 Solution.Persistence.ClaimCheck.Wolverine_ClaimCheck_Nats,
                 Solution.Persistence.ClaimCheck.Wolverine_ClaimCheck_Postgresql,
                 Solution.Persistence.ClaimCheck.Wolverine_ClaimCheck_SqlServer,
+                Solution.Extensions.Wolverine_AI,
                 Solution.Extensions.Wolverine_FluentValidation,
                 Solution.Extensions.Wolverine_FluentValidation_Grpc,
                 Solution.Extensions.Wolverine_DataAnnotationsValidation,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -143,6 +143,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                         {text: 'Aspire Dashboard Integration', link: '/guide/aspire'},
                         {text: 'Code Generation', link: '/guide/codegen'},
                         {text: 'AOT Publishing', link: '/guide/aot'},
+                        {text: 'LLM Callouts', link: '/guide/ai'},
                         {text: 'Extensions', link: '/guide/extensions'},
                         {text: 'Sample Projects', link: '/guide/samples'}
                     ]

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -1,0 +1,324 @@
+# LLM Callouts
+
+::: tip
+`WolverineFx.AI` is a new package covering **one shot** calls to a large language model. Multi-turn, tool-calling
+agents are a separate, later tier ([GH-4226](https://github.com/JasperFx/wolverine/issues/4226)).
+:::
+
+## An LLM Call is a Message
+
+A handler that awaits a model inline holds a database transaction and an envelope open for seconds against a
+remote service that is slow, rate limited, and occasionally down. Every one of those problems already has an
+answer in Wolverine — it just needs the model call to be a message rather than an inline `await`.
+
+That is all this package is. `LlmCallout` is an ordinary Wolverine message that happens to be handled by calling
+a model:
+
+<!-- snippet: sample_llm_callout_from_a_handler -->
+<a id='snippet-sample_llm_callout_from_a_handler'></a>
+```cs
+public static class AlertSeenHandler
+{
+    // The callout is returned as a cascading message next to the storage action, so it is enrolled
+    // in the same outbox as the write: a callout cannot fire for a transaction that did not commit.
+    public static (IStorageAction<Incident>, LlmCallout) Handle(AlertSeen message, Incident incident)
+    {
+        return (Storage.Update(incident),
+            LlmCallout.Ask<IncidentTriage>(Prompts.Triage, incident.Snapshot()).Tagged("triage"));
+    }
+}
+
+// The answer arrives as an ordinary message, with an ordinary handler, an ordinary retry policy,
+// and its own place in the correlation chain.
+public static class TriageHandler
+{
+    public static void Handle(IncidentTriage triage)
+    {
+        // page someone, open a ticket, whatever the severity calls for
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L58-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_from_a_handler' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Because the callout is a message, it inherits the whole runtime with no extra work:
+
+* **The outbox.** Returned next to a storage action, the callout is enrolled in the same transaction as the write.
+  A callout cannot fire for a transaction that rolled back, and cannot be lost to a restart in between.
+* **Retries and error policies.** A 503 from the provider is retried on a cooldown schedule. A prompt the model
+  cannot answer is dead lettered.
+* **Back pressure.** The callout queue caps how many calls are in flight, no matter how fast callouts are published.
+* **Scheduling.** `DeliveryOptions.ScheduleDelay` delays a callout like any other message.
+* **Observability.** Every callout is an envelope, so correlation and causation ids already answer "what did this
+  model call come from, and what did it cause".
+
+The answer comes back as an *ordinary message* with its own handler, its own retry policy, and its own place in the
+correlation chain. There is no correlated request/reply here and no waiting: this is publish only, pub/sub async
+workflows all the way down.
+
+## Getting Started
+
+Install the package:
+
+```bash
+dotnet add package WolverineFx.AI
+```
+
+`WolverineFx.AI` depends only on the **Microsoft.Extensions.AI abstractions**, never on a vendor SDK — the same
+bargain as `ILogger`. Registering the `IChatClient` is yours, which means the provider (Anthropic, OpenAI, Azure,
+Ollama, a local model) and any middleware over it are your choice:
+
+<!-- snippet: sample_llm_callout_bootstrapping -->
+<a id='snippet-sample_llm_callout_bootstrapping'></a>
+```cs
+public static class Bootstrapping
+{
+    public static async Task<IHost> BuildHost(IChatClient chatClient)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Registering the IChatClient is yours. Wolverine.AI only references the
+                // Microsoft.Extensions.AI abstractions, so the provider -- and any middleware
+                // over it, like UseOpenTelemetry() or UseDistributedCache() -- is your choice.
+                opts.Services.AddSingleton(chatClient);
+
+                opts.AddLlmCallouts(ai =>
+                {
+                    ai.DefaultModelId = "claude-sonnet-5";
+                    ai.DefaultSystemPrompt = "You are an experienced site reliability engineer.";
+
+                    // Back pressure: at most this many calls to the model are in flight at once,
+                    // no matter how fast callouts are published.
+                    ai.MaximumParallelCallouts = 5;
+
+                    // Spend guardrails, enforced as middleware on the callout queue.
+                    ai.Budget.MaximumPromptCharacters = 20_000;
+                    ai.Budget.MaximumTokensPerWindow = 200_000;
+                    ai.Budget.Window = 1.Minutes();
+                });
+            }).StartAsync();
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L11-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_bootstrapping' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`AddLlmCallouts()` puts every callout on one dedicated, durable local queue named `llm-callouts`
+(`LlmCallout.QueueName`). Durable is the default and the point — turn it off with `ai.DurableQueue = false` only
+where the application has no message persistence configured at all.
+
+## Structured Answers
+
+`LlmCallout.Ask<TResponse>(...)` asks for a structured answer. Wolverine derives a JSON schema from `TResponse`,
+hands it to the model as the response format, deserializes the answer, and publishes it as an ordinary message:
+
+```csharp
+LlmCallout.Ask<IncidentTriage>("Classify this incident.", incident.Snapshot());
+```
+
+The second argument is optional context. It is serialized to JSON and appended underneath the prompt at the moment
+the callout is created, so what the model will be asked is fully baked into the message. A callout sitting in the
+dead letter queue can be read and understood without re-running anything.
+
+Prompts are yours. This package is not a prompt template framework — a `const string`, a record, or whatever
+templating you already like all work, because by the time a callout exists the prompt is just text.
+
+### The text flavour
+
+`LlmCallout.Ask(...)` with no type parameter asks for plain text, and publishes an `LlmTextResponse` carrying both
+the answer and the callout that produced it. Every text callout in an application publishes that same type, so a
+handler tells one kind from another by its `Tag`. When that starts to feel like a switch statement pretending to be
+a type, that is the signal to move to the structured flavour and let each answer be its own message.
+
+## From a Projection
+
+Because the vocabulary is messages, event store integration needs nothing new. `RaiseSideEffects` on the
+JasperFx.Events projection base already publishes messages atomically with the projection update, and a callout is
+just a message:
+
+<!-- snippet: sample_llm_callout_from_a_projection -->
+<a id='snippet-sample_llm_callout_from_a_projection'></a>
+```cs
+public class IncidentProjection : SingleStreamProjection<Incident, Guid>
+{
+    public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<Incident> slice)
+    {
+        if (slice.Snapshot is { IsEscalated: true } incident &&
+            slice.Events().OfType<IEvent<IncidentEscalated>>().Any())
+        {
+            slice.PublishMessage(LlmCallout
+                .Ask<IncidentTriage>("Classify this incident and recommend a next action.", incident)
+                .Tagged("triage")
+
+                // Stream id plus version is the natural logical identity here: a daemon retry that
+                // reprocesses this slice republishes the identical callout, and this is what lets
+                // deduplication recognize it as the same intent rather than a second one.
+                .DeduplicatedBy($"{incident.Id}:{slice.Events().Last().Version}"));
+        }
+
+        return new ValueTask();
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/LlmCalloutSamples.cs#L27-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_from_a_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+One integration serves Marten, Polecat, and Fisher alike. Two things are worth knowing here:
+
+**Rebuilds do not re-trigger callouts.** Side effects are suppressed during a projection rebuild by default, which
+is exactly right — rebuilding a projection over two years of history must not re-triage two years of incidents, and
+must not bill you for doing it.
+
+**Daemon retries can republish.** A slice that fails partway through is reprocessed, and the callout is published
+again. Give republish-prone callouts a logical identity with `DeduplicatedBy(...)` — stream id plus version is the
+natural key — and turn on enforcement:
+
+```csharp
+opts.Durability.EnableMessageDeduplication();
+opts.AddLlmCallouts(ai => ai.DeduplicateCallouts = true);
+```
+
+The id is carried on the message either way; `DeduplicateCallouts` is what makes Wolverine claim it before calling
+the model. Callouts without an id still execute, since only the republish-prone sources have a natural key.
+
+## Budgets and Failure
+
+A runaway prompt or a loop that publishes callouts faster than anyone notices is the expensive failure mode here,
+so the guardrails are middleware on the callout queue rather than advice in a doc page:
+
+```csharp
+opts.AddLlmCallouts(ai =>
+{
+    ai.Budget.MaximumPromptCharacters = 20_000;
+    ai.Budget.MaximumTokensPerWindow = 200_000;
+    ai.Budget.Window = 1.Minutes();
+});
+```
+
+`MaximumPromptCharacters` refuses a callout **before** the provider is called, so a context accidentally assembled
+from an unbounded collection costs nothing. `MaximumTokensPerWindow` refuses callouts once the node has burned
+through its allowance, counted from the usage the provider actually reported.
+
+::: warning
+The token ledger is **per process**, not cluster wide. On a fleet of N nodes the effective ceiling is N times the
+configured number. Treat it as a circuit breaker against a runaway loop, not as billing enforcement.
+:::
+
+Both limits **dead letter rather than retry**, and so does an answer that cannot be parsed into the requested
+response type. A callout that is over budget is over budget on every attempt, and a prompt the model cannot answer
+in the requested shape produces the identical unusable answer every time — retrying either one is precisely the
+runaway spend the guardrails exist to stop. The raw model output is carried on `LlmCalloutException.RawResponse` so
+a dead letter can be triaged without a re-run.
+
+Everything else — a 503, a socket reset, a timeout — is transient and gets the cooldown schedule:
+
+```csharp
+opts.AddLlmCallouts(ai => ai.RetryCooldowns = [1.Seconds(), 5.Seconds(), 15.Seconds()]);
+```
+
+`LlmCalloutOptions.Timeout` (2 minutes by default) caps any single callout. Note that this depends on the
+registered `IChatClient` honouring its cancellation token — every HTTP-based provider does.
+
+## Observability
+
+Callouts appear in Wolverine's own metrics, logs, and OpenTelemetry spans like any other message, keyed by the
+`llm-callouts` queue. On top of that, `WolverineFx.AI` emits token counters on a `Wolverine.AI` meter, tagged by
+the callout's `Tag` and the responding model:
+
+| Instrument | Description |
+| --- | --- |
+| `wolverine.ai.callout.input_tokens` | Input tokens consumed |
+| `wolverine.ai.callout.output_tokens` | Output tokens produced |
+| `wolverine.ai.callout.total_tokens` | Total tokens billed |
+
+For full GenAI semantic convention spans, add Microsoft.Extensions.AI's own
+`.UseOpenTelemetry()` middleware when registering the `IChatClient`. What Wolverine adds is the labelling that
+middleware cannot see: which *callout* the spend belongs to.
+
+## Testing
+
+The message-shaped design makes testing without a model trivial, which is deliberate — it is most of the argument
+for the design. `StubChatClient` is a scripted `IChatClient` that ships in the package:
+
+<!-- snippet: sample_llm_callout_testing -->
+<a id='snippet-sample_llm_callout_testing'></a>
+```cs
+[Fact]
+public async Task triage_an_escalated_incident()
+{
+    // A scripted IChatClient: no key, no network, no model.
+    var chat = new StubChatClient()
+        .Respond(new IncidentTriage("high", "page the on-call"));
+
+    using var host = await Host.CreateDefaultBuilder()
+        .UseWolverine(opts =>
+        {
+            opts.Services.AddSingleton<IChatClient>(chat);
+            opts.AddLlmCallouts(ai => ai.DurableQueue = false);
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+    var session = await host.InvokeMessageAndWaitAsync(new AlertRaised("INC-1", "database is on fire"));
+
+    // Assert on the callout the handler produced...
+    var callout = session.Sent.SingleMessage<LlmCallout>();
+    callout.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+    callout.Tag.ShouldBe("triage");
+
+    // ...on what was actually sent to the model...
+    chat.Requests.ShouldHaveSingleItem().Prompt.ShouldContain("INC-1");
+
+    // ...and on the answer coming back as an ordinary message.
+    session.Received.SingleMessage<IncidentTriage>().Severity.ShouldBe("high");
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L85-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_testing' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Answers are handed out in the order they were queued, and an exhausted script is an error rather than a repeat: a
+test that quietly reuses the last answer for a callout it did not know it was making is a test that passes for the
+wrong reason. `Throw(...)` scripts a failure, and `RespondAfter(...)` scripts a slow answer for exercising the
+timeout.
+
+Better still, a handler that returns a callout is a pure function, so the most valuable test needs no host at all:
+
+<!-- snippet: sample_llm_callout_unit_test -->
+<a id='snippet-sample_llm_callout_unit_test'></a>
+```cs
+[Fact]
+public void the_handler_asks_for_a_triage()
+{
+    var incident = new Incident("INC-1", "database is on fire", true);
+
+    var (_, callout) = AlertSeenHandler.Handle(new AlertSeen("INC-1"), incident);
+
+    callout.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+    callout.Prompt.ShouldBe(Prompts.Triage);
+    callout.Context.ShouldNotBeNull().ShouldContain("INC-1");
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L117-L131' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_unit_test' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Why the Callout is Not Generic
+
+`LlmCallout.Ask<TResponse>(...)` is generic but `LlmCallout` itself is not, and the response type rides on the
+message as data. That is a deliberate choice, recorded in [GH-4227](https://github.com/JasperFx/wolverine/issues/4227).
+
+A callout has to survive being written to a durable inbox and read back after a process restart. Wolverine's
+message type registry is a flat name lookup, so a closed `LlmCallout<IncidentTriage>` recovered on a cold start
+would have no route back to a `Type` unless every response type in the application had been enumerated at
+bootstrap — and the recovery sweep runs before the application has published a callout of its own. The type
+parameter also carries no behaviour: its whole job is to name a type twice, once for the schema and once for the
+deserialization.
+
+One message type means one handler chain, one dead letter identity, one queue, and one place for the budget
+middleware. The typing that actually matters — the handler that receives the answer — is untouched.
+
+## Not In Scope
+
+* **Agents, tools, and model loops.** Tier 2, tracked in [GH-4226](https://github.com/JasperFx/wolverine/issues/4226).
+* **Embedding generation.** `IEmbeddingGenerator<,>` is the obvious seam for event store integrations, but it is
+  separate adapter work.
+* **AOT.** `WolverineFx.AI` is not trim or AOT compatible: the response type is named on the message at runtime and
+  its schema is built reflectively. Making it trim-clean needs source-generated schemas and a `JsonSerializerContext`.

--- a/src/Extensions/Wolverine.AI.Tests/Samples.cs
+++ b/src/Extensions/Wolverine.AI.Tests/Samples.cs
@@ -1,0 +1,132 @@
+using JasperFx.Core;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.AI.Testing;
+using Wolverine.Persistence;
+using Wolverine.Tracking;
+
+namespace Wolverine.AI.Tests;
+
+#region sample_llm_callout_bootstrapping
+
+public static class Bootstrapping
+{
+    public static async Task<IHost> BuildHost(IChatClient chatClient)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // Registering the IChatClient is yours. Wolverine.AI only references the
+                // Microsoft.Extensions.AI abstractions, so the provider -- and any middleware
+                // over it, like UseOpenTelemetry() or UseDistributedCache() -- is your choice.
+                opts.Services.AddSingleton(chatClient);
+
+                opts.AddLlmCallouts(ai =>
+                {
+                    ai.DefaultModelId = "claude-sonnet-5";
+                    ai.DefaultSystemPrompt = "You are an experienced site reliability engineer.";
+
+                    // Back pressure: at most this many calls to the model are in flight at once,
+                    // no matter how fast callouts are published.
+                    ai.MaximumParallelCallouts = 5;
+
+                    // Spend guardrails, enforced as middleware on the callout queue.
+                    ai.Budget.MaximumPromptCharacters = 20_000;
+                    ai.Budget.MaximumTokensPerWindow = 200_000;
+                    ai.Budget.Window = 1.Minutes();
+                });
+            }).StartAsync();
+    }
+}
+
+#endregion
+
+public record Incident(string Id, string Summary, bool JustEscalated)
+{
+    public IncidentSnapshot Snapshot() => new(Id, Summary, 12);
+}
+
+public record AlertSeen(string IncidentId);
+
+public static class Prompts
+{
+    public const string Triage =
+        "Classify the severity of this incident and recommend a single next action.";
+}
+
+#region sample_llm_callout_from_a_handler
+
+public static class AlertSeenHandler
+{
+    // The callout is returned as a cascading message next to the storage action, so it is enrolled
+    // in the same outbox as the write: a callout cannot fire for a transaction that did not commit.
+    public static (IStorageAction<Incident>, LlmCallout) Handle(AlertSeen message, Incident incident)
+    {
+        return (Storage.Update(incident),
+            LlmCallout.Ask<IncidentTriage>(Prompts.Triage, incident.Snapshot()).Tagged("triage"));
+    }
+}
+
+// The answer arrives as an ordinary message, with an ordinary handler, an ordinary retry policy,
+// and its own place in the correlation chain.
+public static class TriageHandler
+{
+    public static void Handle(IncidentTriage triage)
+    {
+        // page someone, open a ticket, whatever the severity calls for
+    }
+}
+
+#endregion
+
+public class SampleTests
+{
+    #region sample_llm_callout_testing
+
+    [Fact]
+    public async Task triage_an_escalated_incident()
+    {
+        // A scripted IChatClient: no key, no network, no model.
+        var chat = new StubChatClient()
+            .Respond(new IncidentTriage("high", "page the on-call"));
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IChatClient>(chat);
+                opts.AddLlmCallouts(ai => ai.DurableQueue = false);
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var session = await host.InvokeMessageAndWaitAsync(new AlertRaised("INC-1", "database is on fire"));
+
+        // Assert on the callout the handler produced...
+        var callout = session.Sent.SingleMessage<LlmCallout>();
+        callout.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+        callout.Tag.ShouldBe("triage");
+
+        // ...on what was actually sent to the model...
+        chat.Requests.ShouldHaveSingleItem().Prompt.ShouldContain("INC-1");
+
+        // ...and on the answer coming back as an ordinary message.
+        session.Received.SingleMessage<IncidentTriage>().Severity.ShouldBe("high");
+    }
+
+    #endregion
+
+    #region sample_llm_callout_unit_test
+
+    [Fact]
+    public void the_handler_asks_for_a_triage()
+    {
+        var incident = new Incident("INC-1", "database is on fire", true);
+
+        var (_, callout) = AlertSeenHandler.Handle(new AlertSeen("INC-1"), incident);
+
+        callout.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+        callout.Prompt.ShouldBe(Prompts.Triage);
+        callout.Context.ShouldNotBeNull().ShouldContain("INC-1");
+    }
+
+    #endregion
+}

--- a/src/Extensions/Wolverine.AI.Tests/TestMessages.cs
+++ b/src/Extensions/Wolverine.AI.Tests/TestMessages.cs
@@ -1,0 +1,64 @@
+using Wolverine.AI;
+using Wolverine.Persistence;
+
+namespace Wolverine.AI.Tests;
+
+public record AlertRaised(string IncidentId, string Summary);
+
+public record IncidentTriage(string Severity, string RecommendedAction);
+
+public record IncidentSnapshot(string IncidentId, string Summary, int MinutesOpen);
+
+public static class AlertRaisedHandler
+{
+    public static LlmCallout Handle(AlertRaised message)
+    {
+        return LlmCallout
+            .Ask<IncidentTriage>("Triage this incident.",
+                new IncidentSnapshot(message.IncidentId, message.Summary, 12))
+            .Tagged("triage");
+    }
+}
+
+/// <summary>
+/// Records what the application actually received, so the tests assert on the far side of the callout
+/// rather than on the executor's return value.
+/// </summary>
+public static class TriageResults
+{
+    private static readonly List<object> _received = new();
+
+    public static void Record(object message)
+    {
+        lock (_received) _received.Add(message);
+    }
+
+    public static IReadOnlyList<object> Received
+    {
+        get
+        {
+            lock (_received) return _received.ToArray();
+        }
+    }
+
+    public static void Clear()
+    {
+        lock (_received) _received.Clear();
+    }
+}
+
+public static class IncidentTriageHandler
+{
+    public static void Handle(IncidentTriage triage)
+    {
+        TriageResults.Record(triage);
+    }
+}
+
+public static class LlmTextResponseHandler
+{
+    public static void Handle(LlmTextResponse response)
+    {
+        TriageResults.Record(response);
+    }
+}

--- a/src/Extensions/Wolverine.AI.Tests/Usings.cs
+++ b/src/Extensions/Wolverine.AI.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using Shouldly;

--- a/src/Extensions/Wolverine.AI.Tests/Wolverine.AI.Tests.csproj
+++ b/src/Extensions/Wolverine.AI.Tests/Wolverine.AI.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit.v3"/>
+        <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Wolverine.AI\Wolverine.AI.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="$(SolutionDir)xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+    </ItemGroup>
+
+  <ItemGroup>
+    <!-- Core WolverineFx no longer ships the Roslyn runtime compiler (#2876); this
+         Dynamic-mode test project needs it. The package auto-registers via its [WolverineModule]. -->
+    <ProjectReference Include="../../Wolverine.RuntimeCompilation/Wolverine.RuntimeCompilation.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Extensions/Wolverine.AI.Tests/callout_specs.cs
+++ b/src/Extensions/Wolverine.AI.Tests/callout_specs.cs
@@ -1,0 +1,84 @@
+using Wolverine.Attributes;
+
+namespace Wolverine.AI.Tests;
+
+public class callout_specs
+{
+    [Fact]
+    public void ask_captures_the_response_type()
+    {
+        var callout = LlmCallout.Ask<IncidentTriage>("triage this");
+
+        callout.Prompt.ShouldBe("triage this");
+        callout.Context.ShouldBeNull();
+        callout.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+        callout.ExpectsResponse<IncidentSnapshot>().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_text_flavour_expects_no_response_type()
+    {
+        var callout = LlmCallout.Ask("summarize this");
+
+        callout.ResponseType.ShouldBeNull();
+        callout.ExpectsResponse<IncidentTriage>().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void context_is_serialized_to_json()
+    {
+        var callout = LlmCallout.Ask<IncidentTriage>("triage this", new IncidentSnapshot("INC-1", "fire", 3));
+
+        callout.Context.ShouldNotBeNull();
+        callout.Context.ShouldContain("INC-1");
+        callout.Context.ShouldContain("minutesOpen");
+    }
+
+    [Fact]
+    public void an_ordinary_response_type_is_identified_by_its_assembly_qualified_name()
+    {
+        // Assembly qualified rather than Wolverine's message type alias, so that a callout recovered
+        // from a durable inbox on a cold start resolves with nothing having been registered first.
+        LlmCallout.IdentifierFor(typeof(IncidentTriage))
+            .ShouldBe($"{typeof(IncidentTriage).FullName}, Wolverine.AI.Tests");
+
+        Type.GetType(LlmCallout.IdentifierFor(typeof(IncidentTriage))).ShouldBe(typeof(IncidentTriage));
+    }
+
+    [Fact]
+    public void a_response_type_with_MessageIdentity_is_identified_by_its_stable_alias()
+    {
+        LlmCallout.IdentifierFor(typeof(RenameProofTriage)).ShouldBe("renamed-proof-triage");
+    }
+
+    [Fact]
+    public void fluent_configuration_sets_every_knob()
+    {
+        var callout = LlmCallout.Ask<IncidentTriage>("triage this")
+            .WithSystemPrompt("you are an SRE")
+            .UsingModel("claude-sonnet-5")
+            .WithTemperature(0.2f)
+            .WithMaxOutputTokens(256)
+            .Tagged("triage")
+            .DeduplicatedBy("INC-1:7");
+
+        callout.SystemPrompt.ShouldBe("you are an SRE");
+        callout.ModelId.ShouldBe("claude-sonnet-5");
+        callout.Temperature.ShouldBe(0.2f);
+        callout.MaxOutputTokens.ShouldBe(256);
+        callout.Tag.ShouldBe("triage");
+        callout.DeduplicationId.ShouldBe("INC-1:7");
+    }
+
+    [Fact]
+    public void to_string_names_the_tag_and_the_expected_answer()
+    {
+        LlmCallout.Ask("summarize").ToString().ShouldBe("LlmCallout expecting text");
+
+        LlmCallout.Ask<IncidentTriage>("triage").Tagged("triage").ToString()
+            .ShouldStartWith("LlmCallout 'triage' expecting ");
+    }
+}
+
+[MessageIdentity("renamed-proof-triage")]
+public record RenameProofTriage(string Severity);

--- a/src/Extensions/Wolverine.AI.Tests/configuration_specs.cs
+++ b/src/Extensions/Wolverine.AI.Tests/configuration_specs.cs
@@ -1,0 +1,140 @@
+using JasperFx.Core;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.AI.Internals;
+using Wolverine.AI.Testing;
+using Wolverine.Runtime;
+using Wolverine.Configuration;
+using Wolverine.Transports;
+using Wolverine.Transports.Local;
+
+namespace Wolverine.AI.Tests;
+
+public class configuration_specs
+{
+    private static async Task<IHost> hostFor(Action<LlmCalloutOptions>? configure = null)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IChatClient>(new StubChatClient());
+                opts.AddLlmCallouts(ai =>
+                {
+                    ai.DurableQueue = false;
+                    configure?.Invoke(ai);
+                });
+            }).StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static LocalQueue calloutQueue(IHost host)
+    {
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        return runtime.Options.Transports.GetOrCreate<LocalTransport>().QueueFor(LlmCallout.QueueName);
+    }
+
+    [Fact]
+    public async Task callouts_land_on_their_own_dedicated_local_queue()
+    {
+        using var host = await hostFor();
+
+        var queue = calloutQueue(host);
+        queue.MaxDegreeOfParallelism.ShouldBe(5);
+
+        // The [LocalQueue] attribute on LlmCallout is what puts every callout on this one queue rather
+        // than on a queue named after the message type.
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        runtime.Options.Transports.GetOrCreate<LocalTransport>()
+            .FindOrCreateQueueForMessageTypeByConvention(typeof(LlmCallout))
+            .EndpointName.ShouldBe(LlmCallout.QueueName);
+    }
+
+    [Fact]
+    public async Task the_parallelism_cap_is_configurable()
+    {
+        using var host = await hostFor(ai => ai.MaximumParallelCallouts = 2);
+
+        calloutQueue(host).MaxDegreeOfParallelism.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task opting_out_of_durability_gives_a_buffered_queue()
+    {
+        using var host = await hostFor();
+
+        calloutQueue(host).Mode.ShouldBe(EndpointMode.BufferedInMemory);
+    }
+
+    [Fact]
+    public async Task the_queue_is_durable_by_default()
+    {
+        // Durability is the whole point of the tier: a callout returned from a handler is enrolled in
+        // that handler's outbox, so it cannot fire for a transaction that did not commit.
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IChatClient>(new StubChatClient());
+                opts.AddLlmCallouts();
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        calloutQueue(host).Mode.ShouldBe(EndpointMode.Durable);
+    }
+
+    [Fact]
+    public async Task ConfigureQueue_runs_after_the_defaults_so_it_wins()
+    {
+        using var host = await hostFor(ai =>
+        {
+            ai.MaximumParallelCallouts = 5;
+            ai.ConfigureQueue(q => q.Sequential());
+        });
+
+        calloutQueue(host).MaxDegreeOfParallelism.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_missing_IChatClient_fails_at_bootstrap_rather_than_on_the_first_callout()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts => opts.AddLlmCallouts())
+                .StartAsync(TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain("IChatClient");
+    }
+
+    [Fact]
+    public async Task calling_AddLlmCallouts_twice_is_an_error()
+    {
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Services.AddSingleton<IChatClient>(new StubChatClient());
+                    opts.AddLlmCallouts();
+                    opts.AddLlmCallouts();
+                }).StartAsync(TestContext.Current.CancellationToken);
+        });
+    }
+
+    [Fact]
+    public async Task the_budget_middleware_is_only_woven_in_when_a_budget_is_configured()
+    {
+        using var withoutBudget = await hostFor();
+        chainFor(withoutBudget).Middleware.OfType<object>()
+            .Any(x => x.ToString()!.Contains(nameof(LlmBudgetMiddleware))).ShouldBeFalse();
+
+        using var withBudget = await hostFor(ai => ai.Budget.MaximumPromptCharacters = 1000);
+        chainFor(withBudget).Middleware.OfType<object>()
+            .Any(x => x.ToString()!.Contains(nameof(LlmBudgetMiddleware))).ShouldBeTrue();
+    }
+
+    private static Wolverine.Runtime.Handlers.HandlerChain chainFor(IHost host)
+    {
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+        return runtime.Options.HandlerGraph.ChainFor(typeof(LlmCallout))!;
+    }
+}

--- a/src/Extensions/Wolverine.AI.Tests/durable_round_trip.cs
+++ b/src/Extensions/Wolverine.AI.Tests/durable_round_trip.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Wolverine.Runtime.Serialization;
+
+namespace Wolverine.AI.Tests;
+
+/// <summary>
+/// The reason <see cref="LlmCallout" /> is not generic (GH-4227): a callout has to survive being
+/// written to a durable inbox, read back after a process restart, and executed — with nothing having
+/// been registered first, because on a cold start the recovery sweep runs before the application has
+/// published a single callout of its own.
+/// </summary>
+public class durable_round_trip
+{
+    private static readonly SystemTextJsonSerializer _serializer = new(new JsonSerializerOptions());
+
+    [Fact]
+    public void a_callout_survives_serialization()
+    {
+        var callout = LlmCallout
+            .Ask<IncidentTriage>("Triage this incident.", new IncidentSnapshot("INC-1", "on fire", 12))
+            .WithSystemPrompt("You are an SRE.")
+            .UsingModel("claude-sonnet-5")
+            .WithTemperature(0.2f)
+            .WithMaxOutputTokens(512)
+            .Tagged("triage")
+            .DeduplicatedBy("INC-1:7");
+
+        var envelope = new Envelope(callout);
+        var read = (LlmCallout)_serializer.ReadFromData(typeof(LlmCallout),
+            new Envelope { Data = _serializer.Write(envelope) });
+
+        read.Prompt.ShouldBe(callout.Prompt);
+        read.Context.ShouldBe(callout.Context);
+        read.SystemPrompt.ShouldBe("You are an SRE.");
+        read.ResponseType.ShouldBe(callout.ResponseType);
+        read.ModelId.ShouldBe("claude-sonnet-5");
+        read.Temperature.ShouldBe(0.2f);
+        read.MaxOutputTokens.ShouldBe(512);
+        read.Tag.ShouldBe("triage");
+        read.DeduplicationId.ShouldBe("INC-1:7");
+
+        read.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_response_type_resolves_from_the_wire_value_alone()
+    {
+        // Written by hand rather than through Ask<T>() on purpose: this is what a callout recovered
+        // from the inbox looks like, and nothing in this process has mentioned IncidentTriage to
+        // Wolverine yet. A generic LlmCallout<IncidentTriage> would have nothing to resolve here.
+        var identifier = $"{typeof(IncidentTriage).FullName}, Wolverine.AI.Tests";
+
+        Type.GetType(identifier).ShouldBe(typeof(IncidentTriage));
+    }
+
+    [Fact]
+    public void a_callout_has_a_single_stable_message_type_name()
+    {
+        // One name for every callout in the application, which is what gives the callout queue one
+        // handler chain, one dead letter identity, and one place for the budget middleware.
+        LlmCallout.Ask<IncidentTriage>("a").GetType()
+            .ShouldBe(LlmCallout.Ask<IncidentSnapshot>("b").GetType());
+    }
+}

--- a/src/Extensions/Wolverine.AI.Tests/end_to_end.cs
+++ b/src/Extensions/Wolverine.AI.Tests/end_to_end.cs
@@ -1,0 +1,135 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.AI.Testing;
+using Wolverine.Tracking;
+
+namespace Wolverine.AI.Tests;
+
+public class end_to_end : IAsyncLifetime
+{
+    private readonly StubChatClient _chat = new();
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        TriageResults.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IChatClient>(_chat);
+
+                opts.AddLlmCallouts(ai =>
+                {
+                    // No message store in these tests, so the callout queue cannot be durable. The
+                    // durable path is covered by durable_callout_queue.cs against Postgres.
+                    ai.DurableQueue = false;
+                    ai.DefaultModelId = "stub-model";
+                });
+            }).StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync(TestContext.Current.CancellationToken);
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_callout_is_published_as_a_cascading_message()
+    {
+        _chat.Respond(new IncidentTriage("high", "page the on-call"));
+
+        var session = await _host.InvokeMessageAndWaitAsync(new AlertRaised("INC-1", "database is on fire"));
+
+        var callout = session.Sent.SingleMessage<LlmCallout>();
+        callout.ExpectsResponse<IncidentTriage>().ShouldBeTrue();
+        callout.Tag.ShouldBe("triage");
+        callout.Prompt.ShouldBe("Triage this incident.");
+    }
+
+    [Fact]
+    public async Task the_answer_comes_back_as_an_ordinary_typed_message()
+    {
+        _chat.Respond(new IncidentTriage("high", "page the on-call"));
+
+        await _host.InvokeMessageAndWaitAsync(new AlertRaised("INC-1", "database is on fire"));
+
+        var triage = TriageResults.Received.OfType<IncidentTriage>().ShouldHaveSingleItem();
+        triage.Severity.ShouldBe("high");
+        triage.RecommendedAction.ShouldBe("page the on-call");
+    }
+
+    [Fact]
+    public async Task the_callout_context_is_appended_underneath_the_prompt()
+    {
+        _chat.Respond(new IncidentTriage("low", "wait"));
+
+        await _host.InvokeMessageAndWaitAsync(new AlertRaised("INC-7", "disk nearly full"));
+
+        var request = _chat.Requests.ShouldHaveSingleItem();
+        request.Prompt.ShouldStartWith("Triage this incident.");
+        request.Prompt.ShouldContain("INC-7");
+        request.Prompt.ShouldContain("disk nearly full");
+    }
+
+    [Fact]
+    public async Task a_structured_callout_asks_the_model_for_a_json_schema()
+    {
+        _chat.Respond(new IncidentTriage("low", "wait"));
+
+        await _host.InvokeMessageAndWaitAsync(new AlertRaised("INC-7", "disk nearly full"));
+
+        var request = _chat.Requests.ShouldHaveSingleItem();
+        request.IsStructured.ShouldBeTrue();
+
+        var format = request.Options!.ResponseFormat.ShouldBeOfType<ChatResponseFormatJson>();
+        format.SchemaName.ShouldBe(nameof(IncidentTriage));
+        format.Schema!.Value.ToString().ShouldContain("recommendedAction");
+    }
+
+    [Fact]
+    public async Task the_configured_default_model_is_used()
+    {
+        _chat.Respond(new IncidentTriage("low", "wait"));
+
+        await _host.InvokeMessageAndWaitAsync(new AlertRaised("INC-7", "disk nearly full"));
+
+        _chat.Requests.ShouldHaveSingleItem().Options!.ModelId.ShouldBe("stub-model");
+    }
+
+    [Fact]
+    public async Task the_text_flavour_publishes_an_LlmTextResponse()
+    {
+        _chat.Respond("Everything is fine.");
+
+        var callout = LlmCallout.Ask("Summarize the last hour.").Tagged("summary");
+
+        await _host.SendMessageAndWaitAsync(callout);
+
+        var response = TriageResults.Received.OfType<LlmTextResponse>().ShouldHaveSingleItem();
+        response.Text.ShouldBe("Everything is fine.");
+        response.Callout.Tag.ShouldBe("summary");
+
+        _chat.Requests.ShouldHaveSingleItem().IsStructured.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_per_callout_model_and_system_prompt_override_the_defaults()
+    {
+        _chat.Respond("ok");
+
+        await _host.SendMessageAndWaitAsync(LlmCallout.Ask("Summarize.")
+            .UsingModel("some-other-model")
+            .WithSystemPrompt("You are terse.")
+            .WithTemperature(0.1f)
+            .WithMaxOutputTokens(64));
+
+        var options = _chat.Requests.ShouldHaveSingleItem().Options!;
+        options.ModelId.ShouldBe("some-other-model");
+        options.Instructions.ShouldBe("You are terse.");
+        options.Temperature.ShouldBe(0.1f);
+        options.MaxOutputTokens.ShouldBe(64);
+    }
+}

--- a/src/Extensions/Wolverine.AI.Tests/failure_handling.cs
+++ b/src/Extensions/Wolverine.AI.Tests/failure_handling.cs
@@ -1,0 +1,136 @@
+using JasperFx.Core;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.AI.Testing;
+using Wolverine.Tracking;
+
+namespace Wolverine.AI.Tests;
+
+public class failure_handling
+{
+    private readonly StubChatClient _chat = new();
+
+    private Task<IHost> hostFor(Action<LlmCalloutOptions> configure)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddSingleton<IChatClient>(_chat);
+                opts.AddLlmCallouts(ai =>
+                {
+                    ai.DurableQueue = false;
+                    configure(ai);
+                });
+            }).StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task an_unparseable_answer_is_dead_lettered_rather_than_retried()
+    {
+        _chat.Respond("I'm afraid I can't do that, Dave.");
+
+        using var host = await hostFor(_ => { });
+
+        var session = await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>("triage this"));
+
+        session.MovedToErrorQueue.MessagesOf<LlmCallout>().ShouldHaveSingleItem();
+
+        var exception = session.AllExceptions().OfType<LlmCalloutException>().ShouldHaveSingleItem();
+        exception.RawResponse.ShouldBe("I'm afraid I can't do that, Dave.");
+
+        // One attempt, not four: retrying sends the identical prompt and gets the identical
+        // unusable answer, so the retry schedule must not apply here.
+        _chat.Requests.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_transient_failure_is_retried_on_the_cooldown_schedule()
+    {
+        _chat.Throw(new HttpRequestException("503 from the provider"));
+        _chat.Respond(new IncidentTriage("high", "page the on-call"));
+
+        using var host = await hostFor(ai => ai.RetryCooldowns = [1.Milliseconds()]);
+
+        var session = await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>("triage this"));
+
+        session.MovedToErrorQueue.MessagesOf<LlmCallout>().ShouldBeEmpty();
+        _chat.Requests.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task an_over_long_prompt_is_refused_before_the_model_is_called()
+    {
+        using var host = await hostFor(ai => ai.Budget.MaximumPromptCharacters = 50);
+
+        var session = await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>(new string('x', 500)));
+
+        session.MovedToErrorQueue.MessagesOf<LlmCallout>().ShouldHaveSingleItem();
+        session.AllExceptions().OfType<LlmBudgetExceededException>().ShouldHaveSingleItem();
+
+        // The point of the guard: the provider is never called, so the runaway prompt costs nothing.
+        _chat.Requests.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_budget_counts_the_context_that_gets_appended_to_the_prompt()
+    {
+        using var host = await hostFor(ai => ai.Budget.MaximumPromptCharacters = 30);
+
+        var session = await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>("triage",
+                new IncidentSnapshot("INC-1", "a long enough summary to blow the budget", 4)));
+
+        session.AllExceptions().OfType<LlmBudgetExceededException>().ShouldHaveSingleItem();
+        _chat.Requests.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_spent_token_budget_refuses_the_next_callout()
+    {
+        _chat.InputTokenCount = 60;
+        _chat.OutputTokenCount = 60;
+        _chat.Respond(new IncidentTriage("high", "page"));
+
+        using var host = await hostFor(ai =>
+        {
+            ai.Budget.MaximumTokensPerWindow = 100;
+            ai.Budget.Window = 5.Minutes();
+        });
+
+        // The first callout is under budget when it starts, and spends 120 tokens.
+        await host.SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>("first"));
+
+        var session = await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>("second"));
+
+        session.AllExceptions().OfType<LlmBudgetExceededException>().ShouldHaveSingleItem();
+        _chat.Requests.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_callout_that_outlives_its_timeout_is_reported_as_a_timeout()
+    {
+        _chat.RespondAfter(5.Seconds(), new IncidentTriage("high", "page"));
+
+        using var host = await hostFor(ai =>
+        {
+            ai.Timeout = 20.Milliseconds();
+            ai.RetryCooldowns = [];
+        });
+
+        var session = await host.TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .SendMessageAndWaitAsync(LlmCallout.Ask<IncidentTriage>("triage this"));
+
+        session.AllExceptions().OfType<TimeoutException>().ShouldNotBeEmpty();
+    }
+}

--- a/src/Extensions/Wolverine.AI/AssemblyAttributes.cs
+++ b/src/Extensions/Wolverine.AI/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wolverine.AI.Tests")]

--- a/src/Extensions/Wolverine.AI/Internals/LlmBudgetLedger.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmBudgetLedger.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Tracks token spend over a trailing window so the budget middleware can refuse callouts once the
+/// application has burned through its allowance.
+/// </summary>
+public interface ILlmBudgetLedger
+{
+    /// <summary>
+    /// Total tokens recorded within the trailing window as of now.
+    /// </summary>
+    long TokensInWindow();
+
+    /// <summary>
+    /// Record what a completed callout actually cost, as reported by the provider.
+    /// </summary>
+    void Record(long tokens);
+}
+
+/// <summary>
+/// A single node's view of recent token spend. Deliberately a bounded ring of per second buckets rather
+/// than a list of individual entries: the window is coarse anyway, and a busy application must not
+/// accumulate one allocation per callout in a structure that is read on every callout.
+/// </summary>
+internal class LlmBudgetLedger : ILlmBudgetLedger
+{
+    private readonly long[] _buckets;
+    private readonly long[] _bucketSeconds;
+    private readonly int _windowSeconds;
+    private readonly object _lock = new();
+
+    public LlmBudgetLedger(LlmBudget budget)
+    {
+        _windowSeconds = Math.Max(1, (int)Math.Ceiling(budget.Window.TotalSeconds));
+        _buckets = new long[_windowSeconds];
+        _bucketSeconds = new long[_windowSeconds];
+    }
+
+    // Stopwatch rather than the wall clock: the ledger only ever compares two of its own readings, and
+    // a clock adjustment mid-window would otherwise either strand spend inside the window forever or
+    // wipe it early.
+    private static long NowSeconds() => Stopwatch.GetTimestamp() / Stopwatch.Frequency;
+
+    public long TokensInWindow()
+    {
+        var now = NowSeconds();
+        var oldest = now - _windowSeconds + 1;
+
+        lock (_lock)
+        {
+            long total = 0;
+            for (var i = 0; i < _buckets.Length; i++)
+            {
+                if (_bucketSeconds[i] >= oldest) total += _buckets[i];
+            }
+
+            return total;
+        }
+    }
+
+    public void Record(long tokens)
+    {
+        if (tokens <= 0) return;
+
+        var now = NowSeconds();
+        var index = (int)(now % _windowSeconds);
+
+        lock (_lock)
+        {
+            if (_bucketSeconds[index] != now)
+            {
+                _bucketSeconds[index] = now;
+                _buckets[index] = 0;
+            }
+
+            _buckets[index] += tokens;
+        }
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmBudgetMiddleware.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmBudgetMiddleware.cs
@@ -1,0 +1,39 @@
+using JasperFx.Core;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Enforces <see cref="LlmBudget" /> before a callout reaches the model. Applied as ordinary Wolverine
+/// middleware on the callout chain, so it shows up in <c>codegen describe</c> alongside everything else
+/// and an application can see exactly where its spend guard sits.
+/// </summary>
+public static class LlmBudgetMiddleware
+{
+    public static void Before(LlmCallout callout, LlmCalloutOptions options, ILlmBudgetLedger ledger)
+    {
+        var budget = options.Budget;
+
+        if (budget.MaximumPromptCharacters is { } maximumCharacters)
+        {
+            var length = LlmCalloutPrompt.Compose(callout).Length;
+            if (length > maximumCharacters)
+            {
+                throw new LlmBudgetExceededException(
+                    $"{callout} composes a {length} character prompt, over the configured " +
+                    $"LlmBudget.MaximumPromptCharacters of {maximumCharacters}.");
+            }
+        }
+
+        if (budget.MaximumTokensPerWindow is { } maximumTokens)
+        {
+            var spent = ledger.TokensInWindow();
+            if (spent >= maximumTokens)
+            {
+                throw new LlmBudgetExceededException(
+                    $"{callout} was refused: this node has spent {spent} tokens in the trailing " +
+                    $"{budget.Window.ToDisplay()}, at or over the configured LlmBudget.MaximumTokensPerWindow " +
+                    $"of {maximumTokens}.");
+            }
+        }
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmCalloutChainPolicy.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmCalloutChainPolicy.cs
@@ -1,0 +1,53 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.Core.Reflection;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Persistence;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Applies the callout chain's error handling and, when asked for, its deduplication requirement.
+/// </summary>
+/// <remarks>
+/// A policy rather than attributes on <see cref="LlmCalloutHandler" /> because both are configurable:
+/// the retry schedule comes from <see cref="LlmCalloutOptions.RetryCooldowns" /> and deduplication is
+/// opt in, and neither can be spelled as a constant in an attribute argument.
+/// </remarks>
+internal class LlmCalloutChainPolicy : IHandlerPolicy
+{
+    private readonly LlmCalloutOptions _options;
+
+    public LlmCalloutChainPolicy(LlmCalloutOptions options)
+    {
+        _options = options;
+    }
+
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        foreach (var chain in chains.Where(x => x.MessageType == typeof(LlmCallout)))
+        {
+            // Both of these are terminal on purpose. A prompt the model cannot answer in the requested
+            // shape produces the identical unusable answer on every attempt, and a callout that blows the
+            // budget blows it again on every attempt -- retrying either one is the runaway spend and the
+            // pointless bill that the dead letter queue exists to stop.
+            chain.OnException<LlmBudgetExceededException>().MoveToErrorQueue();
+            chain.OnException<LlmCalloutException>().MoveToErrorQueue();
+
+            if (_options.RetryCooldowns.Any())
+            {
+                chain.OnException<Exception>().RetryWithCooldown(_options.RetryCooldowns);
+            }
+
+            if (_options.DeduplicateCallouts)
+            {
+                // Required = false because a mixed stream is the normal case: only the republish prone
+                // sources -- a projection's RaiseSideEffects, say -- have a natural logical key, and
+                // refusing every unkeyed callout would break the ordinary handler pattern outright.
+                chain.Deduplication = new DeduplicationRequirement { Required = false };
+            }
+        }
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmCalloutExecutor.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmCalloutExecutor.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using ImTools;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Runs a single <see cref="LlmCallout" /> against the registered <see cref="IChatClient" /> and returns
+/// whatever should be published as the cascading answer.
+/// </summary>
+public interface ILlmCalloutExecutor
+{
+    Task<object> ExecuteAsync(LlmCallout callout, CancellationToken cancellationToken);
+}
+
+// The whole class is reflection over a Type carried as a string on the message, which is the reason
+// WolverineFx.AI is not marked IsAotCompatible. Suppressions here would claim a guarantee the design
+// cannot make; making it trim clean needs source generated schemas and a JsonSerializerContext keyed
+// off the registered response types. See the csproj comment and GH-4227.
+[RequiresUnreferencedCode("Builds a JSON schema and deserializes an answer for a response type named on the message at runtime")]
+[RequiresDynamicCode("Builds a JSON schema and deserializes an answer for a response type named on the message at runtime")]
+internal class LlmCalloutExecutor : ILlmCalloutExecutor
+{
+    private readonly IChatClient _client;
+    private readonly LlmCalloutOptions _options;
+    private readonly ILlmBudgetLedger _ledger;
+    private readonly ILogger<LlmCalloutExecutor> _logger;
+    private readonly IWolverineRuntime _runtime;
+
+    // Schema construction walks the response type's properties, which is meaningfully more expensive
+    // than the rest of the per callout work. ImHashMap per the repo's hot path convention: lock free,
+    // non-allocating reads, copy on write.
+    private ImHashMap<Type, JsonElement> _schemas = ImHashMap<Type, JsonElement>.Empty;
+    private ImHashMap<string, Type> _responseTypes = ImHashMap<string, Type>.Empty;
+
+    private const string chatModelUnknown = "(unspecified)";
+
+    public LlmCalloutExecutor(IChatClient client, LlmCalloutOptions options, ILlmBudgetLedger ledger,
+        ILogger<LlmCalloutExecutor> logger, IWolverineRuntime runtime)
+    {
+        _client = client;
+        _options = options;
+        _ledger = ledger;
+        _logger = logger;
+        _runtime = runtime;
+    }
+
+    public async Task<object> ExecuteAsync(LlmCallout callout, CancellationToken cancellationToken)
+    {
+        var responseType = callout.ResponseType.IsEmpty() ? null : ResolveResponseType(callout.ResponseType!);
+
+        var chatOptions = new ChatOptions
+        {
+            ModelId = callout.ModelId ?? _options.DefaultModelId,
+            Instructions = callout.SystemPrompt ?? _options.DefaultSystemPrompt,
+            Temperature = callout.Temperature,
+            MaxOutputTokens = callout.MaxOutputTokens
+        };
+
+        if (responseType != null)
+        {
+            chatOptions.ResponseFormat = ChatResponseFormat.ForJsonSchema(
+                SchemaFor(responseType),
+                schemaName: responseType.Name,
+                schemaDescription: $"The structured answer expected for a {callout.Tag ?? "Wolverine"} LLM callout");
+        }
+
+        var message = new ChatMessage(ChatRole.User, LlmCalloutPrompt.Compose(callout));
+
+        // The timeout is linked to, not a replacement for, the handler's own token: a shutdown still
+        // cancels the call, and a hung provider request surfaces as a Wolverine retry rather than as a
+        // handler that never returns.
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(_options.Timeout);
+
+        ChatResponse response;
+        try
+        {
+            response = await _client.GetResponseAsync([message], chatOptions, timeout.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"LLM callout {callout} timed out after {_options.Timeout}. Raise LlmCalloutOptions.Timeout, or lower MaxOutputTokens.");
+        }
+
+        RecordUsage(callout, response);
+
+        if (responseType == null)
+        {
+            return new LlmTextResponse(response.Text, callout);
+        }
+
+        return Deserialize(callout, responseType, response.Text);
+    }
+
+    private object Deserialize(LlmCallout callout, Type responseType, string text)
+    {
+        if (text.IsEmpty())
+        {
+            throw new LlmCalloutException(
+                $"The model returned an empty response for {callout}, which expects {responseType.FullNameInCode()}")
+            {
+                RawResponse = text
+            };
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize(text, responseType, _options.JsonSerializerOptions)
+                   ?? throw new LlmCalloutException(
+                       $"The model returned a JSON null for {callout}, which expects {responseType.FullNameInCode()}")
+                   {
+                       RawResponse = text
+                   };
+        }
+        catch (JsonException e)
+        {
+            throw new LlmCalloutException(
+                $"The model's answer to {callout} could not be read as {responseType.FullNameInCode()}. " +
+                "The raw response is on this exception's RawResponse property.", e)
+            {
+                RawResponse = text
+            };
+        }
+    }
+
+    private void RecordUsage(LlmCallout callout, ChatResponse response)
+    {
+        var usage = response.Usage;
+        if (usage == null) return;
+
+        var total = usage.TotalTokenCount
+                    ?? (usage.InputTokenCount ?? 0) + (usage.OutputTokenCount ?? 0);
+
+        _ledger.Record(total);
+        LlmCalloutMetrics.Record(callout, response, total);
+
+        _logger.LogDebug(
+            "LLM callout {Tag} answered by {ModelId}: {InputTokens} in, {OutputTokens} out, {TotalTokens} total",
+            callout.Tag ?? "(untagged)", response.ModelId ?? chatModelUnknown, usage.InputTokenCount,
+            usage.OutputTokenCount, total);
+    }
+
+    private JsonElement SchemaFor(Type responseType)
+    {
+        if (_schemas.TryFind(responseType, out var schema)) return schema;
+
+        schema = AIJsonUtilities.CreateJsonSchema(responseType, serializerOptions: _options.JsonSerializerOptions);
+        _schemas = _schemas.AddOrUpdate(responseType, schema);
+
+        return schema;
+    }
+
+    /// <summary>
+    /// Turn the identifier written by <see cref="LlmCallout.IdentifierFor" /> back into a
+    /// <see cref="Type" />. Wolverine's message type registry first, so a response type carrying
+    /// <c>[MessageIdentity]</c> resolves under its stable alias; then the assembly qualified name, which
+    /// is what everything else is stored as and which needs nothing to have been registered.
+    /// </summary>
+    private Type ResolveResponseType(string identifier)
+    {
+        if (_responseTypes.TryFind(identifier, out var cached)) return cached;
+
+        Type? resolved = null;
+
+        if (_runtime.Options.HandlerGraph.TryFindMessageType(identifier, out var registered))
+        {
+            resolved = registered;
+        }
+
+        resolved ??= Type.GetType(identifier, throwOnError: false);
+
+        if (resolved == null)
+        {
+            throw new LlmCalloutException(
+                $"Cannot resolve the response type '{identifier}' for an LLM callout. The type has most likely " +
+                "been renamed, moved to a different assembly, or removed since this callout was persisted. " +
+                "Use [MessageIdentity] on response types that need to survive being renamed.");
+        }
+
+        _responseTypes = _responseTypes.AddOrUpdate(identifier, resolved);
+
+        return resolved;
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmCalloutHandler.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmCalloutHandler.cs
@@ -1,0 +1,25 @@
+using Wolverine.Attributes;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// The one handler for every LLM callout in the application. Registered explicitly by
+/// <c>AddLlmCallouts</c> rather than found by conventional discovery, since it lives in
+/// WolverineFx.AI rather than in the application's own assemblies.
+/// </summary>
+/// <remarks>
+/// Returning <see cref="object" /> makes the answer an ordinary cascading message: Wolverine routes and
+/// publishes it exactly as if a handler had returned that type directly, which is what keeps the
+/// response side of a callout indistinguishable from any other message. The cost is that Wolverine
+/// cannot know statically what this chain publishes, so the response types do not appear in
+/// <c>PublishedTypes()</c> or in routing preview output.
+/// </remarks>
+[WolverineHandler]
+public static class LlmCalloutHandler
+{
+    public static Task<object> HandleAsync(LlmCallout callout, ILlmCalloutExecutor executor,
+        CancellationToken cancellationToken)
+    {
+        return executor.ExecuteAsync(callout, cancellationToken);
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmCalloutMetrics.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmCalloutMetrics.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.AI;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Token and duration metrics for LLM callouts, on their own meter so that spend can be alerted on
+/// without pulling in every Wolverine message metric.
+///
+/// <para>
+/// Deliberately thin: <c>IChatClient</c>'s own <c>UseOpenTelemetry</c> middleware already emits the
+/// GenAI semantic convention spans and metrics, and an application that wants the full picture should
+/// use it. What is here is the piece that middleware cannot see — the Wolverine side labelling that
+/// ties spend back to a callout's <see cref="LlmCallout.Tag" />.
+/// </para>
+/// </summary>
+internal static class LlmCalloutMetrics
+{
+    public const string MeterName = "Wolverine.AI";
+
+    private static readonly Meter _meter = new(MeterName);
+
+    private static readonly Counter<long> _inputTokens =
+        _meter.CreateCounter<long>("wolverine.ai.callout.input_tokens", "{token}",
+            "Input tokens consumed by Wolverine LLM callouts");
+
+    private static readonly Counter<long> _outputTokens =
+        _meter.CreateCounter<long>("wolverine.ai.callout.output_tokens", "{token}",
+            "Output tokens produced for Wolverine LLM callouts");
+
+    private static readonly Counter<long> _totalTokens =
+        _meter.CreateCounter<long>("wolverine.ai.callout.total_tokens", "{token}",
+            "Total tokens billed for Wolverine LLM callouts");
+
+    public static void Record(LlmCallout callout, ChatResponse response, long total)
+    {
+        var tag = new KeyValuePair<string, object?>("wolverine.ai.tag", callout.Tag ?? "untagged");
+        var model = new KeyValuePair<string, object?>("gen_ai.response.model", response.ModelId ?? "unspecified");
+
+        if (response.Usage?.InputTokenCount is { } input) _inputTokens.Add(input, tag, model);
+        if (response.Usage?.OutputTokenCount is { } output) _outputTokens.Add(output, tag, model);
+        if (total > 0) _totalTokens.Add(total, tag, model);
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmCalloutPrompt.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmCalloutPrompt.cs
@@ -1,0 +1,18 @@
+using JasperFx.Core;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Composes the single user message sent for a callout. Shared by the executor and the budget
+/// middleware so that the character count the budget enforces is the count of what is actually sent,
+/// not of the prompt before its context was appended.
+/// </summary>
+internal static class LlmCalloutPrompt
+{
+    public static string Compose(LlmCallout callout)
+    {
+        return callout.Context.IsEmpty()
+            ? callout.Prompt
+            : $"{callout.Prompt}{Environment.NewLine}{Environment.NewLine}{callout.Context}";
+    }
+}

--- a/src/Extensions/Wolverine.AI/LlmCallout.cs
+++ b/src/Extensions/Wolverine.AI/LlmCallout.cs
@@ -1,0 +1,238 @@
+using System.Text.Json;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.AI;
+using Wolverine.Attributes;
+using Wolverine.Util;
+
+namespace Wolverine.AI;
+
+/// <summary>
+/// A request for a one shot large language model completion, modeled as an ordinary Wolverine message
+/// so that it inherits the outbox, retries, error policies, back pressure, and observability that every
+/// other message already has.
+///
+/// <para>
+/// Build one with <see cref="Ask{TResponse}(string)" /> and return it from a message handler, an HTTP
+/// endpoint, or a projection's <c>RaiseSideEffects</c>. The answer comes back as a separate, ordinary
+/// message of type <c>TResponse</c> — this is publish only, there is no correlated reply.
+/// </para>
+/// </summary>
+/// <remarks>
+/// This type is deliberately NOT generic. The response type rides on the message as data rather than as
+/// a type parameter because the callout has to survive a durable inbox round trip:
+/// <c>HandlerGraph.TryFindMessageType</c> is a flat lookup, so a closed <c>LlmCallout&lt;T&gt;</c>
+/// recovered after a process restart would have no route back to a <see cref="Type" /> unless every
+/// response type had been enumerated at bootstrap. One message type also means one handler chain, one
+/// dead letter identity, and one place for the budget middleware. See GH-4227.
+/// </remarks>
+[LocalQueue(QueueName)]
+public sealed class LlmCallout
+{
+    /// <summary>
+    /// Name of the dedicated local queue that every callout is executed on. Configure it with
+    /// <c>LlmCalloutOptions.ConfigureQueue</c>, or directly through
+    /// <c>opts.LocalQueue(LlmCallout.QueueName)</c>.
+    /// </summary>
+    public const string QueueName = "llm-callouts";
+
+    /// <summary>
+    /// The prompt sent to the model as the user message. Application owned — Wolverine.AI is not a
+    /// prompt template framework.
+    /// </summary>
+    public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional JSON context appended underneath <see cref="Prompt" /> in the user message. Set by the
+    /// <c>context</c> overloads of <see cref="Ask{TResponse}(string, object)" />, which serialize the
+    /// supplied object with the same options used to build the response schema.
+    /// </summary>
+    public string? Context { get; set; }
+
+    /// <summary>
+    /// Optional system prompt, sent as <see cref="ChatOptions.Instructions" />. Falls back to
+    /// <c>LlmCalloutOptions.DefaultSystemPrompt</c> when null.
+    /// </summary>
+    public string? SystemPrompt { get; set; }
+
+    /// <summary>
+    /// Identifies the CLR type the answer is deserialized into and published as. Null means the text
+    /// flavour, which publishes an <see cref="LlmTextResponse" /> instead.
+    ///
+    /// <para>
+    /// This is an assembly qualified name (<c>Namespace.Type, Assembly</c>) so that a callout recovered
+    /// from a durable inbox on a cold start resolves without depending on anything having been
+    /// registered first. A response type carrying <c>[MessageIdentity]</c> is stored under that stable
+    /// alias instead, and resolved through Wolverine's message type registry.
+    /// </para>
+    /// </summary>
+    public string? ResponseType { get; set; }
+
+    /// <summary>
+    /// Overrides <c>LlmCalloutOptions.DefaultModelId</c> for this one callout.
+    /// </summary>
+    public string? ModelId { get; set; }
+
+    /// <summary>
+    /// Sampling temperature passed straight through to <see cref="ChatOptions.Temperature" />.
+    /// </summary>
+    public float? Temperature { get; set; }
+
+    /// <summary>
+    /// Caps the model's output, passed through to <see cref="ChatOptions.MaxOutputTokens" />.
+    /// </summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>
+    /// A short, stable label for what this callout is <i>for</i> — "triage", "summarize", "classify".
+    /// Carried onto the metrics and log entries the executor emits, and onto
+    /// <see cref="LlmTextResponse" />, which is how a text flavour handler tells one kind of callout
+    /// from another.
+    /// </summary>
+    public string? Tag { get; set; }
+
+    /// <summary>
+    /// A logical identity for this callout, stamped onto the outgoing envelope's
+    /// <see cref="Envelope.DeduplicationId" />. Use it where the same callout can legitimately be
+    /// published more than once — a projection's <c>RaiseSideEffects</c> replayed by a daemon retry,
+    /// say, where stream id + version is the natural key. Carrying the id does not enforce anything on
+    /// its own; turn on <c>LlmCalloutOptions.DeduplicateCallouts</c> plus
+    /// <c>opts.Durability.EnableMessageDeduplication</c> for that.
+    /// </summary>
+    [DeduplicationIdentity]
+    public string? DeduplicationId { get; set; }
+
+    /// <summary>
+    /// Ask the model for a structured answer. The answer is deserialized into
+    /// <typeparamref name="TResponse" /> and published as an ordinary message.
+    /// </summary>
+    public static LlmCallout Ask<TResponse>(string prompt)
+    {
+        return new LlmCallout { Prompt = prompt, ResponseType = IdentifierFor(typeof(TResponse)) };
+    }
+
+    /// <summary>
+    /// Ask the model for a structured answer, with <paramref name="context" /> serialized to JSON and
+    /// appended underneath the prompt.
+    /// </summary>
+    public static LlmCallout Ask<TResponse>(string prompt, object context)
+    {
+        return new LlmCallout
+        {
+            Prompt = prompt,
+            Context = Serialize(context),
+            ResponseType = IdentifierFor(typeof(TResponse))
+        };
+    }
+
+    /// <summary>
+    /// Ask the model for a plain text answer, published as an <see cref="LlmTextResponse" />.
+    /// </summary>
+    public static LlmCallout Ask(string prompt)
+    {
+        return new LlmCallout { Prompt = prompt };
+    }
+
+    /// <summary>
+    /// Ask the model for a plain text answer, with <paramref name="context" /> serialized to JSON and
+    /// appended underneath the prompt. Published as an <see cref="LlmTextResponse" />.
+    /// </summary>
+    public static LlmCallout Ask(string prompt, object context)
+    {
+        return new LlmCallout { Prompt = prompt, Context = Serialize(context) };
+    }
+
+    /// <summary>
+    /// Is this callout expecting an answer of type <typeparamref name="TResponse" />? The assertion
+    /// that pairs with <c>tracked.Sent.SingleMessage&lt;LlmCallout&gt;()</c> in a tracked session test.
+    /// </summary>
+    public bool ExpectsResponse<TResponse>()
+    {
+        return ResponseType == IdentifierFor(typeof(TResponse));
+    }
+
+    /// <summary>
+    /// Set the system prompt for this callout, overriding <c>LlmCalloutOptions.DefaultSystemPrompt</c>.
+    /// </summary>
+    public LlmCallout WithSystemPrompt(string systemPrompt)
+    {
+        SystemPrompt = systemPrompt;
+        return this;
+    }
+
+    /// <summary>
+    /// Run this one callout against a different model than the configured default.
+    /// </summary>
+    public LlmCallout UsingModel(string modelId)
+    {
+        ModelId = modelId;
+        return this;
+    }
+
+    /// <summary>
+    /// Set the sampling temperature for this callout.
+    /// </summary>
+    public LlmCallout WithTemperature(float temperature)
+    {
+        Temperature = temperature;
+        return this;
+    }
+
+    /// <summary>
+    /// Cap the model's output for this callout.
+    /// </summary>
+    public LlmCallout WithMaxOutputTokens(int maxOutputTokens)
+    {
+        MaxOutputTokens = maxOutputTokens;
+        return this;
+    }
+
+    /// <summary>
+    /// Label this callout for metrics, logging, and <see cref="LlmTextResponse" /> dispatch.
+    /// </summary>
+    public LlmCallout Tagged(string tag)
+    {
+        Tag = tag;
+        return this;
+    }
+
+    /// <summary>
+    /// Give this callout a logical identity so that a republished duplicate can be recognized. See
+    /// <see cref="DeduplicationId" />.
+    /// </summary>
+    public LlmCallout DeduplicatedBy(string deduplicationId)
+    {
+        DeduplicationId = deduplicationId;
+        return this;
+    }
+
+    public override string ToString()
+    {
+        var expects = ResponseType ?? "text";
+        return Tag.IsEmpty()
+            ? $"LlmCallout expecting {expects}"
+            : $"LlmCallout '{Tag}' expecting {expects}";
+    }
+
+    /// <summary>
+    /// How a response type is written onto the wire. A type carrying <c>[MessageIdentity]</c> uses that
+    /// stable alias — the point of the attribute is that renaming the type does not strand messages
+    /// already in flight. Everything else uses the assembly qualified name, which
+    /// <see cref="Type.GetType(string)" /> resolves with no registration and no bootstrap scan, cold
+    /// start included.
+    /// </summary>
+    internal static string IdentifierFor(Type responseType)
+    {
+        if (responseType.HasAttribute<MessageIdentityAttribute>())
+        {
+            return responseType.ToMessageTypeName();
+        }
+
+        return $"{responseType.FullName}, {responseType.Assembly.GetName().Name}";
+    }
+
+    private static string Serialize(object context)
+    {
+        return JsonSerializer.Serialize(context, context.GetType(), AIJsonUtilities.DefaultOptions);
+    }
+}

--- a/src/Extensions/Wolverine.AI/LlmCalloutException.cs
+++ b/src/Extensions/Wolverine.AI/LlmCalloutException.cs
@@ -1,0 +1,36 @@
+namespace Wolverine.AI;
+
+/// <summary>
+/// Thrown when a callout reached the model but the answer could not be turned into the requested
+/// response type. Treated as terminal by the default error policy — a retry sends the identical prompt
+/// and gets the identical unusable answer — so the callout is dead lettered with the raw model output
+/// on the exception for triage.
+/// </summary>
+public class LlmCalloutException : Exception
+{
+    public LlmCalloutException(string message) : base(message)
+    {
+    }
+
+    public LlmCalloutException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// The raw text the model returned, when there was any. Null when the failure was in resolving the
+    /// response type rather than in parsing an answer.
+    /// </summary>
+    public string? RawResponse { get; init; }
+}
+
+/// <summary>
+/// Thrown by the budget middleware for a callout that would exceed the configured spend limits. Dead
+/// lettered rather than retried: the same callout will exceed the same budget on every attempt, and
+/// retrying it is exactly the runaway spend the budget exists to stop.
+/// </summary>
+public class LlmBudgetExceededException : Exception
+{
+    public LlmBudgetExceededException(string message) : base(message)
+    {
+    }
+}

--- a/src/Extensions/Wolverine.AI/LlmCalloutOptions.cs
+++ b/src/Extensions/Wolverine.AI/LlmCalloutOptions.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using JasperFx.Core;
+using Microsoft.Extensions.AI;
+using Wolverine.Transports.Local;
+
+namespace Wolverine.AI;
+
+/// <summary>
+/// Configuration for the durable LLM callout tier, supplied through
+/// <c>WolverineOptions.AddLlmCallouts(...)</c>.
+/// </summary>
+public class LlmCalloutOptions
+{
+    private readonly List<Action<LocalQueueConfiguration>> _queueConfigurations = new();
+
+    /// <summary>
+    /// How many callouts may be in flight at once on the callout queue. This is the back pressure knob
+    /// — it caps concurrent calls to the model provider, not the rate at which callouts are published.
+    /// Defaults to 5.
+    /// </summary>
+    public int MaximumParallelCallouts { get; set; } = 5;
+
+    /// <summary>
+    /// Should the callout queue be durable? True by default, which is the whole point: a callout
+    /// published from a handler is then enrolled in the outbox with that handler's write, so a callout
+    /// cannot fire for a transaction that did not commit, and a callout cannot be lost to a process
+    /// restart between the commit and the model call.
+    ///
+    /// <para>
+    /// Set false only where message persistence is not configured at all. The queue then falls back to
+    /// buffered in memory, and callouts are lost on shutdown like any other buffered message.
+    /// </para>
+    /// </summary>
+    public bool DurableQueue { get; set; } = true;
+
+    /// <summary>
+    /// How long any one callout may take before it is cancelled and retried. Defaults to 2 minutes,
+    /// which is generous for a one shot completion and deliberately shorter than most provider level
+    /// defaults, so a hung request surfaces as a Wolverine retry rather than as a stuck handler.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = 2.Minutes();
+
+    /// <summary>
+    /// Cooldown schedule applied to transient callout failures — anything that is not an
+    /// <see cref="LlmCalloutException" /> or an <see cref="LlmBudgetExceededException" />. After the
+    /// last cooldown the callout is dead lettered. Set to an empty array to opt out and configure the
+    /// queue's error handling yourself.
+    /// </summary>
+    public TimeSpan[] RetryCooldowns { get; set; } = [1.Seconds(), 5.Seconds(), 15.Seconds()];
+
+    /// <summary>
+    /// Model id used for any callout that does not name its own with
+    /// <see cref="LlmCallout.UsingModel" />. Null leaves the choice to the registered
+    /// <see cref="IChatClient" />.
+    /// </summary>
+    public string? DefaultModelId { get; set; }
+
+    /// <summary>
+    /// System prompt used for any callout that does not carry its own. Sent as
+    /// <see cref="ChatOptions.Instructions" />.
+    /// </summary>
+    public string? DefaultSystemPrompt { get; set; }
+
+    /// <summary>
+    /// Spend guardrails enforced by middleware on the callout queue.
+    /// </summary>
+    public LlmBudget Budget { get; } = new();
+
+    /// <summary>
+    /// Serializer options used both to build the JSON schema handed to the model and to deserialize its
+    /// answer. Defaults to <see cref="AIJsonUtilities.DefaultOptions" />, which is what the rest of
+    /// Microsoft.Extensions.AI uses.
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions { get; set; } = AIJsonUtilities.DefaultOptions;
+
+    /// <summary>
+    /// Claim each callout's <see cref="LlmCallout.DeduplicationId" /> before executing it, so a callout
+    /// published twice with the same logical identity only reaches the model once. Off by default, and
+    /// it additionally requires <c>opts.Durability.EnableMessageDeduplication</c> and a persistence
+    /// provider that supports it.
+    ///
+    /// <para>
+    /// Callouts without an id are still executed — a mixed stream is the normal case, since only the
+    /// republish prone sources (a projection's <c>RaiseSideEffects</c>, say) have a natural key.
+    /// </para>
+    /// </summary>
+    public bool DeduplicateCallouts { get; set; }
+
+    /// <summary>
+    /// Further configuration of the local queue callouts execute on, beyond
+    /// <see cref="MaximumParallelCallouts" /> and <see cref="DurableQueue" />.
+    /// </summary>
+    public LlmCalloutOptions ConfigureQueue(Action<LocalQueueConfiguration> configure)
+    {
+        _queueConfigurations.Add(configure);
+        return this;
+    }
+
+    internal void ApplyQueueConfiguration(LocalQueueConfiguration queue)
+    {
+        foreach (var configure in _queueConfigurations) configure(queue);
+    }
+}
+
+/// <summary>
+/// Spend guardrails for LLM callouts, enforced by middleware on the callout queue. Both limits dead
+/// letter rather than retry: a callout that is over budget is over budget on every attempt, and
+/// retrying it is the runaway spend the budget exists to stop.
+/// </summary>
+public class LlmBudget
+{
+    /// <summary>
+    /// Rejects any callout whose composed user message exceeds this many characters. The cheap poison
+    /// prompt guard — a runaway context assembled from an unbounded collection is the usual way a
+    /// single callout costs a hundred times what it should. Null disables the check.
+    /// </summary>
+    public int? MaximumPromptCharacters { get; set; }
+
+    /// <summary>
+    /// Rejects callouts once total token usage reported by the provider over the trailing
+    /// <see cref="Window" /> reaches this figure. Null disables the check.
+    ///
+    /// <para>
+    /// This is a per process ledger, not a cluster wide one. On a fleet of N nodes the effective ceiling
+    /// is N times this number — set it accordingly, and treat it as a circuit breaker against a runaway
+    /// loop rather than as billing enforcement.
+    /// </para>
+    /// </summary>
+    public long? MaximumTokensPerWindow { get; set; }
+
+    /// <summary>
+    /// The trailing window <see cref="MaximumTokensPerWindow" /> is measured over. Defaults to one
+    /// minute.
+    /// </summary>
+    public TimeSpan Window { get; set; } = 1.Minutes();
+
+    internal bool IsEnabled => MaximumPromptCharacters.HasValue || MaximumTokensPerWindow.HasValue;
+}

--- a/src/Extensions/Wolverine.AI/LlmTextResponse.cs
+++ b/src/Extensions/Wolverine.AI/LlmTextResponse.cs
@@ -1,0 +1,15 @@
+namespace Wolverine.AI;
+
+/// <summary>
+/// The answer to a text flavour callout — one built with <see cref="LlmCallout.Ask(string)" /> rather
+/// than <see cref="LlmCallout.Ask{TResponse}(string)" />. Published as an ordinary message.
+/// </summary>
+/// <remarks>
+/// Every text callout in an application publishes this same type, so a handler that cares about only
+/// one kind of callout switches on <see cref="LlmCallout.Tag" /> through <see cref="Callout" />. Where
+/// that starts to feel like a switch statement pretending to be a type, that is the signal to move to
+/// the structured flavour and let each answer be its own message.
+/// </remarks>
+/// <param name="Text">The model's answer.</param>
+/// <param name="Callout">The callout that produced it, for correlation and for its tag.</param>
+public record LlmTextResponse(string Text, LlmCallout Callout);

--- a/src/Extensions/Wolverine.AI/Testing/StubChatClient.cs
+++ b/src/Extensions/Wolverine.AI/Testing/StubChatClient.cs
@@ -1,0 +1,227 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Wolverine.AI.Testing;
+
+/// <summary>
+/// A scripted <see cref="IChatClient" /> for tests, so that a callout's whole round trip — the outbox
+/// enrolment, the queue, the handler, the published answer — can be exercised without a model, a key,
+/// or a network.
+///
+/// <para>
+/// Answers are queued in order and handed out one per request. An exhausted script is an error rather
+/// than a repeat, because a test that quietly reuses the last answer for a callout it did not know it
+/// was making is a test that passes for the wrong reason.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// var chat = new StubChatClient()
+///     .Respond(new IncidentTriage("high", "page the on-call"));
+///
+/// using var host = await Host.CreateDefaultBuilder()
+///     .UseWolverine(opts =>
+///     {
+///         opts.Services.AddSingleton&lt;IChatClient&gt;(chat);
+///         opts.AddLlmCallouts();
+///     }).StartAsync();
+/// </code>
+/// </example>
+[SuppressMessage("Trimming", "IL2026", Justification = "Test double; serializes a response object supplied by the test itself")]
+[SuppressMessage("AOT", "IL3050", Justification = "Test double; serializes a response object supplied by the test itself")]
+public class StubChatClient : IChatClient
+{
+    private readonly Queue<Func<ChatRequest, CancellationToken, Task<ChatResponse>>> _script = new();
+    private readonly List<ChatRequest> _requests = new();
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Every request this client has been asked to answer, in order. Assert on
+    /// <c>chat.Requests.Single().Prompt</c> to check what was actually sent to the model.
+    /// </summary>
+    public IReadOnlyList<ChatRequest> Requests
+    {
+        get
+        {
+            lock (_lock) return _requests.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Serializer options used to render <see cref="Respond{T}" /> answers. Match these to
+    /// <c>LlmCalloutOptions.JsonSerializerOptions</c> if the application overrode them.
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions { get; set; } = AIJsonUtilities.DefaultOptions;
+
+    /// <summary>
+    /// Model id reported on every response, so that tests asserting on logged or measured model names
+    /// have something stable to assert against.
+    /// </summary>
+    public string ModelId { get; set; } = "stub-model";
+
+    /// <summary>
+    /// Token counts reported on every response. Set these to drive
+    /// <c>LlmBudget.MaximumTokensPerWindow</c> in a test.
+    /// </summary>
+    public long InputTokenCount { get; set; } = 1;
+
+    /// <summary>
+    /// Token counts reported on every response. See <see cref="InputTokenCount" />.
+    /// </summary>
+    public long OutputTokenCount { get; set; } = 1;
+
+    /// <summary>
+    /// Queue a structured answer. The object is serialized exactly as a real provider would return it,
+    /// so the executor's deserialization is genuinely exercised rather than bypassed.
+    /// </summary>
+    public StubChatClient Respond<T>(T response)
+    {
+        var json = JsonSerializer.Serialize(response, JsonSerializerOptions);
+        return Respond(json);
+    }
+
+    /// <summary>
+    /// Queue a raw text answer. Also how to script a malformed structured answer, to prove that a
+    /// handler's failure path dead letters the way it should.
+    /// </summary>
+    public StubChatClient Respond(string text)
+    {
+        lock (_lock) _script.Enqueue((_, _) => Task.FromResult(BuildResponse(text)));
+        return this;
+    }
+
+    /// <summary>
+    /// Queue an answer computed from the request, for a test that makes several callouts and needs each
+    /// answer to match its prompt.
+    /// </summary>
+    public StubChatClient Respond(Func<ChatRequest, string> respond)
+    {
+        lock (_lock) _script.Enqueue((request, _) => Task.FromResult(BuildResponse(respond(request))));
+        return this;
+    }
+
+    /// <summary>
+    /// Queue an answer that takes <paramref name="delay" /> to arrive, honouring the cancellation token
+    /// the way a real provider's HTTP client does. This is how to exercise
+    /// <c>LlmCalloutOptions.Timeout</c> — and the reason the stub does not simply block: a client that
+    /// ignores its token cannot be timed out, so a stub that ignored it would prove the timeout works
+    /// when it does not.
+    /// </summary>
+    public StubChatClient RespondAfter(TimeSpan delay, string text)
+    {
+        lock (_lock)
+        {
+            _script.Enqueue(async (_, token) =>
+            {
+                await Task.Delay(delay, token).ConfigureAwait(false);
+                return BuildResponse(text);
+            });
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Queue a structured answer that takes <paramref name="delay" /> to arrive. See
+    /// <see cref="RespondAfter(TimeSpan, string)" />.
+    /// </summary>
+    public StubChatClient RespondAfter<T>(TimeSpan delay, T response)
+    {
+        return RespondAfter(delay, JsonSerializer.Serialize(response, JsonSerializerOptions));
+    }
+
+    /// <summary>
+    /// Queue a failure, to exercise the retry and dead letter paths.
+    /// </summary>
+    public StubChatClient Throw(Exception exception)
+    {
+        lock (_lock) _script.Enqueue((_, _) => throw exception);
+        return this;
+    }
+
+    public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new ChatRequest(messages.ToArray(), options);
+
+        Func<ChatRequest, CancellationToken, Task<ChatResponse>> next;
+        lock (_lock)
+        {
+            _requests.Add(request);
+
+            if (_script.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(StubChatClient)} has no scripted answer left for request {_requests.Count}: " +
+                    $"\"{Truncate(request.Prompt)}\". Queue one with Respond(...), or assert on why the " +
+                    "application made a callout the test did not expect.");
+            }
+
+            next = _script.Dequeue();
+        }
+
+        return next(request, cancellationToken);
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // Streaming belongs to the agents tier (GH-4226). A one shot callout never asks for it, so an
+        // honest failure beats a stub that pretends.
+        throw new NotSupportedException(
+            $"{nameof(StubChatClient)} does not script streaming responses. LLM callouts are one shot and " +
+            "never stream.");
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        return serviceKey is null && serviceType.IsInstanceOfType(this) ? this : null;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private ChatResponse BuildResponse(string text)
+    {
+        return new ChatResponse(new ChatMessage(ChatRole.Assistant, text))
+        {
+            ModelId = ModelId,
+            Usage = new UsageDetails
+            {
+                InputTokenCount = InputTokenCount,
+                OutputTokenCount = OutputTokenCount,
+                TotalTokenCount = InputTokenCount + OutputTokenCount
+            }
+        };
+    }
+
+    private static string Truncate(string text)
+    {
+        return text.Length <= 120 ? text : text[..120] + "...";
+    }
+}
+
+/// <summary>
+/// One request captured by <see cref="StubChatClient" />.
+/// </summary>
+/// <param name="Messages">The chat messages sent. A callout always sends exactly one user message.</param>
+/// <param name="Options">The options sent, carrying the model id, temperature, system prompt, and the JSON schema derived from the callout's response type.</param>
+public record ChatRequest(IReadOnlyList<ChatMessage> Messages, ChatOptions? Options)
+{
+    /// <summary>
+    /// The composed user message — the callout's prompt with its JSON context appended.
+    /// </summary>
+    public string Prompt => string.Join(Environment.NewLine, Messages.Select(x => x.Text));
+
+    /// <summary>
+    /// The system prompt sent with this request, if any.
+    /// </summary>
+    public string? SystemPrompt => Options?.Instructions;
+
+    /// <summary>
+    /// Did this request ask the model for a structured answer? False for the text flavour.
+    /// </summary>
+    public bool IsStructured => Options?.ResponseFormat is ChatResponseFormatJson;
+}

--- a/src/Extensions/Wolverine.AI/Wolverine.AI.csproj
+++ b/src/Extensions/Wolverine.AI/Wolverine.AI.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Durable LLM callouts as Wolverine messages, on top of Microsoft.Extensions.AI</Description>
+        <PackageId>WolverineFx.AI</PackageId>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <!--
+          NOT AOT-compatible. The callout message carries its response type as a
+          string (see LlmCallout.ResponseType), which the executor resolves back to
+          a Type and then feeds to AIJsonUtilities.CreateJsonSchema + JsonSerializer.
+          Both of those are reflection over a type the trimmer cannot see from any
+          static call site. Making this trim-clean needs a source-generated schema +
+          JsonSerializerContext keyed off the registered response types, which is
+          follow-on work rather than a suppression.
+        -->
+        <IsAotCompatible>false</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Wolverine\Wolverine.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    </ItemGroup>
+
+</Project>

--- a/src/Extensions/Wolverine.AI/WolverineAiExtensions.cs
+++ b/src/Extensions/Wolverine.AI/WolverineAiExtensions.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Wolverine.AI.Internals;
+
+namespace Wolverine.AI;
+
+public static class WolverineAiExtensions
+{
+    /// <summary>
+    /// Turn on Wolverine's durable LLM callout support: <see cref="LlmCallout" /> becomes a message that
+    /// executes on its own local queue against the <see cref="IChatClient" /> registered in the
+    /// application's container, and publishes the model's answer as an ordinary cascading message.
+    ///
+    /// <para>
+    /// Registering the <see cref="IChatClient" /> itself stays with the application. WolverineFx.AI
+    /// depends only on the Microsoft.Extensions.AI abstractions, so the provider — Anthropic, OpenAI,
+    /// Azure, Ollama — and any middleware over it are yours to choose:
+    /// </para>
+    ///
+    /// <example>
+    /// <code>
+    /// builder.Services.AddChatClient(new AnthropicClient(key).AsIChatClient())
+    ///     .UseOpenTelemetry()
+    ///     .UseDistributedCache();
+    ///
+    /// builder.UseWolverine(opts =>
+    /// {
+    ///     opts.AddLlmCallouts(ai =>
+    ///     {
+    ///         ai.DefaultModelId = "claude-sonnet-5";
+    ///         ai.Budget.MaximumTokensPerWindow = 200_000;
+    ///     });
+    /// });
+    /// </code>
+    /// </example>
+    /// </summary>
+    public static WolverineOptions AddLlmCallouts(this WolverineOptions options,
+        Action<LlmCalloutOptions>? configure = null)
+    {
+        if (options.Services.Any(x => x.ServiceType == typeof(LlmCalloutOptions)))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(AddLlmCallouts)}() has already been called on this application. Configure the callout " +
+                "queue, budget, and defaults in a single call.");
+        }
+
+        var ai = new LlmCalloutOptions();
+        configure?.Invoke(ai);
+
+        options.Services.AddSingleton(ai);
+        options.Services.AddSingleton<ILlmBudgetLedger>(new LlmBudgetLedger(ai.Budget));
+        options.Services.TryAddSingleton<ILlmCalloutExecutor, LlmCalloutExecutor>();
+
+        // The handler lives in WolverineFx.AI rather than in the application's own assemblies, so
+        // conventional discovery will never see it.
+        options.Discovery.IncludeType(typeof(LlmCalloutHandler));
+
+        var queue = options.LocalQueue(LlmCallout.QueueName)
+            .MaximumParallelMessages(ai.MaximumParallelCallouts);
+
+        // Durable is the point: a callout returned from a handler is enrolled in that handler's outbox,
+        // so it cannot fire for a transaction that did not commit and cannot be lost to a restart in
+        // between. Buffered is the fallback for applications with no message persistence at all.
+        if (ai.DurableQueue)
+        {
+            queue.UseDurableInbox();
+        }
+        else
+        {
+            queue.BufferedInMemory();
+        }
+
+        ai.ApplyQueueConfiguration(queue);
+
+        if (ai.Budget.IsEnabled)
+        {
+            options.Policies.ForMessagesOfType<LlmCallout>().AddMiddleware(typeof(LlmBudgetMiddleware));
+        }
+
+        options.Policies.Add(new LlmCalloutChainPolicy(ai));
+
+        // Checked lazily rather than here, because registering the chat client after AddLlmCallouts() is
+        // perfectly reasonable. Failing at bootstrap beats failing on the first callout: without this the
+        // application starts clean and only falls over when the model is first needed, in a handler, as a
+        // container resolution error that says nothing about AI.
+        options.ConfigureLazily(o =>
+        {
+            if (o.Services.Any(x => x.ServiceType == typeof(IChatClient))) return;
+
+            throw new InvalidOperationException(
+                $"{nameof(AddLlmCallouts)}() was called, but no {nameof(IChatClient)} is registered in this " +
+                "application's container. Register one from your provider's Microsoft.Extensions.AI adapter, " +
+                "e.g. builder.Services.AddChatClient(...), or use Wolverine.AI.Testing.StubChatClient in tests.");
+        });
+
+        return options;
+    }
+}

--- a/src/Samples/DocumentationSamples/DocumentationSamples.csproj
+++ b/src/Samples/DocumentationSamples/DocumentationSamples.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
+        <ProjectReference Include="..\..\Extensions\Wolverine.AI\Wolverine.AI.csproj"/>
         <ProjectReference Include="..\..\Persistence\Wolverine.Marten\Wolverine.Marten.csproj"/>
         <ProjectReference Include="..\..\Testing\Wolverine.ComplianceTests\Wolverine.ComplianceTests.csproj" />
         <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj"/>

--- a/src/Samples/DocumentationSamples/LlmCalloutSamples.cs
+++ b/src/Samples/DocumentationSamples/LlmCalloutSamples.cs
@@ -1,0 +1,62 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Wolverine.AI;
+
+namespace DocumentationSamples;
+
+public record IncidentEscalated(string Reason);
+
+public record IncidentResolved;
+
+public record IncidentTriage(string Severity, string RecommendedAction);
+
+public class Incident
+{
+    public Guid Id { get; set; }
+    public int Version { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public bool IsEscalated { get; set; }
+
+    public void Apply(IncidentEscalated _) => IsEscalated = true;
+    public void Apply(IncidentResolved _) => IsEscalated = false;
+}
+
+#region sample_llm_callout_from_a_projection
+
+public class IncidentProjection : SingleStreamProjection<Incident, Guid>
+{
+    public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<Incident> slice)
+    {
+        if (slice.Snapshot is { IsEscalated: true } incident &&
+            slice.Events().OfType<IEvent<IncidentEscalated>>().Any())
+        {
+            slice.PublishMessage(LlmCallout
+                .Ask<IncidentTriage>("Classify this incident and recommend a next action.", incident)
+                .Tagged("triage")
+
+                // Stream id plus version is the natural logical identity here: a daemon retry that
+                // reprocesses this slice republishes the identical callout, and this is what lets
+                // deduplication recognize it as the same intent rather than a second one.
+                .DeduplicatedBy($"{incident.Id}:{slice.Events().Last().Version}"));
+        }
+
+        return new ValueTask();
+    }
+}
+
+#endregion
+
+#region sample_llm_callout_projection_answer
+
+public static class IncidentTriageHandler
+{
+    public static void Handle(IncidentTriage triage)
+    {
+        // page someone, open a ticket, whatever the severity calls for
+    }
+}
+
+#endregion

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -16,6 +16,8 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("PolicyTests")]
 [assembly: InternalsVisibleTo("CircuitBreakingTests")]
 [assembly: InternalsVisibleTo("Wolverine.ComplianceTests")]
+[assembly: InternalsVisibleTo("Wolverine.AI")]
+[assembly: InternalsVisibleTo("Wolverine.AI.Tests")]
 [assembly: InternalsVisibleTo("Wolverine.RabbitMq")]
 [assembly: InternalsVisibleTo("Wolverine.RabbitMq.Tests")]
 [assembly: InternalsVisibleTo("Wolverine.AzureServiceBus")]

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -23,6 +23,8 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Extensions/">
+    <Project Path="src/Extensions/Wolverine.AI/Wolverine.AI.csproj" />
+    <Project Path="src/Extensions/Wolverine.AI.Tests/Wolverine.AI.Tests.csproj" />
     <Project Path="src/Extensions/Wolverine.DataAnnotationsValidation.Tests/Wolverine.DataAnnotationsValidation.Tests.csproj" />
     <Project Path="src/Extensions/Wolverine.DataAnnotationsValidation/Wolverine.DataAnnotationsValidation.csproj" />
     <Project Path="src/Extensions/Wolverine.FluentValidation.Grpc/Wolverine.FluentValidation.Grpc.csproj" />


### PR DESCRIPTION
Closes #4227.

A handler that awaits a language model inline holds a transaction and an envelope open for seconds against a remote service that is slow, rate limited, and occasionally down. Every one of those problems already has an answer in Wolverine; it just needed the model call to be a message.

```csharp
public static (IStorageAction<Incident>, LlmCallout) Handle(AlertSeen message, Incident incident)
    => (Storage.Update(incident),
        LlmCallout.Ask<IncidentTriage>(Prompts.Triage, incident.Snapshot()).Tagged("triage"));

// the answer is an ordinary message, with an ordinary handler and an ordinary retry policy
public static void Handle(IncidentTriage triage) { }
```

The callout is enrolled in the same outbox as the write, so it cannot fire for a transaction that did not commit. It executes on a dedicated durable local queue against the application's `IChatClient`, and the model's answer is deserialized into the requested type and published as a cascading message. Retries, back pressure, scheduling, dead lettering, and the correlation chain are inherited rather than rebuilt.

Because the vocabulary is messages, event store integration needed nothing new — `RaiseSideEffects` already publishes messages atomically with a projection update, so one integration serves Marten, Polecat, and Fisher.

## The design changed from the issue's sketch

#4227 specified `LlmCallout<TResponse>`. It does not survive the durable requirement, and the reversal is [written up on the issue](https://github.com/JasperFx/wolverine/issues/4227#issuecomment-5496748582) and folded into its decision list as items 7 and 8.

Short version: `HandlerGraph.TryFindMessageType` is a flat name lookup, so a closed `LlmCallout<IncidentTriage>` recovered from a durable inbox on a cold start has no route back to a `Type` — and the recovery sweep runs before the application has published a callout of its own, so publish-time registration does not rescue it. A generic wire type would require every response type to be enumerated at bootstrap; a source generator can make that enumeration AOT-clean but cannot remove it. The type parameter also carries no behaviour — its whole job is to name a type twice, once for the schema and once for the deserialization.

`Ask<TResponse>(...)` stays generic. One message type buys one handler chain, one dead letter identity, one queue, and one place for the budget middleware, which is what decision 3 wanted.

## What's here

- **`LlmCallout`** and its `Ask<TResponse>` / `Ask` (text) factories, on a dedicated durable local queue (`llm-callouts`). Entry point is `opts.AddLlmCallouts(...)`; `UseAi` is left free for tier 2 (#4226).
- **Abstractions-only dependency.** Structured output is built from `AIJsonUtilities.CreateJsonSchema` + `ChatResponseFormat.ForJsonSchema` rather than `GetResponseAsync<T>`, which lives in the full `Microsoft.Extensions.AI` package that decision 5 rules out. Registering the `IChatClient` stays with the application — and a missing one now fails at bootstrap rather than on the first callout.
- **Budget middleware on the callout queue.** `MaximumPromptCharacters` refuses a callout before the provider is called; `MaximumTokensPerWindow` refuses once the node has burned its allowance, counted from reported usage. Both dead letter rather than retry, and so does an unparseable answer — each produces the identical failure on every attempt, and retrying is the runaway spend the guardrails exist to stop. Everything else gets a cooldown schedule.
- **`StubChatClient`** scripts answers, failures, and slow answers, so a callout's whole round trip is testable with no key, no network, and no model.
- **Docs** at `/guide/ai`, with compiled snippets covering the handler pattern, the `RaiseSideEffects` pattern, rebuild/idempotency, and testing.
- Token counters on a `Wolverine.AI` meter, tagged by the callout's `Tag` and the responding model.

## Notes for review

- **The prose is a draft.** `docs/guide/ai.md` and the CHANGELOG entry are complete rather than placeholders, but the wording is Jeremy's to own — particularly "Why the Callout is Not Generic", which is now the public record of a reversed decision.
- **`ValidatePackList` would have failed the build** without adding the new `<PackageId>` to `Build.NugetProjects`. Working as designed (#3905).
- **`InternalsVisibleTo("Wolverine.AI")`** added to core, matching the existing first-party extension list — `WolverineOptions.HandlerGraph` is internal and the executor consults the message type registry.
- **Not AOT compatible**, tracked as #4230. The response type is named on the message at runtime and its schema built reflectively. `LlmCalloutExecutor` carries `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` rather than a suppression, because a suppression would claim a guarantee the design cannot make. That gap is orthogonal to the generic decision — a generic `LlmCallout<T>` would have needed identical work.

## Verification

- 33 tests in the new `Wolverine.AI.Tests`, wired into `TestExtensions` via a new `AiTests` target.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings.
- `./build.sh ValidatePackList` green.

One finding worth recording: the first `StubChatClient` blocked on `Thread.Sleep`, and the timeout test failed because the executor's linked CTS never fired. A stub that ignores its cancellation token cannot prove a timeout works. `RespondAfter` now awaits `Task.Delay(delay, token)`, and `LlmCalloutOptions.Timeout` is documented as being only as good as the registered client's token handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
