### PR TITLE
GH-4240: a node must not sweep up its own in-flight stop as a wedged shard

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/deliberate_stop_is_not_swept_up_as_a_wedged_shard.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/deliberate_stop_is_not_swept_up_as_a_wedged_shard.cs
@@ -1,0 +1,225 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-4240: an event-subscription agent ends up running on two nodes at once while the durable
+/// assignment record credits only one of them, so nothing in the system can ever stop the extra copy.
+///
+/// <para>The window is inside <see cref="NodeAgentController.StopAgentAsync" />. It awaits
+/// <c>agent.StopAsync()</c> BEFORE taking the agent out of <see cref="NodeAgentController.Agents" />
+/// and before dropping the assignment row, and a real shard flips to
+/// <see cref="AgentStatus.Stopped" /> early in that teardown. So for the whole duration of the
+/// teardown the agent is simultaneously still registered, Stopped, and reporting no failure — which
+/// is exactly the state <c>ReportFailedLocalAgentsAsync</c> treats as a wedged shard to be restarted
+/// (GH-4193). That sweep runs on EVERY node on EVERY health-check tick independently of leadership,
+/// which is why the restart never appears in the leader's own command log: the leader does not issue
+/// it, the stopping node issues it to itself.</para>
+///
+/// <para>The GH-4193 code carries a comment asserting this state is unreachable — "StopAgentAsync
+/// removes it from the dictionary and drops the assignment row, so Stopped-and-still-registered is BY
+/// CONSTRUCTION a wedged shard and never a deliberate stop". That holds only once
+/// <c>StopAgentAsync</c> has RETURNED. These tests pin the behaviour during the await.</para>
+/// </summary>
+public class deliberate_stop_is_not_swept_up_as_a_wedged_shard
+{
+    private readonly WolverineOptions _options;
+    private readonly IWolverineRuntime _runtime;
+    private readonly CancellationTokenSource _cancellation = new();
+
+    public deliberate_stop_is_not_swept_up_as_a_wedged_shard()
+    {
+        _options = new WolverineOptions { ApplicationAssembly = GetType().Assembly };
+        _options.Durability.Mode = DurabilityMode.Solo;
+        _options.Durability.DurabilityAgentEnabled = false;
+        _options.Durability.CheckAssignmentPeriod = 1.Hours();
+
+        _runtime = Substitute.For<IWolverineRuntime>();
+        _runtime.Options.Returns(_options);
+        _runtime.DurabilitySettings.Returns(_options.Durability);
+        _runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+    }
+
+    private static readonly Uri TheAgent = new("event-subscriptions://marten/trip/all");
+
+    private NodeAgentController controllerFor(SlowStoppingAgent agent, INodeAgentPersistence? persistence = null)
+    {
+        var family = new SlowStoppingAgentFamily(TheAgent.Scheme, agent);
+        return new NodeAgentController(_runtime, persistence ?? Substitute.For<INodeAgentPersistence>(), [family],
+            NullLogger<NodeAgentController>.Instance, _cancellation.Token);
+    }
+
+    [Fact]
+    public async Task the_sweep_does_not_restart_an_agent_that_is_mid_stop()
+    {
+        var agent = new SlowStoppingAgent(TheAgent);
+        var controller = controllerFor(agent);
+
+        await controller.StartAgentAsync(TheAgent);
+        agent.StartCount.ShouldBe(1);
+
+        agent.HoldNextStop();
+
+        // Deliberate stop, held open inside agent.StopAsync() the way a Marten shard's teardown holds it
+        // open for hundreds of milliseconds.
+        var stopping = controller.StopAgentAsync(TheAgent);
+        await agent.EnteredStop;
+
+        // The window this test exists for: the agent reports Stopped, reports no failure, and is STILL
+        // registered, because StopAgentAsync has not reached its TryRemove yet.
+        agent.Status.ShouldBe(AgentStatus.Stopped);
+        agent.Failure.ShouldBeNull();
+        controller.Agents.ContainsKey(TheAgent).ShouldBeTrue();
+
+        // A health-check tick lands here. It must recognise a stop in progress rather than a wedged shard.
+        await controller.ReportFailedLocalAgentsAsync();
+
+        agent.StartCount.ShouldBe(1);
+
+        agent.ReleaseStop();
+        await stopping;
+
+        controller.Agents.ContainsKey(TheAgent).ShouldBeFalse();
+        agent.Status.ShouldBe(AgentStatus.Stopped);
+    }
+
+    [Fact]
+    public async Task a_restart_during_the_stop_does_not_leave_the_assignment_row_behind()
+    {
+        // The other half of the damage. StartAgentAsync re-upserts the assignment row (GH-3604 D4), so a
+        // restart inside the window re-asserts ownership that the stop is about to revoke — and the stop's
+        // RemoveAssignmentAsync then lands on a row belonging to an agent that is once again running.
+        var persistence = Substitute.For<INodeAgentPersistence>();
+        var agent = new SlowStoppingAgent(TheAgent);
+        var controller = controllerFor(agent, persistence);
+
+        await controller.StartAgentAsync(TheAgent);
+        persistence.ClearReceivedCalls();
+
+        agent.HoldNextStop();
+
+        var stopping = controller.StopAgentAsync(TheAgent);
+        await agent.EnteredStop;
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        agent.ReleaseStop();
+        await stopping;
+
+        // Nothing may have re-claimed this agent for this node while it was being stopped.
+        await persistence.DidNotReceive()
+            .AddAssignmentAsync(Arg.Any<Guid>(), TheAgent, Arg.Any<CancellationToken>());
+        await persistence.Received(1)
+            .RemoveAssignmentAsync(Arg.Any<Guid>(), TheAgent, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task a_genuinely_wedged_shard_is_still_restarted()
+    {
+        // The guard must not cost GH-4193 its reason to exist: an agent that went Stopped on its own,
+        // with no stop command anywhere near it, is still swept back up.
+        var agent = new SlowStoppingAgent(TheAgent);
+        var controller = controllerFor(agent);
+
+        await controller.StartAgentAsync(TheAgent);
+
+        agent.SimulateWedged();
+
+        await controller.ReportFailedLocalAgentsAsync();
+
+        agent.StartCount.ShouldBe(2);
+    }
+
+    private class SlowStoppingAgentFamily : IAgentFamily
+    {
+        private readonly SlowStoppingAgent _agent;
+
+        public SlowStoppingAgentFamily(string scheme, SlowStoppingAgent agent)
+        {
+            Scheme = scheme;
+            _agent = agent;
+        }
+
+        public string Scheme { get; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>([_agent.Uri]);
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => ValueTask.FromResult<IAgent>(_agent);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>([_agent.Uri]);
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// An event-subscription agent whose StopAsync is held open, standing in for a Marten shard's
+    /// teardown. Status flips to Stopped on the way IN, which is what the real daemon does and what
+    /// makes the agent look wedged to the sweep.
+    /// </summary>
+    private class SlowStoppingAgent : IEventSubscriptionAgent
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public SlowStoppingAgent(Uri uri) => Uri = uri;
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+        public ShardFailure? Failure => null;
+
+        private int _stopCount;
+        private int _holdNextStop;
+
+        public int StartCount { get; private set; }
+        public int StopCount => Volatile.Read(ref _stopCount);
+
+        public Task EnteredStop => _entered.Task;
+
+        /// <summary>Hold the next StopAsync open, standing in for a Marten shard's slow teardown.</summary>
+        public void HoldNextStop() => Interlocked.Exchange(ref _holdNextStop, 1);
+
+        public void ReleaseStop() => _release.TrySetResult();
+
+        /// <summary>The GH-4193 case: the shard died underneath us with no stop command in sight.</summary>
+        public void SimulateWedged() => Status = AgentStatus.Stopped;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            StartCount++;
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _stopCount);
+
+            // A real shard reports Stopped from the moment teardown begins, not when it finishes.
+            Status = AgentStatus.Stopped;
+
+            // Only a stop the test has explicitly armed is held open, and only once. GH-3519's wedge
+            // recovery calls StopAsync again on its way to restarting the agent; holding that one too
+            // would deadlock the test instead of letting it report what the sweep did.
+            if (Interlocked.Exchange(ref _holdNextStop, 0) == 0)
+            {
+                return;
+            }
+
+            _entered.TrySetResult();
+            await _release.Task;
+        }
+
+        public Task RebuildAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -169,6 +169,14 @@ public partial class NodeAgentController
     private long _commandSequence;
     private readonly ConcurrentDictionary<Uri, long> _stopRevocations = new();
 
+    // GH-4240: agents whose deliberate stop is currently in flight. StopAgentAsync awaits the agent's own
+    // teardown BEFORE it deregisters the agent and drops the assignment row, and a real event-subscription
+    // shard reports Stopped from the moment that teardown begins. So for the whole duration of a stop the
+    // agent is registered, Stopped, and reporting no failure -- indistinguishable, to anything reading
+    // Agents, from the wedged shard ReportFailedLocalAgentsAsync exists to restart. Membership here is what
+    // tells the two apart.
+    private readonly ConcurrentDictionary<Uri, byte> _stoppingAgents = new();
+
     internal long CurrentCommandSequence => Volatile.Read(ref _commandSequence);
 
     private bool isRevokedSince(Uri agentUri, long sequence)
@@ -472,32 +480,49 @@ public partial class NodeAgentController
         // budget the setting promises.
         _failedStarts.TryRemove(agentUri, out _);
 
-        if (Agents.TryGetValue(agentUri, out var agent))
-        {
-            try
-            {
-                await agent.StopAsync(_cancellation.Token);
-                Agents.TryRemove(agentUri, out _);
-                _logger.LogInformation("Successfully stopped agent {AgentUri} on node {NodeNumber}", agentUri,
-                    _runtime.Options.Durability.AssignedNodeNumber);
-
-                await _observer.AgentStopped(agentUri);
-            }
-            catch (Exception e)
-            {
-                throw new AgentStoppingException(agentUri, _runtime.Options.UniqueNodeId, e);
-            }
-        }
+        // GH-4240: claim the stop before any of it is observable. Deliberately NOT done by deregistering
+        // the agent up front instead: AllRunningAgentUris() is what answers the leader's QueryAgentPresence
+        // probe, and an agent that stays Running through its own teardown must keep answering "still here"
+        // until the teardown finishes, or the leader reads a confirmed stop and starts the agent on the
+        // destination while the source copy is still winding down.
+        _stoppingAgents[agentUri] = default;
 
         try
         {
-            await _persistence.RemoveAssignmentAsync(_runtime.Options.UniqueNodeId, agentUri, _cancellation.Token);
+            if (Agents.TryGetValue(agentUri, out var agent))
+            {
+                try
+                {
+                    await agent.StopAsync(_cancellation.Token);
+                    Agents.TryRemove(agentUri, out _);
+                    _logger.LogInformation("Successfully stopped agent {AgentUri} on node {NodeNumber}", agentUri,
+                        _runtime.Options.Durability.AssignedNodeNumber);
+
+                    await _observer.AgentStopped(agentUri);
+                }
+                catch (Exception e)
+                {
+                    throw new AgentStoppingException(agentUri, _runtime.Options.UniqueNodeId, e);
+                }
+            }
+
+            try
+            {
+                await _persistence.RemoveAssignmentAsync(_runtime.Options.UniqueNodeId, agentUri,
+                    _cancellation.Token);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Error trying to remove the assignment of agent {AgentUri} to Node {NodeId} in persistence",
+                    agentUri, _runtime.Options.UniqueNodeId);
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _logger.LogError(e,
-                "Error trying to remove the assignment of agent {AgentUri} to Node {NodeId} in persistence", agentUri,
-                _runtime.Options.UniqueNodeId);
+            // Released even when the stop threw. A stop that failed leaves an agent this node genuinely
+            // cannot account for, and that is precisely the case the wedge sweep is for.
+            _stoppingAgents.TryRemove(agentUri, out _);
         }
     }
 
@@ -597,6 +622,19 @@ public partial class NodeAgentController
 
         foreach (var entry in Agents.ToArray())
         {
+            // GH-4240: an agent being deliberately stopped right now is not a wedged shard, is not paused,
+            // and is not asking to be placed elsewhere -- it is on its way out. Skipping the whole
+            // evaluation is deliberate: restarting it here resurrects an agent the cluster has already
+            // decided belongs somewhere else, and StartAgentAsync re-upserts the assignment row on the way
+            // through, so the stop's own RemoveAssignmentAsync then lands on a row belonging to an agent
+            // that is running again. The result is one durable assignment row and two live copies, which
+            // the GH-2602 duplicate healer cannot see (it compares two nodes' durable rows) and therefore
+            // never resolves.
+            if (_stoppingAgents.ContainsKey(entry.Key))
+            {
+                continue;
+            }
+
             if (entry.Value is not IEventSubscriptionAgent subscription)
             {
                 continue;


### PR DESCRIPTION
Closes #4240.

## What was happening

`StopAgentAsync` awaits the agent's own teardown **before** it deregisters the agent and drops the
assignment row, and a real event-subscription shard reports `Stopped` from the moment that teardown
begins. So for the whole duration of a stop the agent is simultaneously:

- still in `Agents`
- `Status == Stopped`
- `Failure == null`

which is exactly the state `ReportFailedLocalAgentsAsync` treats as a wedged shard and restarts
(GH-4193). That sweep runs on **every node on every health-check tick, independently of leadership**
-- which is why the extra start never showed up in the leader's `AssignmentChanged` log in the
issue's data. The leader does not issue it. The stopping node issues it to itself.

The restart is not merely an extra copy. `StartAgentAsync` re-upserts the assignment row on its way
through (GH-3604 D4), so it re-claims the ownership the stop is about to revoke, and the stop's own
`RemoveAssignmentAsync` then lands on a row belonging to an agent that is running again. The result
is one durable row and two live copies -- and `AssignmentGrid.WithNode` seeds `Agent.OriginalNode`
from the durable record, so the GH-2602 duplicate healer compares two nodes' durable rows and cannot
see this shape by construction. That is why it never self-heals, exactly as the issue observed.

The GH-4193 code carries a comment asserting this state is unreachable -- "StopAgentAsync removes it
from the dictionary and drops the assignment row, so Stopped-and-still-registered is BY CONSTRUCTION
a wedged shard and never a deliberate stop". True only once `StopAgentAsync` has RETURNED.

## This also explains the issue's negative results

- **A generic `IAgentFamily` showed no gap and no orphan.** The sweep opens with
  `if (entry.Value is not IEventSubscriptionAgent) continue;` -- it structurally cannot touch a plain
  agent family. A fake agent's `StopAsync` also returns instantly, so there is no window to hit.
- **`HealthCheckPollingTime = 100ms` did not raise the rate.** `_restartedWedgedAgents` limits the
  restart to once per transition, so extra ticks inside the window buy nothing. What matters is
  whether *any* tick lands in it, not how many.
- **The second start landed in the same millisecond as the stop.** Same event chain, ordered around
  one `await` -- which is what the issue's own "points at the stop path rather than at the leader"
  pointer was seeing.

## The fix

A `_stoppingAgents` set claimed for the duration of `StopAgentAsync` and skipped by the sweep. The
skip covers the whole per-agent evaluation, not just the restart: an agent on its way out should not
be reported paused or released for reassignment either. The claim is released in a `finally`,
including when the stop threw -- a stop that failed leaves an agent this node genuinely cannot
account for, which is precisely what the wedge sweep is for.

**Deliberately not fixed by deregistering the agent up front.** `AllRunningAgentUris()` answers the
leader's `QueryAgentPresence` probe, and an agent that stays `Running` through its own teardown has
to keep answering "still here" until that teardown finishes. Removing it early would let the leader
read a confirmed stop and start the agent on the destination while the source copy is still winding
down -- the GH-3698 duplicate wearing a different hat.

**This does not close the window the issue measured, and should not.** The durable record necessarily
lags in-process state while a shard tears down, because the row cannot be dropped before the agent
has actually stopped without lying about ownership. To answer the issue's opening question directly:
the window is intended. Acting on it was not.

## Tests

`deliberate_stop_is_not_swept_up_as_a_wedged_shard` holds an agent's `StopAsync` open and runs the
sweep inside the window. Deterministic and ~75ms, against a defect measured downstream at ~3 in 8.

| test | before | after |
|---|---|---|
| `the_sweep_does_not_restart_an_agent_that_is_mid_stop` | FAIL -- `StartCount` was 2 | pass |
| `a_restart_during_the_stop_does_not_leave_the_assignment_row_behind` | FAIL -- `AddAssignmentAsync` received during the stop | pass |
| `a_genuinely_wedged_shard_is_still_restarted` | pass | pass |

The third is the control: GH-4193's reason to exist must survive the guard.

Full CoreTests: 2759 passed, 0 failed. The issue's own
`event_subscription_agent_orphaned_during_handoff` repro passes 6/6 -- though it passed before the
fix too, so that is a regression check on the handoff rather than evidence about the orphan.

## Related exposure, not changed here

Solo mode's `startAllAgentsAsync` calls `StartAgentAsync` for every known agent on a timer and can
reach the same registered-and-Stopped state during a deliberate stop. Left alone: an orphan needs two
nodes, and in solo mode restarting is the right answer. Flagging rather than deciding it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)