### PR TITLE
Bump the Critter Stack dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,21 +41,21 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.8.0" />
-    <PackageVersion Include="JasperFx" Version="2.59.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0" />
+    <PackageVersion Include="JasperFx" Version="2.60.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.60.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.60.0" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.59.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.60.0" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.23.0" />
+    <PackageVersion Include="Marten" Version="9.30.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="5.19.1" />
-    <PackageVersion Include="Fisher" Version="1.0.2" />
+    <PackageVersion Include="Polecat" Version="5.21.1" />
+    <PackageVersion Include="Fisher" Version="1.0.6" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.23.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.23.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.30.0" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.30.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />
@@ -138,13 +138,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.27.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.27.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.27.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.27.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.27.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.27.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.29.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.29.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.29.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.29.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.29.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.29.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.29.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.


### PR DESCRIPTION
Moves the whole Critter Stack family forward in one step.

| package | from | to |
|---|---|---|
| JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator, JasperFx.SourceGenerator | 2.59.0 | 2.60.0 |
| Marten, Marten.AspNetCore, Marten.Newtonsoft | 9.23.0 | 9.30.0 |
| Polecat | 5.19.1 | 5.21.1 |
| Fisher | 1.0.2 | 1.0.6 |
| Weasel.Core / .EntityFrameworkCore / .MySql / .Oracle / .Postgresql / .SqlServer / .Sqlite | 9.27.0 | 9.29.0 |

`JasperFx.RuntimeCompiler` stays on its own 5.x line, as the comment in the file says.

Nothing here was forced by a version conflict. Every one of these packages declares a floor rather
than a lock, so the versions we were on still resolved -- Polecat 5.21.1 and Fisher 1.0.6 both floor
at JasperFx 2.59.0, which 2.60.0 clears. The reason to take them is what they carry: Polecat 5.21.1
is the release that adopts the `IEventTenancySource` seam added in JasperFx 2.59.0, which is what
closes the async-daemon tenancy gap for a store that is not Marten. JasperFx 2.60.0 itself is a
projection-run CLI command and a `[BoundaryAggregate]` fix on the Evolve path.

## Verification

Built the way CI does, `dotnet build wolverine.slnx -c Release -f net9.0` -- succeeded, 0 warnings,
0 errors. Confirmed the restore actually moved rather than resolving from cache.

| suite | result |
|---|---|
| CoreTests | 2756 passed, 2 skipped |
| MartenTests | 634 passed |
| PolecatTests | 291 passed, 2 skipped |
| FisherTests | 29 passed |
| PostgresqlTests | 538 passed, 1 skipped |

One PostgresqlTests test (`Bug_1942_replay_dlq_to_buffered_or_inline`) failed on the first pass with
a RabbitMQ connection refused -- the local broker container was not running. It passes with the
broker up, and the failure is a socket connect, unrelated to anything in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)