### PR TITLE
GH-3935: support Wolverine parameter attributes on gRPC before/after hooks

### DIFF
--- a/src/Wolverine.Grpc.Tests/ParameterAttributes/GH3935Fixtures.cs
+++ b/src/Wolverine.Grpc.Tests/ParameterAttributes/GH3935Fixtures.cs
@@ -1,0 +1,166 @@
+using System.Reflection;
+using System.ServiceModel;
+using Grpc.Core;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using ProtoBuf;
+using ProtoBuf.Grpc;
+using Wolverine.Attributes;
+using Wolverine.Configuration;
+using Wolverine.Grpc.Tests.ParameterAttributes.Generated;
+using IServiceContainer = JasperFx.IServiceContainer;
+
+namespace Wolverine.Grpc.Tests.ParameterAttributes;
+
+/// <summary>
+/// GH-3935: a test-only <see cref="WolverineParameterAttribute"/>. The real family
+/// (<c>[Entity]</c>, <c>[All]</c>, <c>[Queryable]</c>, the aggregate attributes) all resolve through
+/// a persistence provider, and none is registered in this project — but every one of them reaches
+/// the chain through the same <see cref="WolverineParameterAttribute.TryApply"/> call, so what is
+/// actually under test is whether the gRPC chains make that call at all. This attribute answers with
+/// a literal expression, which needs no declaration frame and is therefore visible in the generated
+/// source and observable at runtime.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class GH3935ValueAttribute : WolverineParameterAttribute
+{
+    public const string Marker = "GH3935_APPLIED";
+
+    public override Variable Modify(IChain chain, ParameterInfo parameter, IServiceContainer container,
+        GenerationRules rules)
+    {
+        return new Variable(parameter.ParameterType, $"\"{Marker}\"");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Proto-first
+// ---------------------------------------------------------------------------
+
+[WolverineGrpcService]
+public abstract partial class ParameterAttributeStub : ParameterAttributeTest.ParameterAttributeTestBase
+{
+    [WolverineBefore]
+    public static void BeforeWithParameterAttribute([GH3935Value] string marker)
+    {
+        GH3935Sink.Record("proto-first:before", marker);
+    }
+
+    [WolverineAfter]
+    public static void AfterWithParameterAttribute([GH3935Value] string marker)
+    {
+        GH3935Sink.Record("proto-first:after", marker);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Code-first. Hooks live on the HANDLER class for this flavour — see
+// CodeFirstGrpcServiceChain's middleware discovery.
+// ---------------------------------------------------------------------------
+
+[ServiceContract]
+[WolverineGrpcService]
+public interface IGH3935CodeFirstService
+{
+    Task<GH3935Reply> Echo(GH3935Request request, CallContext context = default);
+}
+
+[ProtoContract]
+public class GH3935Request
+{
+    [ProtoMember(1)] public string Name { get; set; } = string.Empty;
+}
+
+[ProtoContract]
+public class GH3935Reply
+{
+    [ProtoMember(1)] public string Message { get; set; } = string.Empty;
+}
+
+public class GH3935CodeFirstHandler
+{
+    [WolverineBefore]
+    public static void Before([GH3935Value] string marker)
+    {
+        GH3935Sink.Record("code-first:before", marker);
+    }
+
+    [WolverineAfter]
+    public static void After([GH3935Value] string marker)
+    {
+        GH3935Sink.Record("code-first:after", marker);
+    }
+
+    public static GH3935Reply Handle(GH3935Request request) => new() { Message = request.Name };
+}
+
+// ---------------------------------------------------------------------------
+// Hand-written
+// ---------------------------------------------------------------------------
+
+[ServiceContract]
+public interface IGH3935HandWrittenContract
+{
+    Task<GH3935HandWrittenReply> Echo(GH3935HandWrittenRequest request, CallContext context = default);
+}
+
+[ProtoContract]
+public class GH3935HandWrittenRequest
+{
+    [ProtoMember(1)] public string Name { get; set; } = string.Empty;
+}
+
+[ProtoContract]
+public class GH3935HandWrittenReply
+{
+    [ProtoMember(1)] public string Message { get; set; } = string.Empty;
+}
+
+// Named with the GrpcService suffix on purpose -- that is the hand-written discovery predicate
+// (GrpcGraph.IsHandWrittenServiceClass), and the contract interface must NOT carry
+// [WolverineGrpcService] or the generated-implementation path claims it instead.
+public class GH3935HandWrittenGrpcService : IGH3935HandWrittenContract
+{
+    [WolverineBefore]
+    public static void Before([GH3935Value] string marker)
+    {
+        GH3935Sink.Record("hand-written:before", marker);
+    }
+
+    [WolverineAfter]
+    public static void After([GH3935Value] string marker)
+    {
+        GH3935Sink.Record("hand-written:after", marker);
+    }
+
+    public Task<GH3935HandWrittenReply> Echo(GH3935HandWrittenRequest request, CallContext context = default)
+        => Task.FromResult(new GH3935HandWrittenReply { Message = request.Name });
+}
+
+/// <summary>Collects what the hooks were actually handed, for the runtime half of the tests.</summary>
+public static class GH3935Sink
+{
+    private static readonly List<(string Hook, string Value)> _entries = new();
+
+    public static void Record(string hook, string value)
+    {
+        lock (_entries) _entries.Add((hook, value));
+    }
+
+    public static (string Hook, string Value)[] Entries
+    {
+        get { lock (_entries) return _entries.ToArray(); }
+    }
+
+    public static void Clear()
+    {
+        lock (_entries) _entries.Clear();
+    }
+}
+
+/// <summary>Handler for the proto-first stub's RPC, which forwards to the message bus.</summary>
+public class GH3935ProtoFirstHandler
+{
+    public static Generated.ParamReply Handle(Generated.ParamRequest request)
+        => new() { Message = request.Name };
+}

--- a/src/Wolverine.Grpc.Tests/ParameterAttributes/Protos/grpc_parameter_attributes_test.proto
+++ b/src/Wolverine.Grpc.Tests/ParameterAttributes/Protos/grpc_parameter_attributes_test.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option csharp_namespace = "Wolverine.Grpc.Tests.ParameterAttributes.Generated";
+
+package wolverine.grpc.tests.parameter_attributes;
+
+// Test-only service for GH-3935. Its own proto rather than a second stub over an existing one,
+// so this suite's before/after hooks cannot alter what any other suite discovers.
+service ParameterAttributeTest {
+  rpc Echo (ParamRequest) returns (ParamReply);
+}
+
+message ParamRequest {
+  string name = 1;
+}
+
+message ParamReply {
+  string message = 1;
+}

--- a/src/Wolverine.Grpc.Tests/ParameterAttributes/grpc_parameter_attributes_3935.cs
+++ b/src/Wolverine.Grpc.Tests/ParameterAttributes/grpc_parameter_attributes_3935.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Server;
+using Shouldly;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.ParameterAttributes;
+
+/// <summary>
+/// GH-3935: none of Wolverine's <see cref="Wolverine.Attributes.WolverineParameterAttribute"/> family
+/// worked on gRPC services. <c>TryApply</c> is called from <c>HandlerChain.configureFrames</c> for
+/// message handlers and from <c>HttpChainParameterAttributeStrategy</c> for HTTP endpoints, and
+/// nothing in Wolverine.Grpc called it at all.
+///
+/// <para>Scope is the user-authored before/after hooks, which are the only place on a gRPC service
+/// with a parameter list somebody can decorate. The RPC methods themselves stay out: their signatures
+/// are proto-defined, and the answer there is the downstream message handler, which has supported the
+/// whole family all along.</para>
+///
+/// <para>These assertions are on the generated source, so they cannot be satisfied by anything at
+/// runtime -- the substituted variable either reached the emitted call or it did not.</para>
+/// </summary>
+[Collection("GrpcSerialTests")]
+public class grpc_parameter_attributes_3935
+{
+    private static async Task<WebApplication> startAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+        builder.WebHost.UseTestServer();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.ApplicationAssembly = typeof(GH3935ValueAttribute).Assembly;
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeType(typeof(GH3935CodeFirstHandler));
+            opts.Discovery.IncludeType(typeof(GH3935ProtoFirstHandler));
+        });
+
+        builder.Services.AddCodeFirstGrpc();
+        builder.Services.AddWolverineGrpc();
+
+        var app = builder.Build();
+        app.UseRouting();
+
+        // This is what drives AssembleTypes and therefore populates SourceCode -- discovery alone
+        // does not compile anything.
+        app.MapWolverineGrpcServices();
+
+        await app.StartAsync();
+        return app;
+    }
+
+    [Fact]
+    public async Task applies_parameter_attributes_to_proto_first_hooks()
+    {
+        await using var host = await startAsync();
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+
+        var chain = graph.Chains.Single(c => c.StubType == typeof(ParameterAttributeStub));
+
+        chain.SourceCode.ShouldNotBeNull();
+
+        // Both hooks are called with the attribute's substituted value rather than a resolved
+        // service or a compile error.
+        chain.SourceCode!.ShouldContain(
+            $"{nameof(ParameterAttributeStub.BeforeWithParameterAttribute)}(\"{GH3935ValueAttribute.Marker}\")");
+        chain.SourceCode.ShouldContain(
+            $"{nameof(ParameterAttributeStub.AfterWithParameterAttribute)}(\"{GH3935ValueAttribute.Marker}\")");
+    }
+
+    [Fact]
+    public async Task applies_parameter_attributes_to_code_first_hooks()
+    {
+        await using var host = await startAsync();
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+
+        var chain = graph.CodeFirstChains
+            .Single(c => c.ServiceContractType == typeof(IGH3935CodeFirstService));
+
+        chain.SourceCode.ShouldNotBeNull();
+        chain.SourceCode!.ShouldContain($"Before(\"{GH3935ValueAttribute.Marker}\")");
+        chain.SourceCode.ShouldContain($"After(\"{GH3935ValueAttribute.Marker}\")");
+    }
+
+    [Fact]
+    public async Task applies_parameter_attributes_to_hand_written_hooks()
+    {
+        await using var host = await startAsync();
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+
+        var chain = graph.HandWrittenChains
+            .Single(c => c.ServiceClassType == typeof(GH3935HandWrittenGrpcService));
+
+        chain.SourceCode.ShouldNotBeNull();
+        chain.SourceCode!.ShouldContain($"Before(\"{GH3935ValueAttribute.Marker}\")");
+        chain.SourceCode.ShouldContain($"After(\"{GH3935ValueAttribute.Marker}\")");
+    }
+
+    [Fact]
+    public async Task leaves_the_rpc_methods_themselves_alone()
+    {
+        // The deliberate non-goal. A proto-defined RPC signature has nowhere to hang an attribute,
+        // and the forwarding call must keep passing the real request through rather than anything a
+        // parameter attribute produced.
+        await using var host = await startAsync();
+        var graph = host.Services.GetRequiredService<GrpcGraph>();
+
+        var chain = graph.Chains.Single(c => c.StubType == typeof(ParameterAttributeStub));
+
+        var code = chain.SourceCode!;
+        code.ShouldContain("InvokeAsync");
+        code.ShouldNotContain($"InvokeAsync<Generated.ParamReply>(\"{GH3935ValueAttribute.Marker}\"");
+    }
+}

--- a/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
+++ b/src/Wolverine.Grpc.Tests/Wolverine.Grpc.Tests.csproj
@@ -71,6 +71,7 @@
         <Protobuf Include="GrpcClientStreaming\Protos\grpc_client_stream_test.proto" GrpcServices="Both"/>
         <Protobuf Include="GrpcMiddlewareScoping\Protos\middleware_scoping_test.proto" GrpcServices="Both"/>
         <Protobuf Include="GrpcValidateConvention\Protos\grpc_validate_test.proto" GrpcServices="Both"/>
+        <Protobuf Include="ParameterAttributes\Protos\grpc_parameter_attributes_test.proto" GrpcServices="Both"/>
     </ItemGroup>
 
 </Project>

--- a/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/CodeFirstGrpcServiceChain.cs
@@ -89,6 +89,27 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
         new(StringComparer.Ordinal) { "Handle", "HandleAsync", "Consume", "ConsumeAsync" };
 
     /// <summary>
+    ///     GH-3935: the owning graph, for the <see cref="IServiceContainer"/> and
+    ///     <see cref="GenerationRules"/> that <see cref="WolverineParameterAttribute.TryApply"/> needs
+    ///     when the before/after hooks are woven in <c>AssembleTypes</c>. Set by
+    ///     <see cref="GrpcGraph.DiscoverServices"/> after construction, on the same footing as
+    ///     <see cref="ApplicationAssemblies"/> below -- null in unit-test contexts that build the chain
+    ///     directly, in which case parameter attributes are simply not applied.
+    /// </summary>
+    internal GrpcGraph? Parent { get; set; }
+
+    /// <summary>
+    ///     GH-3935: apply any <see cref="WolverineParameterAttribute"/> on a discovered before/after
+    ///     hook's parameters. A no-op when <see cref="Parent"/> was never set, which keeps chains built
+    ///     directly in a unit test working exactly as before.
+    /// </summary>
+    private void applyParameterAttributes(MethodCall call)
+    {
+        if (Parent == null) return;
+        WolverineParameterAttribute.TryApply(call, Parent.Container, Parent.Rules, this);
+    }
+
+    /// <summary>
     ///     The application assemblies to scan for handler types. Set by <see cref="GrpcGraph.DiscoverServices"/>
     ///     after construction. Null in unit-test contexts that build the chain directly.
     /// </summary>
@@ -305,6 +326,13 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
                     if (!IsBeforeApplicable(before, rpcRequestType)) continue;
 
                     var call = new MethodCall(before.DeclaringType!, before);
+
+                    // GH-3935: the before/after hooks are the one user-authored parameter list on a
+                    // gRPC service, so this is where [Entity], [All], [Queryable] and the rest of the
+                    // family belong. The RPC methods themselves stay out on purpose -- proto-defined
+                    // signatures leave nowhere to hang an attribute.
+                    applyParameterAttributes(call);
+
                     generatedMethod.Frames.Add(call);
 
                     var statusVar = call.Creates.FirstOrDefault(v => v.VariableType == typeof(Status?));
@@ -348,7 +376,12 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
             if (rpc.Kind == CodeFirstMethodKind.Unary)
             {
                 foreach (var after in afters)
-                    generatedMethod.Frames.Add(new MethodCall(after.DeclaringType!, after));
+                {
+                    // GH-3935: same as the before-hooks above.
+                    var call = new MethodCall(after.DeclaringType!, after);
+                    applyParameterAttributes(call);
+                    generatedMethod.Frames.Add(call);
+                }
             }
 
             // Global middleware afters (from grpc.AddMiddleware<T>()) — cloned per method.
@@ -425,6 +458,13 @@ public class CodeFirstGrpcServiceChain : Chain<CodeFirstGrpcServiceChain, Modify
         foreach (var p in before.GetParameters())
         {
             if (p.ParameterType == typeof(CallContext)) continue;
+
+            // GH-3935: a parameter carrying a WolverineParameterAttribute ([Entity], [All],
+            // [Queryable], ...) is resolved by that attribute, not bound from the RPC request, so it
+            // must not disqualify the hook. Without this the applicability rule silently drops
+            // exactly the before-hooks the attribute family exists to enable -- the attribute would
+            // appear to do nothing at all.
+            if (p.HasAttribute<WolverineParameterAttribute>()) continue;
             if (!p.ParameterType.IsAssignableFrom(rpcRequestType)) return false;
         }
         return true;

--- a/src/Wolverine.Grpc/GrpcGraph.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.cs
@@ -99,13 +99,14 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
             {
                 _codeFirstChains.Add(new CodeFirstGrpcServiceChain(contract)
                 {
-                    ApplicationAssemblies = _options.Assemblies
+                    ApplicationAssemblies = _options.Assemblies,
+                    Parent = this // GH-3935
                 });
             }
 
             foreach (var serviceClass in registry.HandWrittenServiceTypes())
             {
-                _handWrittenChains.Add(new HandWrittenGrpcServiceChain(serviceClass));
+                _handWrittenChains.Add(new HandWrittenGrpcServiceChain(serviceClass) { Parent = this }); // GH-3935
             }
         }
         else
