### PR TITLE
Concurrent IHost.StopAsync no longer tears the agents down twice

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs
@@ -58,7 +58,7 @@ public class Bug_using_host_stop
     {
         var field = typeof(WolverineRuntime).GetField("_hasStopped",
             BindingFlags.NonPublic | BindingFlags.Instance);
-        return (bool?)field?.GetValue(runtime) == false;
+        return (int?)field?.GetValue(runtime) == 0;
     }
 
     private static async Task<IHost> CreateHostAsync(HostType hostType) =>

--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs
@@ -56,9 +56,10 @@ public class Bug_using_host_stop
 
     static bool IsRunning(WolverineRuntime runtime)
     {
-        var field = typeof(WolverineRuntime).GetField("_hasStopped",
+        var field = typeof(WolverineRuntime).GetField("_stopped",
             BindingFlags.NonPublic | BindingFlags.Instance);
-        return (int?)field?.GetValue(runtime) == 0;
+        field.ShouldNotBeNull("WolverineRuntime._stopped was renamed; this probe needs updating");
+        return field.GetValue(runtime) is null;
     }
 
     private static async Task<IHost> CreateHostAsync(HostType hostType) =>

--- a/src/Persistence/PostgresqlTests/Bugs/Bug_concurrent_stop_tears_agents_down_twice.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_concurrent_stop_tears_agents_down_twice.cs
@@ -1,19 +1,22 @@
 using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using NSubstitute;
 using Shouldly;
 using Wolverine;
 using Wolverine.Postgresql;
-using Wolverine.Tracking;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
 using Xunit;
 
 namespace PostgresqlTests.Bugs;
 
 /// <summary>
-/// WolverineRuntime.StopAsync guards itself with a "have I already stopped" latch, but it used to set
-/// that latch only AFTER awaiting the agent cancellation. Both IHostedService.StopAsync and
-/// IAsyncDisposable.DisposeAsync route into it, so two callers could each read the latch as unset, pass
-/// the guard, and then run the entire shutdown -- including teardownAgentsAsync -- concurrently. That
-/// method clears every field it disposes, so the second pass saw its own
+/// WolverineRuntime.StopAsync guards itself against running twice, but it used to read that guard,
+/// await the agent cancellation, and only then set it. Both IHostedService.StopAsync and
+/// IAsyncDisposable.DisposeAsync route into it, so two callers could each see "not stopped", pass the
+/// guard, and run the entire shutdown concurrently. teardownAgentsAsync is not written for that: it
+/// clears every field it disposes, so the second pass saw its own
 /// <c>NodeController?.DeferredWork != null</c> check pass and then dereferenced a field the first pass
 /// had already cleared, throwing NullReferenceException out of IHost.StopAsync:
 ///
@@ -31,25 +34,37 @@ namespace PostgresqlTests.Bugs;
 public class Bug_concurrent_stop_tears_agents_down_twice : PostgresqlContext
 {
     [Fact]
-    public async Task second_caller_is_latched_out_before_the_first_yields()
+    public async Task two_concurrent_callers_only_tear_the_node_down_once()
     {
-        using var host = await Host.CreateDefaultBuilder()
+        using var host = Host.CreateDefaultBuilder()
             .UseWolverine(opts =>
             {
                 opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "concurrent_stop");
                 opts.Durability.Mode = DurabilityMode.Balanced;
-            }).StartAsync(TestContext.Current.CancellationToken);
+            }).Build();
 
-        var runtime = host.GetRuntime();
+        // NodeAgentController.StopAsync is the tail of the agent teardown and is not itself guarded: it
+        // deletes this node's row and reports NodeStopped() every time it runs, so the call count is a
+        // direct count of teardown passes. The controller captures runtime.Observer in its constructor,
+        // which happens during StartAsync, so this has to be swapped in before the host starts.
+        var runtime = (WolverineRuntime)host.Services.GetRequiredService<IWolverineRuntime>();
+        var observer = Substitute.For<IWolverineObserver>();
+        runtime.Observer = observer;
 
