### PR TITLE
GH-4246: stop a node record description from overflowing its column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   which is 768 characters of utf8mb4.
 
   An existing database is widened in place on the next migration, by an `ALTER TABLE ... MODIFY` that
-  keeps the rows -- but only with Weasel 9.30.0. Before that, the schema differ compared column types
+  keeps the rows -- but only with Weasel 9.29.1. Before that, the schema differ compared column types
   with the size stripped off, so a widened `varchar` was invisible to it and an existing table kept
   the narrow column forever.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@
   shard tears down, because the row cannot be dropped before the agent has actually stopped without
   lying about ownership. Acting on the window was the defect, not the window.
 
+### WolverineFx.RDBMS (all relational providers)
+
+- **Node record descriptions no longer overflow the column and fail the insert.** (closes
+  [#4246](https://github.com/JasperFx/wolverine/issues/4246)) An `AssignmentChanged` record's
+  description is an agent command's `ToString()`, which carries an agent URI, a schema name and a
+  destination node -- long enough on a real cluster to overrun the `description` column on
+  `wolverine_node_records` and fail the insert, taking the whole `AgentCommand` batch behind it down
+  with it. The reporter hit it on MySQL with an overridden `Durability.MessageStorageSchemaName`:
+  "Data too long for column 'description'".
+
+  The bounded `description` columns now declare 1000 characters (`NodeRecord.DescriptionLength`) on
+  MySQL, SQL Server and Oracle, and every write path clamps the description to that width first, so a
+  description long enough to overflow loses its tail rather than failing an insert. These rows are
+  append-only diagnostics; the tail is expendable and the assignment is not.
+
+  MySQL was the provider that failed because it was the only one leaning on Weasel's default string
+  mapping, `VARCHAR(255)` -- narrower than every other provider, and narrower than the calling code
+  assumed. The rest of that node-table family had the same defect waiting in it and is widened to 500
+  to match the widths SQL Server and Oracle have always declared: `wolverine_nodes.uri` and
+  `.description`, `wolverine_node_assignments.id` (an agent URI as the primary key),
+  `wolverine_node_records.event_name`, `wolverine_agent_restrictions.uri` and `.type`, the control
+  queue's `message_type`, the dynamic listener registry's `uri`, and the tenant table's
+  `connection_string`. Widths in a key stay at 500 because InnoDB caps an index key at 3072 bytes,
+  which is 768 characters of utf8mb4.
+
+  An existing database is widened in place on the next migration, by an `ALTER TABLE ... MODIFY` that
+  keeps the rows -- but only with Weasel 9.30.0. Before that, the schema differ compared column types
+  with the size stripped off, so a widened `varchar` was invisible to it and an existing table kept
+  the narrow column forever.
+
 ### WolverineFx.Http
 
 - **DataAnnotations validation works with `ServiceLocationPolicy.NotAllowed`.** (closes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,94 @@
 
 ## Unreleased
 
+### WolverineFx (core)
+
+- **A node no longer sweeps up its own in-flight stop as a wedged shard.** (closes
+  [#4240](https://github.com/JasperFx/wolverine/issues/4240)) An event-subscription agent could end up
+  running on two nodes at once while `wolverine_nodes` credited only one of them, so nothing in the
+  system could ever stop the extra copy. `StopAgentAsync` awaits the agent's own teardown before it
+  deregisters the agent and drops the assignment row, and a real shard reports `Stopped` from the
+  moment that teardown begins -- so for the whole duration of a stop the agent was registered,
+  `Stopped`, and reporting no failure, which is exactly the state the health-check sweep treats as a
+  wedged shard and restarts.
+
+  That sweep runs on every node on every tick independently of leadership, which is why the extra
+  start never appeared in the leader's own command log: the leader does not issue it, the stopping
+  node issues it to itself. The restart also re-upserts the assignment row on its way through, so it
+  re-claimed ownership the stop was about to revoke -- leaving one durable row and two live copies,
+  a shape the GH-2602 duplicate healer compares two nodes' durable rows to find and therefore cannot
+  see at all.
+
+  The window itself is left open deliberately. The durable record has to lag in-process state while a
+  shard tears down, because the row cannot be dropped before the agent has actually stopped without
+  lying about ownership. Acting on the window was the defect, not the window.
+
+### WolverineFx.Http
+
+- **DataAnnotations validation works with `ServiceLocationPolicy.NotAllowed`.** (closes
+  [#4238](https://github.com/JasperFx/wolverine/issues/4238)) Under the Wolverine 6 default the
+  application threw `InvalidServiceLocationException` at bootstrap and could not start. This was
+  fallout from GH-4171: that change deliberately stopped `IServiceProvider` being answered silently
+  out of `httpContext.RequestServices`, which is right for user code, but the DataAnnotations executor
+  takes one to build its `ValidationContext` and so Wolverine's own middleware began tripping the
+  user's policy. The validation policy now supplies that argument itself.
+
+- **An application-wide default for the duplicate status code.**
+  `opts.DefaultDuplicateStatusCode` on `MapWolverineEndpoints` sets the answer for every deduplicated
+  endpoint that did not state one, so an application wanting something other than 409 says it once
+  rather than on every `[Deduplicated]`. An endpoint that names a code still wins, **including when it
+  names 409** -- the two are told apart by whether a code was stated rather than by comparing against
+  409, so an endpoint that deliberately insists on 409 keeps it.
+
+- **Deduplication refusals advertise their problem document in OpenAPI.** The refusal status codes
+  reached the generated document, but the content type did not: `Produces` without a response type
+  leaves Swashbuckle emitting the status with no content at all, so the spec announced that an
+  endpoint could return a 409 while saying nothing about the `ProblemDetails` body it actually
+  returns. A benign 2xx is still advertised as a bare status, deliberately -- a problem document
+  describing a response the application has declared benign would be actively wrong.
+
+### WolverineFx.EntityFrameworkCore
+
+- **A failed rollback no longer displaces the exception that caused it.** (closes
+  [#4239](https://github.com/JasperFx/wolverine/issues/4239)) The generated `catch` for a
+  `[Transactional]` handler under Wolverine-managed multi-tenancy called
+  `RollbackTransactionAsync(cancellation)` unguarded, and lost the original exception two ways. With a
+  token already cancelled on the way in -- which is what `DefaultExecutionTimeout` hands a nested
+  `InvokeAsync` -- `BeginTransactionAsync` threw without creating a transaction and the rollback then
+  threw "The connection does not have any active transactions", escaping the catch so the `throw;`
+  never ran and the real failure reached neither a log nor a dead letter queue. With a token cancelled
+  after the transaction opened, the rollback was handed that same token, threw, and left the
+  transaction open until the `DbContext` was disposed.
+
+  Both now go through a guarded helper: only roll back a transaction that exists, never let the token
+  that caused the failure also cancel the cleanup, and never let a failure of the rollback itself
+  replace the exception being unwound.
+
+### WolverineFx.Grpc
+
+- **Wolverine parameter attributes work on gRPC before/after hooks.** (closes
+  [#3935](https://github.com/JasperFx/wolverine/issues/3935)) `[Entity]`, `[All]`, `[Queryable]`,
+  `[WriteAggregate]`, `[ReadAggregate]`, `[ReadModel]`, `[FromQuerySpecification]` and the DCB
+  attributes were unavailable on gRPC services -- nothing in `Wolverine.Grpc` called
+  `WolverineParameterAttribute.TryApply` at all. The hooks are the only place on a gRPC service
+  carrying a parameter list somebody can decorate; the RPC methods stay out on purpose, since a
+  proto-defined signature leaves nowhere to hang an attribute and the answer there is the downstream
+  message handler, which has supported the whole family all along.
+
+  This also needed the before-hook applicability rule to stop rejecting them. That rule requires every
+  parameter to be assignable from the RPC request type, and an `[Entity] Invoice` parameter is not --
+  so the hook was dropped from codegen entirely, and the attributes would have appeared to do nothing
+  while after-hooks worked fine.
+
+### Dependencies
+
+- JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator and JasperFx.SourceGenerator to
+  **2.60.0**. `JasperFx.RuntimeCompiler` stays on its own 5.x line.
+- Marten, Marten.AspNetCore and Marten.Newtonsoft to **9.30.0**, Polecat to **5.21.1**, Fisher to
+  **1.0.6**, and the Weasel packages to **9.29.0**. Polecat 5.21.1 is the release that adopts the
+  `IEventTenancySource` seam from JasperFx 2.59.0, which closes the async-daemon tenancy gap for a
+  store that is not Marten.
+
 ### WolverineFx.AI (new package)
 
 - **New package for one shot LLM callouts as durable messages.** (closes

--- a/src/Persistence/MySql/MySqlTests/Agents/Bug_4246_long_node_record_description.cs
+++ b/src/Persistence/MySql/MySqlTests/Agents/Bug_4246_long_node_record_description.cs
@@ -1,0 +1,161 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Shouldly;
+using Wolverine;
+using Wolverine.MySql;
+using Wolverine.Persistence.Durability;
+using Weasel.Core;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Durability;
+using Wolverine.RDBMS.Sagas;
+using Wolverine.Runtime.Agents;
+using Xunit;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace MySqlTests.Agents;
+
+/// <summary>
+/// GH-4246. Every string column in the MySQL node-table family used to take Weasel's default string
+/// mapping, which on MySQL is <c>VARCHAR(255)</c> -- narrower than the widths the SQL Server and Oracle
+/// stores have always declared for the same columns, and narrower than any of the calling code assumed.
+/// A leader writing an <c>AssignmentChanged</c> record, whose description is an agent command's
+/// ToString(), overflowed the column and failed the insert, which failed the AgentCommand batch behind
+/// it: "Data too long for column 'description'". A non-default schema name was enough to get there.
+/// </summary>
+[Collection("mysql")]
+public class Bug_4246_long_node_record_description : IAsyncLifetime
+{
+    private const string SchemaName = "node_record_description";
+    private MySqlMessageStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new MySqlConnection(Servers.MySqlConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"DROP DATABASE IF EXISTS `{SchemaName}`";
+            await cmd.ExecuteNonQueryAsync();
+            await conn.CloseAsync();
+        }
+
+        var dataSource = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString);
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.MySqlConnectionString,
+            SchemaName = SchemaName,
+            Role = MessageStoreRole.Main
+        };
+
+        _store = new MySqlMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<MySqlMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await _store.Admin.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _store.DisposeAsync();
+    }
+
+    private async Task<long> characterLengthOfAsync(string table, string column)
+    {
+        await using var conn = new MySqlConnection(Servers.MySqlConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select character_maximum_length from information_schema.columns " +
+            "where table_schema = @schema and table_name = @table and column_name = @column";
+        cmd.Parameters.AddWithValue("schema", SchemaName);
+        cmd.Parameters.AddWithValue("table", table);
+        cmd.Parameters.AddWithValue("column", column);
+
+        var raw = await cmd.ExecuteScalarAsync();
+        raw.ShouldNotBeNull($"{SchemaName}.{table}.{column} was not provisioned");
+        return Convert.ToInt64(raw);
+    }
+
+    /// <summary>
+    /// Run the record through the same PersistNodeRecord operation the durability batcher hands to the
+    /// database -- the operation that appears at the top of the stack trace on the issue -- rather than
+    /// through INodeAgentPersistence, which needs a started runtime behind it to have a batcher at all.
+    /// </summary>
+    private async Task persistAsync(params NodeRecord[] records)
+    {
+        var settings = new DatabaseSettings { SchemaName = SchemaName };
+        var operation = new PersistNodeRecord(settings, records);
+
+        await using var conn = new MySqlConnection(Servers.MySqlConnectionString);
+        await conn.OpenAsync();
+
+        var builder = new DbCommandBuilder(conn);
+        operation.ConfigureCommand(builder);
+
+        await conn.ExecuteNonQueryAsync(builder);
+        await conn.CloseAsync();
+    }
+
+    [Fact]
+    public async Task the_description_column_is_wide_enough_for_a_node_record()
+    {
+        (await characterLengthOfAsync("wolverine_node_records", "description"))
+            .ShouldBe(NodeRecord.DescriptionLength);
+    }
+
+    [Theory]
+    // The rest of the family that used to default to 255. Every one of these holds an agent URI, a
+    // connection string or a machine description -- none of which fits a 255 character budget reliably.
+    [InlineData("wolverine_nodes", "uri")]
+    [InlineData("wolverine_nodes", "description")]
+    [InlineData("wolverine_node_assignments", "id")]
+    [InlineData("wolverine_node_records", "event_name")]
+    [InlineData("wolverine_agent_restrictions", "uri")]
+    [InlineData("wolverine_agent_restrictions", "type")]
+    public async Task the_node_family_string_columns_no_longer_default_to_255(string table, string column)
+    {
+        (await characterLengthOfAsync(table, column)).ShouldBe(500);
+    }
+
+    [Fact]
+    public async Task write_and_read_back_the_description_that_broke_gh_4246()
+    {
+        // Verbatim from the report: an AssignAgent against an overridden MessageStorageSchemaName.
+        const string reported =
+            "AssignAgent { AgentUri = wolverinedb://mysql/localhost/servix_local/servix_local, " +
+            "Destination = NodeDestination { NodeId = a8965d0c-d6f5-45b9-8b52-fb1f50dde7ba, " +
+            "ControlUri = dbcontrol://a8965d0c-d6f5-45b9-8b52-fb1f50dde7ba/ }, " +
+            "DestinationNodeId = a8965d0c-d6f5-45b9-8b52-fb1f50dde7ba }";
+
+        reported.Length.ShouldBeGreaterThan(255);
+
+        await persistAsync(new NodeRecord
+        {
+            NodeNumber = 5,
+            RecordType = NodeRecordType.AssignmentChanged,
+            Description = reported
+        });
+
+        var records = await _store.Nodes.FetchRecentRecordsAsync(10);
+        records.Single().Description.ShouldBe(reported);
+    }
+
+    [Fact]
+    public async Task a_description_past_the_column_width_is_truncated_rather_than_failing_the_insert()
+    {
+        // The column is wider now, but it is still bounded, so the write path has to clamp. Losing the
+        // tail of a diagnostic row beats taking down the AgentCommand batch that produced it.
+        var enormous = new string('x', NodeRecord.DescriptionLength * 4);
+
+        await persistAsync(new NodeRecord
+        {
+            NodeNumber = 5,
+            RecordType = NodeRecordType.AgentPaused,
+            Description = enormous
+        });
+
+        var stored = (await _store.Nodes.FetchRecentRecordsAsync(10)).Single().Description;
+        stored.Length.ShouldBe(NodeRecord.DescriptionLength);
+        stored.ShouldEndWith("...");
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -545,8 +545,15 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             nodeTable.AddColumn<int>("node_number").NotNull()
                 .AutoIncrement()
                 .AddIndex(idx => idx.IsUnique = true);
-            nodeTable.AddColumn<string>("description").NotNull();
-            nodeTable.AddColumn<string>("uri").NotNull();
+            // GH-4246: every string column in this node-table family used to take Weasel's default
+            // string mapping, which on MySQL is VARCHAR(255) -- the narrowest of any provider, and
+            // narrower than what the SQL Server and Oracle stores have always declared for the same
+            // columns. Declaring the widths explicitly puts MySQL on the same footing instead of leaving
+            // it a provider-specific ceiling nobody sees until an insert fails. Widths stay at or under
+            // 500 for anything in a key: InnoDB caps an index key at 3072 bytes, which is 768 characters
+            // of utf8mb4.
+            nodeTable.AddColumn("description", "varchar(500)").NotNull();
+            nodeTable.AddColumn("uri", "varchar(500)").NotNull();
             nodeTable.AddColumn<DateTimeOffset>("started").DefaultValueByExpression("(UTC_TIMESTAMP(6))").NotNull();
             nodeTable.AddColumn<DateTimeOffset>("health_check").NotNull().DefaultValueByExpression("(UTC_TIMESTAMP(6))");
             nodeTable.AddColumn<string>("version");
@@ -555,7 +562,7 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             yield return nodeTable;
 
             var assignmentTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeAssignmentsTableName));
-            assignmentTable.AddColumn<string>("id").AsPrimaryKey();
+            assignmentTable.AddColumn("id", "varchar(500)").AsPrimaryKey();
             assignmentTable.AddColumn<Guid>("node_id")
                 .ForeignKeyTo(nodeTable.Identifier, "id", onDelete: Weasel.Core.CascadeAction.Cascade);
             assignmentTable.AddColumn<DateTimeOffset>("started").DefaultValueByExpression("(UTC_TIMESTAMP(6))").NotNull();
@@ -566,7 +573,7 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             {
                 var queueTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.ControlQueueTableName));
                 queueTable.AddColumn<Guid>("id").AsPrimaryKey();
-                queueTable.AddColumn<string>("message_type").NotNull();
+                queueTable.AddColumn(DatabaseConstants.MessageType, "varchar(500)").NotNull();
                 queueTable.AddColumn<Guid>("node_id").NotNull();
                 queueTable.AddColumn(DatabaseConstants.Body, "LONGBLOB").NotNull();
                 queueTable.AddColumn<DateTimeOffset>("posted").NotNull().DefaultValueByExpression("(UTC_TIMESTAMP(6))");
@@ -579,7 +586,7 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             {
                 var tenantTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.TenantsTableName));
                 tenantTable.AddColumn<string>(StorageConstants.TenantIdColumn).AsPrimaryKey();
-                tenantTable.AddColumn<string>(StorageConstants.ConnectionStringColumn).NotNull();
+                tenantTable.AddColumn(StorageConstants.ConnectionStringColumn, "varchar(500)").NotNull();
                 tenantTable.AddColumn<bool>(DatabaseConstants.DisabledColumn).DefaultValueByExpression("false").NotNull();
                 yield return tenantTable;
             }
@@ -587,16 +594,16 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             var eventTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeRecordTableName));
             eventTable.AddColumn<int>("id").AsPrimaryKey().AutoIncrement();
             eventTable.AddColumn<int>("node_number").NotNull();
-            eventTable.AddColumn<string>("event_name").NotNull();
+            eventTable.AddColumn("event_name", "varchar(500)").NotNull();
             eventTable.AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("(UTC_TIMESTAMP(6))").NotNull();
-            eventTable.AddColumn<string>("description").AllowNulls();
+            eventTable.AddColumn("description", $"varchar({NodeRecord.DescriptionLength})").AllowNulls();
             yield return eventTable;
 
             var restrictionTable =
                 new Table(new DbObjectName(SchemaName, DatabaseConstants.AgentRestrictionsTableName));
             restrictionTable.AddColumn<Guid>("id").AsPrimaryKey();
-            restrictionTable.AddColumn<string>("uri").NotNull();
-            restrictionTable.AddColumn<string>("type").NotNull();
+            restrictionTable.AddColumn("uri", "varchar(500)").NotNull();
+            restrictionTable.AddColumn("type", "varchar(500)").NotNull();
             restrictionTable.AddColumn<int>("node").NotNull().DefaultValue(0);
             yield return restrictionTable;
 
@@ -606,7 +613,7 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             {
                 var listenerTable =
                     new Table(new DbObjectName(SchemaName, DatabaseConstants.ListenersTableName));
-                listenerTable.AddColumn<string>("uri").AsPrimaryKey();
+                listenerTable.AddColumn("uri", "varchar(500)").AsPrimaryKey();
                 yield return listenerTable;
             }
         }

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.cs
@@ -330,7 +330,10 @@ internal partial class OracleMessageStore : IMessageDatabase, IMessageInbox, IMe
             eventTable.AddColumn("event_name", "VARCHAR2(500)").NotNull();
             eventTable.AddColumn<DateTimeOffset>("timestamp")
                 .DefaultValueByExpression("SYSTIMESTAMP AT TIME ZONE ''UTC''").NotNull();
-            eventTable.AddColumn("description", "VARCHAR2(500)").AllowNulls();
+            // GH-4246: widened for the same reason as the SQL Server and MySQL stores. Deliberately plain
+            // VARCHAR2 rather than the CHAR length semantics -- Oracle reports data_length in bytes, so a
+            // "1000 CHAR" declaration would read back as 4000 and report drift on every schema check.
+            eventTable.AddColumn("description", $"VARCHAR2({NodeRecord.DescriptionLength})").AllowNulls();
             yield return eventTable;
 
             var restrictionTable = new Table(new OracleObjectName(SchemaName, DatabaseConstants.AgentRestrictionsTableName.ToUpperInvariant()));

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
@@ -353,7 +353,9 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
                     "VALUES (:nodeNumber, :eventName, :description)");
                 cmd.With("nodeNumber", record.NodeNumber);
                 cmd.With("eventName", record.RecordType.ToString());
-                cmd.With("description", record.Description ?? string.Empty);
+                // GH-4246: same clamp the shared PersistNodeRecord operation applies -- Oracle writes
+                // node records through this hand-rolled path instead, so it needs it too.
+                cmd.With("description", NodeRecord.TruncateDescription(record.Description));
                 await cmd.ExecuteNonQueryAsync();
             }
         }

--- a/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/PersistNodeRecord.cs
@@ -48,7 +48,13 @@ public class PersistNodeRecord : IDatabaseOperation, IDoNotReturnData
             builder.Append(", ");
             builder.AppendParameter(@event.RecordType.ToString());
             builder.Append(", ");
-            builder.AppendParameter(@event.Description!);
+
+            // GH-4246: clamped to the width every bounded description column now declares. An
+            // AssignmentChanged record's description is an agent command's ToString(), which grows with
+            // the agent URI, the schema name and the destination node -- long enough on a real cluster to
+            // overflow the column and fail this insert, which fails the whole AgentCommand batch behind
+            // it. These rows are diagnostics; losing a tail beats losing an assignment.
+            builder.AppendParameter(NodeRecord.TruncateDescription(@event.Description));
             builder.Append(");");
         }
     }

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -700,7 +700,10 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
             eventTable.AddColumn<int>("node_number").NotNull();
             eventTable.AddColumn("event_name", "varchar(500)").NotNull();
             eventTable.AddColumn<DateTimeOffset>("timestamp").DefaultValueByExpression("GETUTCDATE()").NotNull();
