### PR TITLE
Azure Service Bus: configurable prefix for system queues + transport-wide default dead letter queue name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,40 @@
   so the hook was dropped from codegen entirely, and the attributes would have appeared to do nothing
   while after-hooks worked fine.
 
+### WolverineFx.AzureServiceBus
+
+- **Wolverine's own system queues can carry an application-owned prefix, so several applications can
+  share one Azure Service Bus namespace.** (related:
+  [#3696](https://github.com/JasperFx/wolverine/issues/3696)) `SystemQueuePrefix("my-project")` on the
+  transport configuration prepends that prefix to the four queues Wolverine names for itself:
+  `my-project.wolverine.response.{ServiceName}.{node}`, `my-project.wolverine.retries.{servicename}`,
+  `my-project.wolverine.control.{node}`, and `my-project.wolverine-dead-letter-queue`. Only two of
+  those carry the service name today, so the control queue and the dead letter queue were shared by
+  every Wolverine application pointed at the namespace -- and if you had turned on dead letter queue
+  recovery, one application's recovery listener was quietly draining everybody else's dead letters
+  into its own storage. Nothing changes without the opt in: with no prefix set, every one of those
+  names is byte for byte what it has always been.
+
+  I made this prepend rather than replace so the `wolverine` token survives and the queues are still
+  obviously Wolverine's when you go looking in the Azure Portal. It is deliberately a separate knob
+  from `PrefixIdentifiers()`, which renames your application's own queues and topics and does not
+  reach the system queues -- and should not, because two cooperating applications that message each
+  other have to keep addressing the same application queue names even while each one wants its own
+  control and dead letter queues. Combine the two when you want everything isolated. A name you supply
+  yourself is never prefixed; that is an explicit choice and Wolverine has no business second guessing
+  it. The control queue is built eagerly at configuration time because the message stores read it
+  before the transports initialize, so calling `SystemQueuePrefix()` after
+  `EnableWolverineControlQueues()` rebuilds it under the prefixed name rather than leaving a stale
+  queue behind.
+
+- **A transport-wide default dead letter queue name.** `DefaultDeadLetterQueueName("orders-errors")`
+  changes the fallback for every Azure Service Bus endpoint that does not name a dead letter queue of
+  its own, instead of repeating `ConfigureDeadLetterQueue(...)` on each one. This is the Azure Service
+  Bus counterpart of RabbitMQ's `CustomizeDeadLetterQueueing()` and of the SQS method of the same
+  name. Resolution per endpoint is per-endpoint configuration first, then the transport default, then
+  the prefixed default, then `wolverine-dead-letter-queue` -- and it resolves on read, so the order of
+  those calls during bootstrapping does not matter.
+
 ### Dependencies
 
 - JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator and JasperFx.SourceGenerator to

--- a/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
+++ b/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
@@ -42,7 +42,7 @@ await host.StartAsync();
 
 ### Buffered Endpoints
 
-For buffered endpoints, Wolverine sends failed messages to a designated dead letter queue. By default, this queue is named `wolverine-dead-letter-queue`.
+For buffered endpoints, Wolverine sends failed messages to a designated dead letter queue. By default, this queue is named `wolverine-dead-letter-queue` — or `[prefix].wolverine-dead-letter-queue` if you opted into [prefixing the system queues](/guide/messaging/transports/azureservicebus/#prefixing-system-queues).
 
 To customize the dead letter queue for buffered endpoints:
 
@@ -103,6 +103,57 @@ await host.StartAsync();
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L809-L830' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_durable_dlq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Overriding the Default Dead Letter Queue Name <Badge type="tip" text="6.34" />
+
+`wolverine-dead-letter-queue` is fine for a single application, but it carries no service name at all, so several
+applications sharing one Azure Service Bus namespace all dead letter into the same queue. Rather than repeating
+`ConfigureDeadLetterQueue(...)` on every endpoint, override the default for the whole transport in one call — this is
+the Azure Service Bus counterpart of RabbitMQ's `CustomizeDeadLetterQueueing()` and of SQS's method of the same name:
+
+<!-- snippet: sample_asb_default_dead_letter_queue_name -->
+<a id='snippet-sample_asb_default_dead_letter_queue_name'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    var azureServiceBusConnectionString = builder
+        .Configuration
+        .GetConnectionString("azure-service-bus")!;
+
+    opts.UseAzureServiceBus(azureServiceBusConnectionString)
+        .AutoProvision()
+
+        // Every endpoint that doesn't configure a dead letter queue of its
+        // own now dead letters to "orders-errors" instead of
+        // "wolverine-dead-letter-queue"
+        .DefaultDeadLetterQueueName("orders-errors");
+
+    // ...but per endpoint configuration still wins
+    opts.ListenToAzureServiceBusQueue("orders")
+        .ConfigureDeadLetterQueue("orders-rejects");
+
+    opts.ListenToAzureServiceBusQueue("notifications")
+        .DisableDeadLetterQueueing();
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L983-L1011' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_default_dead_letter_queue_name' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Resolution order, per endpoint:
+
+1. `ConfigureDeadLetterQueue("name")` on the endpoint wins.
+2. `DisableDeadLetterQueueing()` on the endpoint wins — no dead letter queue for that one, and failures fall back to Wolverine's durable dead letter storage.
+3. Otherwise the transport-wide `DefaultDeadLetterQueueName(...)`.
+4. Otherwise `wolverine-dead-letter-queue`, with any [system queue prefix](/guide/messaging/transports/azureservicebus/#prefixing-system-queues) prepended.
+
+The name is resolved when Wolverine reads it rather than when the endpoint is declared, so the order of these calls
+during bootstrapping does not matter. A name you supply here is taken as fully qualified and is *not* prefixed by
+`SystemQueuePrefix()` — only the name Wolverine picks for itself is. It is sanitized to legal Azure Service Bus entity
+characters the same way per-endpoint names are.
+
 ## Disabling Dead Letter Queues
 
 You can disable dead letter queuing for specific endpoints if needed:
@@ -135,7 +186,8 @@ await host.StartAsync();
 
 Azure Service Bus dead letters land in one of two places depending on the endpoint mode: buffered and
 durable endpoints move failures to a Wolverine-managed dead letter **queue** (default
-`wolverine-dead-letter-queue`), while inline endpoints — and Azure Service Bus itself, on TTL or
+`wolverine-dead-letter-queue`, or whatever `DefaultDeadLetterQueueName()` / `SystemQueuePrefix()` resolve it to),
+while inline endpoints — and Azure Service Bus itself, on TTL or
 max-delivery — use the native
 [`$DeadLetterQueue` sub-queue](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues)
 of the source entity. Either way, those messages are only visible through Azure tooling. Tools that

--- a/docs/guide/messaging/transports/azureservicebus/index.md
+++ b/docs/guide/messaging/transports/azureservicebus/index.md
@@ -125,8 +125,9 @@ overload that takes explicit connection strings, and the opt in namespace cleanu
 ## Request/Reply
 
 [Request/reply](https://www.enterpriseintegrationpatterns.com/patterns/messaging/RequestReply.html) mechanics (`IMessageBus.InvokeAsync<T>()`) are possible with the Azure Service Bus transport *if* Wolverine has the ability to auto-provision
-a specific response queue for each node. That queue would be named like `wolverine.response.[application node id]` if you happen
-to notice that in the Azure Portal.
+a specific response queue for each node. That queue would be named like `wolverine.response.[service name].[application node id]` if you happen
+to notice that in the Azure Portal — or `[prefix].wolverine.response.[service name].[application node id]` if you opted into
+[prefixing the system queues](#prefixing-system-queues).
 
 And also see the next section. 
 
@@ -186,6 +187,87 @@ using var host = await Host.CreateDefaultBuilder()
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L242-L256' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_system_queues_in_azure_service_bus' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Prefixing System Queues <Badge type="tip" text="6.34" />
+
+Wolverine creates a handful of queues for its own use, and by default their names all start with the `wolverine`
+token:
+
+| Queue | Default name |
+|-------|--------------|
+| Response queue (request/reply) | `wolverine.response.[service name].[node]` |
+| Retry queue | `wolverine.retries.[service name]` |
+| Node control queue | `wolverine.control.[node]` |
+| Dead letter queue | `wolverine-dead-letter-queue` |
+
+Only the first two carry the service name. The control queue and the dead letter queue do not, so several unrelated
+applications sharing one Azure Service Bus namespace will happily collide on them — and if you turned on
+[dead letter queue recovery](/guide/messaging/transports/azureservicebus/deadletterqueues), one application's recovery
+listener will merrily drain another application's dead letters into its own storage.
+
+`SystemQueuePrefix()` prepends a prefix of your choosing to all four of those names, so each application owns its own
+set:
+
+<!-- snippet: sample_asb_system_queue_prefix -->
+<a id='snippet-sample_asb_system_queue_prefix'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    var azureServiceBusConnectionString = builder
+        .Configuration
+        .GetConnectionString("azure-service-bus")!;
+
+    opts.ServiceName = "Orders";
+
+    opts.UseAzureServiceBus(azureServiceBusConnectionString)
+        .AutoProvision()
+
+        // Every queue that Wolverine creates for its own use is now
+        // prefixed with "my-project.", so this application can share an
+        // Azure Service Bus namespace with unrelated applications:
+        //
+        //   my-project.wolverine.response.Orders.{node}
+        //   my-project.wolverine.retries.orders
+        //   my-project.wolverine.control.{node}
+        //   my-project.wolverine-dead-letter-queue
+        .SystemQueuePrefix("my-project")
+
+        .EnableWolverineControlQueues();
+
+    // Application queue names are untouched, so cooperating applications
+    // still address exactly the same queues
+    opts.ListenToAzureServiceBusQueue("orders");
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs#L944-L978' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asb_system_queue_prefix' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The prefix is joined with the Azure Service Bus identifier delimiter (`.`), and the `wolverine` token is kept so the
+queues are still recognizable as Wolverine's in the Azure Portal. Without a prefix — the default — every one of these
+names is exactly what it has always been, so this is safe to leave alone in an existing application.
+
+::: tip
+This is a different thing than [`PrefixIdentifiers()`](/guide/messaging/transports/azureservicebus/object-management#identifier-prefixing-for-shared-brokers),
+which renames your *application* queues, topics, and subscriptions and deliberately leaves Wolverine's system queues
+alone. That distinction matters: two cooperating applications that send messages to each other have to keep addressing
+the same application queue names, so `PrefixIdentifiers()` is not usable there, while each still needs its own control,
+response, retry, and dead letter queues. The two can also be combined when you want full isolation — say, per developer
+against a shared namespace.
+:::
+
+A dead letter queue that you name yourself is taken as fully qualified and is never prefixed. That applies to both
+`ConfigureDeadLetterQueue("x")` on a single endpoint and
+[`DefaultDeadLetterQueueName("x")`](/guide/messaging/transports/azureservicebus/deadletterqueues#overriding-the-default-dead-letter-queue-name)
+across the transport.
+
+Order does not matter with respect to `EnableWolverineControlQueues()`. The control queue has to be built eagerly at
+configuration time, because Wolverine's message stores and node agent read it long before the transports initialize, so
+calling `SystemQueuePrefix()` afterwards rebuilds the control queue under the prefixed name and discards the unprefixed
+one.
 
 ## Connecting To Multiple Namespaces <Badge type="tip" text="5.0" />
 

--- a/docs/guide/messaging/transports/azureservicebus/object-management.md
+++ b/docs/guide/messaging/transports/azureservicebus/object-management.md
@@ -90,6 +90,28 @@ opts.UseAzureServiceBus("some connection string")
 
 The default delimiter between the prefix and the original name is `.` for Azure Service Bus (e.g., `dev-john.orders`).
 
+### System Queues Are Not Prefixed <Badge type="tip" text="6.34" />
+
+`PrefixIdentifiers()` only touches the queues, topics, and subscriptions that *your application* names. Wolverine's own
+system queues — the response, retry, control, and dead letter queues — keep their names, because two cooperating
+applications that message each other have to keep addressing the same application queue names even while each needs its
+own set of system queues.
+
+Use [`SystemQueuePrefix()`](/guide/messaging/transports/azureservicebus/#prefixing-system-queues) to prefix those
+instead. For full per-developer isolation against a shared namespace, combine the two:
+
+```csharp
+opts.UseAzureServiceBus("some connection string")
+    .AutoProvision()
+
+    // Application queues, topics, and subscriptions
+    .PrefixIdentifiers("dev-john")
+
+    // ...and Wolverine's own response, retry, control,
+    // and dead letter queues
+    .SystemQueuePrefix("dev-john");
+```
+
 ## Configuring Queues
 
 If Wolverine is provisioning the queues for you, you can use one of these options

--- a/src/Testing/MetricsTests/is_system_endpoint_tests.cs
+++ b/src/Testing/MetricsTests/is_system_endpoint_tests.cs
@@ -10,6 +10,10 @@ public class is_system_endpoint_tests
     [InlineData("rabbitmq://localhost/wolverine.response.abc123", true)]
     [InlineData("rabbitmq://localhost/wolverine.Response.ABC123", true)]
     [InlineData("redis://localhost/wolverine.response.node1", true)]
+    // Azure Service Bus can prepend an application-owned prefix to its system queue names so that
+    // several applications can share one namespace. The "wolverine.response" token survives that,
+    // which is exactly why this check stays a Contains() rather than a StartsWith().
+    [InlineData("asb://queue/my-project.wolverine.response.myapp.1", true)]
     [InlineData("local://replies", true)]
     [InlineData("local://durable", true)]
     [InlineData("rabbitmq://localhost/my-queue", false)]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/DocumentationSamples.cs
@@ -938,6 +938,78 @@ opts.ListenToAzureServiceBusQueue("incoming")
 
         #endregion
     }
+
+    public async Task system_queue_prefix()
+    {
+        #region sample_asb_system_queue_prefix
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.ServiceName = "Orders";
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString)
+                .AutoProvision()
+
+                // Every queue that Wolverine creates for its own use is now
+                // prefixed with "my-project.", so this application can share an
+                // Azure Service Bus namespace with unrelated applications:
+                //
+                //   my-project.wolverine.response.Orders.{node}
+                //   my-project.wolverine.retries.orders
+                //   my-project.wolverine.control.{node}
+                //   my-project.wolverine-dead-letter-queue
+                .SystemQueuePrefix("my-project")
+
+                .EnableWolverineControlQueues();
+
+            // Application queue names are untouched, so cooperating applications
+            // still address exactly the same queues
+            opts.ListenToAzureServiceBusQueue("orders");
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
+
+    public async Task default_dead_letter_queue_name()
+    {
+        #region sample_asb_default_dead_letter_queue_name
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            var azureServiceBusConnectionString = builder
+                .Configuration
+                .GetConnectionString("azure-service-bus")!;
+
+            opts.UseAzureServiceBus(azureServiceBusConnectionString)
+                .AutoProvision()
+
+                // Every endpoint that doesn't configure a dead letter queue of its
+                // own now dead letters to "orders-errors" instead of
+                // "wolverine-dead-letter-queue"
+                .DefaultDeadLetterQueueName("orders-errors");
+
+            // ...but per endpoint configuration still wins
+            opts.ListenToAzureServiceBusQueue("orders")
+                .ConfigureDeadLetterQueue("orders-rejects");
+
+            opts.ListenToAzureServiceBusQueue("notifications")
+                .DisableDeadLetterQueueing();
+        });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        #endregion
+    }
 }
 
 public record OrderPlaced(string OrderId);

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/system_queue_prefix.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/system_queue_prefix.cs
@@ -1,0 +1,268 @@
+using NSubstitute;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+// Several unrelated applications sharing one Azure Service Bus namespace used to collide on
+// Wolverine's own system queues -- the control queue and the dead letter queue are not scoped by
+// service name at all, so the dead letter recovery listener of one application happily drained
+// another's dead letters. SystemQueuePrefix() gives each application its own set of those queues
+// while leaving the *application* queue names alone, which is what PrefixIdentifiers() would have
+// broken for cooperating applications that must keep addressing the same queues.
+public class system_queue_prefix
+{
+    private const string ConnectionString =
+        "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=x;SharedAccessKey=y";
+
+    // Drives tryBuildSystemEndpoints without ever touching a broker. Both Azure clients on the
+    // transport are Lazy, so nothing here connects to anything.
+    private static async Task<AzureServiceBusTransport> initializeAsync(WolverineOptions options)
+    {
+        var transport = options.Transports.GetOrCreate<AzureServiceBusTransport>();
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(options);
+        runtime.DurabilitySettings.Returns(options.Durability);
+
+        await transport.InitializeEndpointsAsync(runtime);
+
+        return transport;
+    }
+
+    private static AzureServiceBusQueue[] systemQueues(AzureServiceBusTransport transport)
+    {
+        return transport.Endpoints().Where(x => x.Role == EndpointRole.System).OfType<AzureServiceBusQueue>()
+            .ToArray();
+    }
+
+    // The default has to stay byte for byte what it always was -- these names address queues that
+    // already exist in production namespaces.
+    [Fact]
+    public async Task no_prefix_leaves_every_system_queue_name_alone()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString);
+        options.ListenToAzureServiceBusQueue("one");
+
+        var transport = await initializeAsync(options);
+
+        var queues = systemQueues(transport);
+        queues.ShouldContain(x => x.QueueName.StartsWith("wolverine.response."));
+        queues.ShouldContain(x => x.QueueName.StartsWith("wolverine.retries."));
+
+        transport.DefaultDeadLetterQueueName.ShouldBe("wolverine-dead-letter-queue");
+        transport.Queues["one"].DeadLetterQueueName.ShouldBe("wolverine-dead-letter-queue");
+    }
+
+    [Fact]
+    public async Task response_and_retry_queues_are_prefixed()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString).SystemQueuePrefix("my-project");
+
+        var transport = await initializeAsync(options);
+
+        var queues = systemQueues(transport);
+
+        // The response queue keeps the service name's casing -- it always has, and lower casing it
+        // now would rename the queue out from under any service with a capital letter in its name.
+        queues.ShouldContain(x => x.QueueName.StartsWith("my-project.wolverine.response.MyApp."));
+
+        // The retry queue has always been lower cased and sanitized.
+        queues.ShouldContain(x => x.QueueName == "my-project.wolverine.retries.myapp");
+
+        transport.RetryQueue.ShouldNotBeNull();
+        transport.RetryQueue!.QueueName.ShouldBe("my-project.wolverine.retries.myapp");
+        transport.RetryQueue.Role.ShouldBe(EndpointRole.System);
+    }
+
+    [Fact]
+    public async Task the_default_dead_letter_queue_is_prefixed()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString).SystemQueuePrefix("my-project");
+        options.ListenToAzureServiceBusQueue("one");
+
+        var transport = await initializeAsync(options);
+
+        transport.DefaultDeadLetterQueueName.ShouldBe("my-project.wolverine-dead-letter-queue");
+        transport.Queues["one"].DeadLetterQueueName.ShouldBe("my-project.wolverine-dead-letter-queue");
+
+        // endpoints() fills in a real endpoint for every referenced dead letter queue name
+        transport.Endpoints().OfType<AzureServiceBusQueue>()
+            .ShouldContain(x => x.QueueName == "my-project.wolverine-dead-letter-queue");
+    }
+
+    // The dead letter queue name resolves on read, so a queue declared before the prefix was
+    // configured still picks the prefixed default up.
+    [Fact]
+    public void queue_declared_before_the_prefix_call_still_gets_the_prefixed_default()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        var configuration = options.UseAzureServiceBus(ConnectionString);
+        options.ListenToAzureServiceBusQueue("one");
+
+        configuration.SystemQueuePrefix("my-project");
+
+        options.Transports.GetOrCreate<AzureServiceBusTransport>().Queues["one"].DeadLetterQueueName
+            .ShouldBe("my-project.wolverine-dead-letter-queue");
+    }
+
+    // A name you supply yourself is fully qualified. Prefixing it would be Wolverine second guessing
+    // an explicit choice.
+    [Fact]
+    public void explicit_transport_default_dead_letter_queue_name_is_not_prefixed()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString)
+            .SystemQueuePrefix("my-project")
+            .DefaultDeadLetterQueueName("errors");
+
+        options.ListenToAzureServiceBusQueue("one");
+
+        var transport = options.Transports.GetOrCreate<AzureServiceBusTransport>();
+        transport.DefaultDeadLetterQueueName.ShouldBe("errors");
+        transport.Queues["one"].DeadLetterQueueName.ShouldBe("errors");
+    }
+
+    [Fact]
+    public async Task per_queue_dead_letter_queue_wins_over_the_transport_default()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString)
+            .SystemQueuePrefix("my-project")
+            .DefaultDeadLetterQueueName("errors");
+
+        options.ListenToAzureServiceBusQueue("one").ConfigureDeadLetterQueue("special");
+        options.ListenToAzureServiceBusQueue("two");
+
+        var transport = await initializeAsync(options);
+
+        transport.Queues["one"].DeadLetterQueueName.ShouldBe("special");
+        transport.Queues["two"].DeadLetterQueueName.ShouldBe("errors");
+    }
+
+    // Null has to keep meaning "disabled" rather than "nobody said", or DisableDeadLetterQueueing()
+    // would silently fall back to the transport default.
+    [Fact]
+    public async Task disabling_dead_letter_queueing_survives_the_transport_default()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString).SystemQueuePrefix("my-project");
+        options.ListenToAzureServiceBusQueue("one").DisableDeadLetterQueueing();
+
+        var transport = await initializeAsync(options);
+
+        var queue = transport.Queues["one"];
+        queue.DeadLetterQueueName.ShouldBeNull();
+        queue.DeadLetterStorage.ShouldBe(DeadLetterStorageMode.Durable);
+    }
+
+    [Fact]
+    public void configuring_a_dead_letter_queue_that_is_disabled_throws_a_useful_message()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString);
+
+        var queue = options.Transports.GetOrCreate<AzureServiceBusTransport>().Queues["one"];
+        queue.DeadLetterQueueName = null;
+
+        Should.Throw<InvalidOperationException>(() => queue.ConfigureDeadLetterQueue(_ => { }));
+    }
+
+    [Fact]
+    public void control_queue_is_prefixed_when_the_prefix_is_configured_first()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        options.UseAzureServiceBus(ConnectionString)
+            .SystemQueuePrefix("my-project")
+            .EnableWolverineControlQueues();
+
+        var control = options.Transports.NodeControlEndpoint.ShouldBeOfType<AzureServiceBusQueue>();
+        control.QueueName.ShouldStartWith("my-project.wolverine.control.");
+        control.Role.ShouldBe(EndpointRole.System);
+    }
+
+    // The control queue has to be built eagerly at configuration time -- the message stores and the
+    // node agent read NodeControlEndpoint long before the transports initialize -- so a later
+    // SystemQueuePrefix() call has to go back and rebuild it.
+    [Fact]
+    public void control_queue_is_rebuilt_when_the_prefix_is_configured_afterwards()
+    {
+        var options = new WolverineOptions { ServiceName = "MyApp" };
+        var configuration = options.UseAzureServiceBus(ConnectionString).EnableWolverineControlQueues();
+
+        var original = options.Transports.NodeControlEndpoint.ShouldBeOfType<AzureServiceBusQueue>();
+        original.QueueName.ShouldStartWith("wolverine.control.");
+
+        configuration.SystemQueuePrefix("my-project");
+
+        var control = options.Transports.NodeControlEndpoint.ShouldBeOfType<AzureServiceBusQueue>();
+        control.QueueName.ShouldBe("my-project." + original.QueueName);
+        control.ShouldNotBeSameAs(original);
+        control.IsListener.ShouldBeTrue();
+        control.EndpointName.ShouldBe("Control");
+
+        // The stale queue must not be left behind, or the transport would provision and listen to a
+        // queue nothing points at. Enumerate rather than index -- indexing a LightweightCache
+        // creates the entry.
+        var transport = options.Transports.GetOrCreate<AzureServiceBusTransport>();
+        transport.Queues.Select(x => x.QueueName).ShouldNotContain(original.QueueName);
+        transport.Queues.Select(x => x.QueueName).ShouldContain(control.QueueName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void empty_prefixes_are_rejected(string? prefix)
+    {
+        var options = new WolverineOptions();
+        var configuration = options.UseAzureServiceBus(ConnectionString);
+
+        Should.Throw<ArgumentException>(() => configuration.SystemQueuePrefix(prefix!));
+    }
+
+    // Azure Service Bus only accepts letters, numbers, '.', '-', '_' and '/' in an entity name, and
+    // rejects anything else with a 400 at provisioning time. Sanitizing here means an illegal prefix
+    // can never make it as far as the broker.
+    [Theory]
+    [InlineData("my-project", "my-project")]
+    [InlineData("  My_Project! ", "my_project_")]
+    [InlineData("my-project.", "my-project")]
+    [InlineData("my-project...", "my-project")]
+    [InlineData("my project", "my_project")]
+    public void prefixes_are_sanitized(string prefix, string expected)
+    {
+        var options = new WolverineOptions();
+        options.UseAzureServiceBus(ConnectionString).SystemQueuePrefix(prefix);
+
+        options.Transports.GetOrCreate<AzureServiceBusTransport>().SystemQueuePrefix.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void a_prefix_that_sanitizes_away_to_nothing_is_rejected()
+    {
+        var options = new WolverineOptions();
+        var configuration = options.UseAzureServiceBus(ConnectionString);
+
+        Should.Throw<ArgumentException>(() => configuration.SystemQueuePrefix("..."));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void empty_default_dead_letter_queue_names_are_rejected(string? name)
+    {
+        var options = new WolverineOptions();
+        var configuration = options.UseAzureServiceBus(ConnectionString);
+
+        Should.Throw<ArgumentException>(() => configuration.DefaultDeadLetterQueueName(name!));
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/system_queue_prefix_end_to_end.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/system_queue_prefix_end_to_end.cs
@@ -1,0 +1,94 @@
+using Azure.Messaging.ServiceBus.Administration;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AzureServiceBus.Internal;
+using Wolverine.Configuration;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.AzureServiceBus.Tests;
+
+// Proves the prefixed system queues are actually provisioned and usable against the emulator, not
+// just named correctly in memory: a host with a prefix still round trips a message, and the
+// response, retry and dead letter queues exist in the namespace under the prefixed names.
+public class system_queue_prefix_end_to_end : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "PrefixedApp";
+
+                // UseAzureServiceBusTesting() already turns on AutoProvision()
+                opts.UseAzureServiceBusTesting()
+                    .AutoPurgeOnStartup()
+                    .SystemQueuePrefix("acme");
+
+                opts.ListenToAzureServiceBusQueue("prefixed_send_and_receive");
+                opts.PublishMessage<PrefixedAsbMessage>().ToAzureServiceBusQueue("prefixed_send_and_receive");
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        await AzureServiceBusTesting.DeleteAllEmulatorObjectsAsync();
+    }
+
+    [Fact]
+    public async Task send_and_receive_with_prefixed_system_queues()
+    {
+        var message = new PrefixedAsbMessage("Stefon Diggs");
+
+        var session = await _host.TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(message);
+
+        session.Received.SingleMessage<PrefixedAsbMessage>()
+            .Name.ShouldBe(message.Name);
+    }
+
+    [Fact]
+    public async Task the_prefixed_system_queues_are_provisioned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var transport = _host.GetRuntime().Options.Transports.GetOrCreate<AzureServiceBusTransport>();
+        var systemQueues = transport
+            .Endpoints()
+            .Where(x => x.Role == EndpointRole.System)
+            .OfType<AzureServiceBusQueue>()
+            .ToArray();
+
+        // The response queue carries the node identifier, so take the real name from the transport
+        // rather than trying to reconstruct it here.
+        var responseQueueName = systemQueues.Single(x => x.QueueName.Contains("wolverine.response")).QueueName;
+        responseQueueName.ShouldStartWith("acme.wolverine.response.PrefixedApp.");
+
+        var admin = new ServiceBusAdministrationClient(Servers.AzureServiceBusManagementConnectionString);
+
+        (await admin.QueueExistsAsync(responseQueueName, ct)).Value.ShouldBeTrue();
+        (await admin.QueueExistsAsync("acme.wolverine.retries.prefixedapp", ct)).Value.ShouldBeTrue();
+        (await admin.QueueExistsAsync("acme.wolverine-dead-letter-queue", ct)).Value.ShouldBeTrue();
+
+        // ...and nothing was provisioned under the unprefixed names
+        (await admin.QueueExistsAsync("wolverine-dead-letter-queue", ct)).Value.ShouldBeFalse();
+    }
+}
+
+public record PrefixedAsbMessage(string Name);
+
+public static class PrefixedAsbMessageHandler
+{
+    public static void Handle(PrefixedAsbMessage message)
+    {
+        // nothing
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusConfiguration.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusConfiguration.cs
@@ -281,7 +281,99 @@ public class AzureServiceBusConfiguration : BrokerExpression<AzureServiceBusTran
         Transport.SystemQueuesEnabled = enabled;
         return this;
     }
-    
+
+    /// <summary>
+    /// Prepend a prefix to the names of the queues that Wolverine creates for its own use, so that
+    /// several unrelated applications can share one Azure Service Bus namespace without colliding.
+    /// With a prefix of "my-project" the system queues become
+    /// "my-project.wolverine.response.{ServiceName}.{node}", "my-project.wolverine.retries.{servicename}",
+    /// "my-project.wolverine.control.{node}", and "my-project.wolverine-dead-letter-queue". Without a
+    /// prefix -- the default -- those names are exactly what they have always been.
+    ///
+    /// <para>
+    /// Only queues that Wolverine names for itself are affected. A dead letter queue you name
+    /// yourself, through either <c>ConfigureDeadLetterQueue("x")</c> on an endpoint or
+    /// <see cref="DefaultDeadLetterQueueName"/> on the transport, is taken as fully qualified and is
+    /// never prefixed.
+    /// </para>
+    ///
+    /// <para>
+    /// This is a separate concept from <c>PrefixIdentifiers()</c>, which renames the *application*
+    /// queues and topics and deliberately does not reach Wolverine's system queues. The two can be
+    /// combined: use <c>PrefixIdentifiers()</c> when every application queue should be renamed too,
+    /// and this when cooperating applications must keep sharing the same application queue names
+    /// while still each owning their own control, response, retry and dead letter queues.
+    /// </para>
+    ///
+    /// <para>
+    /// Order does not matter with respect to <see cref="EnableWolverineControlQueues"/>: calling
+    /// this afterwards rebuilds the control queue under the prefixed name.
+    /// </para>
+    /// </summary>
+    /// <param name="prefix">
+    /// The prefix. Sanitized to legal Azure Service Bus entity characters, and any trailing
+    /// delimiter is trimmed
+    /// </param>
+    /// <returns></returns>
+    public AzureServiceBusConfiguration SystemQueuePrefix(string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            throw new ArgumentException("The system queue prefix must be a non-empty value", nameof(prefix));
+        }
+
+        var sanitized = Transport.SanitizeIdentifier(prefix.Trim()).TrimEnd('.', '/');
+        if (sanitized.IsEmpty())
+        {
+            throw new ArgumentException(
+                $"'{prefix}' does not leave any usable Azure Service Bus entity name characters to use as a system queue prefix",
+                nameof(prefix));
+        }
+
+        Transport.SystemQueuePrefix = sanitized;
+
+        // The control queue has to be built eagerly (see EnableWolverineControlQueues below), so if it
+        // was already built under the unprefixed name, rebuild it here under the new one.
+        if (Transport.ControlQueue != null)
+        {
+            buildControlQueue();
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Override the transport wide default dead letter queue name, which is otherwise
+    /// "wolverine-dead-letter-queue" with any <see cref="SystemQueuePrefix"/> prepended. The name
+    /// given here is taken as fully qualified and is never prefixed.
+    ///
+    /// <para>
+    /// This is only the default. Per endpoint configuration still wins:
+    /// <c>ConfigureDeadLetterQueue("x")</c> names a different dead letter queue for one endpoint, and
+    /// <c>DisableDeadLetterQueueing()</c> turns the native dead letter queue off for one endpoint
+    /// regardless of what is set here.
+    /// </para>
+    /// </summary>
+    /// <param name="queueName">
+    /// The default dead letter queue name. Must be non-null and non-empty; call
+    /// <c>DisableDeadLetterQueueing()</c> on an endpoint to turn dead letter queueing off instead
+    /// </param>
+    /// <returns></returns>
+    public AzureServiceBusConfiguration DefaultDeadLetterQueueName(string queueName)
+    {
+        if (string.IsNullOrWhiteSpace(queueName))
+        {
+            throw new ArgumentException(
+                "The default dead letter queue name must be a non-empty value. Use DisableDeadLetterQueueing() on an endpoint to disable dead letter queueing.",
+                nameof(queueName));
+        }
+
+        Transport.DefaultDeadLetterQueueName = Transport.SanitizeIdentifier(queueName.Trim());
+
+        return this;
+    }
+
+
     /// <summary>
     /// Utilize an Azure Service Bus queue as the control queue between Wolverine nodes
     /// This is more efficient than the built in Wolverine database control
@@ -290,13 +382,31 @@ public class AzureServiceBusConfiguration : BrokerExpression<AzureServiceBusTran
     /// <returns></returns>
     public AzureServiceBusConfiguration EnableWolverineControlQueues()
     {
+        buildControlQueue();
+
+        return this;
+    }
+
+    // The control queue is built here and now rather than in tryBuildSystemEndpoints, because
+    // Options.Transports.NodeControlEndpoint is read by the message stores and the node agent
+    // (MessageDatabase, WolverineNode) before the transports ever initialize.
+    private void buildControlQueue()
+    {
         // In Solo mode the assigned node number is always 1 (#3188); key the per-node control queue
         // on the unique node id so multiple Solo hosts on one namespace don't collide. See #3189.
         var controlNode = Options.Durability.Mode == DurabilityMode.Solo
             ? Options.UniqueNodeId.ToString("N")
             : Options.Durability.AssignedNodeNumber.ToString();
-        var queueName = "wolverine.control." + controlNode;
-        
+        var queueName = Transport.PrefixSystemQueueName("wolverine.control." + controlNode);
+
+        // SystemQueuePrefix() can be called after EnableWolverineControlQueues(), in which case the
+        // control queue already exists under the unprefixed name. Take it back out so the transport
+        // doesn't go on to provision and listen to a queue nothing points at anymore.
+        if (Transport.ControlQueue != null && Transport.ControlQueue.QueueName != queueName)
+        {
+            Transport.Queues.Remove(Transport.ControlQueue.QueueName);
+        }
+
         var queue = Transport.Queues[queueName];
 
         queue.Options.AutoDeleteOnIdle = 5.Minutes();
@@ -307,7 +417,6 @@ public class AzureServiceBusConfiguration : BrokerExpression<AzureServiceBusTran
         queue.Role = EndpointRole.System;
 
         Options.Transports.NodeControlEndpoint = queue;
-
-        return this;
+        Transport.ControlQueue = queue;
     }
 }

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/AzureServiceBusTransport.cs
@@ -126,6 +126,46 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     /// </summary>
     public bool SystemQueuesEnabled { get; set; } = true;
 
+    /// <summary>
+    /// Optional prefix prepended to the names of the queues Wolverine creates for its own use --
+    /// the response queue, the retry queue, the node control queue, and the default dead letter
+    /// queue. Null or empty (the default) leaves those names exactly as they have always been.
+    /// Set through <see cref="AzureServiceBusConfiguration.SystemQueuePrefix"/>, which sanitizes
+    /// the value; setting this property directly is also sanitized defensively when the names are
+    /// built, so an illegal entity name can't get through.
+    /// </summary>
+    public string? SystemQueuePrefix { get; set; }
+
+    /// <summary>
+    /// Prepend <see cref="SystemQueuePrefix"/> to a Wolverine system queue name, using the Azure
+    /// Service Bus identifier delimiter ('.'). Returns the name untouched when no prefix is
+    /// configured, so the default naming is byte for byte what it was before the prefix existed.
+    /// </summary>
+    /// <param name="name">The unprefixed Wolverine system queue name</param>
+    /// <returns></returns>
+    public string PrefixSystemQueueName(string name)
+    {
+        if (SystemQueuePrefix.IsEmpty()) return name;
+
+        return $"{SanitizeIdentifier(SystemQueuePrefix!)}{IdentifierDelimiter}{name}";
+    }
+
+    private string? _defaultDeadLetterQueueName;
+
+    /// <summary>
+    /// The transport wide default dead letter queue name used by every Azure Service Bus queue that
+    /// does not configure a dead letter queue of its own. Defaults to
+    /// <see cref="DeadLetterQueueName"/> ("wolverine-dead-letter-queue"), with
+    /// <see cref="SystemQueuePrefix"/> prepended when one is configured. An explicitly assigned
+    /// name is taken as given and is never prefixed. Set through
+    /// <see cref="AzureServiceBusConfiguration.DefaultDeadLetterQueueName"/>.
+    /// </summary>
+    public string DefaultDeadLetterQueueName
+    {
+        get => _defaultDeadLetterQueueName ?? PrefixSystemQueueName(DeadLetterQueueConstants.DefaultQueueName);
+        set => _defaultDeadLetterQueueName = value;
+    }
+
     private int? _prefetchCount;
 
     /// <summary>
@@ -284,7 +324,7 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
         var responseNode = runtime.Options.Durability.Mode == DurabilityMode.Solo
             ? runtime.Options.UniqueNodeId.ToString("N")
             : runtime.DurabilitySettings.AssignedNodeNumber.ToString();
-        var queueName = $"wolverine.response.{runtime.Options.ServiceName}.{responseNode}";
+        var queueName = PrefixSystemQueueName($"wolverine.response.{runtime.Options.ServiceName}.{responseNode}");
 
         var queue = Queues[queueName];
 
@@ -296,7 +336,8 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
         queue.Role = EndpointRole.System;
 
 
-        var retryName = SanitizeIdentifier($"wolverine.retries.{runtime.Options.ServiceName}".ToLower());
+        var retryName =
+            SanitizeIdentifier(PrefixSystemQueueName($"wolverine.retries.{runtime.Options.ServiceName}").ToLower());
         var retryQueue = Queues[retryName];
         retryQueue.Mode = EndpointMode.BufferedInMemory;
         retryQueue.IsListener = true;
@@ -315,6 +356,14 @@ public partial class AzureServiceBusTransport : BrokerTransport<AzureServiceBusE
     }
 
     internal AzureServiceBusQueue? RetryQueue { get; set; }
+
+    /// <summary>
+    /// The node control queue built eagerly by <see cref="AzureServiceBusConfiguration.EnableWolverineControlQueues"/>,
+    /// tracked here rather than on the configuration object because a single transport can be reached through more
+    /// than one AzureServiceBusConfiguration instance. Kept so that a later
+    /// <see cref="AzureServiceBusConfiguration.SystemQueuePrefix"/> call can rebuild it under the prefixed name.
+    /// </summary>
+    internal AzureServiceBusQueue? ControlQueue { get; set; }
 
     /// <summary>
     /// The host name of the connected Azure Service Bus namespace, parsed from the <c>Endpoint</c> segment of

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusQueue.cs
@@ -226,15 +226,48 @@ public class AzureServiceBusQueue : AzureServiceBusEndpoint, IBrokerQueue, IMass
         return Parent.BuildSenderForQueue(runtime, this);
     }
 
+    private string? _deadLetterQueueName;
+    private bool _deadLetterQueueNameSetExplicitly;
+
     /// <summary>
-    /// Name of the dead letter queue for this ASB queue where failed messages will be moved
+    /// Name of the dead letter queue for this ASB queue where failed messages will be moved.
+    /// Resolution order:
+    /// <list type="number">
+    ///   <item>If <c>ConfigureDeadLetterQueue</c> or <c>DisableDeadLetterQueueing</c> ran on this
+    ///   endpoint, the explicit value wins -- including <c>null</c>, which means "dead lettering is
+    ///   disabled here".</item>
+    ///   <item>Otherwise <see cref="AzureServiceBusTransport.DefaultDeadLetterQueueName"/> on the
+    ///   parent transport, which is either the name given to
+    ///   <c>UseAzureServiceBus().DefaultDeadLetterQueueName(...)</c> or
+    ///   "wolverine-dead-letter-queue" with any configured
+    ///   <see cref="AzureServiceBusTransport.SystemQueuePrefix"/> prepended.</item>
+    /// </list>
+    /// Because the fallback is resolved on read, the order between the transport level
+    /// configuration and the per endpoint bootstrap calls does not matter.
     /// </summary>
-    public string? DeadLetterQueueName { get; set; } = AzureServiceBusTransport.DeadLetterQueueName;
+    public string? DeadLetterQueueName
+    {
+        get => _deadLetterQueueNameSetExplicitly
+            ? _deadLetterQueueName
+            : Parent.DefaultDeadLetterQueueName;
+        set
+        {
+            _deadLetterQueueName = value;
+            _deadLetterQueueNameSetExplicitly = true;
+        }
+    }
 
 
     internal void ConfigureDeadLetterQueue(Action<AzureServiceBusQueue> configure)
     {
-        var dlq = Parent.Queues[DeadLetterQueueName!];
+        var deadLetterQueueName = DeadLetterQueueName;
+        if (deadLetterQueueName.IsEmpty())
+        {
+            throw new InvalidOperationException(
+                $"Dead letter queueing is disabled for the Azure Service Bus queue '{QueueName}', so there is no dead letter queue to configure. Remove the DisableDeadLetterQueueing() call, or name a dead letter queue with ConfigureDeadLetterQueue(name, ...).");
+        }
+
+        var dlq = Parent.Queues[deadLetterQueueName!];
         configure(dlq);
     }
     


### PR DESCRIPTION
## Problem

Several Wolverine applications sharing one Azure Service Bus namespace collide on the queues Wolverine names for itself. The response and retry queues carry the service name, but `wolverine.control.{node}` and `wolverine-dead-letter-queue` do not, so unrelated apps end up sharing a control queue and a dead letter queue. With dead letter queue recovery enabled, one app's recovery listener drains everybody else's dead letters into its own storage.

`PrefixIdentifiers()` doesn't help here: it renames *application* queues, which cooperating apps that message each other can't do, and it intentionally leaves the system queues alone (see #3696).

## Change

### `SystemQueuePrefix("my-project")`

Prepends an application-owned prefix, using the ASB `.` delimiter, to all four system queue names:

| Queue | Name with prefix |
|---|---|
| Response | `my-project.wolverine.response.{ServiceName}.{node}` |
| Retries | `my-project.wolverine.retries.{servicename}` |
| Control | `my-project.wolverine.control.{node}` |
| Default DLQ | `my-project.wolverine-dead-letter-queue` |

- The `wolverine` token is kept so the queues stay recognizable in the portal, and `IsSystemEndpoint` (a `Contains("wolverine.response")`) keeps excluding the response queue from CritterWatch metrics.
- Without a prefix (the default) every name is byte for byte what it has always been.
- The prefix is validated and sanitized to legal ASB entity characters.
- The control queue has to stay eager (`NodeControlEndpoint` is read by message stores and the node agent before transports initialize), so calling `SystemQueuePrefix()` *after* `EnableWolverineControlQueues()` rebuilds the control queue under the prefixed name and removes the stale entry. Order doesn't matter.

### `DefaultDeadLetterQueueName("orders-errors")`

Transport-wide default, the ASB counterpart of RabbitMQ's `CustomizeDeadLetterQueueing()` and SQS's method of the same name. `AzureServiceBusQueue.DeadLetterQueueName` became tri-state (mirroring `AmazonSqsQueue`) and resolves the transport default on read, so bootstrap call order no longer matters. Resolution per endpoint:

1. `ConfigureDeadLetterQueue("x")` on the endpoint
2. `DisableDeadLetterQueueing()` on the endpoint (explicit null)
3. Transport `DefaultDeadLetterQueueName(...)`
4. `wolverine-dead-letter-queue` with any system queue prefix prepended

Explicitly supplied names are treated as fully qualified and never prefixed. `ConfigureDeadLetterQueue` now throws a descriptive `InvalidOperationException` instead of an NRE when dead lettering was disabled first.

## Tests

- `system_queue_prefix.cs`: 22 broker-free unit tests (naming, tri-state DLQ resolution, control queue built before/after the prefix, validation and sanitization) driving `tryBuildSystemEndpoints` through `InitializeEndpointsAsync` with a substituted runtime.
- `system_queue_prefix_end_to_end.cs`: emulator test proving the prefixed response/retry/DLQ queues are actually provisioned, nothing is provisioned under the unprefixed DLQ name, and a message round trips.
- `is_system_endpoint_tests.cs`: prefixed ASB response URI is still recognized as a system endpoint.
- Existing ASB transport, DLQ, and end-to-end suites pass; `dotnet build wolverine.slnx -c Release` is clean (0 warnings).

## Docs

New "Prefixing System Queues" section on the ASB index page, a note under "Identifier Prefixing for Shared Brokers" in object-management, and an "Overriding the Default Dead Letter Queue Name" section on the DLQ page, all badged 6.34. Snippets are in `DocumentationSamples.cs`; the rendered blocks were written by hand in mdsnippets' format and will be regenerated on the next docs build. CHANGELOG has a new `WolverineFx.AzureServiceBus` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