-        // Both calls start on this thread, so the second one can only get past the guard if the first
-        // one yielded before latching it.
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        // Both calls start on this thread, so the second one can only run a shutdown of its own if the
+        // first yielded before claiming it.
         var first = runtime.StopAsync(CancellationToken.None);
         var second = runtime.StopAsync(CancellationToken.None);
 
-        second.IsCompletedSuccessfully.ShouldBeTrue(
-            "the second caller has to be latched out, or it runs the agent teardown concurrently with the first");
-
         await Task.WhenAll(first, second);
+
+        await observer.Received(1).NodeStopped();
+
+        // And the claim is joinable rather than skippable, which is what keeps
+        // IAsyncDisposable.DisposeAsync from disposing endpoints and transports out from under a
+        // shutdown that is still running: every later caller gets the one shutdown, finished.
+        runtime.StopAsync(CancellationToken.None).IsCompletedSuccessfully.ShouldBeTrue();
     }
 }

--- a/src/Persistence/PostgresqlTests/Bugs/Bug_concurrent_stop_tears_agents_down_twice.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_concurrent_stop_tears_agents_down_twice.cs
@@ -1,0 +1,55 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PostgresqlTests.Bugs;
+
+/// <summary>
+/// WolverineRuntime.StopAsync guards itself with a "have I already stopped" latch, but it used to set
+/// that latch only AFTER awaiting the agent cancellation. Both IHostedService.StopAsync and
+/// IAsyncDisposable.DisposeAsync route into it, so two callers could each read the latch as unset, pass
+/// the guard, and then run the entire shutdown -- including teardownAgentsAsync -- concurrently. That
+/// method clears every field it disposes, so the second pass saw its own
+/// <c>NodeController?.DeferredWork != null</c> check pass and then dereferenced a field the first pass
+/// had already cleared, throwing NullReferenceException out of IHost.StopAsync:
+///
+/// <code>
+/// System.NullReferenceException : Object reference not set to an instance of an object.
+///    at Wolverine.Runtime.WolverineRuntime.teardownAgentsAsync() in WolverineRuntime.Agents.cs:line 436
+///    at Wolverine.Runtime.WolverineRuntime.StopAsync(CancellationToken cancellationToken)
+///    at Microsoft.Extensions.Hosting.Internal.Host.StopAsync(CancellationToken cancellationToken)
+/// </code>
+///
+/// A Balanced node is what makes this reachable: only Balanced builds the DeferredWork runner, and only
+/// Balanced puts a linked token source on the agent cancellation, which is what makes CancelAsync()
+/// genuinely yield and open the window. Hence a real message store here rather than CoreTests.
+/// </summary>
+public class Bug_concurrent_stop_tears_agents_down_twice : PostgresqlContext
+{
+    [Fact]
+    public async Task second_caller_is_latched_out_before_the_first_yields()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "concurrent_stop");
+                opts.Durability.Mode = DurabilityMode.Balanced;
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.GetRuntime();
+
+        // Both calls start on this thread, so the second one can only get past the guard if the first
+        // one yielded before latching it.
+        var first = runtime.StopAsync(CancellationToken.None);
+        var second = runtime.StopAsync(CancellationToken.None);
+
+        second.IsCompletedSuccessfully.ShouldBeTrue(
+            "the second caller has to be latched out, or it runs the agent teardown concurrently with the first");
+
+        await Task.WhenAll(first, second);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -160,7 +160,19 @@ public partial class NodeAgentController
 
     // GH-3748: background executor for remotely-received batched agent commands, created by
     // WolverineRuntime for Balanced-mode nodes. See DeferredAgentCommandRunner.
-    internal DeferredAgentCommandRunner? DeferredWork { get; set; }
+    private DeferredAgentCommandRunner? _deferredWork;
+
+    internal DeferredAgentCommandRunner? DeferredWork
+    {
+        get => _deferredWork;
+        set => _deferredWork = value;
+    }
+
+    /// <summary>
+    ///     Claim the deferred command runner for disposal, so that only one of two racing teardown
+    ///     passes owns it and the loser gets null rather than a field cleared out from under it.
+    /// </summary>
+    internal DeferredAgentCommandRunner? TakeDeferredWork() => Interlocked.Exchange(ref _deferredWork, null);
 
     // GH-3748: the serial control lane used to guarantee that a stop command arriving after a batch of
     // starts also EXECUTED after those starts. With batch execution deferred off the lane, that ordering

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -421,27 +421,34 @@ public partial class WolverineRuntime : IAgentRuntime
         _heartbeatLoop?.SafeDispose();
         _healthCheckLoop?.SafeDispose();
 
