### PR TITLE
Add an application-wide default duplicate status code for Wolverine.HTTP

### DIFF
--- a/docs/guide/http/deduplication.md
+++ b/docs/guide/http/deduplication.md
@@ -59,6 +59,37 @@ Any 2xx code is written as a bare status with no body. Anything else is written 
 document, so a refusal always carries a machine-readable reason rather than a status code the caller
 has to guess at.
 
+## Changing the default for the whole application
+
+`DuplicateStatusCode` on the attribute is per endpoint. When an application wants a different answer
+everywhere, set it once instead:
+
+```csharp
+app.MapWolverineEndpoints(opts =>
+{
+    opts.DefaultDuplicateStatusCode = 422;
+});
+```
+
+An endpoint that names a code still wins, **including when it names 409**. The two are told apart by
+whether a code was stated at all rather than by comparing against 409, so an endpoint that deliberately
+insists on 409 keeps it under an application default of something else:
+
+```csharp
+// Answers 422 -- it stated nothing, so it follows the application default
+[Deduplicated]
+[WolverinePost("/orders")]
+public static string PostOrder(CreateOrder command) => "ok";
+
+// Answers 409 -- it asked for 409, and meant it
+[Deduplicated(DuplicateStatusCode = 409)]
+[WolverinePost("/payments")]
+public static string PostPayment(CapturePayment command) => "ok";
+```
+
+The application default reaches the endpoint early enough to be advertised in the OpenAPI document
+too, so the spec and the runtime never disagree about which code a duplicate gets.
+
 ## Using a different key
 
 The header name and the source are both configurable, exactly as for message handlers:

--- a/src/Http/Wolverine.Http.Tests/default_duplicate_status_code_for_http.cs
+++ b/src/Http/Wolverine.Http.Tests/default_duplicate_status_code_for_http.cs
@@ -1,0 +1,171 @@
+using Alba;
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Attributes;
+using Wolverine.Postgresql;
+using Xunit;
+
+namespace Wolverine.Http.Tests;
+
+/// <summary>
+/// An application-wide default for the duplicate status code, so an app that wants every deduplicated
+/// endpoint to answer something other than 409 says it once rather than on every attribute.
+///
+/// <para>
+/// The interesting case is the one that is easy to get wrong: an endpoint asking explicitly for 409
+/// must keep 409 even when the application default is something else. That is why the resolution is
+/// keyed off whether a code was <i>stated</i> rather than off its value -- a sentinel comparison
+/// against 409 would quietly override the endpoint that meant it.
+/// </para>
+/// </summary>
+public class default_duplicate_status_code_for_http : IAsyncLifetime
+{
+    private IAlbaHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder([]);
+
+        builder.Host.UseWolverine(opts =>
+        {
+            opts.Durability.Mode = DurabilityMode.Solo;
+            opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "http_dedup_default");
+
+            opts.Durability.EnableMessageDeduplication = true;
+            opts.Durability.DeduplicationWindow = 1.Hours();
+
+            opts.Discovery.DisableConventionalDiscovery();
+            opts.Discovery.IncludeAssembly(typeof(default_duplicate_status_code_for_http).Assembly);
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        theHost = await AlbaHost.For(builder, app => app.MapWolverineEndpoints(opts =>
+        {
+            // The whole point of this fixture: one application-wide setting rather than an attribute
+            // argument repeated on every endpoint.
+            opts.DefaultDuplicateStatusCode = 422;
+
+            opts.CustomizeHttpEndpointDiscovery(q =>
+                q.Excludes.WithCondition("Not a default-status test endpoint",
+                    type => type != typeof(InheritsDefaultStatusEndpoint)
+                            && type != typeof(InsistsOn409Endpoint)));
+        }));
+
+        await ((IHost)theHost).ResetResourceState();
+
+        InheritsDefaultStatusEndpoint.Calls.Clear();
+        InsistsOn409Endpoint.Calls.Clear();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task an_endpoint_that_states_nothing_inherits_the_application_default()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("first")).ToUrl("/dedup-default/inherits");
+            x.WithRequestHeader("Idempotency-Key", key);
+            x.StatusCodeShouldBeOk();
+        });
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("replay")).ToUrl("/dedup-default/inherits");
+            x.WithRequestHeader("Idempotency-Key", key);
+            x.StatusCodeShouldBe(422);
+        });
+
+        InheritsDefaultStatusEndpoint.Calls.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task an_endpoint_that_explicitly_asks_for_409_keeps_409()
+    {
+        // The case a "is it still 409?" sentinel check would get wrong.
+        var key = Guid.NewGuid().ToString();
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("first")).ToUrl("/dedup-default/insists");
+            x.WithRequestHeader("Idempotency-Key", key);
+            x.StatusCodeShouldBeOk();
+        });
+
+        await theHost.Scenario(x =>
+        {
+            x.Post.Json(new DedupRequest("replay")).ToUrl("/dedup-default/insists");
+            x.WithRequestHeader("Idempotency-Key", key);
+            x.StatusCodeShouldBe(409);
+        });
+
+        InsistsOn409Endpoint.Calls.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void the_application_default_is_advertised_in_the_endpoint_metadata()
+    {
+        // Metadata is registered inside the HttpChain constructor, before any IHttpPolicy runs, so the
+        // default has to reach the chain earlier than a policy could deliver it. If this drifts, the
+        // runtime answers 422 while the OpenAPI document still promises 409 -- a contract lie that no
+        // request-level test would catch.
+        var graph = theHost.Services.GetRequiredService<WolverineHttpOptions>().Endpoints!;
+
+        var inherits = graph.ChainFor("POST", "/dedup-default/inherits");
+        inherits.ShouldNotBeNull();
+        var inheritsMetadata = inherits.BuildEndpoint(RouteWarmup.Lazy)
+            .Metadata.OfType<IProducesResponseTypeMetadata>().ToArray();
+
+        inheritsMetadata.Any(x => x.StatusCode == 422)
+            .ShouldBeTrue("the application default must be discoverable from the OpenAPI document");
+        inheritsMetadata.Any(x => x.StatusCode == 409)
+            .ShouldBeFalse("409 was overridden by the application default and must not still be advertised");
+
+        var insists = graph.ChainFor("POST", "/dedup-default/insists");
+        insists.ShouldNotBeNull();
+        var insistsMetadata = insists.BuildEndpoint(RouteWarmup.Lazy)
+            .Metadata.OfType<IProducesResponseTypeMetadata>().ToArray();
+
+        insistsMetadata.Any(x => x.StatusCode == 409)
+            .ShouldBeTrue("an endpoint that stated 409 must still advertise 409");
+    }
+}
+
+public static class InheritsDefaultStatusEndpoint
+{
+    public static readonly List<string> Calls = [];
+
+    [Deduplicated]
+    [WolverinePost("/dedup-default/inherits")]
+    public static string Post(DedupRequest request)
+    {
+        Calls.Add(request.Name);
+        return "ok";
+    }
+}
+
+public static class InsistsOn409Endpoint
+{
+    public static readonly List<string> Calls = [];
+
+    [Deduplicated(DuplicateStatusCode = 409)]
+    [WolverinePost("/dedup-default/insists")]
+    public static string Post(DedupRequest request)
+    {
+        Calls.Add(request.Name);
+        return "ok";
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -217,6 +217,16 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         applyMetadata();
     }
 
+    /// <summary>
+    ///     The duplicate status code this endpoint actually answers with: whatever
+    ///     <c>[Deduplicated]</c> asked for, or the application-wide
+    ///     <see cref="WolverineHttpOptions.DefaultDuplicateStatusCode" /> when it asked for nothing.
+    ///     Deliberately keyed off whether a code was stated rather than off its value, so an endpoint
+    ///     that explicitly wants 409 keeps 409 even under an application default of something else.
+    /// </summary>
+    private int effectiveDuplicateStatusCode(DeduplicationRequirement requirement)
+        => requirement.ExplicitDuplicateStatusCode ?? _parent.DefaultDuplicateStatusCode;
+
     private void registerDeduplicationMetadata()
     {
         if (Deduplication is not { } requirement) return;
@@ -226,7 +236,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             Metadata.Produces(400, contentType: "application/problem+json");
         }
 
-        var status = requirement.DuplicateStatusCode;
+        var status = effectiveDuplicateStatusCode(requirement);
 
         if (status is >= 200 and < 300)
         {
@@ -535,7 +545,7 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
             ];
         }
 
-        var status = requirement.DuplicateStatusCode;
+        var status = effectiveDuplicateStatusCode(requirement);
 
         // A success code means the application has declared a replayed request benign, so there is
         // nothing to explain and a problem document would be actively wrong. Anything else is a

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -14,6 +14,8 @@ using Wolverine.Http.Resources;
 using Wolverine.Runtime;
 using Endpoint = Microsoft.AspNetCore.Http.Endpoint;
 
+using Wolverine.Persistence;
+
 namespace Wolverine.Http;
 
 public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServices, IChangeToken, IDescribeMyself
@@ -126,8 +128,19 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
         return description;
     }
 
