### PR TITLE
Give the extension test projects a CI lane, and fix what it found

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
           - CICircuitBreaking
           - CIClaimCheck
           - CIAotSmoke
+          - CIExtensions
           # NOTE: CISlowTests is deliberately NOT here. It is wall-clock bound by design and blew
           # through the 20 minute cap on its first run; it lives in slow-tests.yml as a manual job.
         # HISTORY: from 2026-08 to 2026-08-24 an `include:` block here carried per-target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,21 @@
   returns. A benign 2xx is still advertised as a bare status, deliberately -- a problem document
   describing a response the application has declared benign would be actively wrong.
 
+### WolverineFx.DataAnnotationsValidation
+
+- **DataAnnotations validation works with `ServiceLocationPolicy.NotAllowed` on message handlers too.**
+  ([#4238](https://github.com/JasperFx/wolverine/issues/4238)) The fix above covered HTTP chains and
+  stopped there. A message handler had the identical defect and kept it: `Validate<T>` takes an
+  `IServiceProvider` to build its `ValidationContext`, an unsupplied one is sourced from the container
+  and reported to `ServiceLocationPolicy`, and under the Wolverine 6 default of `NotAllowed` that made
+  the validation middleware unusable on a handler at all. The policy now supplies
+  `context.Runtime.Services` itself, for the same reasons the HTTP twin supplies
+  `httpContext.RequestServices`.
+
+  Six tests in `Wolverine.DataAnnotationsValidation.Tests` had been asserting this and failing. Nobody
+  saw them, because the extension test projects ran in no CI workflow -- `TestExtensions` is reachable
+  only from the `Test` and `Full` targets and no workflow invokes either. They have a lane now.
+
 ### WolverineFx.EntityFrameworkCore
 
 - **A failed rollback no longer displaces the exception that caused it.** (closes

--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1425,4 +1425,47 @@ partial class Build
 
     AbsolutePath PolecatIncidentServiceTests => RootDirectory / "src" / "Persistence" / "Polecat" /
                                                 "PolecatIncidentService.Tests" / "PolecatIncidentService.Tests.csproj";
+    /// <summary>
+    /// The extension test projects. Every one of these was outside CI entirely: <c>TestExtensions</c>
+    /// gathers five of them, but only the <c>Test</c> and <c>Full</c> targets depend on it, and no
+    /// workflow invokes either -- dotnet.yml runs <c>ci</c> (CoreTests + CIMessageRouting) and
+    /// tests.yml runs its own CI* matrix.
+    ///
+    /// <para>VerifyCITargetCoverage did not report this, and is not wrong to have missed it: it audits
+    /// targets whose names begin with CI, which is the convention for "this is a lane". <c>AiTests</c>
+    /// and its siblings never claimed to be lanes. Giving them one is the fix, and the guard covers
+    /// them from here on.</para>
+    ///
+    /// <para>What it cost: Wolverine.AI.Tests went red on main and stayed red, with the first
+    /// WolverineFx.AI release in flight. Wolverine.Protobuf.Tests is worse -- it is in wolverine.slnx,
+    /// so it compiles on every build, but it runs in no Nuke target at all, not even TestExtensions.
+    /// It is included here.</para>
+    ///
+    /// <para>No docker services: none of these projects reference a persistence package or touch
+    /// <c>Servers</c>. That is what makes this lane cheap enough to be uncontroversial.</para>
+    /// </summary>
+    Target CIExtensions => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            var projects = new[]
+            {
+                extensionTests("Wolverine.AI.Tests"),
+                extensionTests("Wolverine.DataAnnotationsValidation.Tests"),
+                extensionTests("Wolverine.FluentValidation.Tests"),
+                extensionTests("Wolverine.MemoryPack.Tests"),
+                extensionTests("Wolverine.MessagePack.Tests"),
+                extensionTests("Wolverine.Protobuf.Tests")
+            };
+
+            BuildTestProjects(projects);
+
+            foreach (var project in projects)
+            {
+                RunTestProject(project);
+            }
+        });
+
+    AbsolutePath extensionTests(string name) => RootDirectory / "src" / "Extensions" / name / $"{name}.csproj";
+
 }

--- a/src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationPolicy.cs
+++ b/src/Extensions/Wolverine.DataAnnotationsValidation/Internals/DataAnnotationsValidationPolicy.cs
@@ -2,6 +2,7 @@
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
 using Wolverine.Configuration;
 using Wolverine.Runtime.Handlers;
 