-        if (_dispatcher != null)
+        // Take each of these once. Re-reading a field after its own null check is what made a
+        // redundant teardown pass throw NullReferenceException instead of no-opping: this method
+        // clears every field it disposes, so the second reader saw the check pass and the
+        // dereference fail. StopAsync latches earlier now, and this no longer depends on it.
+        var dispatcher = Interlocked.Exchange(ref _dispatcher, null);
+        if (dispatcher != null)
         {
-            await _dispatcher.DisposeAsync();
-            _dispatcher = null;
+            await dispatcher.DisposeAsync();
         }
 
-        if (NodeController != null) NodeController.PendingDispatches = null;
+        var controller = NodeController;
+        if (controller == null)
+        {
+            return;
+        }
 
-        if (NodeController?.DeferredWork != null)
+        controller.PendingDispatches = null;
+
+        var deferredWork = controller.TakeDeferredWork();
+        if (deferredWork != null)
         {
             // Safe to await: _agentCancellation is cancelled before teardown, so an in-flight batch
             // lets go at its next cancellation check rather than running to completion.
-            await NodeController.DeferredWork.DisposeAsync();
-            NodeController.DeferredWork = null;
+            await deferredWork.DisposeAsync();
         }
 
-        if (NodeController != null)
-        {
-            var bus = new MessageBus(this);
-            await NodeController.StopAsync(bus);
-        }
+        var bus = new MessageBus(this);
+        await controller.StopAsync(bus);
     }
 
     /// <summary>
@@ -454,27 +461,31 @@ public partial class WolverineRuntime : IAgentRuntime
         _heartbeatLoop?.SafeDispose();
         _healthCheckLoop?.SafeDispose();
 
-        if (_dispatcher != null)
+        // Same single-read discipline as teardownAgentsAsync; a test can run this concurrently with
+        // a host shutdown, and this method additionally clears NodeController itself.
+        var dispatcher = Interlocked.Exchange(ref _dispatcher, null);
+        if (dispatcher != null)
         {
-            await _dispatcher.DisposeAsync();
-            _dispatcher = null;
+            await dispatcher.DisposeAsync();
         }
 
-        if (NodeController != null) NodeController.PendingDispatches = null;
-
-        if (NodeController?.DeferredWork != null)
-        {
-            await NodeController.DeferredWork.DisposeAsync();
-            NodeController.DeferredWork = null;
-        }
-
-        if (NodeController != null)
-        {
-            await NodeController.DisableAgentsAsync();
-            await Storage.Nodes.OverwriteHealthCheckTimeAsync(Options.UniqueNodeId, lastHeartbeatTime);
-        }
-
+        var controller = NodeController;
         NodeController = null;
+        if (controller == null)
+        {
+            return;
+        }
+
+        controller.PendingDispatches = null;
+
+        var deferredWork = controller.TakeDeferredWork();
+        if (deferredWork != null)
+        {
+            await deferredWork.DisposeAsync();
+        }
+
+        await controller.DisableAgentsAsync();
+        await Storage.Nodes.OverwriteHealthCheckTimeAsync(Options.UniqueNodeId, lastHeartbeatTime);
     }
 
     public Task<AgentCommands> StartLocalAgentProcessingAsync()

