### PR TITLE
Bump to 6.33.0 for the release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.32.0</Version>
+        <Version>6.33.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Version bump for the 6.33.0 release. One line: `<Version>` 6.32.0 to 6.33.0.

Headlined by **WolverineFx.AI**, shipping for the first time. It merged about five hours after the 6.32.0 publish ran, so despite being written and documented for that release it has never actually been on nuget.

Also in 6.33.0:

- GH-4246, the node record description overflow, together with its Weasel 9.30.0 half (#4259) that raises the fix from "new databases only" to "existing ones too"
- GH-4238, DataAnnotations validation under `ServiceLocationPolicy.NotAllowed`, on message handlers as well as HTTP
- GH-4240, a node sweeping up its own in-flight stop as a wedged shard
- GH-4239, an EF Core rollback displacing the exception that caused it
- GH-3935, Wolverine parameter attributes on gRPC before/after hooks
- New documentation for tuning the LLM callout queue and its error handling
- A CI lane for the extension test projects, which had never run anywhere

CHANGELOG entries are already under `## Unreleased` from the individual PRs, and the heading stays as-is -- this repo does not convert it per release, matching how 6.32.0 was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)