### PR TITLE
Stop Wolverine.AI.Tests racing itself through a shared static

### DIFF
--- a/src/Extensions/Wolverine.AI.Tests/NoParallelization.cs
+++ b/src/Extensions/Wolverine.AI.Tests/NoParallelization.cs
@@ -1,0 +1,12 @@
+// TriageResults is a static collection that the IncidentTriage and LlmTextResponse handlers record
+// into, because a Wolverine handler is discovered assembly wide and has no per-test seam to write to.
+// end_to_end clears it in InitializeAsync, which is enough within one class and useless across
+// several: xUnit runs test classes in parallel by default, and callout_specs, failure_handling,
+// durable_round_trip, response_binding and Samples all publish IncidentTriage messages of their own.
+// Their answers landed in the same static list while end_to_end was asserting on it, so
+// the_answer_comes_back_as_an_ordinary_typed_message saw three triages where it expects one.
+//
+// Same fix, and the same reason, as the NoParallelization.cs files in PersistenceTests, PolecatTests
+// and Wolverine.AmazonS3.Tests. The suite is 42 tests that run in about a second, so serializing the
+// classes costs nothing worth measuring.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
`Wolverine.AI.Tests` is **red on main**. `end_to_end.the_answer_comes_back_as_an_ordinary_typed_message` asserts a single `IncidentTriage` came back and finds three:

```
Shouldly.ShouldAssertException : TriageResults.Received.OfType<IncidentTriage>()
  should have single item but had 3 items and was
[IncidentTriage { Severity = high, RecommendedAction = page the on-call },
 IncidentTriage { Severity = high, RecommendedAction = page },
 IncidentTriage { Severity = high, RecommendedAction = page the on-call }]
```

The `RecommendedAction = page` in the middle is the tell -- no test in `end_to_end` ever asks for that one.

## Cause

`TriageResults` is a static collection that the `IncidentTriage` and `LlmTextResponse` handlers record into, because a Wolverine handler is discovered assembly wide and has no per-test seam to write to.

`end_to_end` clears it in `InitializeAsync`, which is enough within one class and useless across several. xUnit runs test classes in parallel, and `callout_specs`, `failure_handling`, `durable_round_trip`, `response_binding` and `Samples` all publish `IncidentTriage` messages of their own. Their answers land in the same static list while `end_to_end` is asserting on it.

## Fix

Serializes the test classes with `CollectionPerAssembly` -- the same fix and the same reason as the `NoParallelization.cs` files already in `PersistenceTests`, `PolecatTests` and `Wolverine.AmazonS3.Tests`. The suite is 42 tests that run in about a second, so there is nothing worth measuring in the cost.

The more thorough fix would be to make the recorder a container-registered instance per host and inject it into the handlers, removing the shared mutable state outright. That means registering it in every host bootstrap in the assembly or handler resolution fails, and it is a bigger change than a red suite blocking a release should carry. Worth doing separately if this file ever needs a second reason to exist.

## Verification

| Run | Result |
|---|---|
| net9.0, four consecutive runs | 42/42 passed |
| net10.0 | 42/42 passed |
| clean main, full suite | 41 passed, **1 failed** |

Found while writing #4256; that PR does not cause it and does not fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)