### PR TITLE
GH-4248: a replay test must not orphan poison work in a shared host

### DIFF
--- a/src/Http/Wolverine.Http.Tests/dead_letter_endpoints.cs
+++ b/src/Http/Wolverine.Http.Tests/dead_letter_endpoints.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Shouldly;
 using Wolverine.Persistence.Durability.DeadLetterManagement;
@@ -75,13 +76,26 @@ public class dead_letter_endpoints(AppFixture fixture) : IntegrationContext(fixt
         var all = await result.ReadAsJsonAsync<IReadOnlyList<DeadLetterEnvelopeResults>>();
         var id = all[0].Envelopes.Single().Id;
         
-        await Scenario(x =>
-        {
-            x.Post.Json(new DeadLetterEnvelopeIdsRequest
+        // GH-4248: the replay endpoint only MARKS the dead letter row replayable -- the durability agent
+        // re-enqueues it asynchronously on a later sweep, and the handler then throws
+        // AlwaysDeadLetterException all over again. Returning here without waiting released a poison
+        // message into a host shared by every test in this collection, to fail inside whatever tracked
+        // session happened to be open at the time; that is how an unrelated test ends up reporting
+        // "replayable-{Guid}". Own the work this test started.
+        await Host.TrackActivity(30.Seconds())
+            .DoNotAssertOnExceptionsDetected()
+            // Deliberately WaitForExecutionOf rather than WaitForMessageToBeReceivedAt: the latter is
+            // never satisfied by MovedToErrorQueue on purpose (GH-4125, so a test waiting on a replay
+            // does not return on the failing delivery), and this message ONLY ever dead-letters, so
+            // that condition could never complete here.
+            .WaitForExecutionOf<MessageThatAlwaysGoesToDeadLetter>()
+            .ExecuteAndWaitAsync(_ => Scenario(x =>
             {
-                Ids = [id]
-            }).ToUrl("/dead-letters/replay");
-        });
+                x.Post.Json(new DeadLetterEnvelopeIdsRequest
+                {
+                    Ids = [id]
+                }).ToUrl("/dead-letters/replay");
+            }));
     }
 
     [Fact]

--- a/src/Http/Wolverine.Http.Tests/use_cascaded_messages_with_http.cs
+++ b/src/Http/Wolverine.Http.Tests/use_cascaded_messages_with_http.cs
@@ -1,4 +1,3 @@
-using Wolverine.Tracking;
 using Shouldly;
 using WolverineWebApi;
 
@@ -10,20 +9,6 @@ public class use_cascaded_messages_with_http : IntegrationContext
     {
     }
 
-    // GH-4248: every IntegrationContext test shares one host, and a tracked session observes ALL
-    // message activity on that host rather than only what its own HTTP call caused. dead_letter_endpoints
-    // deliberately publishes MessageThatAlwaysGoesToDeadLetter, whose handler always throws; that class
-    // guards its own sessions with DoNotAssertOnExceptionsDetected(), but the exception was still landing
-    // inside whatever OTHER session happened to be open, and failing it. Both tests below were observed
-    // failing that way on unchanged code, with the foreign exception's own message ("replayable-{Guid}",
-    // minted in dead_letter_endpoints) visible in the failure.
-    //
-    // Ignoring that one message type is enough: TrackedSession.Record() returns before it attaches the
-    // exception when the message type is ignored. Deliberately narrow -- these tests still assert on
-    // exceptions from everything else, which is the point of using a tracked session at all.
-    private static TrackedSessionConfiguration ignoreForeignDeadLetters(TrackedSessionConfiguration config)
-        => config.IgnoreMessageType<MessageThatAlwaysGoesToDeadLetter>();
-
     [Fact]
     public async Task send_cascaded_messages_from_tuple_response()
     {
@@ -33,7 +18,7 @@ public class use_cascaded_messages_with_http : IntegrationContext
         var (tracked, result) = await TrackedHttpCall(x =>
         {
             x.Post.Json(new SpawnInput("Chris Jones")).ToUrl("/spawn");
-        }, ignoreForeignDeadLetters);
+        });
 
         var text = await result.ReadAsTextAsync();
         text.ShouldBe("got it");
@@ -53,7 +38,7 @@ public class use_cascaded_messages_with_http : IntegrationContext
         {
             x.Post.Url("/spawn2");
             x.StatusCodeShouldBe(204);
-        }, ignoreForeignDeadLetters);
+        });
 
         tracked.Sent.SingleMessage<HttpMessage1>().ShouldNotBeNull();
         tracked.Sent.SingleMessage<HttpMessage2>().ShouldNotBeNull();


### PR DESCRIPTION
Closes #4248, and supersedes the per-test workaround merged in #4249.

## The diagnosis in #4248 was wrong, including my own

Both the issue and its first fix assumed this was `TrackedSession` attributing exceptions too
broadly. It is not. It is **one test releasing asynchronous poison work into a host every other test
shares.**

`dead_letter_endpoints.replay_one` POSTs to `/dead-letters/replay` and returns. That endpoint calls
`ReplayDeadLettersAsync`, which only **marks** the dead letter row replayable. The durability agent
re-enqueues it on a later sweep -- **measured at ~3.4 seconds** -- and the handler throws
`AlwaysDeadLetterException` all over again. By then the test that started it is long finished, so the
second failure lands in whatever tracked session happens to be open, and that session fails on an
exception it did not cause.

The failure text was the tell all along: every instance carried `replayable-{Guid}`, which is minted
only in `replay_one`.

This is measured, not reasoned. The tracked session's own timeout diagnostic prints the sequence:

```
| ...MessageThatAlwaysGoesToDeadLetter |  3451 | Received          |
| ...MessageThatAlwaysGoesToDeadLetter |  3452 | ExecutionStarted  |
| ...MessageThatAlwaysGoesToDeadLetter |  3452 | ExecutionFinished |
| ...MessageThatAlwaysGoesToDeadLetter |  3453 | MovedToErrorQueue |

Exceptions detected:
WolverineWebApi.AlwaysDeadLetterException: replayable-65931c65-...
```

## The fix

`replay_one` now owns the work it starts: the replay POST runs inside a session that waits for the
redelivered message to finish executing.

The wait is `WaitForExecutionOf` rather than `WaitForMessageToBeReceivedAt`. `WaitForMessage` is
deliberately never satisfied by `MovedToErrorQueue` (GH-4125, so a test waiting on a replay does not
return on the failing delivery) -- and this message *only* ever dead-letters, so that condition could
never complete. It times out at 30 seconds instead, which is how the mechanism above got measured.

## The #4249 workaround is removed

With the source fixed, the `IgnoreMessageType` added to `use_cascaded_messages_with_http` is no
longer needed, and leaving it would mean those two tests silently tolerate a real regression later.

**Verified by six consecutive full runs of `Wolverine.Http.Tests` with the ignore removed -- 1018
passed every time**, against an original that reproduced in roughly half of full runs. Six runs rather
than one because at a ~50% rate anything less is indistinguishable from luck.

This also covers `sending_messages_from_http_endpoint.send_directly`, which showed the same failure
and which the per-test ignore never touched -- and which is what prompted looking past the workaround
in the first place.

## Nothing in the framework changed

Only two test files. The general question in #4248 -- whether a tracked session should attribute
exceptions only to envelopes it is actually tracking -- turns out not to need answering to fix this:
there was no ambiguity about ownership, just work nobody was waiting on. That question can stay
closed unless something else argues for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)