@@ -136,7 +137,8 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
                 CodeFirstGrpcServiceChain.AssertNoConcreteImplementationConflicts(contract, _options.Assemblies);
                 var codeFirstChain = new CodeFirstGrpcServiceChain(contract)
                 {
-                    ApplicationAssemblies = _options.Assemblies
+                    ApplicationAssemblies = _options.Assemblies,
+                    Parent = this // GH-3935
                 };
                 _codeFirstChains.Add(codeFirstChain);
             }
@@ -149,7 +151,7 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
 
             foreach (var serviceClass in handWritten)
             {
-                _handWrittenChains.Add(new HandWrittenGrpcServiceChain(serviceClass));
+                _handWrittenChains.Add(new HandWrittenGrpcServiceChain(serviceClass) { Parent = this }); // GH-3935
             }
         }
 

--- a/src/Wolverine.Grpc/GrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/GrpcServiceChain.cs
@@ -328,6 +328,14 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
                 foreach (var before in befores)
                 {
                     var call = new MethodCall(StubType, before);
+
+                    // GH-3935: these hooks are the one user-authored parameter list on a gRPC service,
+                    // so they are where [Entity], [All], [Queryable] and the rest of the family belong.
+                    // The RPC methods themselves stay out of scope on purpose -- their signatures are
+                    // proto-defined, there is nowhere to hang an attribute, and the answer for those is
+                    // the downstream message handler, which has supported all of this all along.
+                    WolverineParameterAttribute.TryApply(call, _parent.Container, _parent.Rules, this);
+
                     generatedMethod.Frames.Add(call);
 
                     var statusVar = call.Creates.FirstOrDefault(v => v.VariableType == typeof(Status?));
@@ -370,7 +378,12 @@ public class GrpcServiceChain : Chain<GrpcServiceChain, ModifyGrpcServiceChainAt
             {
                 // Inline after-hooks declared directly on the stub class.
                 foreach (var after in afters)
-                    generatedMethod.Frames.Add(new MethodCall(StubType, after));
+                {
+                    // GH-3935: same as the before-hooks above.
+                    var call = new MethodCall(StubType, after);
+                    WolverineParameterAttribute.TryApply(call, _parent.Container, _parent.Rules, this);
+                    generatedMethod.Frames.Add(call);
+                }
 
                 // Registered middleware afters (from grpc.AddMiddleware<T>()) — cloned per method.
                 foreach (var frame in CodeFirstGrpcServiceChain.CloneFrames(Postprocessors))

--- a/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
+++ b/src/Wolverine.Grpc/HandWrittenGrpcServiceChain.cs
@@ -48,6 +48,25 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
 
     internal string? SourceCode => _generatedType?.SourceCode;
 
+    /// <summary>
+    ///     GH-3935: the owning graph, for the <see cref="IServiceContainer"/> and
+    ///     <see cref="GenerationRules"/> that <see cref="WolverineParameterAttribute.TryApply"/> needs
+    ///     when the before/after hooks are woven in <c>AssembleTypes</c>. Set by
+    ///     <see cref="GrpcGraph.DiscoverServices"/> after construction; null in unit-test contexts that
+    ///     build the chain directly, in which case parameter attributes are simply not applied.
+    /// </summary>
+    internal GrpcGraph? Parent { get; set; }
+
+    /// <summary>
+    ///     GH-3935: apply any <see cref="WolverineParameterAttribute"/> on a discovered before/after
+    ///     hook's parameters. A no-op when <see cref="Parent"/> was never set.
+    /// </summary>
+    private void applyParameterAttributes(MethodCall call)
+    {
+        if (Parent == null) return;
+        WolverineParameterAttribute.TryApply(call, Parent.Container, Parent.Rules, this);
+    }
+
     public HandWrittenGrpcServiceChain(Type serviceClassType)
     {
         ServiceClassType = serviceClassType ?? throw new ArgumentNullException(nameof(serviceClassType));
@@ -255,6 +274,11 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
                     if (!IsBeforeApplicable(before, rpcRequestType)) continue;
 
                     var call = new MethodCall(ServiceClassType, before);
+
+                    // GH-3935: the before/after hooks are the one user-authored parameter list on a
+                    // gRPC service, so this is where [Entity], [All], [Queryable] and the rest of the
+                    // family belong. The RPC methods themselves stay out on purpose.
+                    applyParameterAttributes(call);
                     generatedMethod.Frames.Add(call);
 
                     var statusVar = call.Creates.FirstOrDefault(v => v.VariableType == typeof(Status?));
@@ -275,7 +299,12 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
             if (hasAfters)
             {
                 foreach (var after in afters)
-                    generatedMethod.Frames.Add(new MethodCall(ServiceClassType, after));
+                {
+                    // GH-3935: same as the before-hooks above.
+                    var afterCall = new MethodCall(ServiceClassType, after);
+                    applyParameterAttributes(afterCall);
+                    generatedMethod.Frames.Add(afterCall);
+                }
 
                 // Registered middleware afters (from grpc.AddMiddleware<T>()) — cloned per method.
                 foreach (var frame in CodeFirstGrpcServiceChain.CloneFrames(Postprocessors))
@@ -317,6 +346,13 @@ public class HandWrittenGrpcServiceChain : Chain<HandWrittenGrpcServiceChain, Mo
         foreach (var p in before.GetParameters())
         {
             if (p.ParameterType == typeof(CallContext)) continue;
+
+            // GH-3935: a parameter carrying a WolverineParameterAttribute ([Entity], [All],
+            // [Queryable], ...) is resolved by that attribute, not bound from the RPC request, so it
+            // must not disqualify the hook. Without this the applicability rule silently drops
+            // exactly the before-hooks the attribute family exists to enable -- the attribute would
+            // appear to do nothing at all.
+            if (p.HasAttribute<WolverineParameterAttribute>()) continue;
             if (!p.ParameterType.IsAssignableFrom(rpcRequestType)) return false;
         }
         return true;


### PR DESCRIPTION
Closes #3935.

None of the `WolverineParameterAttribute` family -- `[Entity]`, `[FirstOrDefault]`, `[All]`,
`[Queryable]`, `[WriteAggregate]`, `[ReadAggregate]`, `[ReadModel]`, `[FromQuerySpecification]`, the
DCB attributes -- worked on gRPC services. `TryApply` is called from `HandlerChain.configureFrames`
for message handlers and from `HttpChainParameterAttributeStrategy` for HTTP endpoints, and nothing
in `Wolverine.Grpc` called it at all.

Scope is the before/after hooks, exactly as the issue proposed. The RPC methods stay out
deliberately: proto-defined signatures leave nowhere to hang an attribute, and the answer there is
the downstream message handler, which has supported the whole family all along. There is a test
pinning that non-goal.

## This needed two changes, not one

**1. The plumbing the issue describes.** All three chain types now call
`WolverineParameterAttribute.TryApply` for their discovered before/after `MethodCall`s.
`GrpcServiceChain` already held its `GrpcGraph`; `CodeFirstGrpcServiceChain` and
`HandWrittenGrpcServiceChain` now take a `Parent` the same way they already take
`ApplicationAssemblies` -- set by `GrpcGraph.DiscoverServices` after construction, null for a chain
built directly in a unit test, in which case attributes are simply not applied. Calls stay per RPC
method, which is required: gRPC frames hold per-method mutable state and must never be shared across
a service's RPCs.

**2. `IsBeforeApplicable` rejected the very hooks this enables.** This one was only visible by
running it. That rule requires every non-`CallContext` parameter to be assignable from the RPC
request type -- and an `[Entity] Invoice invoice` parameter is not, so the before-hook was dropped
from codegen **entirely**.

Shipping change 1 alone would have looked like the feature worked: after-hooks emitted correctly
while every attributed before-hook silently vanished. The generated source is what caught it --
`After("GH3935_APPLIED")` was present and `Before(...)` was nowhere. A parameter carrying a
`WolverineParameterAttribute` is resolved by that attribute rather than bound from the request, so it
no longer disqualifies the hook.

## What this is not

This is **not** the `ModifyChainAttribute` pass. gRPC chains deliberately never run
`applyAttributesAndConfigureMethods`, and wiring that in would apply every chain-modifying attribute
to gRPC services at once -- a far bigger behaviour change than this issue is entitled to make.
Parameter attributes and chain attributes remain separate mechanisms.

## Tests

`grpc_parameter_attributes_3935` covers all three flavours, before and after, asserted on the
generated source -- so nothing at runtime can satisfy them; the substituted variable either reached
the emitted call or it did not.

The test attribute is a test-only `WolverineParameterAttribute` returning a literal expression, in
the same idiom as `FromValueSourceAttribute` in `WolverineWebApi` and the `TestAttribute` in
CoreTests. The real family all resolve through a persistence provider and none is registered in this
project, but every one of them reaches the chain through the same `TryApply` call -- which is what is
actually under test. That avoids taking a Marten or EF Core dependency into `Wolverine.Grpc.Tests`
purely to prove a codegen hook fires.

The suite gets its own `.proto` rather than a second stub over an existing one, so its before/after
hooks cannot alter what any other suite discovers.

| check | result |
|---|---|
| GH-3935 tests | 4 passed |
| full Wolverine.Grpc.Tests | 316 passed, 0 failed |
| `dotnet build wolverine.slnx -c Release -f net9.0` | succeeded, 0 warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)