+    /// <summary>
+    ///     The application-wide default duplicate status code, read by each HttpChain while it is being
+    ///     constructed. It has to be available that early: registerDeduplicationMetadata() runs inside the
+    ///     chain constructor, well before IHttpPolicy instances get a look, so a policy-applied default
+    ///     would set the runtime status while OpenAPI still advertised 409.
+    /// </summary>
+    internal int DefaultDuplicateStatusCode { get; private set; } =
+        DeduplicationRequirement.DefaultDuplicateStatusCode;
+
     public void DiscoverEndpoints(WolverineHttpOptions wolverineHttpOptions)
     {
+        DefaultDuplicateStatusCode = wolverineHttpOptions.DefaultDuplicateStatusCode;
+
         var source = new HttpChainSource(_options.Assemblies, wolverineHttpOptions.EndpointDiscovery);
         var logger = Container.GetInstance<ILogger<HttpGraph>>();
 

--- a/src/Http/Wolverine.Http/WolverineHttpOptions.cs
+++ b/src/Http/Wolverine.Http/WolverineHttpOptions.cs
@@ -17,6 +17,8 @@ using Wolverine.Http.Runtime.MultiTenancy;
 using Wolverine.Http.Validation.Internals;
 using Wolverine.Middleware;
 
+using Wolverine.Persistence;
+
 namespace Wolverine.Http;
 
 public enum JsonUsage
@@ -166,6 +168,21 @@ public class WolverineHttpOptions
     /// </summary>
     public ServiceProviderSource ServiceProviderSource { get; set; } = ServiceProviderSource.IsolatedAndScoped;
     
+    /// <summary>
+    ///     The status code returned when an endpoint's logical deduplication id has already been claimed
+    ///     and the endpoint itself did not state a preference. Defaults to 409 Conflict.
+    ///
+    ///     <para>
+    ///     This is the application-wide default only. <c>[Deduplicated(DuplicateStatusCode = ...)]</c> on
+    ///     an individual endpoint always wins, including when it asks for the same 409 this defaults to.
+    ///     A 2xx value produces a bare status with no body, on the reasoning that a problem document
+    ///     describing a response the application has declared benign would be actively wrong; anything
+    ///     else is written as a <c>ProblemDetails</c> document so the caller gets a machine-readable
+    ///     reason.
+    ///     </para>
+    /// </summary>
+    public int DefaultDuplicateStatusCode { get; set; } = DeduplicationRequirement.DefaultDuplicateStatusCode;
+
     /// <summary>
     ///     Apply DataAnnotations Validation middleware to all Wolverine HTTP endpoints
     /// </summary>

--- a/src/Wolverine/Attributes/DeduplicatedAttribute.cs
+++ b/src/Wolverine/Attributes/DeduplicatedAttribute.cs
@@ -86,7 +86,16 @@ public class DeduplicatedAttribute : ModifyChainAttribute
     /// HTTP endpoints only: the status code for an already-claimed id. Default 409 Conflict; use 200 or
     /// 204 where a replayed request is benign. See <see cref="DeduplicationRequirement.DuplicateStatusCode" />.
     /// </summary>
-    public int DuplicateStatusCode { get; set; } = 409;
+    public int DuplicateStatusCode
+    {
+        get => _duplicateStatusCode ?? DeduplicationRequirement.DefaultDuplicateStatusCode;
+        set => _duplicateStatusCode = value;
+    }
+
+    // Null until somebody actually writes DuplicateStatusCode on the attribute. Kept so an endpoint
+    // that said nothing can inherit WolverineHttpOptions.DefaultDuplicateStatusCode while one that
+    // asked for 409 explicitly keeps it even when the application default is something else.
+    private int? _duplicateStatusCode;
 
     public override void Modify(IChain chain, GenerationRules rules, IServiceContainer container)
     {
@@ -98,7 +107,7 @@ public class DeduplicatedAttribute : ModifyChainAttribute
             Source = Source,
             Key = Key,
             Required = Required,
-            DuplicateStatusCode = DuplicateStatusCode
+            ExplicitDuplicateStatusCode = _duplicateStatusCode
         };
     }
 }

--- a/src/Wolverine/Persistence/DeduplicationRequirement.cs
+++ b/src/Wolverine/Persistence/DeduplicationRequirement.cs
@@ -61,7 +61,32 @@ public sealed class DeduplicationRequirement
     /// explains. Message handler and gRPC chains ignore it.
     /// </para>
     /// </summary>
