### PR TITLE
GH-4230: make WolverineFx.AI trim and AOT clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### WolverineFx.AI (new package)
 
+- **AOT and trim support.** (closes
+  [#4230](https://github.com/JasperFx/wolverine/issues/4230)) `WolverineFx.AI` now sets
+  `IsAotCompatible`, on one condition: register response types with `ai.RegisterResponseType<T>()` and
+  assign `LlmCalloutOptions.JsonSerializerOptions` a source-generated `JsonSerializerContext` covering
+  them.
+
+  This turned out to need no schema generator. `AIJsonUtilities.CreateJsonSchema(Type, ...)` carries no
+  trim annotations at all, because it builds the schema from whatever `JsonTypeInfo` the serializer
+  options resolve — hand it source-generated options and the schema generation is already reflection
+  free. What did need changing was the deserialization, which now goes through the `JsonTypeInfo`
+  overload rather than `JsonSerializer.Deserialize(string, Type, JsonSerializerOptions)`, the one that
+  is annotated; and the identifier-to-`Type` resolution, which now consults the registration table
+  before falling back to the message type registry and `Type.GetType`.
+
+  `LlmCallout.Ask(prompt, context)` keeps `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` — 
+  serializing an arbitrary object needs reflection over its shape, and no amount of plumbing changes
+  that. The trim-clean equivalent is `LlmCallout.Ask<T>(prompt).WithContext(context, typeInfo)`, which
+  serializes through source-generated type info, or `WithContext(json)` for context that is already
+  JSON. The annotation's message names the replacement at the call site.
+
+  Gated by a new `Wolverine.AI.AotSmoke` project under `TrimMode=full`, which CI **runs** as well as
+  builds. Running is the point: a `JsonSerializerContext` that does not cover a response type does not
+  throw — `CreateJsonSchema` returns an *empty* schema, the model is handed a constraint that
+  constrains nothing, and the result looks like a quality problem rather than a configuration one. The
+  smoke test asserts on the rendered schema's contents for exactly that reason.
+
+- **Prompt context is serialized compactly.** `AIJsonUtilities.DefaultOptions` sets `WriteIndented`,
+  so every callout carrying context was pretty-printing it into the prompt. Indentation in a prompt is
+  billed input tokens buying nothing, and it inflated every character counted against
+  `LlmBudget.MaximumPromptCharacters`. The naming policy and null handling are unchanged, so what the
+  model is shown is otherwise identical.
+
 - **LLM callouts as durable messages.** (closes
   [#4227](https://github.com/JasperFx/wolverine/issues/4227)) A handler that awaits a language model
   inline holds a transaction and an envelope open for seconds against a remote service that is slow,

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1218,12 +1218,19 @@ partial class Build
         {
             var smoke = RootDirectory / "src" / "Testing" / "Wolverine.AotSmoke" / "Wolverine.AotSmoke.csproj";
             var staticSmoke = RootDirectory / "src" / "Testing" / "Wolverine.AotSmoke.Static" / "Wolverine.AotSmoke.Static.csproj";
+            var aiSmoke = RootDirectory / "src" / "Testing" / "Wolverine.AI.AotSmoke" / "Wolverine.AI.AotSmoke.csproj";
 
             DotNet($"build {smoke} --configuration {Configuration} --framework net9.0");
             DotNet($"run --project {smoke} --no-build --configuration {Configuration} --framework net9.0");
 
             DotNet($"build {staticSmoke} --configuration {Configuration} --framework net9.0");
             DotNet($"run --project {staticSmoke} --no-build --configuration {Configuration} --framework net9.0");
+
+            // GH-4230. Runs as well as builds: the schema generation this gates fails by returning an
+            // empty schema rather than by throwing, so a build-only check would pass over exactly the
+            // regression it exists to catch.
+            DotNet($"build {aiSmoke} --configuration {Configuration} --framework net9.0");
+            DotNet($"run --project {aiSmoke} --no-build --configuration {Configuration} --framework net9.0");
         });
 
     // ─── Azure Service Bus CI Targets ──────────────────────────────────

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -1,18 +1,21 @@
 # LLM Callouts
 
 ::: tip
-`WolverineFx.AI` is a new package covering **one shot** calls to a large language model. Multi-turn, tool-calling
-agents are a separate, later tier ([GH-4226](https://github.com/JasperFx/wolverine/issues/4226)).
+`WolverineFx.AI` is all about **one shot** calls to an LLM. Multi-turn, tool calling agents are a completely
+separate concern that's being designed separately in [GH-4226](https://github.com/JasperFx/wolverine/issues/4226).
 :::
 
-## An LLM Call is a Message
+## An LLM Call is Just a Message
 
-A handler that awaits a model inline holds a database transaction and an envelope open for seconds against a
-remote service that is slow, rate limited, and occasionally down. Every one of those problems already has an
-answer in Wolverine — it just needs the model call to be a message rather than an inline `await`.
+Let's say you want to ask a large language model to triage an incident as part of processing a message. The
+obvious way to do that is to inject an `IChatClient` into your handler and await it right there. That certainly
+works, but think about what you've just done: your handler is now holding a database transaction and an unacked
+message open for however long the model takes to answer -- and models are slow, rate limited, and occasionally
+just down.
 
-That is all this package is. `LlmCallout` is an ordinary Wolverine message that happens to be handled by calling
-a model:
+You've seen this problem before, and so has Wolverine. Slow, flaky, remote work that you'd like to retry, throttle,
+and observe is exactly what messaging is for. So instead of awaiting the model inline, ask for the answer by
+returning a message:
 
 <!-- snippet: sample_llm_callout_from_a_handler -->
 <a id='snippet-sample_llm_callout_from_a_handler'></a>
@@ -41,20 +44,25 @@ public static class TriageHandler
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L58-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_from_a_handler' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Because the callout is a message, it inherits the whole runtime with no extra work:
+`LlmCallout` is an ordinary Wolverine message that happens to be handled by calling a model. Being an ordinary
+message gets you quite a lot for free:
 
-* **The outbox.** Returned next to a storage action, the callout is enrolled in the same transaction as the write.
-  A callout cannot fire for a transaction that rolled back, and cannot be lost to a restart in between.
-* **Retries and error policies.** A 503 from the provider is retried on a cooldown schedule. A prompt the model
-  cannot answer is dead lettered.
-* **Back pressure.** The callout queue caps how many calls are in flight, no matter how fast callouts are published.
-* **Scheduling.** `DeliveryOptions.ScheduleDelay` delays a callout like any other message.
-* **Observability.** Every callout is an envelope, so correlation and causation ids already answer "what did this
-  model call come from, and what did it cause".
+* The callout is enrolled in the **transactional outbox** right alongside the write next to it, so a callout can
+  never fire for a transaction that rolled back, and can't be lost if the process restarts in between
+* **Retries and error policies** apply, so a 503 from your provider is retried on a cooldown schedule
+* **Back pressure** applies, so the callout queue caps how many calls are in flight regardless of how fast you
+  publish them
+* **Scheduling** applies, so `DeliveryOptions.ScheduleDelay` delays a callout like anything else
+* Every callout is an **envelope**, so correlation and causation ids already tell you where a model call came from
+  and what it caused
 
-The answer comes back as an *ordinary message* with its own handler, its own retry policy, and its own place in the
-correlation chain. There is no correlated request/reply here and no waiting: this is publish only, pub/sub async
-workflows all the way down.
+The model's answer comes back as a *completely ordinary message* with its own handler, its own retry policy, and
+its own spot in the correlation chain.
+
+::: info
+This is publish only. There's deliberately no correlated request/reply flavor and no waiting on an answer --
+it's pub/sub async workflows all the way down.
+:::
 
 ## Getting Started
 
@@ -64,9 +72,10 @@ Install the package:
 dotnet add package WolverineFx.AI
 ```
 
-`WolverineFx.AI` depends only on the **Microsoft.Extensions.AI abstractions**, never on a vendor SDK — the same
-bargain as `ILogger`. Registering the `IChatClient` is yours, which means the provider (Anthropic, OpenAI, Azure,
-Ollama, a local model) and any middleware over it are your choice:
+`WolverineFx.AI` only depends on the **Microsoft.Extensions.AI abstractions**, and never on any vendor's SDK. This
+is the same bargain as `ILogger`: Wolverine binds to the BCL-blessed abstraction, and which provider you use --
+Anthropic, OpenAI, Azure, Ollama, something running on your laptop -- is entirely up to you. Registering the
+`IChatClient` is your job, which also means any middleware you want to wrap around it stays your call:
 
 <!-- snippet: sample_llm_callout_bootstrapping -->
 <a id='snippet-sample_llm_callout_bootstrapping'></a>
@@ -104,38 +113,46 @@ public static class Bootstrapping
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L11-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_bootstrapping' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-`AddLlmCallouts()` puts every callout on one dedicated, durable local queue named `llm-callouts`
-(`LlmCallout.QueueName`). Durable is the default and the point — turn it off with `ai.DurableQueue = false` only
-where the application has no message persistence configured at all.
+`AddLlmCallouts()` puts every callout in your application on one dedicated, durable local queue named
+`llm-callouts` (there's a `LlmCallout.QueueName` constant if you need to refer to it). Durability is on by default
+and it's rather the whole point, so only turn it off with `ai.DurableQueue = false` if your application has no
+message persistence configured at all.
 
-## Structured Answers
+## Asking for a Structured Answer
 
-`LlmCallout.Ask<TResponse>(...)` asks for a structured answer. Wolverine derives a JSON schema from `TResponse`,
-hands it to the model as the response format, deserializes the answer, and publishes it as an ordinary message:
+`LlmCallout.Ask<TResponse>()` asks the model for an answer shaped like `TResponse`. Wolverine builds a JSON schema
+from that type, hands it to the model as the response format, reads the answer back, and publishes it as an
+ordinary message:
 
 ```csharp
 LlmCallout.Ask<IncidentTriage>("Classify this incident.", incident.Snapshot());
 ```
 
-The second argument is optional context. It is serialized to JSON and appended underneath the prompt at the moment
-the callout is created, so what the model will be asked is fully baked into the message. A callout sitting in the
-dead letter queue can be read and understood without re-running anything.
+The second argument is optional context. It gets serialized to JSON and appended underneath your prompt at the
+moment you create the callout, which means the exact text the model will be asked is baked into the message. That
+matters more than it might sound: a callout sitting in your dead letter queue can be read and understood without
+re-running anything at all.
 
-Prompts are yours. This package is not a prompt template framework — a `const string`, a record, or whatever
-templating you already like all work, because by the time a callout exists the prompt is just text.
+::: tip
+Prompts are yours. Wolverine isn't trying to be a prompt templating framework here -- a `const string`, a record,
+Scriban, whatever you already like, it's all the same to `LlmCallout` because by the time a callout exists the
+prompt is just text.
+:::
 
-### The text flavour
+### Asking for Plain Text
 
-`LlmCallout.Ask(...)` with no type parameter asks for plain text, and publishes an `LlmTextResponse` carrying both
-the answer and the callout that produced it. Every text callout in an application publishes that same type, so a
-handler tells one kind from another by its `Tag`. When that starts to feel like a switch statement pretending to be
-a type, that is the signal to move to the structured flavour and let each answer be its own message.
+`LlmCallout.Ask()` with no type argument asks for plain text, and publishes an `LlmTextResponse` carrying both the
+answer and the callout that produced it. Every text callout in your application publishes that same type, so a
+handler tells one kind of callout from another by looking at its `Tag`.
 
-## From a Projection
+If that starts turning into a switch statement pretending to be a type, take it as a hint to move over to the
+structured flavor and let each kind of answer be its own message.
 
-Because the vocabulary is messages, event store integration needs nothing new. `RaiseSideEffects` on the
-JasperFx.Events projection base already publishes messages atomically with the projection update, and a callout is
-just a message:
+## Triggering a Callout from a Projection
+
+Here's a nice payoff from callouts being messages: event store integration needed no new concepts at all.
+`RaiseSideEffects()` on the JasperFx.Events projection base class already publishes messages atomically with the
+projection update, and a callout is just a message:
 
 <!-- snippet: sample_llm_callout_from_a_projection -->
 <a id='snippet-sample_llm_callout_from_a_projection'></a>
@@ -164,28 +181,31 @@ public class IncidentProjection : SingleStreamProjection<Incident, Guid>
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/LlmCalloutSamples.cs#L27-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_from_a_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-One integration serves Marten, Polecat, and Fisher alike. Two things are worth knowing here:
+One integration covers Marten, Polecat, and Fisher alike. There are two behaviors worth knowing about here.
 
-**Rebuilds do not re-trigger callouts.** Side effects are suppressed during a projection rebuild by default, which
-is exactly right — rebuilding a projection over two years of history must not re-triage two years of incidents, and
-must not bill you for doing it.
+First, **rebuilds don't re-trigger callouts**, because side effects are suppressed during a projection rebuild by
+default. That's exactly what you want -- rebuilding a projection across two years of history should not re-triage
+two years of incidents, and should certainly not bill you for the privilege.
 
-**Daemon retries can republish.** A slice that fails partway through is reprocessed, and the callout is published
-again. Give republish-prone callouts a logical identity with `DeduplicatedBy(...)` — stream id plus version is the
-natural key — and turn on enforcement:
+Second, **the async daemon can republish**. If a slice fails partway through it gets reprocessed, and your callout
+goes out again. For callouts that can be republished this way, give them a logical identity and turn on
+enforcement:
 
 ```csharp
 opts.Durability.EnableMessageDeduplication();
 opts.AddLlmCallouts(ai => ai.DeduplicateCallouts = true);
 ```
 
-The id is carried on the message either way; `DeduplicateCallouts` is what makes Wolverine claim it before calling
-the model. Callouts without an id still execute, since only the republish-prone sources have a natural key.
+Stream id plus version is usually the natural key, and that's what the sample above uses. The id rides along on
+the message either way; `DeduplicateCallouts` is what makes Wolverine actually claim it before calling the model.
+Callouts with no id still execute, since realistically only the republish-prone sources have a natural key to give
+you.
 
-## Budgets and Failure
+## Budgets and Failures
 
-A runaway prompt or a loop that publishes callouts faster than anyone notices is the expensive failure mode here,
-so the guardrails are middleware on the callout queue rather than advice in a doc page:
+The expensive way for this to go wrong is a runaway prompt, or a loop that publishes callouts faster than anyone
+notices. Since advice in a documentation page has never once stopped that from happening, the guardrails are
+middleware on the callout queue instead:
 
 ```csharp
 opts.AddLlmCallouts(ai =>
@@ -196,35 +216,37 @@ opts.AddLlmCallouts(ai =>
 });
 ```
 
-`MaximumPromptCharacters` refuses a callout **before** the provider is called, so a context accidentally assembled
-from an unbounded collection costs nothing. `MaximumTokensPerWindow` refuses callouts once the node has burned
-through its allowance, counted from the usage the provider actually reported.
+`MaximumPromptCharacters` refuses a callout *before* your provider is ever called, so a context you accidentally
+assembled out of an unbounded collection costs you nothing at all. `MaximumTokensPerWindow` refuses callouts once
+this node has burned through its allowance, counted from the token usage your provider actually reported back.
 
 ::: warning
-The token ledger is **per process**, not cluster wide. On a fleet of N nodes the effective ceiling is N times the
-configured number. Treat it as a circuit breaker against a runaway loop, not as billing enforcement.
+The token ledger is **per process**, not cluster wide. If you're running a fleet of N nodes, the real ceiling is N
+times whatever you configured. Think of it as a circuit breaker against a runaway loop rather than as billing
+enforcement.
 :::
 
-Both limits **dead letter rather than retry**, and so does an answer that cannot be parsed into the requested
-response type. A callout that is over budget is over budget on every attempt, and a prompt the model cannot answer
-in the requested shape produces the identical unusable answer every time — retrying either one is precisely the
-runaway spend the guardrails exist to stop. The raw model output is carried on `LlmCalloutException.RawResponse` so
-a dead letter can be triaged without a re-run.
+Both limits **dead letter instead of retrying**, and so does an answer that can't be parsed into the response type
+you asked for. The reasoning is the same in all three cases: a callout that's over budget will be over budget on
+every single attempt, and a prompt the model can't answer in the shape you wanted will produce the same unusable
+answer every time you ask. Retrying either one is precisely the runaway spend the guardrails exist to prevent. The
+raw text the model sent back is carried on `LlmCalloutException.RawResponse` so you can triage a dead letter
+without re-running it.
 
-Everything else — a 503, a socket reset, a timeout — is transient and gets the cooldown schedule:
+Everything else -- a 503, a socket reset, a timeout -- is treated as transient and gets the cooldown schedule:
 
 ```csharp
 opts.AddLlmCallouts(ai => ai.RetryCooldowns = [1.Seconds(), 5.Seconds(), 15.Seconds()]);
 ```
 
-`LlmCalloutOptions.Timeout` (2 minutes by default) caps any single callout. Note that this depends on the
-registered `IChatClient` honouring its cancellation token — every HTTP-based provider does.
+`LlmCalloutOptions.Timeout` caps any single callout at two minutes by default. Do note that this depends on your
+registered `IChatClient` honoring its cancellation token, though every HTTP based provider does.
 
 ## Observability
 
-Callouts appear in Wolverine's own metrics, logs, and OpenTelemetry spans like any other message, keyed by the
-`llm-callouts` queue. On top of that, `WolverineFx.AI` emits token counters on a `Wolverine.AI` meter, tagged by
-the callout's `Tag` and the responding model:
+Callouts show up in Wolverine's own metrics, logging, and Open Telemetry spans just like any other message, keyed
+by the `llm-callouts` queue. On top of that, `WolverineFx.AI` publishes token counters on a `Wolverine.AI` meter,
+tagged by the callout's `Tag` and by the model that answered:
 
 | Instrument | Description |
 | --- | --- |
@@ -232,14 +254,16 @@ the callout's `Tag` and the responding model:
 | `wolverine.ai.callout.output_tokens` | Output tokens produced |
 | `wolverine.ai.callout.total_tokens` | Total tokens billed |
 
-For full GenAI semantic convention spans, add Microsoft.Extensions.AI's own
-`.UseOpenTelemetry()` middleware when registering the `IChatClient`. What Wolverine adds is the labelling that
-middleware cannot see: which *callout* the spend belongs to.
+::: tip
+If you want the full GenAI semantic convention spans, add Microsoft.Extensions.AI's own `.UseOpenTelemetry()`
+middleware when you register the `IChatClient`. Wolverine isn't trying to duplicate that. What Wolverine adds is
+the labelling that middleware can't see: *which callout* the spend belongs to.
+:::
 
 ## Testing
 
-The message-shaped design makes testing without a model trivial, which is deliberate — it is most of the argument
-for the design. `StubChatClient` is a scripted `IChatClient` that ships in the package:
+Being message shaped makes this easy to test without a model anywhere in sight, and honestly that's most of the
+argument for the design. `StubChatClient` ships in the package as a scripted `IChatClient`:
 
 <!-- snippet: sample_llm_callout_testing -->
 <a id='snippet-sample_llm_callout_testing'></a>
@@ -275,12 +299,13 @@ public async Task triage_an_escalated_incident()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L85-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_testing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Answers are handed out in the order they were queued, and an exhausted script is an error rather than a repeat: a
-test that quietly reuses the last answer for a callout it did not know it was making is a test that passes for the
-wrong reason. `Throw(...)` scripts a failure, and `RespondAfter(...)` scripts a slow answer for exercising the
-timeout.
+Answers come back in the order you queued them, and running out of script is an error rather than a repeat. That's
+on purpose: a test that quietly hands the last answer back for a callout it didn't know it was making is a test
+that passes for the wrong reason. There's also `Throw()` to script a failure, and `RespondAfter()` to script a slow
+answer if you want to exercise the timeout.
 
-Better still, a handler that returns a callout is a pure function, so the most valuable test needs no host at all:
+Better yet, a handler that returns a callout is a pure function, so the test that's actually worth writing needs no
+host at all:
 
 <!-- snippet: sample_llm_callout_unit_test -->
 <a id='snippet-sample_llm_callout_unit_test'></a>
@@ -302,8 +327,8 @@ public void the_handler_asks_for_a_triage()
 
 ## Trimming and AOT
 
-`WolverineFx.AI` is trim and AOT compatible, on one condition: the application has to tell it about its
-response types twice — once for type resolution, once for JSON.
+`WolverineFx.AI` is trim and AOT compatible, but you have to tell it about your response types twice -- once so it
+can resolve them, and once for JSON:
 
 ```csharp
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
@@ -322,54 +347,57 @@ opts.AddLlmCallouts(ai =>
 });
 ```
 
-`RegisterResponseType<T>()` is what turns the identifier a persisted callout carries back into a `Type`
-without `Type.GetType`. The `JsonSerializerContext` is what lets the response schema and the answer's
-deserialization run off source-generated metadata rather than reflection — `CreateJsonSchema` builds the
-schema from whatever type info the options resolve, so no separate schema generator is needed.
+`RegisterResponseType<T>()` is what turns the identifier a persisted callout carries back into a `Type` without
+needing `Type.GetType()`. The `JsonSerializerContext` covers the other two reflective spots, and it covers both of
+them at once -- Microsoft.Extensions.AI builds the response schema from whatever type information your serializer
+options resolve, so a source generated context gets you a source generated schema with no extra machinery.
 
-Both are optional outside a trimmed application, where the message type registry and `Type.GetType` cover
-the same ground. Registering them anyway costs a line each and makes a failure loud at startup rather
-than quiet in a dead letter.
+Neither of these is required outside a trimmed application, where the message type registry and `Type.GetType()`
+cover the same ground perfectly well. Registering them anyway costs you a line each and turns a possible failure
+into a loud one at startup rather than a quiet one in your dead letter queue.
 
-One authoring surface has no AOT-clean form, because serializing an arbitrary object needs reflection
-over its shape:
+There's one authoring API with no trim clean form, because serializing an arbitrary object means reflecting over
+its shape:
 
 ```csharp
 // warns IL2026 / IL3050 under trim analysis
 LlmCallout.Ask<IncidentTriage>(prompt, incident.Snapshot());
 
-// the trim-clean equivalent
+// the trim clean equivalent
 LlmCallout.Ask<IncidentTriage>(prompt)
     .WithContext(incident.Snapshot(), AiJsonContext.Default.IncidentSnapshot);
 ```
 
-`WithContext(string)` takes JSON you produced yourself, which is also the escape hatch when the context
-is not a CLR object at all — a rendered document, a retrieved passage, a diff.
+There's also a `WithContext(string)` that just takes JSON you produced yourself, which is handy anyway when your
+context was never a CLR object to begin with -- a rendered document, a passage you retrieved, a diff.
 
 ::: warning
-A `JsonSerializerContext` that does not cover a response type does not throw. `CreateJsonSchema` returns
-an *empty* schema, and the model is handed a constraint that constrains nothing — it will usually still
-answer, and the answer will usually still parse, so the failure looks like a quality problem rather than
-a configuration one. If structured answers go vague after a trimmed publish, check the context first.
+A `JsonSerializerContext` that's missing a response type does **not** throw. Schema generation quietly answers with
+an *empty* schema, which means the model gets handed a constraint that constrains nothing. It will usually still
+answer you, and the answer will usually still parse, so this shows up looking like a model quality problem rather
+than the configuration problem it actually is. If your structured answers get vague right after a trimmed publish,
+check this first.
 :::
 
-## Why the Callout is Not Generic
+## Why `LlmCallout` Isn't Generic
 
-`LlmCallout.Ask<TResponse>(...)` is generic but `LlmCallout` itself is not, and the response type rides on the
-message as data. That is a deliberate choice, recorded in [GH-4227](https://github.com/JasperFx/wolverine/issues/4227).
+`LlmCallout.Ask<TResponse>()` is generic, but `LlmCallout` itself is not -- the response type rides along on the
+message as data. That was a deliberate reversal of the original design, and the reasoning is recorded in
+[GH-4227](https://github.com/JasperFx/wolverine/issues/4227).
 
-A callout has to survive being written to a durable inbox and read back after a process restart. Wolverine's
-message type registry is a flat name lookup, so a closed `LlmCallout<IncidentTriage>` recovered on a cold start
-would have no route back to a `Type` unless every response type in the application had been enumerated at
-bootstrap — and the recovery sweep runs before the application has published a callout of its own. The type
-parameter also carries no behaviour: its whole job is to name a type twice, once for the schema and once for the
-deserialization.
+The short version is that a callout has to survive being written to a durable inbox and read back after a restart.
+Wolverine's message type registry is a flat name lookup, so a closed `LlmCallout<IncidentTriage>` coming back on a
+cold start has no way back to a `Type` unless every response type in your application was enumerated at bootstrap
+-- and the recovery sweep runs before your application has published a single callout of its own. On top of that,
+the type argument carries no behavior whatsoever. Its entire job is to name a type twice, once for the schema and
+once for the deserialization.
 
-One message type means one handler chain, one dead letter identity, one queue, and one place for the budget
-middleware. The typing that actually matters — the handler that receives the answer — is untouched.
+One message type buys you one handler chain, one dead letter identity, one queue, and one place for the budget
+middleware to live. The typing that actually matters to you -- the handler that receives the answer -- is exactly
+the same either way.
 
-## Not In Scope
+## What's Not Here
 
-* **Agents, tools, and model loops.** Tier 2, tracked in [GH-4226](https://github.com/JasperFx/wolverine/issues/4226).
-* **Embedding generation.** `IEmbeddingGenerator<,>` is the obvious seam for event store integrations, but it is
+* **Agents, tools, and model loops.** That's tier 2, and it's tracked in [GH-4226](https://github.com/JasperFx/wolverine/issues/4226).
+* **Embedding generation.** `IEmbeddingGenerator<,>` is the obvious seam for event store integrations, but that's
   separate adapter work.

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -300,6 +300,59 @@ public void the_handler_asks_for_a_triage()
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Extensions/Wolverine.AI.Tests/Samples.cs#L117-L131' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_llm_callout_unit_test' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Trimming and AOT
+
+`WolverineFx.AI` is trim and AOT compatible, on one condition: the application has to tell it about its
+response types twice — once for type resolution, once for JSON.
+
+```csharp
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(IncidentTriage))]
+[JsonSerializable(typeof(IncidentSnapshot))]
+internal partial class AiJsonContext : JsonSerializerContext;
+
+opts.AddLlmCallouts(ai =>
+{
+    ai.JsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        TypeInfoResolver = AiJsonContext.Default
+    };
+
+    ai.RegisterResponseType<IncidentTriage>();
+});
+```
+
+`RegisterResponseType<T>()` is what turns the identifier a persisted callout carries back into a `Type`
+without `Type.GetType`. The `JsonSerializerContext` is what lets the response schema and the answer's
+deserialization run off source-generated metadata rather than reflection — `CreateJsonSchema` builds the
+schema from whatever type info the options resolve, so no separate schema generator is needed.
+
+Both are optional outside a trimmed application, where the message type registry and `Type.GetType` cover
+the same ground. Registering them anyway costs a line each and makes a failure loud at startup rather
+than quiet in a dead letter.
+
+One authoring surface has no AOT-clean form, because serializing an arbitrary object needs reflection
+over its shape:
+
+```csharp
+// warns IL2026 / IL3050 under trim analysis
+LlmCallout.Ask<IncidentTriage>(prompt, incident.Snapshot());
+
+// the trim-clean equivalent
+LlmCallout.Ask<IncidentTriage>(prompt)
+    .WithContext(incident.Snapshot(), AiJsonContext.Default.IncidentSnapshot);
+```
+
+`WithContext(string)` takes JSON you produced yourself, which is also the escape hatch when the context
+is not a CLR object at all — a rendered document, a retrieved passage, a diff.
+
+::: warning
+A `JsonSerializerContext` that does not cover a response type does not throw. `CreateJsonSchema` returns
+an *empty* schema, and the model is handed a constraint that constrains nothing — it will usually still
+answer, and the answer will usually still parse, so the failure looks like a quality problem rather than
+a configuration one. If structured answers go vague after a trimmed publish, check the context first.
+:::
+
 ## Why the Callout is Not Generic
 
 `LlmCallout.Ask<TResponse>(...)` is generic but `LlmCallout` itself is not, and the response type rides on the
@@ -320,5 +373,3 @@ middleware. The typing that actually matters — the handler that receives the a
 * **Agents, tools, and model loops.** Tier 2, tracked in [GH-4226](https://github.com/JasperFx/wolverine/issues/4226).
 * **Embedding generation.** `IEmbeddingGenerator<,>` is the obvious seam for event store integrations, but it is
   separate adapter work.
-* **AOT.** `WolverineFx.AI` is not trim or AOT compatible: the response type is named on the message at runtime and
-  its schema is built reflectively. Making it trim-clean needs source-generated schemas and a `JsonSerializerContext`.

--- a/docs/guide/aot.md
+++ b/docs/guide/aot.md
@@ -80,6 +80,10 @@ Currently exercised AOT-clean surface (will fail the smoke build if any of these
 
 As the per-file annotation pass in #2746 progresses, the smoke project expands to exercise the newly-annotated entry points — tightening the regression guard incrementally.
 
+### `Wolverine.AI.AotSmoke`
+
+A sister project under the same settings gates `WolverineFx.AI`'s callout path, and is **run** as well as built. Running matters here: the schema generation it covers fails by returning an *empty* schema rather than by throwing, so a build-only check would pass over precisely the regression it exists to catch. It exercises the real `LlmResponseBinder` — the same type `LlmCalloutExecutor` delegates to — across identifier resolution, schema generation, and deserialization. See [LLM Callouts](/guide/ai#trimming-and-aot).
+
 ## Surfaces that intentionally aren't AOT-clean
 
 A handful of Wolverine APIs **require** runtime codegen by design. They carry `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` annotations so the trimmer surfaces a clear warning if your AOT-published app reaches them:
@@ -88,6 +92,7 @@ A handful of Wolverine APIs **require** runtime codegen by design. They carry `[
 - Reflective handler / saga / transport discovery (`HandlerDiscovery.IncludeAssembly` type-scan, the saga-type-descriptor `StartingMessages` reflection, transport `IMessageRoutingConvention` reflection). Static-mode + a pre-generated handler manifest avoid these.
 - `MakeGenericType` / `Activator.CreateInstance` driven factories — the few that still exist in core.
 - The `WolverineFx.Newtonsoft` companion package (Newtonsoft.Json itself isn't AOT-friendly; if you need Newtonsoft, you're not on the AOT path).
+- `LlmCallout.Ask(prompt, context)` in `WolverineFx.AI` — serializing an arbitrary context object needs reflection over its shape. The trim-clean equivalent is `.WithContext(context, typeInfo)`, and the annotation's message says so at the call site.
 
 If you publish AOT in `Dynamic` mode (the default), expect warnings from these surfaces — they tell you what to migrate before you can ship a working AOT binary.
 

--- a/docs/guide/aot.md
+++ b/docs/guide/aot.md
@@ -82,7 +82,9 @@ As the per-file annotation pass in #2746 progresses, the smoke project expands t
 
 ### `Wolverine.AI.AotSmoke`
 
-A sister project under the same settings gates `WolverineFx.AI`'s callout path, and is **run** as well as built. Running matters here: the schema generation it covers fails by returning an *empty* schema rather than by throwing, so a build-only check would pass over precisely the regression it exists to catch. It exercises the real `LlmResponseBinder` — the same type `LlmCalloutExecutor` delegates to — across identifier resolution, schema generation, and deserialization. See [LLM Callouts](/guide/ai#trimming-and-aot).
+There's a sister project under the same settings that guards `WolverineFx.AI`'s [LLM callout](/guide/ai#trimming-and-aot) path, covering type resolution, schema generation, and deserialization. It exercises the real `LlmResponseBinder` that `LlmCalloutExecutor` delegates to, rather than a copy of it.
+
+Note that CI *runs* this one as well as building it, which is a bit unusual for a smoke project. That's because the failure it's guarding against is silent -- when schema generation can't see a type it answers with an empty schema instead of throwing, so a build-only check would sail right past the exact regression the project exists to catch.
 
 ## Surfaces that intentionally aren't AOT-clean
 
@@ -92,7 +94,7 @@ A handful of Wolverine APIs **require** runtime codegen by design. They carry `[
 - Reflective handler / saga / transport discovery (`HandlerDiscovery.IncludeAssembly` type-scan, the saga-type-descriptor `StartingMessages` reflection, transport `IMessageRoutingConvention` reflection). Static-mode + a pre-generated handler manifest avoid these.
 - `MakeGenericType` / `Activator.CreateInstance` driven factories — the few that still exist in core.
 - The `WolverineFx.Newtonsoft` companion package (Newtonsoft.Json itself isn't AOT-friendly; if you need Newtonsoft, you're not on the AOT path).
-- `LlmCallout.Ask(prompt, context)` in `WolverineFx.AI` — serializing an arbitrary context object needs reflection over its shape. The trim-clean equivalent is `.WithContext(context, typeInfo)`, and the annotation's message says so at the call site.
+- `LlmCallout.Ask(prompt, context)` in `WolverineFx.AI` -- serializing an arbitrary context object means reflecting over its shape, and there's no way around that. Use `.WithContext(context, typeInfo)` instead, which the annotation's message tells you right at the call site.
 
 If you publish AOT in `Dynamic` mode (the default), expect warnings from these surfaces — they tell you what to migrate before you can ship a working AOT binary.
 

--- a/src/Extensions/Wolverine.AI.Tests/callout_specs.cs
+++ b/src/Extensions/Wolverine.AI.Tests/callout_specs.cs
@@ -35,6 +35,20 @@ public class callout_specs
     }
 
     [Fact]
+    public void context_is_serialized_compactly()
+    {
+        // Every space and newline in a prompt is a billed input token, and also counts against
+        // LlmBudget.MaximumPromptCharacters. AIJsonUtilities.DefaultOptions sets WriteIndented, so the
+        // context serializer deliberately does not use it. See GH-4230.
+        var context = LlmCallout
+            .Ask<IncidentTriage>("triage", new IncidentSnapshot("INC-1", "on fire", 12))
+            .Context.ShouldNotBeNull();
+
+        context.ShouldNotContain("\n");
+        context.ShouldBe("""{"incidentId":"INC-1","summary":"on fire","minutesOpen":12}""");
+    }
+
+    [Fact]
     public void an_ordinary_response_type_is_identified_by_its_assembly_qualified_name()
     {
         // Assembly qualified rather than Wolverine's message type alias, so that a callout recovered

--- a/src/Extensions/Wolverine.AI.Tests/response_binding.cs
+++ b/src/Extensions/Wolverine.AI.Tests/response_binding.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+using Wolverine.AI.Internals;
+
+namespace Wolverine.AI.Tests;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(IncidentTriage))]
+[JsonSerializable(typeof(IncidentSnapshot))]
+internal partial class TestJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// GH-4230. The three trim-sensitive operations, exercised against both a reflection-based serializer
+/// and a source-generated one — an application on either footing has to get identical behaviour, or the
+/// AOT path is a different feature wearing the same API.
+/// </summary>
+public class response_binding
+{
+    private static LlmCalloutOptions reflectionBased() => new();
+
+    private static LlmCalloutOptions sourceGenerated()
+    {
+        var options = new LlmCalloutOptions
+        {
+            JsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                TypeInfoResolver = TestJsonContext.Default
+            }
+        };
+
+        options.RegisterResponseType<IncidentTriage>();
+
+        return options;
+    }
+
+    public static TheoryData<string, LlmCalloutOptions> Both => new()
+    {
+        { "reflection", reflectionBased() },
+        { "source-generated", sourceGenerated() }
+    };
+
+    [Theory]
+    [MemberData(nameof(Both))]
+    public void builds_a_schema_carrying_the_response_type_properties(string _, LlmCalloutOptions options)
+    {
+        var schema = new LlmResponseBinder(options).SchemaFor(typeof(IncidentTriage)).ToString();
+
+        // Asserting on the contents, not merely that the call returned: CreateJsonSchema answers an
+        // empty schema rather than throwing when the type info resolver cannot see the type, which
+        // would hand the model a constraint that constrains nothing.
+        schema.ShouldContain("severity");
+        schema.ShouldContain("recommendedAction");
+    }
+
+    [Theory]
+    [MemberData(nameof(Both))]
+    public void reads_an_answer_back_into_the_response_type(string _, LlmCalloutOptions options)
+    {
+        var answer = """{"severity":"high","recommendedAction":"page the on-call"}""";
+
+        var value = new LlmResponseBinder(options).Deserialize(answer, typeof(IncidentTriage));
+
+        value.ShouldBeOfType<IncidentTriage>().Severity.ShouldBe("high");
+    }
+
+    [Fact]
+    public void a_registered_response_type_resolves_without_reflection()
+    {
+        var options = sourceGenerated();
+        var identifier = LlmCallout.Ask<IncidentTriage>("triage").ResponseType!;
+
+        new LlmResponseBinder(options).TryResolveRegisteredType(identifier, out var type).ShouldBeTrue();
+        type.ShouldBe(typeof(IncidentTriage));
+    }
+
+    [Fact]
+    public void an_unregistered_response_type_does_not_resolve_through_the_table()
+    {
+        // The trimmed application's failure mode, and it must be a clean miss rather than a throw, so
+        // the executor can fall through to the reflective path an untrimmed application still wants.
+        new LlmResponseBinder(sourceGenerated())
+            .TryResolveRegisteredType(LlmCallout.Ask<IncidentSnapshot>("x").ResponseType!, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WithContext_takes_pre_serialized_json()
+    {
+        LlmCallout.Ask<IncidentTriage>("triage").WithContext("""{"id":"INC-1"}""")
+            .Context.ShouldBe("""{"id":"INC-1"}""");
+    }
+
+    [Fact]
+    public void WithContext_serializes_through_source_generated_type_info()
+    {
+        var callout = LlmCallout.Ask<IncidentTriage>("triage")
+            .WithContext(new IncidentSnapshot("INC-1", "on fire", 12), TestJsonContext.Default.IncidentSnapshot);
+
+        callout.Context.ShouldNotBeNull();
+        callout.Context.ShouldContain("INC-1");
+
+        // Same shape as the reflective overload produces, so moving an application onto the AOT path
+        // does not silently change what the model is shown.
+        var reflective = LlmCallout.Ask<IncidentTriage>("triage", new IncidentSnapshot("INC-1", "on fire", 12));
+        callout.Context.ShouldBe(reflective.Context);
+    }
+}

--- a/src/Extensions/Wolverine.AI/Internals/LlmCalloutExecutor.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmCalloutExecutor.cs
@@ -18,12 +18,6 @@ public interface ILlmCalloutExecutor
     Task<object> ExecuteAsync(LlmCallout callout, CancellationToken cancellationToken);
 }
 
-// The whole class is reflection over a Type carried as a string on the message, which is the reason
-// WolverineFx.AI is not marked IsAotCompatible. Suppressions here would claim a guarantee the design
-// cannot make; making it trim clean needs source generated schemas and a JsonSerializerContext keyed
-// off the registered response types. See the csproj comment and GH-4227.
-[RequiresUnreferencedCode("Builds a JSON schema and deserializes an answer for a response type named on the message at runtime")]
-[RequiresDynamicCode("Builds a JSON schema and deserializes an answer for a response type named on the message at runtime")]
 internal class LlmCalloutExecutor : ILlmCalloutExecutor
 {
     private readonly IChatClient _client;
@@ -31,11 +25,8 @@ internal class LlmCalloutExecutor : ILlmCalloutExecutor
     private readonly ILlmBudgetLedger _ledger;
     private readonly ILogger<LlmCalloutExecutor> _logger;
     private readonly IWolverineRuntime _runtime;
+    private readonly LlmResponseBinder _binder;
 
-    // Schema construction walks the response type's properties, which is meaningfully more expensive
-    // than the rest of the per callout work. ImHashMap per the repo's hot path convention: lock free,
-    // non-allocating reads, copy on write.
-    private ImHashMap<Type, JsonElement> _schemas = ImHashMap<Type, JsonElement>.Empty;
     private ImHashMap<string, Type> _responseTypes = ImHashMap<string, Type>.Empty;
 
     private const string chatModelUnknown = "(unspecified)";
@@ -48,6 +39,7 @@ internal class LlmCalloutExecutor : ILlmCalloutExecutor
         _ledger = ledger;
         _logger = logger;
         _runtime = runtime;
+        _binder = new LlmResponseBinder(options);
     }
 
     public async Task<object> ExecuteAsync(LlmCallout callout, CancellationToken cancellationToken)
@@ -65,7 +57,7 @@ internal class LlmCalloutExecutor : ILlmCalloutExecutor
         if (responseType != null)
         {
             chatOptions.ResponseFormat = ChatResponseFormat.ForJsonSchema(
-                SchemaFor(responseType),
+                _binder.SchemaFor(responseType),
                 schemaName: responseType.Name,
                 schemaDescription: $"The structured answer expected for a {callout.Tag ?? "Wolverine"} LLM callout");
         }
@@ -113,12 +105,27 @@ internal class LlmCalloutExecutor : ILlmCalloutExecutor
 
         try
         {
-            return JsonSerializer.Deserialize(text, responseType, _options.JsonSerializerOptions)
+            // JsonSerializer.Deserialize(string, Type, JsonSerializerOptions) carries
+            // [RequiresUnreferencedCode] / [RequiresDynamicCode]; the JsonTypeInfo overload does not.
+            // Resolving the JsonTypeInfo out of the options is what lets an AOT application supply a
+            // source generated JsonSerializerContext and have this whole path be trim clean, while a
+            // reflection-based application sees no difference at all. See GH-4230.
+            return _binder.Deserialize(text, responseType)
                    ?? throw new LlmCalloutException(
                        $"The model returned a JSON null for {callout}, which expects {responseType.FullNameInCode()}")
                    {
                        RawResponse = text
                    };
+        }
+        catch (NotSupportedException e)
+        {
+            throw new LlmCalloutException(
+                $"No JSON type information is available for {responseType.FullNameInCode()}, the response type of " +
+                $"{callout}. In a trimmed or AOT application, add it to a JsonSerializerContext and assign that " +
+                "context to LlmCalloutOptions.JsonSerializerOptions.TypeInfoResolver.", e)
+            {
+                RawResponse = text
+            };
         }
         catch (JsonException e)
         {
@@ -148,16 +155,6 @@ internal class LlmCalloutExecutor : ILlmCalloutExecutor
             usage.OutputTokenCount, total);
     }
 
-    private JsonElement SchemaFor(Type responseType)
-    {
-        if (_schemas.TryFind(responseType, out var schema)) return schema;
-
-        schema = AIJsonUtilities.CreateJsonSchema(responseType, serializerOptions: _options.JsonSerializerOptions);
-        _schemas = _schemas.AddOrUpdate(responseType, schema);
-
-        return schema;
-    }
-
     /// <summary>
     /// Turn the identifier written by <see cref="LlmCallout.IdentifierFor" /> back into a
     /// <see cref="Type" />. Wolverine's message type registry first, so a response type carrying
@@ -168,25 +165,38 @@ internal class LlmCalloutExecutor : ILlmCalloutExecutor
     {
         if (_responseTypes.TryFind(identifier, out var cached)) return cached;
 
-        Type? resolved = null;
-
-        if (_runtime.Options.HandlerGraph.TryFindMessageType(identifier, out var registered))
+        // Explicit registrations first, and they are the only step a trimmed or AOT application can
+        // rely on: the two below both need metadata the trimmer cannot see from any static call site.
+        if (!_binder.TryResolveRegisteredType(identifier, out var resolved))
         {
-            resolved = registered;
+            resolved = _runtime.Options.HandlerGraph.TryFindMessageType(identifier, out var registered)
+                ? registered
+                : ResolveReflectively(identifier);
         }
-
-        resolved ??= Type.GetType(identifier, throwOnError: false);
 
         if (resolved == null)
         {
             throw new LlmCalloutException(
-                $"Cannot resolve the response type '{identifier}' for an LLM callout. The type has most likely " +
-                "been renamed, moved to a different assembly, or removed since this callout was persisted. " +
-                "Use [MessageIdentity] on response types that need to survive being renamed.");
+                $"Cannot resolve the response type '{identifier}' for an LLM callout. Either the type has been " +
+                "renamed, moved to a different assembly, or removed since this callout was persisted, or this is " +
+                "a trimmed application that has not registered it. Register response types with " +
+                "ai.RegisterResponseType<T>(), and use [MessageIdentity] on ones that need to survive a rename.");
         }
 
         _responseTypes = _responseTypes.AddOrUpdate(identifier, resolved);
 
         return resolved;
+    }
+
+    /// <summary>
+    /// Last resort for a callout whose response type was never registered. Kept deliberately narrow so
+    /// that the registered path above stays trim clean and the AOT smoke gate has something honest to
+    /// prove; an application that registers its response types never reaches this.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2057",
+        Justification = "Reflective fallback for a response type the application did not register. Trimmed and AOT applications must call ai.RegisterResponseType<T>(), which is consulted first and needs no reflection; a type trimmed away here simply fails to resolve and the callout is dead lettered with an actionable message. See the AOT guide and GH-4230.")]
+    private static Type? ResolveReflectively(string identifier)
+    {
+        return Type.GetType(identifier, throwOnError: false);
     }
 }

--- a/src/Extensions/Wolverine.AI/Internals/LlmResponseBinder.cs
+++ b/src/Extensions/Wolverine.AI/Internals/LlmResponseBinder.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using ImTools;
+using Microsoft.Extensions.AI;
+
+namespace Wolverine.AI.Internals;
+
+/// <summary>
+/// Everything a callout does with its response <see cref="Type" />: find it from the identifier the
+/// message carries, build the JSON schema handed to the model, and read the model's answer back.
+/// </summary>
+/// <remarks>
+/// Split out of <see cref="LlmCalloutExecutor" /> so that the three trim-sensitive operations sit in one
+/// place with no <c>IWolverineRuntime</c> dependency — which is what lets Wolverine.AI.AotSmoke exercise
+/// the real production code under trim analysis rather than a reimplementation of it. The executor keeps
+/// only the fallbacks that need the runtime, and those are the ones a trimmed application must not
+/// depend on. See GH-4230.
+/// </remarks>
+public sealed class LlmResponseBinder
+{
+    private readonly LlmCalloutOptions _options;
+
+    // Schema construction walks the response type's properties, which is meaningfully more expensive
+    // than the rest of the per callout work. ImHashMap per the repo's hot path convention: lock free,
+    // non-allocating reads, copy on write.
+    private ImHashMap<Type, JsonElement> _schemas = ImHashMap<Type, JsonElement>.Empty;
+
+    public LlmResponseBinder(LlmCalloutOptions options)
+    {
+        _options = options;
+    }
+
+    /// <summary>
+    /// Resolve a response type from the identifier a callout carries, using only the types the
+    /// application registered with <see cref="LlmCalloutOptions.RegisterResponseType{TResponse}" />.
+    /// The one resolution step a trimmed or AOT application can rely on, because it is a dictionary
+    /// lookup over types that are statically rooted by the registration call itself.
+    /// </summary>
+    public bool TryResolveRegisteredType(string identifier, out Type responseType)
+    {
+        return _options.RegisteredResponseTypes.TryGetValue(identifier, out responseType!);
+    }
+
+    /// <summary>
+    /// The JSON schema handed to the model as its response format.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AIJsonUtilities.CreateJsonSchema" /> carries no trim annotations because it builds the
+    /// schema from the <c>JsonTypeInfo</c> the serializer options resolve, so a source generated
+    /// <c>JsonSerializerContext</c> makes this reflection free. Note the failure mode when the resolver
+    /// cannot see a type: this returns an empty schema rather than throwing, which is why the AOT smoke
+    /// test asserts on the rendered schema's contents instead of merely on the call succeeding.
+    /// </remarks>
+    public JsonElement SchemaFor(Type responseType)
+    {
+        if (_schemas.TryFind(responseType, out var schema)) return schema;
+
+        schema = AIJsonUtilities.CreateJsonSchema(responseType, serializerOptions: _options.JsonSerializerOptions);
+        _schemas = _schemas.AddOrUpdate(responseType, schema);
+
+        return schema;
+    }
+
+    /// <summary>
+    /// Read the model's answer as <paramref name="responseType" />.
+    /// </summary>
+    /// <remarks>
+    /// Through <c>JsonTypeInfo</c> rather than
+    /// <c>JsonSerializer.Deserialize(string, Type, JsonSerializerOptions)</c>, which is the overload
+    /// carrying <c>[RequiresUnreferencedCode]</c> and <c>[RequiresDynamicCode]</c>.
+    /// </remarks>
+    public object? Deserialize(string text, Type responseType)
+    {
+        return JsonSerializer.Deserialize(text, _options.JsonSerializerOptions.GetTypeInfo(responseType));
+    }
+}

--- a/src/Extensions/Wolverine.AI/LlmCallout.cs
+++ b/src/Extensions/Wolverine.AI/LlmCallout.cs
@@ -1,4 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.AI;
@@ -115,6 +118,14 @@ public sealed class LlmCallout
     /// Ask the model for a structured answer, with <paramref name="context" /> serialized to JSON and
     /// appended underneath the prompt.
     /// </summary>
+    /// <remarks>
+    /// Serializing an arbitrary object needs reflection over its shape, which is why this overload is
+    /// annotated. In a trimmed or AOT application use <see cref="Ask{TResponse}(string)" /> and then
+    /// <see cref="WithContext{TContext}(TContext, JsonTypeInfo{TContext})" />, which serializes through
+    /// source generated type info instead.
+    /// </remarks>
+    [RequiresUnreferencedCode("Serializes an arbitrary context object. Use WithContext(context, typeInfo) in trimmed applications.")]
+    [RequiresDynamicCode("Serializes an arbitrary context object. Use WithContext(context, typeInfo) in trimmed applications.")]
     public static LlmCallout Ask<TResponse>(string prompt, object context)
     {
         return new LlmCallout
@@ -137,6 +148,12 @@ public sealed class LlmCallout
     /// Ask the model for a plain text answer, with <paramref name="context" /> serialized to JSON and
     /// appended underneath the prompt. Published as an <see cref="LlmTextResponse" />.
     /// </summary>
+    /// <remarks>
+    /// See <see cref="Ask{TResponse}(string, object)" /> for why this overload is annotated and what a
+    /// trimmed application uses instead.
+    /// </remarks>
+    [RequiresUnreferencedCode("Serializes an arbitrary context object. Use WithContext(context, typeInfo) in trimmed applications.")]
+    [RequiresDynamicCode("Serializes an arbitrary context object. Use WithContext(context, typeInfo) in trimmed applications.")]
     public static LlmCallout Ask(string prompt, object context)
     {
         return new LlmCallout { Prompt = prompt, Context = Serialize(context) };
@@ -149,6 +166,28 @@ public sealed class LlmCallout
     public bool ExpectsResponse<TResponse>()
     {
         return ResponseType == IdentifierFor(typeof(TResponse));
+    }
+
+    /// <summary>
+    /// Attach context that is already JSON, appended underneath the prompt. The trim clean way to give a
+    /// callout context, and the escape hatch when the context is not a CLR object at all — a rendered
+    /// document, a retrieved passage, a diff.
+    /// </summary>
+    public LlmCallout WithContext(string json)
+    {
+        Context = json;
+        return this;
+    }
+
+    /// <summary>
+    /// Attach context serialized through source generated type info, so the whole callout stays trim and
+    /// AOT clean:
+    /// <c>LlmCallout.Ask&lt;IncidentTriage&gt;(prompt).WithContext(snapshot, MyAiContext.Default.IncidentSnapshot)</c>.
+    /// </summary>
+    public LlmCallout WithContext<TContext>(TContext context, JsonTypeInfo<TContext> typeInfo)
+    {
+        Context = JsonSerializer.Serialize(context, typeInfo);
+        return this;
     }
 
     /// <summary>
@@ -231,8 +270,24 @@ public sealed class LlmCallout
         return $"{responseType.FullName}, {responseType.Assembly.GetName().Name}";
     }
 
+    /// <summary>
+    /// Options for rendering a context object into a prompt. Microsoft.Extensions.AI's own
+    /// <see cref="AIJsonUtilities.DefaultOptions" /> matches these except that it sets
+    /// <c>WriteIndented</c>, and indentation in a prompt is billed input tokens buying nothing — it also
+    /// inflates every character against <see cref="LlmBudget.MaximumPromptCharacters" />. The naming
+    /// policy and null handling are kept identical so that what the model is shown does not otherwise
+    /// change.
+    /// </summary>
+    private static readonly JsonSerializerOptions _contextSerialization = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    [RequiresUnreferencedCode("Serializes an arbitrary context object")]
+    [RequiresDynamicCode("Serializes an arbitrary context object")]
     private static string Serialize(object context)
     {
-        return JsonSerializer.Serialize(context, context.GetType(), AIJsonUtilities.DefaultOptions);
+        return JsonSerializer.Serialize(context, context.GetType(), _contextSerialization);
     }
 }

--- a/src/Extensions/Wolverine.AI/LlmCalloutOptions.cs
+++ b/src/Extensions/Wolverine.AI/LlmCalloutOptions.cs
@@ -70,8 +70,39 @@ public class LlmCalloutOptions
     /// Serializer options used both to build the JSON schema handed to the model and to deserialize its
     /// answer. Defaults to <see cref="AIJsonUtilities.DefaultOptions" />, which is what the rest of
     /// Microsoft.Extensions.AI uses.
+    ///
+    /// <para>
+    /// A trimmed or AOT application assigns options whose <c>TypeInfoResolver</c> is a source generated
+    /// <c>JsonSerializerContext</c> over its response types. Both the schema generation and the
+    /// deserialization run off that resolver, so neither needs reflection. See the AOT guide.
+    /// </para>
     /// </summary>
     public JsonSerializerOptions JsonSerializerOptions { get; set; } = AIJsonUtilities.DefaultOptions;
+
+    /// <summary>
+    /// Response types registered by <see cref="RegisterResponseType{TResponse}" />, keyed by the
+    /// identifier a callout carries on the wire.
+    /// </summary>
+    public IReadOnlyDictionary<string, Type> RegisteredResponseTypes => _registeredResponseTypes;
+
+    private readonly Dictionary<string, Type> _registeredResponseTypes = new();
+
+    /// <summary>
+    /// Declare a response type up front, so the executor can turn a persisted callout's identifier back
+    /// into a <see cref="Type" /> without reflection.
+    ///
+    /// <para>
+    /// Optional for an ordinary application — the executor falls back to the message type registry and
+    /// then to <see cref="Type.GetType(string)" />. <b>Required</b> for a trimmed or AOT one, where
+    /// neither fallback can be trusted: register every response type here, and put those same types in
+    /// the <c>JsonSerializerContext</c> assigned to <see cref="JsonSerializerOptions" />.
+    /// </para>
+    /// </summary>
+    public LlmCalloutOptions RegisterResponseType<TResponse>()
+    {
+        _registeredResponseTypes[LlmCallout.IdentifierFor(typeof(TResponse))] = typeof(TResponse);
+        return this;
+    }
 
     /// <summary>
     /// Claim each callout's <see cref="LlmCallout.DeduplicationId" /> before executing it, so a callout

--- a/src/Extensions/Wolverine.AI/Wolverine.AI.csproj
+++ b/src/Extensions/Wolverine.AI/Wolverine.AI.csproj
@@ -9,15 +9,23 @@
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
         <!--
-          NOT AOT-compatible. The callout message carries its response type as a
-          string (see LlmCallout.ResponseType), which the executor resolves back to
-          a Type and then feeds to AIJsonUtilities.CreateJsonSchema + JsonSerializer.
-          Both of those are reflection over a type the trimmer cannot see from any
-          static call site. Making this trim-clean needs a source-generated schema +
-          JsonSerializerContext keyed off the registered response types, which is
-          follow-on work rather than a suppression.
+          AOT-compatible as of GH-4230, on one condition the AOT guide spells out:
+          the application registers its response types with ai.RegisterResponseType()
+          and assigns LlmCalloutOptions.JsonSerializerOptions a source-generated
+          JsonSerializerContext over those same types.
+
+          Neither of the two things the executor does with a response type needs
+          reflection once that holds. AIJsonUtilities.CreateJsonSchema(Type, ...) carries
+          no trim annotations at all, because it builds the schema from the JsonTypeInfo
+          the options resolve, and deserialization goes through the JsonTypeInfo overload
+          rather than JsonSerializer.Deserialize(string, Type, options), which is the one
+          that is annotated. Proven by Wolverine.AI.AotSmoke, which is analyzer-gated
+          under TrimMode=full and run in CIAotSmoke.
+
+          The single reflective site left is the Type.GetType fallback for a response
+          type the application never registered, suppressed narrowly at its call site.
         -->
-        <IsAotCompatible>false</IsAotCompatible>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Testing/Wolverine.AI.AotSmoke/Program.cs
+++ b/src/Testing/Wolverine.AI.AotSmoke/Program.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Wolverine.AI;
+using Wolverine.AI.Internals;
+
+namespace Wolverine.AI.AotSmoke;
+
+public record IncidentSnapshot(string IncidentId, string Summary, int MinutesOpen);
+
+public record IncidentTriage(string Severity, string RecommendedAction, int ConfidencePercent);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(IncidentTriage))]
+[JsonSerializable(typeof(IncidentSnapshot))]
+internal partial class SmokeJsonContext : JsonSerializerContext;
+
+public static class Program
+{
+    public static int Main()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            TypeInfoResolver = SmokeJsonContext.Default
+        };
+
+        var ai = new LlmCalloutOptions { JsonSerializerOptions = options };
+        ai.RegisterResponseType<IncidentTriage>();
+
+        // The real production type, not a reimplementation of it: LlmCalloutExecutor delegates every
+        // trim-sensitive step to this, and cannot itself be constructed here because it needs an
+        // IWolverineRuntime, whose bootstrapping is not AOT-clean on its own account.
+        var binder = new LlmResponseBinder(ai);
+
+        // Authoring a callout: the trim-clean context overload, serializing through source
+        // generated type info rather than through reflection over the object's shape.
+        var callout = LlmCallout.Ask<IncidentTriage>("Classify this incident.")
+            .WithContext(new IncidentSnapshot("INC-1", "database is on fire", 12),
+                SmokeJsonContext.Default.IncidentSnapshot)
+            .Tagged("triage");
+
+        if (!callout.ExpectsResponse<IncidentTriage>()) return Fail("the callout lost its response type");
+        if (callout.Context is null || !callout.Context.Contains("INC-1")) return Fail("the context did not serialize");
+
+        // Resolution: identifier off the wire back to a Type, through the registration table.
+        if (!binder.TryResolveRegisteredType(callout.ResponseType!, out var responseType))
+        {
+            return Fail($"'{callout.ResponseType}' did not resolve through the registration table");
+        }
+
+        // Schema generation from that Type, off the source generated type info.
+        var rendered = binder.SchemaFor(responseType).ToString();
+        Console.WriteLine($"schema: {rendered}");
+
+        // An empty schema is how this fails when the resolver cannot see the type: the call
+        // succeeds and returns {} rather than throwing, and the model is then handed a
+        // constraint that constrains nothing. Assert on a property name it must contain.
+        if (!rendered.Contains("recommendedAction"))
+        {
+            return Fail("the generated schema is missing the response type's properties");
+        }
+
+        // Deserialization into that same runtime Type, through the JsonTypeInfo overload.
+        const string answer = """{"severity":"high","recommendedAction":"page the on-call","confidencePercent":92}""";
+        var value = binder.Deserialize(answer, responseType);
+
+        if (value is not IncidentTriage { Severity: "high", ConfidencePercent: 92 })
+        {
+            return Fail($"the answer deserialized to '{value}'");
+        }
+
+        Console.WriteLine("Wolverine.AI AOT smoke test passed");
+        return 0;
+    }
+
+    private static int Fail(string message)
+    {
+        Console.Error.WriteLine($"Wolverine.AI AOT smoke test FAILED: {message}");
+        return 1;
+    }
+}

--- a/src/Testing/Wolverine.AI.AotSmoke/Wolverine.AI.AotSmoke.csproj
+++ b/src/Testing/Wolverine.AI.AotSmoke/Wolverine.AI.AotSmoke.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+
+        <!--
+        AOT smoke test for WolverineFx.AI (GH-4230), alongside Wolverine.AotSmoke.
+
+        The claim being gated: an application that registers its response types with
+        ai.RegisterResponseType() and assigns a source-generated JsonSerializerContext
+        to LlmCalloutOptions.JsonSerializerOptions gets a fully trim-clean callout path.
+        The executor turns an identifier into a Type through the registration table, then
+        builds the model's response schema and deserializes its answer through the type
+        info that context resolves. No reflection at any step.
+
+        This project exercises exactly that surface with trim analysis on and the IL
+        codes as errors, so the day someone reaches for JsonSerializer.Deserialize(text,
+        Type, options) again, or drops a Type.GetType into the resolution path, the
+        build fails here rather than in a consumer's AOT publish.
+
+        Program.cs also RUNS in CIAotSmoke, so a schema that generates as an empty
+        object, which is how this fails when the type info resolver cannot see a type,
+        is caught too. A build-only gate would miss that.
+
+        Surfaces NOT exercised here, on purpose:
+          - LlmCallout.Ask(prompt, context), which serializes an arbitrary object and is
+            annotated. The trim-clean equivalent is WithContext(context, typeInfo), and
+            that is what this project uses.
+          - Handler discovery and runtime codegen, which are Wolverine.AotSmoke.Static's
+            problem rather than this one's.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
+        <TrimMode>full</TrimMode>
+        <WarningsAsErrors>IL2026;IL2046;IL2055;IL2057;IL2065;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL2111;IL3050;IL3051</WarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Extensions\Wolverine.AI\Wolverine.AI.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/wolverine.slnx
+++ b/wolverine.slnx
@@ -273,6 +273,7 @@
     <Project Path="src/Testing/BackPressureTests/BackPressureTests.csproj" />
     <Project Path="src/Testing/ConsoleApp/ConsoleApp.csproj" />
     <Project Path="src/Testing/CoreTests/CoreTests.csproj" />
+    <Project Path="src/Testing/Wolverine.AI.AotSmoke/Wolverine.AI.AotSmoke.csproj" />
     <Project Path="src/Testing/Wolverine.AotSmoke/Wolverine.AotSmoke.csproj" />
     <Project Path="src/Testing/Wolverine.AotSmoke.Static/Wolverine.AotSmoke.Static.csproj" />
     <Project Path="src/Testing/MessageRoutingTests/MessageRoutingTests.csproj" />


### PR DESCRIPTION
Closes #4230. Follow-on to #4231.

`WolverineFx.AI` now sets `IsAotCompatible`, on one condition the AOT guide spells out: the application registers its response types and gives the callout options a source-generated `JsonSerializerContext` covering them.

```csharp
[JsonSerializable(typeof(IncidentTriage))]
internal partial class AiJsonContext : JsonSerializerContext;

opts.AddLlmCallouts(ai =>
{
    ai.JsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
    {
        TypeInfoResolver = AiJsonContext.Default
    };

    ai.RegisterResponseType<IncidentTriage>();
});
```

## The issue's premise was wrong

I wrote #4230 assuming this needed source-generated schemas. It does not. `AIJsonUtilities.CreateJsonSchema(Type, ...)` carries **no** trim or AOT annotations — it builds the schema from whatever `JsonTypeInfo` the supplied serializer options resolve, so options backed by an ordinary source-generated context already make schema generation reflection-free. Nothing for Wolverine to emit, and no generator to build.

Verified under a real native AOT publish (`TrimMode=full`, IL codes as errors) rather than inferred from an absent attribute — the schema generates correctly from a `Type` pulled out of a dictionary at runtime, camelCase property names and `required` intact.

Three narrower things were the actual blockers:

1. **`JsonSerializer.Deserialize(string, Type, JsonSerializerOptions)` is the annotated overload**; the `JsonTypeInfo` one is not. Deserialization now resolves `options.GetTypeInfo(responseType)` and goes through that.
2. **`Type.GetType(string)`** resolved the response type from the identifier a callout carries. Applications now declare types up front with `ai.RegisterResponseType<T>()`, consulted before the message type registry and before the reflective fallback — which is suppressed narrowly at its own call site rather than by annotating the whole executor, so the registered path is genuinely clean rather than merely claimed to be.
3. **`LlmCallout.Ask(prompt, context)` serializes an arbitrary object** — a site the issue never mentioned, because it is on the authoring path rather than the execution path. The analyzer found it the moment `IsAotCompatible` flipped. A static factory cannot reach the application's `JsonSerializerContext`, so this one keeps its annotation and gains a trim-clean sibling:

```csharp
// warns IL2026 / IL3050 under trim analysis
LlmCallout.Ask<IncidentTriage>(prompt, incident.Snapshot());

// trim-clean
LlmCallout.Ask<IncidentTriage>(prompt)
    .WithContext(incident.Snapshot(), AiJsonContext.Default.IncidentSnapshot);
```

`WithContext(string)` takes JSON you produced yourself, which also covers context that was never a CLR object — a rendered document, a retrieved passage, a diff.

## The gate is shaped by a silent failure mode

A `JsonSerializerContext` that does not cover a response type **does not throw**. `CreateJsonSchema` returns an *empty* schema, the model is handed a constraint that constrains nothing, it usually still answers, and the answer usually still parses. It reads as a model-quality regression rather than a configuration error.

So the new `Wolverine.AI.AotSmoke` is **run** in `CIAotSmoke`, not merely built, and asserts on the rendered schema's contents — a build-only check would sail straight past the exact regression it exists to catch. The three trim-sensitive operations moved into `LlmResponseBinder`, which has no `IWolverineRuntime` dependency, specifically so the smoke project exercises the real production code that `LlmCalloutExecutor` delegates to rather than a reimplementation of it.

I confirmed the gate is load-bearing by reintroducing a reflective call and watching the build fail with the annotation's own message naming the replacement.

## A bug fell out of the work

`AIJsonUtilities.DefaultOptions` sets `WriteIndented`, so every callout carrying context was pretty-printing that context into its prompt. Indentation in a prompt is billed input tokens buying nothing, and it inflated every character counted against `LlmBudget.MaximumPromptCharacters`. Context is now serialized compactly; the naming policy and null handling are unchanged, so what the model is shown is otherwise identical. `response_binding.cs` asserts the reflective and source-generated paths produce byte-identical output, so moving an application onto the AOT path cannot silently change the prompt.

## On the source generator

It is now an **ergonomics** question rather than a correctness one — all it would remove is two lines per response type, in applications that are already hand-writing `JsonSerializerContext`s for everything else they serialize. My recommendation is to leave it unbuilt and revisit alongside #4226, where tool schemas pose a genuinely harder version of the same problem. Reasoning is [on the issue](https://github.com/JasperFx/wolverine/issues/4230#issuecomment-5499858694).

## Notes for review

- **The prose is a draft**, same as #4231: the new "Trimming and AOT" section in `docs/guide/ai.md`, the `Wolverine.AI.AotSmoke` additions to `docs/guide/aot.md`, and the CHANGELOG entry are my wording.
- `Wolverine.AI.AotSmoke` adds `IL2057` to the inherited warnings-as-errors list, since `Type.GetType` is one of the things this specifically guards against.

## Verification

- 42 tests in `Wolverine.AI.Tests`, including `response_binding.cs`, which runs the binder against a reflection-based and a source-generated serializer and requires identical behaviour from both.
- `Wolverine.AI.AotSmoke` builds under `TrimMode=full` with the IL codes as errors, and runs green.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings.
- `./build.sh ValidatePackList` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
