### PR TITLE
GH-4239: a failed EF Core rollback must not displace the exception that caused it

### DIFF
--- a/src/Persistence/EfCoreTests/rollback_does_not_displace_the_original_exception_4239.cs
+++ b/src/Persistence/EfCoreTests/rollback_does_not_displace_the_original_exception_4239.cs
@@ -1,0 +1,189 @@
+using System.Reflection;
+using IntegrationTests;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Wolverine.EntityFrameworkCore.Codegen;
+using Wolverine.EntityFrameworkCore.Internals;
+using Wolverine.Persistence;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace EfCoreTests;
+
+/// <summary>
+/// GH-4239: the generated rollback threw over the exception that caused it, so the original failure
+/// never reached a log or a dead letter queue.
+///
+/// <para>Two distinct defects lived in one line. With a token already cancelled on the way in --
+/// which is what Wolverine's own DefaultExecutionTimeout hands to a nested InvokeAsync --
+/// BeginTransactionAsync threw without creating a transaction, and the catch block's rollback then
+/// threw "The connection does not have any active transactions", escaping the catch so `throw;` was
+/// never reached. With a token cancelled after the transaction opened, the rollback was handed that
+/// same cancelled token, threw TaskCanceledException, and left the transaction open until the
+/// DbContext was disposed.</para>
+/// </summary>
+public class rollback_does_not_displace_the_original_exception_4239
+{
+    public class the_rollback_helper : IAsyncLifetime
+    {
+        private Bug4239DbContext _dbContext = null!;
+
+        public async ValueTask InitializeAsync()
+        {
+            var builder = new DbContextOptionsBuilder<Bug4239DbContext>();
+            builder.UseNpgsql(Servers.PostgresConnectionString);
+            _dbContext = new Bug4239DbContext(builder.Options);
+
+            await _dbContext.Database.OpenConnectionAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _dbContext.Database.CloseConnectionAsync();
+            await _dbContext.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task is_a_no_op_when_the_transaction_was_never_created()
+        {
+            // The GH-4239 case: BeginTransactionAsync threw on an already-cancelled token, so there is
+            // nothing to roll back. The old generated code threw InvalidOperationException here, over
+            // the top of whatever the handler had actually failed with.
+            _dbContext.Database.CurrentTransaction.ShouldBeNull();
+
+            await Should.NotThrowAsync(() => EfCoreTransactionRollback.SafeRollbackAsync(_dbContext));
+        }
+
+        [Fact]
+        public async Task rolls_back_even_though_the_ambient_token_is_already_cancelled()
+        {
+            // The second GH-4239 case. The old code passed the failing token straight into the
+            // rollback, so a cancellation cancelled the cleanup it had just caused and the transaction
+            // stayed open until the DbContext was disposed.
+            using var cancelled = new CancellationTokenSource();
+            await cancelled.CancelAsync();
+
+            await _dbContext.Database.BeginTransactionAsync(CancellationToken.None);
+            _dbContext.Database.CurrentTransaction.ShouldNotBeNull();
+
+            await Should.NotThrowAsync(() => EfCoreTransactionRollback.SafeRollbackAsync(_dbContext));
+
+            _dbContext.Database.CurrentTransaction.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task rolls_back_a_healthy_transaction()
+        {
+            await _dbContext.Database.BeginTransactionAsync(CancellationToken.None);
+
+            await EfCoreTransactionRollback.SafeRollbackAsync(_dbContext);
+
+            _dbContext.Database.CurrentTransaction.ShouldBeNull();
+        }
+
+        // The two tests below characterize the calls the generated catch block USED to make. They are
+        // the reason the helper exists, and they fail loudly if EF Core ever softens either behaviour
+        // and makes the guard unnecessary.
+
+        [Fact]
+        public async Task characterize_the_old_rollback_with_no_transaction_open()
+        {
+            _dbContext.Database.CurrentTransaction.ShouldBeNull();
+
+            // This threw out of the catch block, so the `throw;` on the next line never ran and the
+            // handler's real exception was lost.
+            await Should.ThrowAsync<InvalidOperationException>(
+                () => _dbContext.Database.RollbackTransactionAsync(CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task characterize_the_old_rollback_with_a_cancelled_token()
+        {
+            using var cancelled = new CancellationTokenSource();
+            await cancelled.CancelAsync();
+
+            await _dbContext.Database.BeginTransactionAsync(CancellationToken.None);
+
+            await Should.ThrowAsync<OperationCanceledException>(
+                () => _dbContext.Database.RollbackTransactionAsync(cancelled.Token));
+
+            // ...and the damage: the transaction the rollback was supposed to clean up is still open.
+            _dbContext.Database.CurrentTransaction.ShouldNotBeNull();
+
+            await EfCoreTransactionRollback.SafeRollbackAsync(_dbContext);
+            _dbContext.Database.CurrentTransaction.ShouldBeNull();
+        }
+    }
+
+    public class the_generated_catch_block
+    {
+        private static string generate()
+        {
+            var frame = new StartDatabaseTransactionForDbContext(typeof(Bug4239DbContext), IdempotencyStyle.None);
+
+            var variables = new StubMethodVariables();
+            variables.Store(new Variable(typeof(MessageContext), "context"));
+            variables.Store(new Variable(typeof(Bug4239DbContext), "dbContext"));
+            variables.Store(new Variable(typeof(CancellationToken), "cancellation"));
+
+            frame.FindVariables(variables).ToList();
+
+            using var writer = new SourceWriter();
+            frame.GenerateCode(null!, writer);
+            return writer.Code();
+        }
+
+        [Fact]
+        public void rolls_back_through_the_guarded_helper()
+        {
+            generate().ShouldContain(nameof(EfCoreTransactionRollback.SafeRollbackAsync));
+        }
+
+        [Fact]
+        public void never_hands_the_failing_cancellation_token_to_the_rollback()
+        {
+            // The token is still legitimately used by BeginTransactionAsync above; what must not
+            // happen is a rollback that the very cancellation it is cleaning up can cancel.
+            var code = generate();
+
+            code.ShouldNotContain("RollbackTransactionAsync(cancellation)");
+            code.ShouldContain("BeginTransactionAsync(cancellation)");
+        }
+
+        private sealed class StubMethodVariables : IMethodVariables
+        {
+            private readonly Dictionary<Type, Variable> _byType = new();
+
+            public void Store(Variable variable) => _byType[variable.VariableType] = variable;
+
+            public Variable FindVariable(Type type) => _byType[type];
+
+            public Variable FindVariable(ParameterInfo parameter) => FindVariable(parameter.ParameterType);
+
+            public Variable FindVariableByName(Type dependency, string name)
+            {
+                if (TryFindVariableByName(dependency, name, out var v)) return v;
+                throw new ArgumentOutOfRangeException(nameof(name));
+            }
+
+            public bool TryFindVariableByName(Type dependency, string name, out Variable variable)
+            {
+                variable = default!;
+                if (_byType.TryGetValue(dependency, out var found) && found.Usage == name)
+                {
+                    variable = found;
+                    return true;
+                }
+
+                return false;
+            }
+
+            public Variable? TryFindVariable(Type type, VariableSource source)
+                => _byType.TryGetValue(type, out var found) ? found : null;
+        }
+    }
+}
+
+public class Bug4239DbContext(DbContextOptions<Bug4239DbContext> options) : DbContext(options);

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/StartDatabaseTransactionForDbContext.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/StartDatabaseTransactionForDbContext.cs
@@ -55,7 +55,14 @@ internal class StartDatabaseTransactionForDbContext : AsyncFrame
 
         writer.FinishBlock();
         writer.Write($"BLOCK:catch ({typeof(Exception).FullNameInCode()})");
-        writer.Write($"await {_dbContext.Usage}.Database.RollbackTransactionAsync({_cancellation.Usage}).ConfigureAwait(false);");
+
+        // GH-4239: deliberately NOT `RollbackTransactionAsync(cancellation)`. That call threw over the
+        // exception being unwound whenever there was no transaction to roll back (an already-cancelled
+        // token means BeginTransactionAsync never created one), and it silently skipped the rollback
+        // when the token was cancelled after the transaction opened. Either way the real failure never
+        // reached a log or a dead letter queue. See EfCoreTransactionRollback.
+        writer.Write(
+            $"await {typeof(EfCoreTransactionRollback).FullNameInCode()}.{nameof(EfCoreTransactionRollback.SafeRollbackAsync)}({_dbContext.Usage}).ConfigureAwait(false);");
         writer.Write("throw;");
         writer.FinishBlock();
     }

--- a/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreTransactionRollback.cs
+++ b/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreTransactionRollback.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolverine.EntityFrameworkCore.Internals;
+
+/// <summary>
+/// GH-4239: rolls back a failed EF Core transaction without ever displacing the exception that
+/// caused the rollback.
+///
+/// <para>The generated <c>catch</c> in <see cref="Codegen.StartDatabaseTransactionForDbContext" />
+/// used to call <c>RollbackTransactionAsync(cancellation)</c> unguarded, which lost the original
+/// exception in two separate ways.</para>
+///
+/// <para>First, when the cancellation token was <b>already</b> cancelled on the way in -- Wolverine's
+/// own <c>DefaultExecutionTimeout</c> does exactly this to a nested <c>InvokeAsync</c> --
+/// <c>BeginTransactionAsync</c> threw without creating a transaction, and the rollback in the catch
+/// then threw <c>InvalidOperationException: The connection does not have any active transactions</c>.
+/// That second exception escaped the catch block, so the <c>throw;</c> was never reached and the real
+/// failure never appeared in a log or a dead letter queue.</para>
+///
+/// <para>Second, when the token was cancelled <b>after</b> the transaction was opened, the rollback
+/// was handed that same cancelled token and threw <c>TaskCanceledException</c> instead of rolling
+/// back -- leaving the transaction open until the DbContext was disposed.</para>
+///
+/// <para>Hence all three rules below: only roll back a transaction that exists, never let the token
+/// that caused the failure also cancel the cleanup, and never let a failed rollback replace the
+/// original exception.</para>
+/// </summary>
+public static class EfCoreTransactionRollback
+{
+    /// <summary>
+    /// Roll back <paramref name="dbContext" />'s current transaction if it has one, swallowing any
+    /// failure of the rollback itself. Always safe to call from a catch block.
+    /// </summary>
+    public static async Task SafeRollbackAsync(DbContext dbContext)
+    {
+        if (dbContext.Database.CurrentTransaction == null)
+        {
+            // BeginTransactionAsync never got as far as creating one -- most often because the
+            // cancellation token was already cancelled when the chain started.
+            return;
+        }
+
+        try
+        {
+            // CancellationToken.None deliberately. A cancelled token is the single most likely reason
+            // to be in here, and cancelling the rollback with it would leave the transaction open
+            // until the DbContext is disposed.
+            await dbContext.Database.RollbackTransactionAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // A rollback that fails -- a dropped connection, a transaction the server already killed --
+            // says nothing the caller can act on, and the exception being unwound is the one that
+            // actually explains the failure. Losing it to a cleanup fault is the whole defect in
+            // GH-4239, so this catch is deliberately silent and the original propagates from the
+            // caller's `throw;`.
+        }
+    }
+}


### PR DESCRIPTION
Closes #4239. Thanks to @oventapijt for a diagnosis that was exactly right on both counts.

The generated catch block for a `[Transactional]` handler under Wolverine-managed multi-tenancy
called `RollbackTransactionAsync(cancellation)` unguarded, and lost the original exception in two
separate ways.

**Token already cancelled on the way in** -- which is what Wolverine's own `DefaultExecutionTimeout`
hands to a nested `InvokeAsync`. `BeginTransactionAsync` throws without creating a transaction, so
the rollback throws `InvalidOperationException: The connection does not have any active
transactions`. That escapes the catch, the `throw;` never runs, and the real failure reaches neither
a log nor a dead letter queue.

**Token cancelled after the transaction opened.** The rollback is handed that same cancelled token,
throws `TaskCanceledException` instead of rolling back, and the transaction stays open until the
DbContext is disposed.

## The fix

`EfCoreTransactionRollback.SafeRollbackAsync`, called by the generated catch instead. Three rules:

1. only roll back a transaction that exists;
2. never let the token that caused the failure also cancel the cleanup (`CancellationToken.None`);
3. never let a failure of the rollback itself replace the exception being unwound.

Rule 3 is not in the issue, but it is the same defect one step out -- a rollback can also fail on a
dropped connection or a transaction the server already killed, and that loses the original exception
exactly as the two reported cases do.

Putting it in a helper rather than inlining the guards into emitted source keeps the generated code
readable and, more importantly, makes the behaviour directly testable.

## Tests

Two layers, in `rollback_does_not_displace_the_original_exception_4239`.

**Behavioural**, against real Postgres transactions: no-op when no transaction was created; rolls
back despite an already-cancelled ambient token; rolls back a healthy transaction.

**Characterization**, pinning what the OLD calls actually do -- `RollbackTransactionAsync` with no
transaction throws `InvalidOperationException`, and with a cancelled token throws
`OperationCanceledException` *and leaves the transaction open*. These are the reason the guard
exists, and they fail loudly if EF Core ever softens either behaviour and makes it unnecessary.

**Codegen**, asserting the emitted catch routes through the helper and never hands the failing token
to a rollback. I verified these two genuinely discriminate by reverting the frame change: both fail
without it.

## Verification

| suite | result |
|---|---|
| GH-4239 tests | 7 passed |
| EfCoreTests | 227 passed |
| EfCoreTests.MultiTenancy | 200 passed |
| PersistenceTests | 109 passed |
| Wolverine.EfCore.FSharpTests | 1 passed |
| `dotnet build wolverine.slnx -c Release -f net9.0` | succeeded, 0 warnings |

`EfCoreTests.MultiTenancy` is the meaningful one -- `StartDatabaseTransactionForDbContext` is the
tenanted counterpart to `EnrollDbContextInTransaction`, so those 200 tests are what run the
regenerated catch block end to end.

## Scope note

The single-DbContext path (`EnrollDbContextInTransaction`) emits no rollback at all, so this frame is
the only place in the EF Core integration that had the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)