--- a/src/Wolverine/Runtime/WolverineRuntime.Disposal.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Disposal.cs
@@ -6,10 +6,11 @@ public partial class WolverineRuntime : IAsyncDisposable
 {
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        if (Volatile.Read(ref _hasStopped) == 0)
-        {
-            await StopAsync(CancellationToken.None);
-        }
+        // Unconditional, and this is the point of StopAsync being joinable rather than skippable: a
+        // shutdown another caller is still running has to FINISH before the endpoints and transports
+        // below are torn out from under it. StopAsync is single-entry, so this either drives the
+        // shutdown or waits for the one already in flight.
+        await StopAsync(CancellationToken.None);
 
         Replies.Dispose();
 

--- a/src/Wolverine/Runtime/WolverineRuntime.Disposal.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Disposal.cs
@@ -6,7 +6,7 @@ public partial class WolverineRuntime : IAsyncDisposable
 {
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        if (!_hasStopped)
+        if (Volatile.Read(ref _hasStopped) == 0)
         {
             await StopAsync(CancellationToken.None);
         }

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -396,25 +396,61 @@ public partial class WolverineRuntime
 
     public StopMode StopMode { get; set; } = StopMode.Normal;
     
-    public async Task StopAsync(CancellationToken cancellationToken)
+    /// <summary>
+    ///     Shut Wolverine down. Single-entry and joinable: the first caller drives the shutdown and every
+    ///     later caller gets a task that completes when THAT shutdown has finished.
+    /// </summary>
+    /// <remarks>
+    ///     Both IHostedService.StopAsync and IAsyncDisposable.DisposeAsync route in here. The claim has to
+    ///     happen before the first await: this used to read a "have I stopped" flag, await the agent
+    ///     cancellation, and only then set the flag, so two callers could each see "not stopped", pass the
+    ///     guard, and run this whole method concurrently. Nothing below is written for that --
+    ///     teardownAgentsAsync in particular nulls the fields it has just disposed, so the second pass
+    ///     found them cleared and threw NullReferenceException out of IHost.StopAsync instead of quietly
+    ///     no-opping.
+    /// </remarks>
+    public Task StopAsync(CancellationToken cancellationToken)
     {
         if (DynamicCodeBuilder.WithinCodegenCommand)
         {
-            // Don't do anything here
-            return;
+            // Don't do anything here, and leave the runtime unclaimed for a later real shutdown
+            return Task.CompletedTask;
         }
 
-        // Latch BEFORE the first await. IHostedService.StopAsync and IAsyncDisposable.DisposeAsync
-        // both land here, and cancelling the agents first left an await between reading the latch and
-        // setting it: two callers could each see "not stopped" and run this whole method concurrently.
-        // Nothing below is written for that -- teardownAgentsAsync in particular nulls the fields it
-        // has just disposed, so the second pass found them cleared and threw NullReferenceException
-        // out of IHost.StopAsync instead of quietly no-opping.
-        if (Interlocked.Exchange(ref _hasStopped, 1) == 1)
+        var inFlight = Volatile.Read(ref _stopped);
+        if (inFlight != null)
         {
-            return;
+            return inFlight;
         }
 
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        inFlight = Interlocked.CompareExchange(ref _stopped, completion.Task, null);
+        if (inFlight != null)
+        {
+            return inFlight;
+        }
+
+        return runShutdownAsync(completion);
+    }
+
+    private async Task runShutdownAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await shutdownAsync();
+        }
+        finally
+        {
+            // Joiners are waiting to know the shutdown has finished, not to be told a second time about
+            // a failure that was already reported to whoever drove it -- disposal is a joiner, and
+            // turning one failed stop into a failed Dispose() as well helps nobody.
+            completion.TrySetResult();
+        }
+    }
+
+    private async Task shutdownAsync()
+    {
         await _agentCancellation.CancelAsync();
 
         // Latch health checks ASAP

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -398,20 +398,24 @@ public partial class WolverineRuntime
     
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (_hasStopped)
-        {
-            return;
-        }
-
         if (DynamicCodeBuilder.WithinCodegenCommand)
         {
             // Don't do anything here
             return;
         }
 
-        await _agentCancellation.CancelAsync();
+        // Latch BEFORE the first await. IHostedService.StopAsync and IAsyncDisposable.DisposeAsync
+        // both land here, and cancelling the agents first left an await between reading the latch and
+        // setting it: two callers could each see "not stopped" and run this whole method concurrently.
+        // Nothing below is written for that -- teardownAgentsAsync in particular nulls the fields it
+        // has just disposed, so the second pass found them cleared and threw NullReferenceException
+        // out of IHost.StopAsync instead of quietly no-opping.
+        if (Interlocked.Exchange(ref _hasStopped, 1) == 1)
+        {
+            return;
+        }
 
-        _hasStopped = true;
+        await _agentCancellation.CancelAsync();
 
         // Latch health checks ASAP
         DisableHealthChecks();

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -35,9 +35,10 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
 
     private ImHashMap<Type, object?> _extensions = ImHashMap<Type, object?>.Empty;
 
-    // int rather than bool so StopAsync can latch it with Interlocked.Exchange before its first
-    // await; see the comment on StopAsync. 0 = running, 1 = stopping or stopped.
-    private int _hasStopped;
+    // Non-null the moment a shutdown is claimed, and completes when that shutdown has FINISHED.
+    // Doubles as the single-entry latch for StopAsync: whoever wins the CompareExchange drives the
+    // shutdown and everyone else awaits this. See StopAsync and IAsyncDisposable.DisposeAsync.
+    private Task? _stopped;
 
     private readonly Lazy<MessageStoreCollection> _stores;
 

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -34,7 +34,10 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
     private readonly Guid _uniqueNodeId;
 
     private ImHashMap<Type, object?> _extensions = ImHashMap<Type, object?>.Empty;
-    private bool _hasStopped;
+
+    // int rather than bool so StopAsync can latch it with Interlocked.Exchange before its first
+    // await; see the comment on StopAsync. 0 = running, 1 = stopping or stopped.
+    private int _hasStopped;
 
     private readonly Lazy<MessageStoreCollection> _stores;
 


### PR DESCRIPTION
## The bug

`WolverineRuntime.StopAsync` guards itself with a "have I already stopped" flag, but sets that flag only **after** awaiting the agent cancellation:

```csharp
if (_hasStopped) return;
if (DynamicCodeBuilder.WithinCodegenCommand) return;

await _agentCancellation.CancelAsync();   // <- yields here

_hasStopped = true;
```

Both `IHostedService.StopAsync` and `IAsyncDisposable.DisposeAsync` route into this method, so two callers can each read the flag as unset, pass the guard, and then run the entire shutdown concurrently.

`teardownAgentsAsync` is not written for that. It clears every field it disposes, so the second pass sees its own null check pass and then dereferences a field the first pass has already cleared:

```csharp
if (NodeController?.DeferredWork != null)
{
    await NodeController.DeferredWork.DisposeAsync();   // <- Agents.cs:436
    NodeController.DeferredWork = null;                 // <- the other pass clears it here
}
```

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at Wolverine.Runtime.WolverineRuntime.teardownAgentsAsync() in /_/src/Wolverine/Runtime/WolverineRuntime.Agents.cs:line 436
   at Wolverine.Runtime.WolverineRuntime.StopAsync(CancellationToken cancellationToken) in /_/src/Wolverine/Runtime/WolverineRuntime.HostService.cs:line 462
   at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](...)
   at Microsoft.Extensions.Hosting.Internal.Host.StopAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.DisposeAsync()