-            eventTable.AddColumn("description", "varchar(500)").AllowNulls();
+            // GH-4246: an AssignmentChanged description is an agent command's ToString(), which carries an
+            // agent URI, a schema name and a destination node -- 500 characters is not the ceiling it
+            // looked like on a real cluster.
+            eventTable.AddColumn("description", $"varchar({NodeRecord.DescriptionLength})").AllowNulls();
             yield return eventTable;
 
             // Dynamic listener registry (GH-2685). Provisioned only when the opt-in

--- a/src/Testing/CoreTests/Runtime/Agents/node_record_description_truncation.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/node_record_description_truncation.cs
@@ -1,0 +1,61 @@
+using Shouldly;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-4246. The <c>description</c> column on <c>wolverine_node_records</c> is bounded on every store
+/// that declares a width, and an <c>AssignmentChanged</c> description is an agent command's ToString()
+/// -- an agent URI, a schema name and a destination node, which on a real cluster runs long. When it
+/// overflowed the column the insert failed, and it took the whole AgentCommand batch behind it down
+/// with it. These rows are append-only diagnostics: the tail is expendable, the insert is not.
+/// </summary>
+public class node_record_description_truncation
+{
+    [Fact]
+    public void short_description_passes_through_untouched()
+    {
+        NodeRecord.TruncateDescription("wolverinedb://mysql/localhost/servix_local/servix_local")
+            .ShouldBe("wolverinedb://mysql/localhost/servix_local/servix_local");
+    }
+
+    [Fact]
+    public void null_and_empty_descriptions_become_empty_string()
+    {
+        NodeRecord.TruncateDescription(null).ShouldBe(string.Empty);
+        NodeRecord.TruncateDescription(string.Empty).ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void a_description_exactly_at_the_limit_is_not_truncated()
+    {
+        var description = new string('x', NodeRecord.DescriptionLength);
+        NodeRecord.TruncateDescription(description).ShouldBe(description);
+    }
+
+    [Fact]
+    public void an_over_long_description_is_clamped_and_marked()
+    {
+        var truncated = NodeRecord.TruncateDescription(new string('x', NodeRecord.DescriptionLength * 3));
+
+        truncated.Length.ShouldBe(NodeRecord.DescriptionLength);
+        truncated.ShouldEndWith("...");
+    }
+
+    [Fact]
+    public void the_declared_length_still_clears_the_description_that_broke_gh_4246()
+    {
+        // The exact record from the report -- an AssignAgent command against a non-default schema name.
+        // It is ~230 characters, which cleared varchar(500) on SQL Server and Oracle and did not clear
+        // MySQL's defaulted varchar(255).
+        const string reported =
+            "AssignAgent { AgentUri = wolverinedb://mysql/localhost/servix_local/servix_local, " +
+            "Destination = NodeDestination { NodeId = a8965d0c-d6f5-45b9-8b52-fb1f50dde7ba, " +
+            "ControlUri = dbcontrol://a8965d0c-d6f5-45b9-8b52-fb1f50dde7ba/ }, " +
+            "DestinationNodeId = a8965d0c-d6f5-45b9-8b52-fb1f50dde7ba }";
+
+        reported.Length.ShouldBeGreaterThan(255);
+        NodeRecord.TruncateDescription(reported).ShouldBe(reported);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/IWolverineObserver.cs
+++ b/src/Wolverine/Runtime/Agents/IWolverineObserver.cs
@@ -109,12 +109,6 @@ public interface IWolverineObserver
 
 internal class PersistenceWolverineObserver : IWolverineObserver
 {
-    // The narrowest wolverine_node_records.description column any store provisions.
-    private const int DescriptionLength = 500;
-
-    private static string truncate(string text, int max)
-        => text.Length <= max ? text : text[..(max - 3)] + "...";
-
     private readonly IWolverineRuntime _runtime;
 
     public PersistenceWolverineObserver(IWolverineRuntime runtime)
@@ -219,12 +213,12 @@ internal class PersistenceWolverineObserver : IWolverineObserver
         // AgentUri; the reason is the whole point of this record, so it takes the slot when we have one.
         // Deliberately ShardFailure.ToString() (category + failing event + message) rather than Detail:
         // the full exception text with stack traces belongs in the log line the caller writes, not in a
-        // node-record column every store has to hold. Truncated to the narrowest description column any
-        // store provisions (varchar(500) on SQL Server and Oracle) -- an exception message long enough to
-        // overflow it must not turn this diagnostic record into a failed insert.
+        // node-record column every store has to hold. NodeRecord.TruncateDescription clamps it to the
+        // width every bounded description column declares -- an exception message long enough to overflow
+        // it must not turn this diagnostic record into a failed insert.
         if (failure != null)
         {
-            record.Description = truncate(failure.ToString(), DescriptionLength);
+            record.Description = NodeRecord.TruncateDescription(failure.ToString());
         }
 
         try
@@ -243,10 +237,10 @@ internal class PersistenceWolverineObserver : IWolverineObserver
         var record = NodeRecord.For(_runtime.Options, NodeRecordType.AgentReleased, agentUri);
 
         // Same shape and same reasoning as AgentPaused above: the classified reason takes the
-        // Description slot when there is one, truncated to the narrowest column any store provisions.
+        // Description slot when there is one, clamped to the description column width.
         if (failure != null)
         {
-            record.Description = truncate(failure.ToString(), DescriptionLength);
+            record.Description = NodeRecord.TruncateDescription(failure.ToString());
         }
 
         try

--- a/src/Wolverine/Runtime/Agents/NodeRecordType.cs
+++ b/src/Wolverine/Runtime/Agents/NodeRecordType.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -45,6 +46,32 @@ public enum NodeRecordType
 // any concern about serialization settings
 public class NodeRecord : ISerializable
 {
+    /// <summary>
+    /// The width of the <c>description</c> column in the <c>wolverine_node_records</c> table for every
+    /// store that provisions a bounded one, and therefore the ceiling every description is truncated to
+    /// on the way to the database. GH-4246: MySQL was the one provider that took Weasel's default string
+    /// column instead of declaring a width, so it got <c>VARCHAR(255)</c> while the code assumed 500 --
+    /// and an <c>AssignmentChanged</c> record, whose description is an agent command's ToString() and so
+    /// carries an agent URI plus a node destination, blew past it and failed the insert. Every bounded
+    /// store now declares this width, and <see cref="TruncateDescription"/> guarantees nothing wider is
+    /// ever handed to one.
+    /// </summary>
+    public const int DescriptionLength = 1000;
+
+    /// <summary>
+    /// Clamp a node record description to <see cref="DescriptionLength"/>, marking the tail that was cut.
+    /// These records are append-only diagnostics; a description long enough to overflow the column must
+    /// lose its tail rather than turn the insert into a failure that takes an agent command down with it.
+    /// </summary>
+    public static string TruncateDescription(string? description)
+    {
+        if (description.IsEmpty()) return string.Empty;
+
+        return description!.Length <= DescriptionLength
+            ? description
+            : description[..(DescriptionLength - 3)] + "...";
+    }
+
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public int NodeNumber { get; set; }
     public NodeRecordType RecordType { get; set; }


### PR DESCRIPTION
Closes #4246.

An `AssignmentChanged` record's description is an agent command's `ToString()`, which carries an agent URI, a schema name and a destination node -- long enough on a real cluster to overrun the `description` column on `wolverine_node_records` and fail the insert, taking the whole `AgentCommand` batch behind it down with it. The reporter hit it on MySQL with an overridden `Durability.MessageStorageSchemaName`: `Data too long for column 'description'`.

The reporter's diagnosis is correct. MySQL failed because it is the only provider that leaned on Weasel's default string mapping, `VARCHAR(255)` -- narrower than every other provider, and narrower than the calling code assumed. SQL Server and Oracle have always declared `varchar(500)` here explicitly; PostgreSQL and SQLite are unbounded.

There was a second half to it. `PersistenceWolverineObserver` carried a private 500-character clamp described as "the narrowest description column any store provisions" -- which was wrong about MySQL, and, more to the point, only applied to `AgentPaused` and `AgentReleased`. `AssignmentChanged`, the record type that actually failed, went to the database untouched.

## The fix

The bounded `description` columns now declare `NodeRecord.DescriptionLength` (1000) on MySQL, SQL Server and Oracle, and **both** write paths -- the shared `PersistNodeRecord` operation and Oracle's hand-rolled insert -- clamp to it first. No record type can overflow the column on any store now. These rows are append-only diagnostics: losing a tail beats losing an assignment.

The rest of the MySQL node-table family had the same defect waiting in it, and is widened to 500 to match what SQL Server and Oracle already declared:

| Table | Column | Was | Now |
|---|---|---|---|
| `wolverine_nodes` | `description`, `uri` | `varchar(255)` | `varchar(500)` |
| `wolverine_node_assignments` | `id` (an agent URI, as the PK) | `varchar(255)` | `varchar(500)` |
| `wolverine_node_records` | `event_name` | `varchar(255)` | `varchar(500)` |
| `wolverine_node_records` | `description` | `varchar(255)` | `varchar(1000)` |
| `wolverine_agent_restrictions` | `uri`, `type` | `varchar(255)` | `varchar(500)` |
| `wolverine_control_queue` | `message_type` | `varchar(255)` | `varchar(500)` |
| `wolverine_listeners` | `uri` (PK) | `varchar(255)` | `varchar(500)` |
| tenant table | `connection_string` | `varchar(255)` | `varchar(500)` |

A 255-character ceiling on a tenant connection string was a live bug waiting to happen. Widths in a key stay at 500 deliberately: InnoDB caps an index key at 3072 bytes, which is 768 characters of utf8mb4. The tenant id PK is left at 255 rather than narrowed to SQL Server's `varchar(100)` -- narrowing a key column would break existing rows.

## Ordering: this needs JasperFx/weasel#550 first

Widening the declarations only helps **newly created** databases. Weasel's `TableColumn.RawType()` strips the size off a type before comparing, so `varchar(255)` and `varchar(1000)` are identical to the schema differ. I verified empirically on both MySQL and SQL Server that `MigrateAsync` against an existing table leaves the old width in place.

JasperFx/weasel#550 fixes that. Once Wolverine is on a Weasel that compares character lengths, an existing database is widened in place on the next migration by an `ALTER TABLE ... MODIFY` that keeps the rows. Until then, an existing MySQL install still needs the one hand-written `ALTER` the reporter already ran.

The Wolverine-side migration test is deliberately **not** in this PR rather than committed red -- it lands with the Weasel bump. The upgrade path is covered in the meantime by Weasel's own `patching_widens_the_column_in_place`, which asserts the rows survive the `MODIFY COLUMN`.

## Verification

`Bug_4246_long_node_record_description` was confirmed to reproduce the reported failure against the old schema, with the reporter's exact exception:

```
MySqlConnector.MySqlException : Data too long for column 'description' at row 1
```

| Suite | Result |
|---|---|
| `wolverine.slnx` Release build, `-f net9.0` | clean |
| CoreTests | 2764 passed, 2 skipped |
| MySqlTests | 183 passed |
| SqlServerTests | 409 passed, 2 skipped |
| OracleTests | 164 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)