@@ -33,6 +34,25 @@ public class DataAnnotationsValidationPolicy : IHandlerPolicy
         {
             CommentText = "Execute DataAnnotations validation"
         };
+
+        // GH-4238, the message handler half. #4244 fixed this for HTTP chains and stopped there,
+        // because nothing ran Wolverine.DataAnnotationsValidation.Tests -- the extension test projects
+        // were outside every CI workflow, so six failing tests sat on main saying so.
+        //
+        // Same defect, same shape: Validate<T> takes an IServiceProvider to build the
+        // ValidationContext, and an unsupplied one goes through the service container and is reported
+        // to ServiceLocationPolicy. Under the 6.0 default of NotAllowed that made Wolverine's own
+        // validation middleware unusable on a message handler at all -- the application threw
+        // InvalidServiceLocationException at bootstrap.
+        //
+        // context.Runtime.Services is the right provider for the same reasons the HTTP twin uses
+        // httpContext.RequestServices: the only thing the ValidationContext's provider ever does is
+        // answer GetService for a ValidationAttribute or an IValidatableObject, and this runs before
+        // any handler scope is relevant. "context" is safe to name directly -- it is the generated
+        // HandleAsync parameter, and ContextVariable.OverrideName is a deliberate no-op so that any
+        // other frame wanting the name gets renamed instead.
+        methodCall.TrySetArgument(new Variable(typeof(IServiceProvider), "context.Runtime.Services"));
+
         chain.Middleware.Add(methodCall);
     }
 }


### PR DESCRIPTION
Two commits: the CI lane you cannot see the value of until it runs, and the shipped bug it found in its first thirty seconds.

## The gap

None of the extension test projects ran anywhere. `TestExtensions` gathers five of them, but only the `Test` and `Full` targets depend on it, and no workflow invokes either -- `dotnet.yml` runs `ci` (CoreTests + CIMessageRouting) and `tests.yml` runs its own `CI*` matrix. `Wolverine.Protobuf.Tests` is worse still: it is in `wolverine.slnx` so it compiles on every build, but it runs in **no Nuke target at all**, not even `TestExtensions`.

`VerifyCITargetCoverage` did not report this, and is not wrong to have missed it. It audits targets whose names begin with `CI`, which is the convention for "this is a lane". `AiTests` and its siblings never claimed to be lanes. Giving them one is the fix; the guard covers them from here on, and now walks 43 `CI*` targets reporting every one reachable.

## What it found

- **Six failing tests in `Wolverine.DataAnnotationsValidation.Tests`**, fixed in the first commit. #4244 fixed GH-4238 for HTTP chains and stopped there; a message handler had the identical defect and kept it. `Validate<T>` takes an `IServiceProvider` to build its `ValidationContext`, an unsupplied one is sourced from the container and reported to `ServiceLocationPolicy`, and under the Wolverine 6 default of `NotAllowed` that made Wolverine's own validation middleware unusable on a handler at all -- `InvalidServiceLocationException` at bootstrap. The policy now supplies `context.Runtime.Services`, mirroring the HTTP twin's `httpContext.RequestServices`.

  The CHANGELOG entry for #4238 said DataAnnotations validation works under `NotAllowed`. For handlers it did not. That entry now has a companion saying so.

- **`Wolverine.AI.Tests` red on main** (fixed separately in #4257), with the first `WolverineFx.AI` release in flight.

## One caveat worth reading

The AI failure surfaces in this lane as **"1 passed on retry"**, not as a failure -- the flaky-retry harness absorbs it. So the lane alone would not have made that one obvious; it took running the suite directly. Worth knowing before treating a green lane as proof that everything under it is healthy.

## Verification

`./build.sh CIExtensions --framework net9.0`, exit 0, 27 seconds:

| Suite | Result |
|---|---|
| Wolverine.AI.Tests | 40 passed (1 on retry, see caveat) |
| Wolverine.DataAnnotationsValidation.Tests | 12 passed (was 6 passed / 6 failed) |
| Wolverine.FluentValidation.Tests | 24 passed |
| Wolverine.MemoryPack.Tests | 3 passed |
| Wolverine.MessagePack.Tests | 5 passed |
| Wolverine.Protobuf.Tests | 1 passed |

`VerifyCITargetCoverage` passes with the new lane registered. No docker services: none of these projects reference a persistence package or touch `Servers`, which is what keeps the lane cheap enough to be uncontroversial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)