```

That is a real trace from a downstream CI run — roughly 1 in 80 runs of one integration fixture, thrown out of `WebApplicationFactory.DisposeAsync()` after the test's assertions had already passed. `_dispatcher` a few lines above has the same shape and can fail the same way.

The crash is only the visible half. The quiet half is that the node gets torn down **twice**: `NodeAgentController.StopAsync` is the tail of the teardown and is not itself guarded, so it deletes this node's row and reports `NodeStopped()` once per pass.

Only a **Balanced** node can reach any of this, which is why it shows up under integration tests with a real message store rather than in Solo hosts:

- Balanced is what builds the `DeferredWork` runner (`Agents.cs:281`).
- Balanced is what puts a linked token source on `_agentCancellation`, which is what makes `CancelAsync()` genuinely yield and open the window. A storeless Solo host has no registrations, so `CancelAsync()` returns `Task.CompletedTask` and the window never opens.

The code is unchanged on `main` as of 6.32.0.

## The fix

**1. The shutdown claim becomes a joinable `Task`, taken before the first await.** The caller that wins the `CompareExchange` drives the shutdown; every later caller gets a task that completes when *that* shutdown has finished:

```csharp
var inFlight = Volatile.Read(ref _stopped);
if (inFlight != null) return inFlight;

var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
inFlight = Interlocked.CompareExchange(ref _stopped, completion.Task, null);
if (inFlight != null) return inFlight;

