### PR TITLE
GH-4238: DataAnnotations validation must not trip the user's ServiceLocationPolicy

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_4238_dataannotations_with_service_location_not_allowed.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_4238_dataannotations_with_service_location_not_allowed.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+using Alba;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using IntegrationTests;
+using JasperFx.CodeGeneration.Model;
+using Marten;
+using Wolverine.Http.Validation;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests.Bugs;
+
+/// <summary>
+/// GH-4238: the DataAnnotations validation middleware could not be used together with
+/// <see cref="ServiceLocationPolicy.NotAllowed" />, which is the Wolverine 6 default.
+///
+/// <para>The executor takes an <see cref="IServiceProvider" /> so it can build the
+/// <see cref="ValidationContext" />, and GH-4171 deliberately stopped <c>IServiceProvider</c> being
+/// answered silently from <c>httpContext.RequestServices</c> as a derived variable — it now goes
+/// through the normal service-variable machinery, which reports it as a service location. Correct for
+/// user code, but it meant Wolverine's own middleware tripped the policy and the application could not
+/// bootstrap at all.</para>
+/// </summary>
+public class Bug_4238_dataannotations_with_service_location_not_allowed
+{
+    private static async Task<IAlbaHost> hostAsync(ServiceLocationPolicy policy)
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IgnoreAssembly(typeof(OpenApiEndpoints).Assembly);
+            opts.Discovery.IncludeAssembly(typeof(Bug_4238_dataannotations_with_service_location_not_allowed).Assembly);
+
+            opts.ServiceLocationPolicy = policy;
+
+            // Endpoint discovery sweeps this whole assembly, and plenty of its endpoints are
+            // Marten-backed. Nothing here uses Marten; it just has to resolve.
+            opts.Services.AddMarten(Servers.PostgresConnectionString);
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        return await AlbaHost.For(builder, app =>
+        {
+            app.MapWolverineEndpoints(opts => opts.UseDataAnnotationsValidationProblemDetailMiddleware());
+        });
+    }
+
+    [Fact]
+    public async Task can_bootstrap_and_validate_with_service_location_not_allowed()
+    {
+        // The bug: this threw at bootstrap, so nothing below was reachable.
+        using var host = await hostAsync(ServiceLocationPolicy.NotAllowed);
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new Bug4238Command("")).ToUrl("/bug4238/validate");
+            x.StatusCodeShouldBe(400);
+        });
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new Bug4238Command("ok")).ToUrl("/bug4238/validate");
+            x.StatusCodeShouldBeOk();
+        });
+    }
+
+    [Fact]
+    public async Task still_works_with_service_location_allowed()
+    {
+        // The control: the permissive policy was never broken, and must stay unbroken.
+        using var host = await hostAsync(ServiceLocationPolicy.AlwaysAllowed);
+
+        await host.Scenario(x =>
+        {
+            x.Post.Json(new Bug4238Command("")).ToUrl("/bug4238/validate");
+            x.StatusCodeShouldBe(400);
+        });
+    }
+}
+
+public record Bug4238Command([property: Required] string Name);
+
+public static class Bug4238Endpoint
+{
+    [WolverinePost("/bug4238/validate")]
+    public static string Post(Bug4238Command command) => "ok";
+}

--- a/src/Http/Wolverine.Http/Validation/Internals/HttpChainDataAnnotationsValidationPolicy.cs
+++ b/src/Http/Wolverine.Http/Validation/Internals/HttpChainDataAnnotationsValidationPolicy.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Http;
 using Wolverine.Http.CodeGen;
@@ -39,6 +40,20 @@ internal class HttpChainDataAnnotationsValidationPolicy : IHttpPolicy
             {
                 CommentText = "Execute DataAnnotation validation"
             };
+
+        // GH-4238: supply the IServiceProvider ourselves rather than letting the codegen source it.
+        // GH-4171 deliberately stopped IServiceProvider being answered as a derived HttpContext
+        // variable, so an unsupplied one now goes through the service container and is reported to
+        // ServiceLocationPolicy -- correct for user code, but it meant Wolverine's own validation
+        // middleware could not be used at all under the 6.0 default of NotAllowed.
+        //
+        // HttpContext.RequestServices is the right provider here regardless of ServiceProviderSource:
+        // the only thing the ValidationContext's provider does is answer GetService for a
+        // ValidationAttribute or IValidatableObject, this runs against the inbound request before any
+        // handler scope is relevant, and it is the same provider ASP.NET Core's own model validation
+        // hands to a ValidationContext.
+        methodCall.TrySetArgument(
+            new Variable(typeof(IServiceProvider), $"httpContext.{nameof(HttpContext.RequestServices)}"));
 
         var maybeResult = new MaybeEndWithResultFrame(methodCall.ReturnVariable!);
         chain.Middleware.InsertRange(0, [methodCall, maybeResult]);


### PR DESCRIPTION
Closes #4238.

The DataAnnotations validation middleware could not be used together with
`ServiceLocationPolicy.NotAllowed` -- the Wolverine 6 default. The application threw
`InvalidServiceLocationException` at bootstrap and could not start at all:

```
Found service locations while generating code for POST_bug4238_validate, but
ServiceLocationPolicy.NotAllowed is in effect.
```

## Why

This is fallout from GH-4171, already on main. That change deliberately removed `IServiceProvider`
from the derived `HttpContext` variables so it would stop being answered silently out of
`httpContext.RequestServices` no matter what `ServiceProviderSource` said, and would instead go
through the normal service-variable machinery -- where it is reported to `ServiceLocationPolicy`.
Right for user code. But `DataAnnotationsHttpValidationExecutor.Validate` takes an
`IServiceProvider` so it can build the `ValidationContext`, so **Wolverine's own middleware** began
being reported as a service location inside the user's chain.

## The fix

The policy supplies that argument itself via `TrySetArgument` rather than leaving the codegen to
source it, bound to `httpContext.RequestServices`.

`RequestServices` is the right provider here regardless of `ServiceProviderSource`. The only thing
the `ValidationContext`'s provider ever does is answer `GetService` for a `ValidationAttribute` or an
`IValidatableObject`; it runs against the inbound request before any handler scope is relevant; and
it is the same provider ASP.NET Core's own model validation hands to a `ValidationContext`. Routing
it through `IWolverineRuntime`, as the issue suggested, would add an indirection to arrive in the
same place.

## Tests

`Bug_4238_dataannotations_with_service_location_not_allowed` bootstraps an endpoint carrying
DataAnnotations under `NotAllowed` and exercises both the invalid (400) and valid paths. Before the
fix it threw at bootstrap, so neither was reachable. A second test pins `AlwaysAllowed`, which was
never broken and must stay unbroken.

Full `Wolverine.Http.Tests`: 1017 passed, 10 skipped. The one failure in that run,
`use_cascaded_messages_with_http`, reproduces on clean main without this change -- and a different
method in that same class fails from run to run, so it is a pre-existing tracked-session bleed in
that class rather than anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)