### PR TITLE
GH-4248: stop use_cascaded_messages_with_http failing on another test's dead letter

### DIFF
--- a/src/Http/Wolverine.Http.Tests/use_cascaded_messages_with_http.cs
+++ b/src/Http/Wolverine.Http.Tests/use_cascaded_messages_with_http.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly;
+using Wolverine.Tracking;
+using Shouldly;
 using WolverineWebApi;
 
 namespace Wolverine.Http.Tests;
@@ -9,6 +10,20 @@ public class use_cascaded_messages_with_http : IntegrationContext
     {
     }
 
+    // GH-4248: every IntegrationContext test shares one host, and a tracked session observes ALL
+    // message activity on that host rather than only what its own HTTP call caused. dead_letter_endpoints
+    // deliberately publishes MessageThatAlwaysGoesToDeadLetter, whose handler always throws; that class
+    // guards its own sessions with DoNotAssertOnExceptionsDetected(), but the exception was still landing
+    // inside whatever OTHER session happened to be open, and failing it. Both tests below were observed
+    // failing that way on unchanged code, with the foreign exception's own message ("replayable-{Guid}",
+    // minted in dead_letter_endpoints) visible in the failure.
+    //
+    // Ignoring that one message type is enough: TrackedSession.Record() returns before it attaches the
+    // exception when the message type is ignored. Deliberately narrow -- these tests still assert on
+    // exceptions from everything else, which is the point of using a tracked session at all.
+    private static TrackedSessionConfiguration ignoreForeignDeadLetters(TrackedSessionConfiguration config)
+        => config.IgnoreMessageType<MessageThatAlwaysGoesToDeadLetter>();
+
     [Fact]
     public async Task send_cascaded_messages_from_tuple_response()
     {
@@ -18,7 +33,7 @@ public class use_cascaded_messages_with_http : IntegrationContext
         var (tracked, result) = await TrackedHttpCall(x =>
         {
             x.Post.Json(new SpawnInput("Chris Jones")).ToUrl("/spawn");
-        });
+        }, ignoreForeignDeadLetters);
 
         var text = await result.ReadAsTextAsync();
         text.ShouldBe("got it");
@@ -38,7 +53,7 @@ public class use_cascaded_messages_with_http : IntegrationContext
         {
             x.Post.Url("/spawn2");
             x.StatusCodeShouldBe(204);
-        });
+        }, ignoreForeignDeadLetters);
 
         tracked.Sent.SingleMessage<HttpMessage1>().ShouldNotBeNull();
         tracked.Sent.SingleMessage<HttpMessage2>().ShouldNotBeNull();


### PR DESCRIPTION
Addresses #4248 -- the narrow fix. See the caveat at the bottom.

Both methods in `use_cascaded_messages_with_http` failed intermittently in a full-suite run and
passed every time in isolation. Neither was failing on anything to do with cascading messages.

## What was actually happening

Every `IntegrationContext` test shares one host (`[Collection("integration")]` over a single
`ICollectionFixture<AppFixture>`), and a tracked session observes **all** message activity on that
host rather than only what its own HTTP call caused.

`dead_letter_endpoints` deliberately publishes `MessageThatAlwaysGoesToDeadLetter`, whose handler
always throws `AlwaysDeadLetterException`. That class correctly guards its own sessions with
`DoNotAssertOnExceptionsDetected()` -- but the exception still landed inside whatever *other* session
happened to be open, and `AssertNoExceptionsWereThrown()` failed the wrong test.

The exception text is what identifies it. The failure carried `replayable-{Guid}`, which is minted at
`dead_letter_endpoints.cs:55` and appears nowhere in this class:

```
System.AggregateException : One or more errors occurred. (replayable-4be14399-...)
---- WolverineWebApi.AlwaysDeadLetterException : replayable-4be14399-...
   at Wolverine.Tracking.TrackedSession.AssertNoExceptionsWereThrown()
   at Wolverine.Http.Tests.use_cascaded_messages_with_http...
   at WolverineWebApi.MessageHandler.Handle(MessageThatAlwaysGoesToDeadLetter message)
```

Which of the two methods lost the race varied run to run, which is why the failing method moved
around.

## The fix

Ignore that one message type on these two sessions, via the `TrackedHttpCall` overload that already
exists for stating what a session cares about. `TrackedSession.Record()` returns on an ignored message
type **before** it attaches the exception, so the foreign failure is suppressed at the source rather
than tolerated downstream.

Deliberately narrow: these tests still assert on exceptions from everything else, which is the reason
to use a tracked session at all. `DoNotAssertOnExceptionsDetected()` would have made them blind
instead, which is a worse test for the same green.

## Verification

Five consecutive full runs of `Wolverine.Http.Tests` -- **1018 passed, 0 failed, every time**.

A single green run would prove nothing here. The original reproduced in roughly half of full-suite
runs and alternated between the two methods, so anything less than repeated full runs is
indistinguishable from luck.

## What this does NOT close

The general question in #4248 stands: should a tracked session attribute exceptions only to the
envelopes it is actually tracking? Any test in the `integration` collection that opens a default
tracked session while a dead-letter test is in flight is exposed to the same thing --
`use_cascaded_messages_with_http` is just the one that overlapped most often. I would leave #4248
open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)