return runShutdownAsync(completion);
```

`IAsyncDisposable.DisposeAsync` then awaits it unconditionally rather than deciding whether to skip, so it can never dispose endpoints and transports out from under a shutdown that is still running. That hazard predates this PR — the old flag was also set near the top of `StopAsync`, long before the endpoint drain, store drain, ownership release and agent teardown — and this is where it gets closed rather than moved. (Raised by the Copilot review; see [the follow-up comment](https://github.com/JasperFx/wolverine/pull/4241#issuecomment-5509073717).)

The joinable task always completes successfully (`TrySetResult` in a `finally`). Joiners want to know the shutdown is over; propagating a stop failure that was already reported to whoever drove it would turn one failed stop into a failed `Dispose()` as well.

`_hasStopped` is gone in favour of `_stopped`, so there is one piece of shutdown state rather than a flag plus a task. The `WithinCodegenCommand` early-out sits above the claim, so that path still leaves the runtime unclaimed for a later real shutdown, exactly as before.

**2. Single-read discipline in the two teardown paths**, so neither depends on (1): `teardownAgentsAsync` and its `DisableAgentsAsync` twin read `NodeController` once into a local, and claim the dispatcher and the deferred runner with `Interlocked.Exchange` (`NodeAgentController.TakeDeferredWork()`) so only one pass owns each and the loser gets `null` rather than a field cleared out from under it.

Collapsing the three `if (NodeController != null)` blocks in each method onto one early return is a straight refactor: all three were guarded on the same condition.

## Regression test

`src/Persistence/PostgresqlTests/Bugs/Bug_concurrent_stop_tears_agents_down_twice.cs`. It starts a Balanced host on Postgres and calls `StopAsync` twice from the same thread — the second call can only run a shutdown of its own if the first yielded before claiming it. Because `NodeAgentController.StopAsync` is unguarded, the observer's `NodeStopped()` count is a direct count of teardown passes:

```csharp
var first = runtime.StopAsync(CancellationToken.None);
var second = runtime.StopAsync(CancellationToken.None);

await Task.WhenAll(first, second);

await observer.Received(1).NodeStopped();
```

The controller captures `runtime.Observer` in its constructor during `StartAsync`, so the substitute is swapped in on a built-but-not-started host.

It lives under `PostgresqlTests` rather than `CoreTests` because it needs a real message store to be a Balanced node at all.

Verified in both directions against the same test, forcing a recompile each way:

- original ordering: **FAIL** — `Expected to receive exactly 1 call matching NodeStopped() … Actually received 2 matching calls`
- with the fix: **PASS** — 1

The `NullReferenceException` itself needs a specific interleaving inside that window, so the test pins the double teardown, which is deterministic.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors.
- `Wolverine.Http.Tests` (net9.0 via `DOTNET_ROLL_FORWARD`) — 1017 passed, 10 skipped. This is the suite that leans hardest on host stop and dispose, and it covers the `Bug_using_host_stop` probe change.
- `PostgresqlTests.LeaderElection` (net10.0) — 15/15. This is what exercises the restructured `DisableAgentsAsync`.
- `PersistenceTests` agents (net10.0) — 10/10.
- `PostgresqlTests` (net10.0, full project) — 539 passed, 1 skipped. The single failure is `Bug_1942_replay_dlq_to_buffered_or_inline.inline_rabbitmq_listener_replay_does_not_loop`, `BrokerUnreachableException` on 127.0.0.1:5672 — I only had the `postgresql` compose service up.
- `CoreTests` (net10.0, full project) — 2752 passed, 2 skipped, 4 failed: `result_types_end_to_end` ×3 and `Bug_2896_mixed_lifetime_enumerable_dependency`, all `Cannot resolve scoped service … from root provider`. Confirmed pre-existing — the same 4 fail identically in a clean worktree at `upstream/main`.

No .NET 9 runtime on this machine, so test runs are net10.0 except the roll-forward one; the net9.0 build gate from `CLAUDE.md` was run as specified.
