### PR TITLE
Bump Weasel to 9.30.0 and land the GH-4246 migration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   which is 768 characters of utf8mb4.
 
   An existing database is widened in place on the next migration, by an `ALTER TABLE ... MODIFY` that
-  keeps the rows -- but only with Weasel 9.29.1. Before that, the schema differ compared column types
+  keeps the rows -- but only with Weasel 9.30.0. Before that, the schema differ compared column types
   with the size stripped off, so a widened `varchar` was invisible to it and an existing table kept
   the narrow column forever.
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -138,13 +138,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.5" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.5" />
-    <PackageVersion Include="Weasel.Core" Version="9.29.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.29.0" />
-    <PackageVersion Include="Weasel.MySql" Version="9.29.0" />
-    <PackageVersion Include="Weasel.Oracle" Version="9.29.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.29.0" />
-    <PackageVersion Include="Weasel.SqlServer" Version="9.29.0" />
-    <PackageVersion Include="Weasel.Sqlite" Version="9.29.0" />
+    <PackageVersion Include="Weasel.Core" Version="9.30.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.30.0" />
+    <PackageVersion Include="Weasel.MySql" Version="9.30.0" />
+    <PackageVersion Include="Weasel.Oracle" Version="9.30.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.30.0" />
+    <PackageVersion Include="Weasel.SqlServer" Version="9.30.0" />
+    <PackageVersion Include="Weasel.Sqlite" Version="9.30.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- xUnit v3. Test projects use xunit.v3 and must set <OutputType>Exe</OutputType>.

--- a/src/Persistence/MySql/MySqlTests/Agents/Bug_4246_widening_an_existing_database.cs
+++ b/src/Persistence/MySql/MySqlTests/Agents/Bug_4246_widening_an_existing_database.cs
@@ -1,0 +1,106 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Shouldly;
+using Wolverine;
+using Wolverine.MySql;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace MySqlTests.Agents;
+
+/// <summary>
+/// GH-4246, the other half: an application already running against MySQL has a
+/// <c>wolverine_node_records</c> table with the defaulted <c>VARCHAR(255)</c> description, and the whole
+/// point of the fix is that it stops failing without anyone hand-editing the schema. Weasel's MySQL
+/// table delta turns a widened column into an in-place <c>ALTER TABLE ... MODIFY COLUMN</c>, so the
+/// existing rows come through untouched -- this is what pins that.
+///
+/// Requires Weasel 9.29.1 or later. Before that the schema differ stripped the size off a column type
+/// before comparing, so a widened varchar was invisible to it and this test fails at 255.
+/// </summary>
+[Collection("mysql")]
+public class Bug_4246_widening_an_existing_database : IAsyncLifetime
+{
+    private const string SchemaName = "node_record_widening";
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new MySqlConnection(Servers.MySqlConnectionString);
+        await conn.OpenAsync();
+
+        await executeAsync(conn, $"DROP DATABASE IF EXISTS `{SchemaName}`");
+        await executeAsync(conn, $"CREATE DATABASE `{SchemaName}`");
+
+        // The table exactly as Wolverine 6.32 provisioned it -- description defaulted to VARCHAR(255).
+        await executeAsync(conn, $"""
+            CREATE TABLE `{SchemaName}`.`wolverine_node_records` (
+                `id` INT NOT NULL AUTO_INCREMENT,
+                `node_number` INT NOT NULL,
+                `event_name` VARCHAR(255) NOT NULL,
+                `timestamp` DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6)),
+                `description` VARCHAR(255) NULL,
+                CONSTRAINT `pkey_wolverine_node_records_id` PRIMARY KEY (`id`)
+            )
+            """);
+
+        await executeAsync(conn,
+            $"INSERT INTO `{SchemaName}`.`wolverine_node_records` (node_number, event_name, description) " +
+            "VALUES (1, 'NodeStarted', 'an existing row')");
+
+        await conn.CloseAsync();
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static async Task executeAsync(MySqlConnection conn, string sql)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task migrating_widens_the_description_in_place_and_keeps_the_rows()
+    {
+        var dataSource = MySqlDataSourceFactory.Create(Servers.MySqlConnectionString);
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.MySqlConnectionString,
+            SchemaName = SchemaName,
+            Role = MessageStoreRole.Main
+        };
+
+        await using var store = new MySqlMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<MySqlMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await store.Admin.MigrateAsync();
+
+        await using var conn = new MySqlConnection(Servers.MySqlConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using (var widthCommand = conn.CreateCommand())
+        {
+            widthCommand.CommandText =
+                "select character_maximum_length from information_schema.columns " +
+                $"where table_schema = '{SchemaName}' and table_name = 'wolverine_node_records' " +
+                "and column_name = 'description'";
+            Convert.ToInt64(await widthCommand.ExecuteScalarAsync(TestContext.Current.CancellationToken))
+                .ShouldBe(NodeRecord.DescriptionLength);
+        }
+
+        // MODIFY COLUMN, not a rebuild: the diagnostics that were already there are still there.
+        await using (var rowCommand = conn.CreateCommand())
+        {
+            rowCommand.CommandText =
+                $"select description from `{SchemaName}`.`wolverine_node_records` where node_number = 1";
+            (await rowCommand.ExecuteScalarAsync(TestContext.Current.CancellationToken))
+                .ShouldBe("an existing row");
+        }
+
+        await conn.CloseAsync();
+    }
+}


### PR DESCRIPTION
The second half of GH-4246, and the last thing before 6.33.0.

#4255 widened the node record `description` columns, which on its own only helped a **newly created** database. Weasel's schema differ stripped the size off a column type before comparing, so a widened `varchar` was invisible to it and an existing table kept the narrow column forever -- exactly the hand-written `ALTER` the reporter had already run for themselves.

[JasperFx/weasel#550](https://github.com/JasperFx/weasel/pull/550), shipped in Weasel 9.30.0, compares character lengths. That raises the fix from "new databases only" to "existing ones too".

## The held-back test

`Bug_4246_widening_an_existing_database` was deliberately kept out of #4255 rather than committed red. It builds the table exactly as 6.32 provisioned it -- `description` defaulted to `VARCHAR(255)` -- migrates, then asserts both halves of what matters:

- the column reaches `NodeRecord.DescriptionLength`
- a pre-existing row is still there, which is what distinguishes an in-place `MODIFY COLUMN` from a rebuild

## All seven pins move together

Weasel ships its packages in lockstep off one `<Version>`. A partial bump would leave `Weasel.Core` -- where the shared comparison actually lives -- behind the providers that call it.

## Verification

The new comparison emits width `ALTER`s in **both directions**, so a Wolverine model declaring a column narrower than an existing database would now generate a narrowing `ALTER` that could fail on real data. That is the one real risk in this bump, and it is why the whole persistence surface was run rather than just MySQL:

| Suite | Result |
|---|---|
| MySqlTests | 184 passed |
| SqlServerTests | 409 passed, 2 skipped |
| OracleTests | 164 passed |
| PostgresqlTests | 540 passed, 1 skipped |
| SqliteTests | 217 passed, 1 skipped |
| PersistenceTests | 109 passed |

**1,623 passed, 0 failed.** Plus a clean `wolverine.slnx` Release build pinned to `-f net9.0`, with the NuGet HTTP cache cleared first so the freshly published 9.30.0 actually resolved rather than falling back.

Postgres and SQLite matter here even though their comparison is untouched -- they still take the new `Weasel.Core`.

Also corrects the CHANGELOG, which named 9.29.1 from when this was going out as a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)