-    public int DuplicateStatusCode { get; init; } = 409;
+    public int DuplicateStatusCode
+    {
+        get => _duplicateStatusCode ?? DefaultDuplicateStatusCode;
+        init => _duplicateStatusCode = value;
+    }
+
+    private readonly int? _duplicateStatusCode;
+
+    /// <summary>
+    /// Whether a status code was actually chosen here, as opposed to falling through to the default.
+    /// <see cref="DuplicateStatusCode" /> cannot answer that on its own -- it reports 409 either way --
+    /// and Wolverine.HTTP needs the distinction so that
+    /// <c>WolverineHttpOptions.DefaultDuplicateStatusCode</c> applies to endpoints that did not state a
+    /// preference without overriding the ones that did.
+    /// </summary>
+    internal int? ExplicitDuplicateStatusCode
+    {
+        get => _duplicateStatusCode;
+        init => _duplicateStatusCode = value;
+    }
+
+    /// <summary>
+    /// The built-in default for an already-claimed id: 409 Conflict. An application-wide override for
+    /// HTTP endpoints lives on <c>WolverineHttpOptions.DefaultDuplicateStatusCode</c>.
+    /// </summary>
+    public const int DefaultDuplicateStatusCode = 409;
 
     /// <summary>
     /// The conventional header/metadata name carrying a logical idempotency key, matching the IETF


### PR DESCRIPTION
Follows on from #4180, which already gave Wolverine.HTTP the deduplication behaviour itself.

## Context: HTTP deduplication was already done

Worth saying up front, since the question that prompted this was whether HTTP had been covered at
all. It had -- in the same PR as the handler side, not as a follow-up:

| case | response | since |
|---|---|---|
| duplicate id | **409 Conflict** + `ProblemDetails` | #4180 |
| required id missing | **400 Bad Request** + `ProblemDetails` | #4180 |
| duplicate, configured benign | your 2xx, bare, no body | #4180 |

409 was already the default, and 400 was already in use -- but for the *missing key* case rather than
as an alternative to 409, so the two coexist rather than compete. OpenAPI metadata and five tests
came with it.

## What was actually missing

A way to say it once. An application wanting a different answer everywhere had to repeat
`DuplicateStatusCode` on every attribute, which is the one part that was not "configurable similar to
other features".

```csharp
app.MapWolverineEndpoints(opts =>
{
    opts.DefaultDuplicateStatusCode = 422;
});
```

## Two decisions worth reviewing

**Stated, not valued.** An endpoint naming a code still wins, *including when it names 409*. The
tempting shortcut is to treat "still 409" as "didn't choose", but that silently overrides the endpoint
that meant it. Not theoretical: swapping the resolution for a sentinel comparison **fails two of the
three new tests**, which is how I checked rather than assumed.

Keeping the distinction cost a nullable backing field on `DeduplicatedAttribute` and
`DeduplicationRequirement`. The public shape of both is unchanged -- `DuplicateStatusCode` is still an
`int` still defaulting to 409 -- so this is not a breaking change, and the new
`ExplicitDuplicateStatusCode` is internal.

**Read at construction, not applied by a policy.** `registerDeduplicationMetadata()` runs inside the
`HttpChain` constructor, well before any `IHttpPolicy` gets a look. A policy-applied default would
have set the runtime status while the OpenAPI document still advertised 409 -- a contract lie no
request-level test would catch. There is a metadata test guarding exactly that drift.

Message handler and gRPC chains are untouched; the status code was always documented HTTP-only.

## Verification

| check | result |
|---|---|
| `dotnet build wolverine.slnx -c Release -f net9.0` | succeeded, 0 warnings |
| HTTP deduplication tests | 8 passed (3 new + the 5 from #4180) |
| Wolverine.Grpc.Tests | 316 passed |
| CoreTests | 2759 passed |

### One unrelated failure, confirmed pre-existing

A full `Wolverine.Http.Tests` run showed `sending_messages_from_http_endpoint.send_directly` failing.
It is **not** caused by this change:

- passes in isolation, and passed on an immediate full re-run (1021 passed, 0 failed)
- has nothing to do with deduplication
- **clean `main` without this change reproduced the same class of failure in 1 of 3 full runs**
  (`use_cascaded_messages_with_http`)

It is #4248 -- a tracked session on the shared host picking up an exception another test deliberately
caused -- surfacing in a second test, which is exactly what that issue predicted. Worth noting as
evidence that the narrow fix in #4249 treats a symptom and the general fix is the one that closes it.

## Docs

[docs/guide/http/deduplication.md](docs/guide/http/deduplication.md) gains a section. That prose is
mine -- reword it before it ships if it does not sound like you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)