### PR TITLE
GH-4261: an advisory lock's connection is not two callers' to share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,43 @@
 
 ### WolverineFx.RDBMS (all relational providers)
 
+- **The advisory lock no longer shares one connection with nothing guarding it.** (closes
+  [#4261](https://github.com/JasperFx/wolverine/issues/4261)) Every `AdvisoryLock` implementation --
+  Postgres, SQL Server, MySQL, Oracle and SQLite -- kept one long-lived connection and synchronised
+  access to it with nothing at all: no semaphore, no lock, no `Interlocked`. `HasLock` runs
+  *synchronous* I/O on that connection for the GH-2602 liveness ping, while `TryAttainLockAsync`,
+  `ReleaseLockAsync` and `DisposeAsync` run *asynchronous* I/O on the same field, and no ADO.NET
+  provider supports concurrent use of one connection.
+
+  The two sides are reachable together in an ordinary shutdown, which is why this is not theoretical.
+  `writeHeartbeats` and `executeHealthChecks` run on the runtime-wide `Cancellation` token, which
+  `shutdownAsync` only cancels *after* `teardownAgentsAsync` has returned -- and teardown "stops" those
+  loops with `Task.SafeDispose()`, which disposes the `Task` object and does nothing whatsoever to the
+  loop still running. A health check already past its own cancellation guard therefore reaches
+  `ejectStaleNodes` -> `HasLeadershipLock()` at the same moment teardown reaches
+  `NodeAgentController.StopAsync` -> `ReleaseLeadershipLockAsync`.
+
+  It cost two different things. Where the driver *noticed* the concurrent use it threw, and `HasLock`
+  reads any exception as "the server dropped our session": it cleared every held lock id and returned
+  false, which `DoHealthChecksInternalAsync` reads as lost leadership and answers with `stepDownAsync`
+  -- precisely the churn GH-2602 and GH-3604 were fighting. Where the driver did *not* notice, the
+  protocol desynced and shutdown parked forever inside `NpgsqlConnection.CloseAsync()`, which takes no
+  `CancellationToken` and so is beyond the reach of `HostOptions.ShutdownTimeout` even though that
+  timeout is correctly threaded all the way down to `WolverineRuntime.StopAsync`. The reporter caught
+  that one in two independent process dumps with frame-for-frame identical stacks, and its symptom is
+  distinctive: every test passes and is counted, then the process never exits, because the hang lives
+  in fixture disposal after the last test has already reported.
+
+  Each implementation now serialises every touch of its connection behind a semaphore, with the held
+  lock ids guarded separately so the one path that must not wait -- `HasLock`, which is synchronous and
+  sits on the health-check tick -- can still read them. When that path finds the connection busy it
+  reports the last state it actually established rather than `false`, and skips the ping for one tick:
+  a busy connection means another advisory-lock operation is in flight *on this node*, which is no
+  evidence at all that the server dropped the session, and answering `false` there is what fires the
+  spurious stepdown. Every close is additionally bounded and abandoned on timeout, so a connection that
+  somehow still desyncs costs seconds rather than the process.
+
+
 - **Node record descriptions no longer overflow the column and fail the insert.** (closes
   [#4246](https://github.com/JasperFx/wolverine/issues/4246)) An `AssignmentChanged` record's
   description is an agent command's `ToString()`, which carries an agent URI, a schema name and a

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlAdvisoryLock.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlAdvisoryLock.cs
@@ -14,6 +14,27 @@ namespace Wolverine.MySql;
 /// </summary>
 internal class MySqlAdvisoryLock : IAdvisoryLock
 {
+    // GH-4261. One long-lived MySqlConnection shared by a SYNCHRONOUS HasLock and three ASYNC methods,
+    // with nothing serialising them. Reported against Postgres, where the interleaving desynced the
+    // driver's protocol and parked shutdown forever inside an uncancellable CloseAsync; MySqlConnector
+    // likewise does not support concurrent operations on one connection, and this class has the
+    // identical shape. The two callers are reachable together: writeHeartbeats / executeHealthChecks
+    // (WolverineRuntime.Agents.cs) run on the runtime-wide Cancellation token, which shutdownAsync only
+    // cancels AFTER teardownAgentsAsync returns, and teardownAgentsAsync "stops" them with
+    // Task.SafeDispose() -- which disposes the Task object and does nothing to the running loop.
+    //
+    // _gate serialises every touch of _conn. _locksLock guards the held-id list separately, so the one
+    // path that deliberately does not wait for the gate -- HasLock on timeout -- can still read it
+    // safely. Ordering is always _gate then _locksLock, never the reverse.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _locksLock = new();
+
+    // Short on purpose: HasLock is synchronous and sits on the health-check tick.
+    private static readonly TimeSpan GateTimeout = 250.Milliseconds();
+
+    // Generous on purpose: this bounds shutdown paths, where the alternative is an unbounded hang.
+    private static readonly TimeSpan CloseBudget = 5.Seconds();
+
     private readonly string _databaseName;
     private readonly List<int> _locks = new();
     private readonly ILogger _logger;
@@ -29,8 +50,40 @@ internal class MySqlAdvisoryLock : IAdvisoryLock
 
     public bool HasLock(int lockId)
     {
+        // Cheap negative outside the gate: an id we never took cannot be held.
+        if (!holdsId(lockId)) return false;
+
+        if (!_gate.Wait(GateTimeout))
+        {
+            // GH-4261: a busy gate means another advisory-lock operation on THIS node is in flight, not
+            // that the server dropped our session. A wrong `false` here is read by
+            // NodeAgentController.DoHealthChecksInternalAsync as lost leadership and fires
+            // stepDownAsync -- exactly the churn GH-2602 and GH-3604 were fighting. Report the last
+            // state we established and skip the keepalive for this tick.
+            _logger.LogDebug(
+                "Advisory lock connection for database {Database} was busy; reporting the last known state of lock {LockId} without pinging",
+                _databaseName, lockId);
+            return true;
+        }
+
+        try
+        {
+            return hasLockUnsafe(lockId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The GH-2602 liveness ping. Callers MUST hold <c>_gate</c> -- it does synchronous I/O on the
+    /// shared connection and may replace it.
+    /// </summary>
+    private bool hasLockUnsafe(int lockId)
+    {
         if (_conn is null) return false;
-        if (!_locks.Contains(lockId)) return false;
+        if (!holdsId(lockId)) return false;
 
         // MySQL named locks (GET_LOCK / RELEASE_LOCK) are session-scoped,
         // so the lock evaporates the moment the connection's MySQL session
@@ -50,9 +103,9 @@ internal class MySqlAdvisoryLock : IAdvisoryLock
         {
             _logger.LogWarning(e,
                 "Lost advisory-lock connection for database {Database}; clearing held lock ids {Locks}",
-                _databaseName, _locks);
+                _databaseName, heldIds());
 
-            _locks.Clear();
+            clearIds();
             try
             {
                 _conn.Dispose();
@@ -66,95 +119,153 @@ internal class MySqlAdvisoryLock : IAdvisoryLock
         }
     }
 
+    private bool holdsId(int lockId)
+    {
+        lock (_locksLock) return _locks.Contains(lockId);
+    }
+
+    private bool anyIdsHeld()
+    {
+        lock (_locksLock) return _locks.Count > 0;
+    }
+
+    private int[] heldIds()
+    {
+        lock (_locksLock) return _locks.ToArray();
+    }
+
+    private void addId(int lockId)
+    {
+        lock (_locksLock) _locks.Add(lockId);
+    }
+
+    private void removeId(int lockId)
+    {
+        lock (_locksLock) _locks.Remove(lockId);
+    }
+
+    private void clearIds()
+    {
+        lock (_locksLock) _locks.Clear();
+    }
+
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
-        if (_conn == null)
-        {
-            _conn = _source.CreateConnection();
-            await _conn.OpenAsync(token).ConfigureAwait(false);
-        }
+        await _gate.WaitAsync(token).ConfigureAwait(false);
 
-        if (_conn.State == ConnectionState.Closed)
+        try
         {
-            try
+            if (_conn == null)
             {
-                await _conn.DisposeAsync().ConfigureAwait(false);
+                _conn = _source.CreateConnection();
+                await _conn.OpenAsync(token).ConfigureAwait(false);
             }
-            catch (Exception e)
+
+            if (_conn.State == ConnectionState.Closed)
             {
-                _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                try
+                {
+                    await _conn.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                }
+                finally
+                {
+                    _conn = null;
+                }
+
+                return false;
             }
-            finally
+
+            var lockName = ToLockName(lockId);
+
+            await using var cmd = _conn.CreateCommand();
+            cmd.CommandText = "SELECT GET_LOCK(@lockName, 0)";
+            cmd.Parameters.AddWithValue("@lockName", lockName);
+
+            var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+
+            // GET_LOCK returns 1 if lock was obtained, 0 if timeout (we used 0 for non-blocking), NULL on error
+            if (result is int intResult && intResult == 1)
             {
-                _conn = null;
+                addId(lockId);
+                return true;
+            }
+
+            // For MySQL 8.0+, result might be long
+            if (result is long longResult && longResult == 1)
+            {
+                addId(lockId);
+                return true;
             }
 
             return false;
         }
-
-        var lockName = ToLockName(lockId);
-
-        await using var cmd = _conn.CreateCommand();
-        cmd.CommandText = "SELECT GET_LOCK(@lockName, 0)";
-        cmd.Parameters.AddWithValue("@lockName", lockName);
-
-        var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
-
-        // GET_LOCK returns 1 if lock was obtained, 0 if timeout (we used 0 for non-blocking), NULL on error
-        if (result is int intResult && intResult == 1)
+        finally
         {
-            _locks.Add(lockId);
-            return true;
+            _gate.Release();
         }
-
-        // For MySQL 8.0+, result might be long
-        if (result is long longResult && longResult == 1)
-        {
-            _locks.Add(lockId);
-            return true;
-        }
-
-        return false;
     }
 
     public async Task ReleaseLockAsync(int lockId)
     {
-        if (!_locks.Contains(lockId))
+        if (!holdsId(lockId))
         {
             return;
         }
 
-        if (_conn == null || _conn.State == ConnectionState.Closed)
+        // GH-4261: bounded rather than indefinite. If the gate is still held past the budget something
+        // is wedged on the connection, and waiting longer turns a released lock into a hung shutdown.
+        // MySQL releases named locks when the session ends, so an abandoned lock clears itself when this
+        // process exits.
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
         {
-            _locks.Remove(lockId);
+            _logger.LogWarning(
+                "Timed out waiting to release advisory lock {LockId} for database {Identifier}; leaving it to be released when the session ends",
+                lockId, _databaseName);
             return;
         }
-
-        using var cancellation = new CancellationTokenSource();
-        cancellation.CancelAfter(1.Seconds());
-
-        var lockName = ToLockName(lockId);
-
-        await using var cmd = _conn.CreateCommand();
-        cmd.CommandText = "SELECT RELEASE_LOCK(@lockName)";
-        cmd.Parameters.AddWithValue("@lockName", lockName);
 
         try
         {
-            await cmd.ExecuteScalarAsync(cancellation.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // Ignore timeout - lock will be released when connection closes
-        }
+            if (_conn == null || _conn.State == ConnectionState.Closed)
+            {
+                removeId(lockId);
+                return;
+            }
 
-        _locks.Remove(lockId);
+            using var cancellation = new CancellationTokenSource();
+            cancellation.CancelAfter(1.Seconds());
 
-        if (!_locks.Any())
+            var lockName = ToLockName(lockId);
+
+            await using (var cmd = _conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT RELEASE_LOCK(@lockName)";
+                cmd.Parameters.AddWithValue("@lockName", lockName);
+
+                try
+                {
+                    await cmd.ExecuteScalarAsync(cancellation.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ignore timeout - lock will be released when connection closes
+                }
+            }
+
+            removeId(lockId);
+
+            if (!anyIdsHeld())
+            {
+                await safeCloseConnectionAsync().ConfigureAwait(false);
+            }
+        }
+        finally
         {
-            await _conn.CloseAsync().ConfigureAwait(false);
-            await _conn.DisposeAsync().ConfigureAwait(false);
-            _conn = null;
+            _gate.Release();
         }
     }
 
@@ -165,34 +276,109 @@ internal class MySqlAdvisoryLock : IAdvisoryLock
             return;
         }
 
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
+        {
+            _logger.LogWarning(
+                "Timed out waiting to dispose the advisory lock connection for database {Identifier}; abandoning it",
+                _databaseName);
+            return;
+        }
+
         try
         {
-            foreach (var lockId in _locks)
+            if (_conn == null)
             {
-                var lockName = ToLockName(lockId);
-
-                await using var cmd = _conn.CreateCommand();
-                cmd.CommandText = "SELECT RELEASE_LOCK(@lockName)";
-                cmd.Parameters.AddWithValue("@lockName", lockName);
-
-                await cmd.ExecuteScalarAsync(CancellationToken.None).ConfigureAwait(false);
+                return;
             }
 
-            await _conn.CloseAsync().ConfigureAwait(false);
-            await _conn.DisposeAsync().ConfigureAwait(false);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Error trying to dispose of advisory locks for database {Identifier}",
-                _databaseName);
+            try
+            {
+                foreach (var lockId in heldIds())
+                {
+                    var lockName = ToLockName(lockId);
+
+                    await using var cmd = _conn.CreateCommand();
+                    cmd.CommandText = "SELECT RELEASE_LOCK(@lockName)";
+                    cmd.Parameters.AddWithValue("@lockName", lockName);
+
+                    await cmd.ExecuteScalarAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error trying to dispose of advisory locks for database {Identifier}",
+                    _databaseName);
+            }
+
+            await safeCloseConnectionAsync().ConfigureAwait(false);
         }
         finally
         {
-            if (_conn != null)
-            {
-                await _conn.DisposeAsync().ConfigureAwait(false);
-            }
+            _gate.Release();
         }
+    }
+
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>.
+    /// </summary>
+    private async Task safeCloseConnectionAsync()
+    {
+        // GH-4261: take the connection off the field FIRST, so an abandoned close cannot leave a dead
+        // connection reachable for the next caller.
+        var conn = _conn;
+        _conn = null;
+        if (conn == null) return;
+
+        try
+        {
+            if (conn.State == ConnectionState.Open && !await closeWithinBudgetAsync(conn).ConfigureAwait(false))
+            {
+                // Deliberately no DisposeAsync: that would race the CloseAsync still parked on this
+                // connection. Dropping the reference is enough.
+                return;
+            }
+
+            await conn.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error trying to close advisory lock connection for database {Identifier}",
+                _databaseName);
+        }
+    }
+
+    /// <summary>
+    /// GH-4261. <see cref="MySqlConnection.CloseAsync"/> takes no <see cref="CancellationToken"/>, so a
+    /// caller's shutdown budget cannot reach it. The gate above should stop a connection ever getting
+    /// into a state where the close does not return; this makes it survivable if one ever does. Returns
+    /// false when the close was abandoned.
+    /// </summary>
+    private async Task<bool> closeWithinBudgetAsync(MySqlConnection conn)
+    {
+        var closing = conn.CloseAsync();
+
+        using var delay = new CancellationTokenSource();
+        var finished = await Task.WhenAny(closing, Task.Delay(CloseBudget, delay.Token)).ConfigureAwait(false);
+        await delay.CancelAsync().ConfigureAwait(false);
+
+        if (!ReferenceEquals(finished, closing))
+        {
+            _logger.LogWarning(
+                "Timed out after {Budget} closing the advisory lock connection for database {Identifier}; abandoning it",
+                CloseBudget, _databaseName);
+
+            // Observe the abandoned close, so that if it eventually faults the exception cannot resurface
+            // as an UnobservedTaskException on the finalizer thread long after anyone could act on it.
+            _ = closing.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return false;
+        }
+
+        // Surface a genuine close failure to the caller's catch rather than swallowing it here.
+        await closing.ConfigureAwait(false);
+        return true;
     }
 
     /// <summary>

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
@@ -14,6 +14,30 @@ namespace Wolverine.Oracle;
 /// </summary>
 internal class OracleAdvisoryLock : IAdvisoryLock
 {
+    // GH-4261. Unlike its four siblings this one keeps a connection PER LOCK rather than one shared
+    // connection, but the hazard is the same: a SYNCHRONOUS HasLock pings held.conn while
+    // ReleaseLockAsync / DisposeAsync concurrently roll back that same transaction, close that same
+    // connection, and drop it from _heldLocks -- with nothing serialising them, and with _locks and
+    // _heldLocks themselves being a plain List and Dictionary mutated from both. Reported against
+    // Postgres, where the interleaving desynced the driver's protocol and parked shutdown forever
+    // inside an uncancellable CloseAsync. The two callers are reachable together: writeHeartbeats /
+    // executeHealthChecks (WolverineRuntime.Agents.cs) run on the runtime-wide Cancellation token,
+    // which shutdownAsync only cancels AFTER teardownAgentsAsync returns, and teardownAgentsAsync
+    // "stops" them with Task.SafeDispose() -- which disposes the Task object and does nothing to the
+    // running loop.
+    //
+    // _gate serialises every touch of the held connections. _locksLock guards the bookkeeping on its
+    // own, so the one path that deliberately does not wait for the gate -- HasLock on timeout -- can
+    // still read it safely. Ordering is always _gate then _locksLock, never the reverse.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _locksLock = new();
+
+    // Short on purpose: HasLock is synchronous and sits on the health-check tick.
+    private static readonly TimeSpan GateTimeout = 250.Milliseconds();
+
+    // Generous on purpose: this bounds shutdown paths, where the alternative is an unbounded hang.
+    private static readonly TimeSpan CloseBudget = 5.Seconds();
+
     private readonly string _schemaName;
     private readonly List<int> _locks = new();
     private readonly ILogger _logger;
@@ -29,8 +53,40 @@ internal class OracleAdvisoryLock : IAdvisoryLock
 
     public bool HasLock(int lockId)
     {
-        if (!_locks.Contains(lockId)) return false;
-        if (!_heldLocks.TryGetValue(lockId, out var held)) return false;
+        // Cheap negative outside the gate: an id we never took cannot be held.
+        if (!holdsId(lockId)) return false;
+
+        if (!_gate.Wait(GateTimeout))
+        {
+            // GH-4261: a busy gate means another advisory-lock operation on THIS node is in flight, not
+            // that the row lock evaporated. A wrong `false` here is read by
+            // NodeAgentController.DoHealthChecksInternalAsync as lost leadership and fires
+            // stepDownAsync -- exactly the churn GH-2602 and GH-3604 were fighting. Report the last
+            // state we established and skip the keepalive for this tick.
+            _logger.LogDebug(
+                "Advisory lock connection for schema {Schema} was busy; reporting the last known state of lock {LockId} without pinging",
+                _schemaName, lockId);
+            return true;
+        }
+
+        try
+        {
+            return hasLockUnsafe(lockId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The GH-2602 liveness ping. Callers MUST hold <c>_gate</c> -- it does synchronous I/O on a held
+    /// connection and may tear that connection down.
+    /// </summary>
+    private bool hasLockUnsafe(int lockId)
+    {
+        if (!holdsId(lockId)) return false;
+        if (!tryFindHeld(lockId, out var held)) return false;
 
         // Oracle row-level FOR UPDATE locks are tied to the transaction
         // that took them, which is in turn tied to the holding connection.
@@ -52,8 +108,7 @@ internal class OracleAdvisoryLock : IAdvisoryLock
                 "Lost advisory-lock connection for lock {LockId} in schema {Schema}; clearing held state",
                 lockId, _schemaName);
 
-            _locks.Remove(lockId);
-            _heldLocks.Remove(lockId);
+            forgetId(lockId);
             try
             {
                 held.tx.Dispose();
@@ -74,8 +129,52 @@ internal class OracleAdvisoryLock : IAdvisoryLock
         }
     }
 
+    private bool holdsId(int lockId)
+    {
+        lock (_locksLock) return _locks.Contains(lockId);
+    }
+
+    private int[] heldIds()
+    {
+        lock (_locksLock) return _locks.ToArray();
+    }
+
+    private bool tryFindHeld(int lockId, out (OracleConnection conn, OracleTransaction tx) held)
+    {
+        lock (_locksLock) return _heldLocks.TryGetValue(lockId, out held);
+    }
+
+    private void rememberId(int lockId, OracleConnection conn, OracleTransaction tx)
+    {
+        lock (_locksLock)
+        {
+            _locks.Add(lockId);
+            _heldLocks[lockId] = (conn, tx);
+        }
+    }
+
+    /// <summary>
+    /// Drop a lock id and hand back the connection/transaction that was holding it, so the caller can
+    /// tear those down knowing nobody else can still find them.
+    /// </summary>
+    private bool forgetId(int lockId, out (OracleConnection conn, OracleTransaction tx) held)
+    {
+        lock (_locksLock)
+        {
+            _locks.Remove(lockId);
+            return _heldLocks.Remove(lockId, out held);
+        }
+    }
+
+    private void forgetId(int lockId)
+    {
+        forgetId(lockId, out _);
+    }
+
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
+        await _gate.WaitAsync(token).ConfigureAwait(false);
+
         try
         {
             var conn = await _source.OpenConnectionAsync(token);
@@ -107,14 +206,13 @@ internal class OracleAdvisoryLock : IAdvisoryLock
             try
             {
                 await lockCmd.ExecuteScalarAsync(token);
-                _locks.Add(lockId);
-                _heldLocks[lockId] = (conn, tx);
+                rememberId(lockId, conn, tx);
                 return true;
             }
             catch (OracleException ex) when (ex.Number == 54) // ORA-00054: resource busy
             {
                 await tx.RollbackAsync(token);
-                await conn.CloseAsync();
+                await closeWithinBudgetAsync(conn).ConfigureAwait(false);
                 await conn.DisposeAsync();
                 return false;
             }
@@ -124,43 +222,82 @@ internal class OracleAdvisoryLock : IAdvisoryLock
             _logger.LogError(e, "Error trying to attain advisory lock {LockId}", lockId);
             return false;
         }
+        finally
+        {
+            _gate.Release();
+        }
     }
 
     public async Task ReleaseLockAsync(int lockId)
     {
-        if (!_locks.Contains(lockId)) return;
+        if (!holdsId(lockId)) return;
 
-        _locks.Remove(lockId);
-
-        if (_heldLocks.TryGetValue(lockId, out var held))
+        // GH-4261: bounded rather than indefinite. If the gate is still held past the budget something
+        // is wedged on the connection, and waiting longer turns a released lock into a hung shutdown.
+        // Oracle drops the row lock when the holding session ends, so an abandoned lock clears itself
+        // when this process exits.
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
         {
-            _heldLocks.Remove(lockId);
-            try
-            {
-                using var cancellation = new CancellationTokenSource();
-                cancellation.CancelAfter(1.Seconds());
+            _logger.LogWarning(
+                "Timed out waiting to release advisory lock {LockId} in schema {Schema}; leaving it to be released when the session ends",
+                lockId, _schemaName);
+            return;
+        }
 
-                await held.tx.RollbackAsync(cancellation.Token);
-                await held.conn.CloseAsync();
-                await held.conn.DisposeAsync();
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Error releasing advisory lock {LockId}", lockId);
-            }
+        try
+        {
+            await releaseLockUnsafeAsync(lockId).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>. Split out because <see cref="DisposeAsync"/> releases every held
+    /// lock in a loop and SemaphoreSlim is not reentrant -- going back through the public method would
+    /// deadlock against the gate this method's caller already holds.
+    /// </summary>
+    private async Task releaseLockUnsafeAsync(int lockId)
+    {
+        if (!forgetId(lockId, out var held)) return;
+
+        try
+        {
+            using var cancellation = new CancellationTokenSource();
+            cancellation.CancelAfter(1.Seconds());
+
+            await held.tx.RollbackAsync(cancellation.Token);
+            await closeWithinBudgetAsync(held.conn).ConfigureAwait(false);
+            await held.conn.DisposeAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error releasing advisory lock {LockId}", lockId);
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var lockId in _locks.ToArray())
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
         {
-            if (_heldLocks.TryGetValue(lockId, out var held))
+            _logger.LogWarning(
+                "Timed out waiting to dispose the advisory locks for schema {Schema}; abandoning them",
+                _schemaName);
+            return;
+        }
+
+        try
+        {
+            foreach (var lockId in heldIds())
             {
+                if (!forgetId(lockId, out var held)) continue;
+
                 try
                 {
                     await held.tx.RollbackAsync(CancellationToken.None);
-                    await held.conn.CloseAsync();
+                    await closeWithinBudgetAsync(held.conn).ConfigureAwait(false);
                     await held.conn.DisposeAsync();
                 }
                 catch (Exception e)
@@ -169,8 +306,44 @@ internal class OracleAdvisoryLock : IAdvisoryLock
                 }
             }
         }
+        finally
+        {
+            _gate.Release();
+        }
+    }
 
-        _locks.Clear();
-        _heldLocks.Clear();
+    /// <summary>
+    /// GH-4261. <see cref="OracleConnection.CloseAsync"/> takes no <see cref="CancellationToken"/>, so a
+    /// caller's shutdown budget cannot reach it. The gate above should stop a connection ever getting
+    /// into a state where the close does not return; this makes it survivable if one ever does. Returns
+    /// false when the close was abandoned -- the caller's DisposeAsync then runs against a connection
+    /// whose close never completed, which the surrounding catch absorbs.
+    /// </summary>
+    private async Task<bool> closeWithinBudgetAsync(OracleConnection conn)
+    {
+        var closing = conn.CloseAsync();
+
+        using var delay = new CancellationTokenSource();
+        var finished = await Task.WhenAny(closing, Task.Delay(CloseBudget, delay.Token)).ConfigureAwait(false);
+        await delay.CancelAsync().ConfigureAwait(false);
+
+        if (!ReferenceEquals(finished, closing))
+        {
+            _logger.LogWarning(
+                "Timed out after {Budget} closing an advisory lock connection for schema {Schema}; abandoning it",
+                CloseBudget, _schemaName);
+
+            // Observe the abandoned close, so that if it eventually faults the exception cannot resurface
+            // as an UnobservedTaskException on the finalizer thread long after anyone could act on it.
+            _ = closing.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return false;
+        }
+
+        // Surface a genuine close failure to the caller's catch rather than swallowing it here.
+        await closing.ConfigureAwait(false);
+        return true;
     }
 }

--- a/src/Persistence/PostgresqlTests/Bugs/Bug_4261_advisory_lock_connection_races.cs
+++ b/src/Persistence/PostgresqlTests/Bugs/Bug_4261_advisory_lock_connection_races.cs
@@ -1,0 +1,185 @@
+using System.Diagnostics;
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Xunit;
+using AdvisoryLock = Wolverine.Postgresql.AdvisoryLock;
+
+namespace PostgresqlTests.Bugs;
+
+/// <summary>
+/// GH-4261. <see cref="AdvisoryLock"/> keeps one long-lived <see cref="NpgsqlConnection"/> and used to
+/// synchronise access to it with nothing at all -- no semaphore, no lock, no Interlocked.
+/// <c>HasLock</c> runs SYNCHRONOUS I/O on that connection (the GH-2602 liveness ping) while
+/// <c>TryAttainLockAsync</c>, <c>ReleaseLockAsync</c> and <c>DisposeAsync</c> run ASYNC I/O on the same
+/// field. Npgsql explicitly does not support concurrent use of one connection.
+///
+/// <para>The two sides are reachable together in a normal shutdown. <c>writeHeartbeats</c> and
+/// <c>executeHealthChecks</c> run on the runtime-wide <c>Cancellation</c> token, which
+/// <c>shutdownAsync</c> only cancels AFTER <c>teardownAgentsAsync</c> has returned; teardown "stops"
+/// them with <c>Task.SafeDispose()</c>, which disposes the Task object and does nothing whatsoever to
+/// the running loop. So a health check already past its own guard reaches
+/// <c>ejectStaleNodes -> HasLeadershipLock() -> HasLock</c> at the same moment teardown reaches
+/// <c>NodeAgentController.StopAsync -> ReleaseLeadershipLockAsync</c>.</para>
+///
+/// <para>Two failure modes were reported, and the tests below cover both:</para>
+/// <list type="number">
+/// <item>An uncancellable hang. The reader left orphaned by the interleaving never completes, and
+/// <c>NpgsqlConnection.CloseAsync()</c> -- which takes no CancellationToken, so
+/// <c>HostOptions.ShutdownTimeout</c> cannot reach it -- parks forever draining it. Two independent
+/// process dumps caught frame-for-frame identical stacks down to every async state number. The symptom
+/// is distinctive: every test passes and is counted, then the process never exits, because the hang is
+/// inside collection-fixture disposal after the last test has already reported.</item>
+/// <item>A spurious loss of leadership. Where Npgsql DOES notice the concurrent use it throws, and
+/// <c>HasLock</c>'s catch reads any exception as "the server dropped our session", clears EVERY held
+/// lock id and returns false. <c>NodeAgentController.DoHealthChecksInternalAsync</c> reads that false
+/// as lost leadership and calls <c>stepDownAsync</c> -- which is exactly the churn GH-2602 and GH-3604
+/// were fighting.</item>
+/// </list>
+///
+/// <para>⚠️ These are stress tests against a real Postgres. They cannot prove a race absent; a single
+/// green run is weak evidence and the iteration counts are deliberately generous.</para>
+/// </summary>
+public class Bug_4261_advisory_lock_connection_races : PostgresqlContext
+{
+    private const int LockId = unchecked((int)0xB0BCA7);
+
+    [Fact]
+    public async Task hammering_HasLock_while_attaining_and_releasing_never_corrupts_the_connection()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        var advisoryLock = new AdvisoryLock(dataSource, NullLogger.Instance, "gh4261-hammer");
+
+        var failures = new List<Exception>();
+        using var stop = new CancellationTokenSource();
+
+        // Four pingers, standing in for the health-check tick's HasLeadershipLock() call.
+        var pingers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                try
+                {
+                    advisoryLock.HasLock(LockId);
+                }
+                catch (Exception e)
+                {
+                    lock (failures) failures.Add(e);
+                    return;
+                }
+            }
+        })).ToArray();
+
+        try
+        {
+            // ...against the attain/release cycle the heartbeat and a stepdown drive.
+            for (var i = 0; i < 60; i++)
+            {
+                (await advisoryLock.TryAttainLockAsync(LockId, CancellationToken.None))
+                    .ShouldBeTrue($"the lock should have been attainable on round {i}");
+
+                await advisoryLock.ReleaseLockAsync(LockId);
+            }
+        }
+        finally
+        {
+            await stop.CancelAsync();
+            await Task.WhenAll(pingers);
+            await advisoryLock.DisposeAsync();
+        }
+
+        failures.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_still_held_lock_is_never_reported_as_lost_while_the_connection_is_busy()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        var advisoryLock = new AdvisoryLock(dataSource, NullLogger.Instance, "gh4261-stepdown");
+
+        (await advisoryLock.TryAttainLockAsync(LockId, CancellationToken.None)).ShouldBeTrue();
+
+        var lostIt = 0;
+        var failures = new List<Exception>();
+        using var stop = new CancellationTokenSource();
+
+        var pingers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                try
+                {
+                    if (!advisoryLock.HasLock(LockId))
+                    {
+                        Interlocked.Increment(ref lostIt);
+                    }
+                }
+                catch (Exception e)
+                {
+                    lock (failures) failures.Add(e);
+                    return;
+                }
+            }
+        })).ToArray();
+
+        try
+        {
+            // The heartbeat renewal: TryAttainLeadershipLockAsync fires on EVERY tick, including ticks
+            // where this node already holds the lock. Nothing here ever releases, so no ping has any
+            // business reporting the lock lost.
+            for (var i = 0; i < 60; i++)
+            {
+                (await advisoryLock.TryAttainLockAsync(LockId, CancellationToken.None))
+                    .ShouldBeTrue($"the renewal on tick {i} should still report the lock held");
+            }
+        }
+        finally
+        {
+            await stop.CancelAsync();
+            await Task.WhenAll(pingers);
+            await advisoryLock.DisposeAsync();
+        }
+
+        failures.ShouldBeEmpty();
+        lostIt.ShouldBe(0,
+            "HasLock reporting false on a lock nothing released is read as lost leadership by DoHealthChecksInternalAsync and fires stepDownAsync");
+    }
+
+    [Fact]
+    public async Task disposal_completes_within_a_bound_while_HasLock_is_hammering()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(Servers.PostgresConnectionString);
+        var advisoryLock = new AdvisoryLock(dataSource, NullLogger.Instance, "gh4261-dispose");
+
+        (await advisoryLock.TryAttainLockAsync(LockId, CancellationToken.None)).ShouldBeTrue();
+
+        using var stop = new CancellationTokenSource();
+        var pingers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                try
+                {
+                    advisoryLock.HasLock(LockId);
+                }
+                catch
+                {
+                    // Covered by the other tests; this one is only about whether disposal returns.
+                }
+            }
+        })).ToArray();
+
+        // The reported symptom was an INFINITE park inside CloseAsync, so any finite bound distinguishes
+        // fixed from broken. Generous enough not to be a timing test in its own right: the gate waits
+        // are 5s apiece and there is exactly one lock to release.
+        var stopwatch = Stopwatch.StartNew();
+        await advisoryLock.DisposeAsync();
+        stopwatch.Stop();
+
+        await stop.CancelAsync();
+        await Task.WhenAll(pingers);
+
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(30));
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
@@ -400,6 +400,39 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
 
 internal class AdvisoryLock : IAdvisoryLock
 {
+    // GH-4261. Everything below shares ONE long-lived NpgsqlConnection, and Npgsql does not support
+    // concurrent use of a connection. Nothing used to stop that: HasLock ran SYNCHRONOUS I/O on _conn
+    // while ReleaseLockAsync / TryAttainLockAsync / DisposeAsync ran ASYNC I/O on the same field, and
+    // both are reachable at once. writeHeartbeats and executeHealthChecks (WolverineRuntime.Agents.cs)
+    // run on the runtime-wide Cancellation token, which shutdownAsync only cancels AFTER
+    // teardownAgentsAsync has returned; teardownAgentsAsync "stops" them with Task.SafeDispose(), which
+    // disposes the Task object and does nothing to the running loop. So a health check already past its
+    // own cancellation guard runs ejectStaleNodes -> HasLeadershipLock() -> the ping below at the same
+    // moment teardown runs NodeAgentController.StopAsync -> ReleaseLeadershipLockAsync.
+    //
+    // When they interleave the protocol desyncs: the second caller consumes the messages the first
+    // caller's reader was waiting for, and the orphaned reader's Close never completes. Two independent
+    // process dumps caught it parked forever inside NpgsqlConnection.CloseAsync -> CloseOngoingOperations
+    // -> NpgsqlDataReader.Consume -> NextResult, frame-for-frame identical down to every async state
+    // number, with the backend already Idle and the connector unbound from the command. CloseAsync takes
+    // no CancellationToken, so HostOptions.ShutdownTimeout -- correctly threaded down to
+    // WolverineRuntime.StopAsync -- could not break it, and the whole process hung: every test passed
+    // and reported, then nothing exited, because the hang lives in fixture disposal after the last test.
+    //
+    // _gate serialises every touch of _conn. _locksLock guards the held-id list on its own, so the one
+    // path that deliberately does NOT wait for the gate -- HasLock on timeout -- can still read it
+    // safely. Ordering is always _gate then _locksLock, never the reverse: no _locksLock section does
+    // I/O or takes the gate.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _locksLock = new();
+
+    // Short on purpose. HasLock is synchronous and sits on the health-check tick, so it must not block
+    // behind a slow release; a quarter second covers an ordinary round-trip and nothing more.
+    private static readonly TimeSpan GateTimeout = 250.Milliseconds();
+
+    // Generous on purpose. This bounds shutdown paths, where the alternative is the unbounded hang above.
+    private static readonly TimeSpan CloseBudget = 5.Seconds();
+
     private readonly string _databaseName;
     private readonly List<int> _locks = new();
     private readonly ILogger _logger;
@@ -415,8 +448,43 @@ internal class AdvisoryLock : IAdvisoryLock
 
     public bool HasLock(int lockId)
     {
+        // Cheap negative outside the gate. An id we never took cannot be held no matter what any
+        // concurrent operation is doing.
+        if (!holdsId(lockId)) return false;
+
+        if (!_gate.Wait(GateTimeout))
+        {
+            // GH-4261: the gate is busy only because another advisory-lock operation on THIS node is in
+            // flight -- a release during shutdown, or the re-attain from this same health-check tick.
+            // That is not evidence the server dropped our session, and a wrong `false` here is not
+            // cheap: NodeAgentController.DoHealthChecksInternalAsync reads it as lost leadership and
+            // calls stepDownAsync, which is precisely the churn GH-2602 and GH-3604 were fighting. So
+            // report the last state we actually established and skip the keepalive for this tick. The
+            // next tick pings.
+            _logger.LogDebug(
+                "Advisory lock connection for database {Database} was busy; reporting the last known state of lock {LockId} without pinging",
+                _databaseName, lockId);
+            return true;
+        }
+
+        try
+        {
+            return hasLockUnsafe(lockId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The GH-2602 liveness ping. Callers MUST hold <c>_gate</c> -- it does synchronous I/O on the
+    /// shared connection and may replace it.
+    /// </summary>
+    private bool hasLockUnsafe(int lockId)
+    {
         if (_conn is null) return false;
-        if (!_locks.Contains(lockId)) return false;
+        if (!holdsId(lockId)) return false;
 
         // Postgres releases session-level advisory locks the moment the
         // backend session ends — network blip, idle-connection cull,
@@ -447,9 +515,9 @@ internal class AdvisoryLock : IAdvisoryLock
         {
             _logger.LogWarning(e,
                 "Lost advisory-lock connection for database {Database}; clearing held lock ids {Locks}",
-                _databaseName, _locks);
+                _databaseName, heldIds());
 
-            _locks.Clear();
+            clearIds();
             try
             {
                 _conn.Dispose();
@@ -461,6 +529,36 @@ internal class AdvisoryLock : IAdvisoryLock
             _conn = null;
             return false;
         }
+    }
+
+    private bool holdsId(int lockId)
+    {
+        lock (_locksLock) return _locks.Contains(lockId);
+    }
+
+    private bool anyIdsHeld()
+    {
+        lock (_locksLock) return _locks.Count > 0;
+    }
+
+    private int[] heldIds()
+    {
+        lock (_locksLock) return _locks.ToArray();
+    }
+
+    private void addId(int lockId)
+    {
+        lock (_locksLock) _locks.Add(lockId);
+    }
+
+    private void removeId(int lockId)
+    {
+        lock (_locksLock) _locks.Remove(lockId);
+    }
+
+    private void clearIds()
+    {
+        lock (_locksLock) _locks.Clear();
     }
 
     /// <summary>
@@ -497,89 +595,119 @@ internal class AdvisoryLock : IAdvisoryLock
 
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
-        // Idempotent against repeated calls on the same session. Postgres
-        // session-level advisory locks STACK ("Multiple lock requests stack,
-        // so that if the same resource is locked three times it must then be
-        // unlocked three times to be released" — Postgres docs). Since the
-        // a84d6a262 heartbeat-renewal change calls TryAttainLeadershipLockAsync
-        // every tick — including ticks where the leader already holds the
-        // lock — without this short-circuit the leader's lock count grows by
-        // one per heartbeat. The single ReleaseLeadershipLockAsync call
-        // during DisableAgentsAsync or stepDownAsync then only decrements
-        // once, leaving the lock still held server-side and silently
-        // blocking failover (no error logged, just a stalled election).
-        if (_locks.Contains(lockId) && HasLock(lockId))
-        {
-            return true;
-        }
+        await _gate.WaitAsync(token).ConfigureAwait(false);
 
-        if (_conn == null)
+        try
         {
-            _conn = _source.CreateConnection();
-            await _conn.OpenAsync(token).ConfigureAwait(false);
-            await tagSessionAsync(_conn, token).ConfigureAwait(false);
-        }
+            // Idempotent against repeated calls on the same session. Postgres
+            // session-level advisory locks STACK ("Multiple lock requests stack,
+            // so that if the same resource is locked three times it must then be
+            // unlocked three times to be released" — Postgres docs). Since the
+            // a84d6a262 heartbeat-renewal change calls TryAttainLeadershipLockAsync
+            // every tick — including ticks where the leader already holds the
+            // lock — without this short-circuit the leader's lock count grows by
+            // one per heartbeat. The single ReleaseLeadershipLockAsync call
+            // during DisableAgentsAsync or stepDownAsync then only decrements
+            // once, leaving the lock still held server-side and silently
+            // blocking failover (no error logged, just a stalled election).
+            //
+            // GH-4261: hasLockUnsafe, not HasLock — we already hold the gate, and SemaphoreSlim is not
+            // reentrant.
+            if (hasLockUnsafe(lockId))
+            {
+                return true;
+            }
 
-        if (_conn.State == ConnectionState.Closed)
-        {
-            try
+            if (_conn == null)
             {
-                await _conn.DisposeAsync().ConfigureAwait(false);
+                _conn = _source.CreateConnection();
+                await _conn.OpenAsync(token).ConfigureAwait(false);
+                await tagSessionAsync(_conn, token).ConfigureAwait(false);
             }
-            catch (Exception e)
+
+            if (_conn.State == ConnectionState.Closed)
             {
-                _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                try
+                {
+                    await _conn.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                }
+                finally
+                {
+                    _conn = null;
+                }
+
+                return false;
             }
-            finally
+
+            var attained = await _conn.TryGetGlobalLock(lockId, token).ConfigureAwait(false);
+            if (attained == AttainLockResult.Success)
             {
-                _conn = null;
+                addId(lockId);
+                return true;
             }
 
             return false;
         }
-
-
-        var attained = await _conn.TryGetGlobalLock(lockId, token).ConfigureAwait(false);
-        if (attained == AttainLockResult.Success)
+        finally
         {
-            _locks.Add(lockId);
-            return true;
+            _gate.Release();
         }
-
-        return false;
     }
 
     public async Task ReleaseLockAsync(int lockId)
     {
-        if (!_locks.Contains(lockId))
+        if (!holdsId(lockId))
         {
             return;
         }
 
-        if (_conn == null || _conn.State != ConnectionState.Open)
+        // GH-4261: bounded rather than indefinite. If the gate is still held past the budget, something
+        // is wedged on the connection and waiting longer only turns a released lock into a hung
+        // shutdown. Postgres drops every session-level advisory lock when the backend session ends, so
+        // the abandoned lock clears itself the moment this process exits.
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
         {
-            _locks.Remove(lockId);
+            _logger.LogWarning(
+                "Timed out waiting to release advisory lock {LockId} for database {Identifier}; leaving it to be released when the session ends",
+                lockId, _databaseName);
             return;
         }
 
         try
         {
-            using var cancellation = new CancellationTokenSource();
-            cancellation.CancelAfter(1.Seconds());
+            if (_conn == null || _conn.State != ConnectionState.Open)
+            {
+                removeId(lockId);
+                return;
+            }
 
-            await _conn.ReleaseGlobalLock(lockId, cancellation.Token).ConfigureAwait(false);
+            try
+            {
+                using var cancellation = new CancellationTokenSource();
+                cancellation.CancelAfter(1.Seconds());
+
+                await _conn.ReleaseGlobalLock(lockId, cancellation.Token).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error trying to release advisory lock {LockId} for database {Identifier}",
+                    lockId, _databaseName);
+            }
+
+            removeId(lockId);
+
+            if (!anyIdsHeld())
+            {
+                await safeCloseConnectionAsync().ConfigureAwait(false);
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _logger.LogDebug(e, "Error trying to release advisory lock {LockId} for database {Identifier}",
-                lockId, _databaseName);
-        }
-
-        _locks.Remove(lockId);
-
-        if (!_locks.Any())
-        {
-            await safeCloseConnectionAsync().ConfigureAwait(false);
+            _gate.Release();
         }
     }
 
@@ -590,55 +718,117 @@ internal class AdvisoryLock : IAdvisoryLock
             return;
         }
 
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
+        {
+            _logger.LogWarning(
+                "Timed out waiting to dispose the advisory lock connection for database {Identifier}; abandoning it",
+                _databaseName);
+            return;
+        }
+
         try
         {
-            if (_conn.State == ConnectionState.Open)
+            if (_conn == null)
             {
-                foreach (var i in _locks)
-                {
-                    try
-                    {
-                        await _conn.ReleaseGlobalLock(i, CancellationToken.None).ConfigureAwait(false);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogDebug(e,
-                            "Error trying to release advisory lock {LockId} during dispose for database {Identifier}",
-                            i, _databaseName);
-                    }
-                }
+                return;
             }
 
-            await safeCloseConnectionAsync().ConfigureAwait(false);
+            try
+            {
+                if (_conn.State == ConnectionState.Open)
+                {
+                    foreach (var i in heldIds())
+                    {
+                        try
+                        {
+                            await _conn.ReleaseGlobalLock(i, CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogDebug(e,
+                                "Error trying to release advisory lock {LockId} during dispose for database {Identifier}",
+                                i, _databaseName);
+                        }
+                    }
+                }
+
+                await safeCloseConnectionAsync().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error trying to dispose of advisory locks for database {Identifier}",
+                    _databaseName);
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _logger.LogDebug(e, "Error trying to dispose of advisory locks for database {Identifier}",
-                _databaseName);
+            _gate.Release();
         }
     }
 
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>.
+    /// </summary>
     private async Task safeCloseConnectionAsync()
     {
-        if (_conn == null) return;
+        // GH-4261: take the connection off the field FIRST. If the close below has to be abandoned, the
+        // dead connection must not stay reachable for the next caller to find and use.
+        var conn = _conn;
+        _conn = null;
+        if (conn == null) return;
 
         try
         {
-            if (_conn.State == ConnectionState.Open)
+            if (conn.State == ConnectionState.Open && !await closeWithinBudgetAsync(conn).ConfigureAwait(false))
             {
-                await _conn.CloseAsync().ConfigureAwait(false);
+                // Deliberately no DisposeAsync: that would race the CloseAsync still parked on this
+                // connection. Dropping the reference is enough -- the abandoned await sits on a
+                // thread-pool thread, which cannot hold the process open, and the backend session ends
+                // with the process.
+                return;
             }
 
-            await _conn.DisposeAsync().ConfigureAwait(false);
+            await conn.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception e)
         {
             _logger.LogDebug(e, "Error trying to close advisory lock connection for database {Identifier}",
                 _databaseName);
         }
-        finally
+    }
+
+    /// <summary>
+    /// GH-4261. <see cref="NpgsqlConnection.CloseAsync"/> takes no <see cref="CancellationToken"/>, so a
+    /// caller's shutdown budget cannot reach it and a connection whose protocol has desynced parks in
+    /// there forever draining an orphaned reader. The gate above should stop that happening at all; this
+    /// makes it survivable if anything ever produces one anyway. Returns false when the close was
+    /// abandoned.
+    /// </summary>
+    private async Task<bool> closeWithinBudgetAsync(NpgsqlConnection conn)
+    {
+        var closing = conn.CloseAsync();
+
+        using var delay = new CancellationTokenSource();
+        var finished = await Task.WhenAny(closing, Task.Delay(CloseBudget, delay.Token)).ConfigureAwait(false);
+        await delay.CancelAsync().ConfigureAwait(false);
+
+        if (!ReferenceEquals(finished, closing))
         {
-            _conn = null;
+            _logger.LogWarning(
+                "Timed out after {Budget} closing the advisory lock connection for database {Identifier}; abandoning it",
+                CloseBudget, _databaseName);
+
+            // Observe the abandoned close, so that if it eventually faults the exception cannot resurface
+            // as an UnobservedTaskException on the finalizer thread long after anyone could act on it.
+            _ = closing.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return false;
         }
+
+        // Surface a genuine close failure to the caller's catch rather than swallowing it here.
+        await closing.ConfigureAwait(false);
+        return true;
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerAdvisoryLock.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerAdvisoryLock.cs
@@ -20,6 +20,27 @@ namespace Wolverine.SqlServer.Persistence;
 /// </summary>
 internal class SqlServerAdvisoryLock : IAdvisoryLock
 {
+    // GH-4261. One long-lived SqlConnection shared by a SYNCHRONOUS HasLock and three ASYNC methods,
+    // with nothing serialising them. Reported against Postgres, where the interleaving desynced the
+    // Npgsql protocol and parked shutdown forever inside an uncancellable CloseAsync; SqlConnection is
+    // likewise documented as not supporting concurrent operations, and this class has the identical
+    // shape. The two callers are reachable together: writeHeartbeats / executeHealthChecks
+    // (WolverineRuntime.Agents.cs) run on the runtime-wide Cancellation token, which shutdownAsync only
+    // cancels AFTER teardownAgentsAsync returns, and teardownAgentsAsync "stops" them with
+    // Task.SafeDispose() -- which disposes the Task object and does nothing to the running loop.
+    //
+    // _gate serialises every touch of _conn. _locksLock guards the held-id list separately, so the one
+    // path that deliberately does not wait for the gate -- HasLock on timeout -- can still read it
+    // safely. Ordering is always _gate then _locksLock, never the reverse.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _locksLock = new();
+
+    // Short on purpose: HasLock is synchronous and sits on the health-check tick.
+    private static readonly TimeSpan GateTimeout = 250.Milliseconds();
+
+    // Generous on purpose: this bounds shutdown paths, where the alternative is an unbounded hang.
+    private static readonly TimeSpan CloseBudget = 5.Seconds();
+
     private readonly Func<SqlConnection> _source;
     private readonly ILogger _logger;
     private readonly string _databaseName;
@@ -35,8 +56,40 @@ internal class SqlServerAdvisoryLock : IAdvisoryLock
 
     public bool HasLock(int lockId)
     {
+        // Cheap negative outside the gate: an id we never took cannot be held.
+        if (!holdsId(lockId)) return false;
+
+        if (!_gate.Wait(GateTimeout))
+        {
+            // GH-4261: a busy gate means another advisory-lock operation on THIS node is in flight, not
+            // that the server dropped our session. A wrong `false` here is read by
+            // NodeAgentController.DoHealthChecksInternalAsync as lost leadership and fires
+            // stepDownAsync -- exactly the churn GH-2602 and GH-3604 were fighting. Report the last
+            // state we established and skip the keepalive for this tick.
+            _logger.LogDebug(
+                "Advisory lock connection for database {Database} was busy; reporting the last known state of lock {LockId} without pinging",
+                _databaseName, lockId);
+            return true;
+        }
+
+        try
+        {
+            return hasLockUnsafe(lockId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The GH-2602 liveness ping. Callers MUST hold <c>_gate</c> -- it does synchronous I/O on the
+    /// shared connection and may replace it.
+    /// </summary>
+    private bool hasLockUnsafe(int lockId)
+    {
         if (_conn is null) return false;
-        if (!_locks.Contains(lockId)) return false;
+        if (!holdsId(lockId)) return false;
 
         // SQL Server session-scoped application locks (sp_getapplock /
         // sp_releaseapplock) are released the instant the SQL session ends —
@@ -56,9 +109,9 @@ internal class SqlServerAdvisoryLock : IAdvisoryLock
         {
             _logger.LogWarning(e,
                 "Lost advisory-lock connection for database {Database}; clearing held lock ids {Locks}",
-                _databaseName, _locks);
+                _databaseName, heldIds());
 
-            _locks.Clear();
+            clearIds();
             try
             {
                 _conn.Dispose();
@@ -72,89 +125,150 @@ internal class SqlServerAdvisoryLock : IAdvisoryLock
         }
     }
 
+    private bool holdsId(int lockId)
+    {
+        lock (_locksLock) return _locks.Contains(lockId);
+    }
+
+    private bool anyIdsHeld()
+    {
+        lock (_locksLock) return _locks.Count > 0;
+    }
+
+    private int[] heldIds()
+    {
+        lock (_locksLock) return _locks.ToArray();
+    }
+
+    private void addId(int lockId)
+    {
+        lock (_locksLock) _locks.Add(lockId);
+    }
+
+    private void removeId(int lockId)
+    {
+        lock (_locksLock) _locks.Remove(lockId);
+    }
+
+    private void clearIds()
+    {
+        lock (_locksLock) _locks.Clear();
+    }
+
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
-        // Idempotent against repeated calls on the same session. SQL Server
-        // session-scoped application locks (sp_getapplock) are reentrant —
-        // "If a lock has been requested in the current transaction or by the
-        // current session, sp_getapplock can be called multiple times for it
-        // (with the same name and lock owner). For each request that returns
-        // success ... sp_releaseapplock must also be called." The
-        // a84d6a262 heartbeat-renewal change calls TryAttainLeadershipLockAsync
-        // every tick — including ticks where the leader already holds the
-        // lock — so without this short-circuit the leader's lock count grows
-        // by one per heartbeat. The single ReleaseLeadershipLockAsync call
-        // during DisableAgentsAsync or stepDownAsync then only decrements
-        // once, leaving the lock still held server-side and silently
-        // blocking failover (no error logged, just a stalled election).
-        if (_locks.Contains(lockId) && HasLock(lockId))
-        {
-            return true;
-        }
+        await _gate.WaitAsync(token).ConfigureAwait(false);
 
-        if (_conn == null)
+        try
         {
-            _conn = _source();
-            await _conn.OpenAsync(token).ConfigureAwait(false);
-        }
+            // Idempotent against repeated calls on the same session. SQL Server
+            // session-scoped application locks (sp_getapplock) are reentrant —
+            // "If a lock has been requested in the current transaction or by the
+            // current session, sp_getapplock can be called multiple times for it
+            // (with the same name and lock owner). For each request that returns
+            // success ... sp_releaseapplock must also be called." The
+            // a84d6a262 heartbeat-renewal change calls TryAttainLeadershipLockAsync
+            // every tick — including ticks where the leader already holds the
+            // lock — so without this short-circuit the leader's lock count grows
+            // by one per heartbeat. The single ReleaseLeadershipLockAsync call
+            // during DisableAgentsAsync or stepDownAsync then only decrements
+            // once, leaving the lock still held server-side and silently
+            // blocking failover (no error logged, just a stalled election).
+            //
+            // GH-4261: hasLockUnsafe, not HasLock — we already hold the gate, and SemaphoreSlim is not
+            // reentrant.
+            if (hasLockUnsafe(lockId))
+            {
+                return true;
+            }
 
-        if (_conn.State == ConnectionState.Closed)
-        {
-            try
+            if (_conn == null)
             {
-                await _conn.DisposeAsync().ConfigureAwait(false);
+                _conn = _source();
+                await _conn.OpenAsync(token).ConfigureAwait(false);
             }
-            catch (Exception e)
+
+            if (_conn.State == ConnectionState.Closed)
             {
-                _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                try
+                {
+                    await _conn.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                }
+                finally
+                {
+                    _conn = null;
+                }
+
+                return false;
             }
-            finally
+
+            var attained = await _conn.TryGetGlobalLock(lockId.ToString(), cancellation: token).ConfigureAwait(false);
+            if (attained)
             {
-                _conn = null;
+                addId(lockId);
+                return true;
             }
 
             return false;
         }
-
-        var attained = await _conn.TryGetGlobalLock(lockId.ToString(), cancellation: token).ConfigureAwait(false);
-        if (attained)
+        finally
         {
-            _locks.Add(lockId);
-            return true;
+            _gate.Release();
         }
-
-        return false;
     }
 
     public async Task ReleaseLockAsync(int lockId)
     {
-        if (!_locks.Contains(lockId)) return;
+        if (!holdsId(lockId)) return;
 
-        if (_conn == null || _conn.State == ConnectionState.Closed)
+        // GH-4261: bounded rather than indefinite. If the gate is still held past the budget something
+        // is wedged on the connection, and waiting longer turns a released lock into a hung shutdown.
+        // SQL Server drops session-scoped application locks when the session ends, so an abandoned lock
+        // clears itself when this process exits.
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
         {
-            _locks.Remove(lockId);
+            _logger.LogWarning(
+                "Timed out waiting to release advisory lock {LockId} for database {Identifier}; leaving it to be released when the session ends",
+                lockId, _databaseName);
             return;
         }
 
         try
         {
-            using var cancellation = new CancellationTokenSource();
-            cancellation.CancelAfter(1.Seconds());
+            if (_conn == null || _conn.State == ConnectionState.Closed)
+            {
+                removeId(lockId);
+                return;
+            }
 
-            await _conn.ReleaseGlobalLock(lockId.ToString(), cancellation: cancellation.Token).ConfigureAwait(false);
+            try
+            {
+                using var cancellation = new CancellationTokenSource();
+                cancellation.CancelAfter(1.Seconds());
+
+                await _conn.ReleaseGlobalLock(lockId.ToString(), cancellation: cancellation.Token).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e,
+                    "Error trying to release advisory lock {LockId} for database {Identifier}",
+                    lockId, _databaseName);
+            }
+
+            removeId(lockId);
+
+            if (!anyIdsHeld())
+            {
+                await safeCloseConnectionAsync().ConfigureAwait(false);
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _logger.LogDebug(e,
-                "Error trying to release advisory lock {LockId} for database {Identifier}",
-                lockId, _databaseName);
-        }
-
-        _locks.Remove(lockId);
-
-        if (!_locks.Any())
-        {
-            await safeCloseConnectionAsync().ConfigureAwait(false);
+            _gate.Release();
         }
     }
 
@@ -162,55 +276,111 @@ internal class SqlServerAdvisoryLock : IAdvisoryLock
     {
         if (_conn == null) return;
 
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
+        {
+            _logger.LogWarning(
+                "Timed out waiting to dispose the advisory lock connection for database {Identifier}; abandoning it",
+                _databaseName);
+            return;
+        }
+
         try
         {
-            if (_conn.State == ConnectionState.Open)
+            if (_conn == null) return;
+
+            try
             {
-                foreach (var i in _locks)
+                if (_conn.State == ConnectionState.Open)
                 {
-                    try
+                    foreach (var i in heldIds())
                     {
-                        await _conn.ReleaseGlobalLock(i.ToString(), CancellationToken.None).ConfigureAwait(false);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogDebug(e,
-                            "Error trying to release advisory lock {LockId} during dispose for database {Identifier}",
-                            i, _databaseName);
+                        try
+                        {
+                            await _conn.ReleaseGlobalLock(i.ToString(), CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogDebug(e,
+                                "Error trying to release advisory lock {LockId} during dispose for database {Identifier}",
+                                i, _databaseName);
+                        }
                     }
                 }
-            }
 
-            await safeCloseConnectionAsync().ConfigureAwait(false);
+                await safeCloseConnectionAsync().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "Error trying to dispose of advisory locks for database {Identifier}",
+                    _databaseName);
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _logger.LogDebug(e, "Error trying to dispose of advisory locks for database {Identifier}",
-                _databaseName);
+            _gate.Release();
         }
     }
 
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>.
+    /// </summary>
     private async Task safeCloseConnectionAsync()
     {
-        if (_conn == null) return;
+        // GH-4261: take the connection off the field FIRST, so an abandoned close cannot leave a dead
+        // connection reachable for the next caller.
+        var conn = _conn;
+        _conn = null;
+        if (conn == null) return;
 
         try
         {
-            if (_conn.State == ConnectionState.Open)
+            if (conn.State == ConnectionState.Open && !await closeWithinBudgetAsync(conn).ConfigureAwait(false))
             {
-                await _conn.CloseAsync().ConfigureAwait(false);
+                // Deliberately no DisposeAsync: that would race the CloseAsync still parked on this
+                // connection. Dropping the reference is enough.
+                return;
             }
 
-            await _conn.DisposeAsync().ConfigureAwait(false);
+            await conn.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception e)
         {
             _logger.LogDebug(e, "Error trying to close advisory lock connection for database {Identifier}",
                 _databaseName);
         }
-        finally
+    }
+
+    /// <summary>
+    /// GH-4261. <see cref="SqlConnection.CloseAsync"/> takes no <see cref="CancellationToken"/>, so a
+    /// caller's shutdown budget cannot reach it. The gate above should stop a connection ever getting
+    /// into a state where the close does not return; this makes it survivable if one ever does. Returns
+    /// false when the close was abandoned.
+    /// </summary>
+    private async Task<bool> closeWithinBudgetAsync(SqlConnection conn)
+    {
+        var closing = conn.CloseAsync();
+
+        using var delay = new CancellationTokenSource();
+        var finished = await Task.WhenAny(closing, Task.Delay(CloseBudget, delay.Token)).ConfigureAwait(false);
+        await delay.CancelAsync().ConfigureAwait(false);
+
+        if (!ReferenceEquals(finished, closing))
         {
-            _conn = null;
+            _logger.LogWarning(
+                "Timed out after {Budget} closing the advisory lock connection for database {Identifier}; abandoning it",
+                CloseBudget, _databaseName);
+
+            // Observe the abandoned close, so that if it eventually faults the exception cannot resurface
+            // as an UnobservedTaskException on the finalizer thread long after anyone could act on it.
+            _ = closing.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return false;
         }
+
+        // Surface a genuine close failure to the caller's catch rather than swallowing it here.
+        await closing.ConfigureAwait(false);
+        return true;
     }
 }

--- a/src/Persistence/Wolverine.Sqlite/SqliteAdvisoryLock.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteAdvisoryLock.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using JasperFx.Events.Daemon;
 using System.Data.Common;
+using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Weasel.Core;
 using Wolverine.RDBMS;
@@ -22,6 +23,28 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
     // accommodates the 10s heartbeat default with healthy headroom for GC
     // pauses, slow recovery cycles, or temporary I/O stalls.
     internal static readonly TimeSpan DefaultLockTtl = TimeSpan.FromMinutes(2);
+
+    // GH-4261. One long-lived DbConnection shared by a SYNCHRONOUS HasLock and three ASYNC methods,
+    // with nothing serialising them. Reported against Postgres, where the interleaving desynced the
+    // driver's protocol and parked shutdown forever inside an uncancellable CloseAsync; this class has
+    // the identical shape, and SQLite additionally takes one writer at a time, so two callers on one
+    // connection is not something to leave to chance. The two callers are reachable together:
+    // writeHeartbeats / executeHealthChecks (WolverineRuntime.Agents.cs) run on the runtime-wide
+    // Cancellation token, which shutdownAsync only cancels AFTER teardownAgentsAsync returns, and
+    // teardownAgentsAsync "stops" them with Task.SafeDispose() -- which disposes the Task object and
+    // does nothing to the running loop.
+    //
+    // _gate serialises every touch of _conn. _locksLock guards the held-id list separately, so the one
+    // path that deliberately does not wait for the gate -- HasLock on timeout -- can still read it
+    // safely. Ordering is always _gate then _locksLock, never the reverse.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _locksLock = new();
+
+    // Short on purpose: HasLock is synchronous and sits on the health-check tick.
+    private static readonly TimeSpan GateTimeout = 250.Milliseconds();
+
+    // Generous on purpose: this bounds shutdown paths, where the alternative is an unbounded hang.
+    private static readonly TimeSpan CloseBudget = 5.Seconds();
 
     private readonly DbDataSource _dataSource;
     private readonly ILogger _logger;
@@ -45,8 +68,40 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
 
     public bool HasLock(int lockId)
     {
+        // Cheap negative outside the gate: an id we never took cannot be held.
+        if (!holdsId(lockId)) return false;
+
+        if (!_gate.Wait(GateTimeout))
+        {
+            // GH-4261: a busy gate means another advisory-lock operation on THIS node is in flight, not
+            // that the row was reaped. A wrong `false` here is read by
+            // NodeAgentController.DoHealthChecksInternalAsync as lost leadership and fires
+            // stepDownAsync -- exactly the churn GH-2602 and GH-3604 were fighting. Report the last
+            // state we established and skip the keepalive for this tick.
+            _logger.LogDebug(
+                "Advisory lock connection for database {Database} was busy; reporting the last known state of lock {LockId} without pinging",
+                _databaseName, lockId);
+            return true;
+        }
+
+        try
+        {
+            return hasLockUnsafe(lockId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The GH-2602 liveness ping. Callers MUST hold <c>_gate</c> -- it does synchronous I/O on the
+    /// shared connection and may replace it.
+    /// </summary>
+    private bool hasLockUnsafe(int lockId)
+    {
         if (_conn is null) return false;
-        if (!_locks.Contains(lockId)) return false;
+        if (!holdsId(lockId)) return false;
 
         // SQLite advisory locks are table rows; in single-process tests
         // the connection is unlikely to die out from under us, but for
@@ -65,9 +120,9 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
         {
             _logger.LogWarning(e,
                 "Lost advisory-lock connection for database {Database}; clearing held lock ids {Locks}",
-                _databaseName, _locks);
+                _databaseName, heldIds());
 
-            _locks.Clear();
+            clearIds();
             try
             {
                 _conn.Dispose();
@@ -81,77 +136,122 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
         }
     }
 
+    private bool holdsId(int lockId)
+    {
+        lock (_locksLock) return _locks.Contains(lockId);
+    }
+
+    private bool anyIdsHeld()
+    {
+        lock (_locksLock) return _locks.Count > 0;
+    }
+
+    private int[] heldIds()
+    {
+        lock (_locksLock) return _locks.ToArray();
+    }
+
+    private void addId(int lockId)
+    {
+        lock (_locksLock) _locks.Add(lockId);
+    }
+
+    private void removeId(int lockId)
+    {
+        lock (_locksLock) _locks.Remove(lockId);
+    }
+
+    private void clearIds()
+    {
+        lock (_locksLock) _locks.Clear();
+    }
+
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
-        // Idempotent: if we already hold this lock and the connection is healthy,
-        // re-attempting must report success. The previous implementation would run
-        // INSERT OR IGNORE again, get result==0, and falsely return false.
-        if (HasLock(lockId))
-        {
-            await refreshHeartbeatAsync(lockId, token).ConfigureAwait(false);
-            return true;
-        }
-
-        if (_conn == null)
-        {
-            _conn = await _dataSource.OpenConnectionAsync(token).ConfigureAwait(false);
-        }
-
-        if (_conn.State == ConnectionState.Closed)
-        {
-            try
-            {
-                await _conn.DisposeAsync().ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
-            }
-            finally
-            {
-                _conn = null;
-            }
-
-            return false;
-        }
+        await _gate.WaitAsync(token).ConfigureAwait(false);
 
         try
         {
-            // SQLite doesn't have advisory locks like PostgreSQL.
-            // We use a row in wolverine_locks; the table is created by the message
-            // store's normal schema migration. The migration lock itself uses
-            // BEGIN EXCLUSIVE (see SqliteMessageStore.acquireMigrationLockAsync) so
-            // there is no chicken-and-egg between this table and migration.
+            // Idempotent: if we already hold this lock and the connection is healthy,
+            // re-attempting must report success. The previous implementation would run
+            // INSERT OR IGNORE again, get result==0, and falsely return false.
             //
-            // Stale-row sweep: if a previous holder died without releasing, its
-            // row would block all peers forever. Reap rows whose acquired_at is
-            // older than TTL before attempting INSERT OR IGNORE. Live holders
-            // refresh acquired_at on every re-attempt, so they're never reaped.
-            await _conn.CreateCommand(
-                    "DELETE FROM wolverine_locks WHERE lock_id = @lockId AND acquired_at < @cutoff")
-                .With("lockId", lockId)
-                .With("cutoff", DateTime.UtcNow.Subtract(_lockTtl).ToString("yyyy-MM-dd HH:mm:ss"))
-                .ExecuteNonQueryAsync(token);
-
-            var result = await _conn.CreateCommand("INSERT OR IGNORE INTO wolverine_locks (lock_id, acquired_at) VALUES (@lockId, datetime('now'))")
-                .With("lockId", lockId)
-                .ExecuteNonQueryAsync(token);
-
-            if (result > 0)
+            // GH-4261: hasLockUnsafe, not HasLock — we already hold the gate, and SemaphoreSlim is not
+            // reentrant.
+            if (hasLockUnsafe(lockId))
             {
-                _locks.Add(lockId);
+                await refreshHeartbeatAsync(lockId, token).ConfigureAwait(false);
                 return true;
             }
 
-            return false;
+            if (_conn == null)
+            {
+                _conn = await _dataSource.OpenConnectionAsync(token).ConfigureAwait(false);
+            }
+
+            if (_conn.State == ConnectionState.Closed)
+            {
+                try
+                {
+                    await _conn.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                }
+                finally
+                {
+                    _conn = null;
+                }
+
+                return false;
+            }
+
+            try
+            {
+                // SQLite doesn't have advisory locks like PostgreSQL.
+                // We use a row in wolverine_locks; the table is created by the message
+                // store's normal schema migration. The migration lock itself uses
+                // BEGIN EXCLUSIVE (see SqliteMessageStore.acquireMigrationLockAsync) so
+                // there is no chicken-and-egg between this table and migration.
+                //
+                // Stale-row sweep: if a previous holder died without releasing, its
+                // row would block all peers forever. Reap rows whose acquired_at is
+                // older than TTL before attempting INSERT OR IGNORE. Live holders
+                // refresh acquired_at on every re-attempt, so they're never reaped.
+                await _conn.CreateCommand(
+                        "DELETE FROM wolverine_locks WHERE lock_id = @lockId AND acquired_at < @cutoff")
+                    .With("lockId", lockId)
+                    .With("cutoff", DateTime.UtcNow.Subtract(_lockTtl).ToString("yyyy-MM-dd HH:mm:ss"))
+                    .ExecuteNonQueryAsync(token);
+
+                var result = await _conn.CreateCommand("INSERT OR IGNORE INTO wolverine_locks (lock_id, acquired_at) VALUES (@lockId, datetime('now'))")
+                    .With("lockId", lockId)
+                    .ExecuteNonQueryAsync(token);
+
+                if (result > 0)
+                {
+                    addId(lockId);
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error trying to attain advisory lock {LockId}", lockId);
+                return false;
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogError(ex, "Error trying to attain advisory lock {LockId}", lockId);
-            return false;
+            _gate.Release();
         }
     }
 
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>.
+    /// </summary>
     private async Task refreshHeartbeatAsync(int lockId, CancellationToken token)
     {
         if (_conn == null) return;
@@ -173,14 +273,42 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
 
     public async Task ReleaseLockAsync(int lockId)
     {
-        if (!_locks.Contains(lockId))
+        if (!holdsId(lockId))
         {
             return;
         }
 
+        // GH-4261: bounded rather than indefinite. If the gate is still held past the budget something
+        // is wedged on the connection, and waiting longer turns a released lock into a hung shutdown.
+        // The row's TTL sweep reaps an abandoned lock, so this is recoverable without us.
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
+        {
+            _logger.LogWarning(
+                "Timed out waiting to release advisory lock {LockId} for database {Identifier}; leaving it to the TTL sweep",
+                lockId, _databaseName);
+            return;
+        }
+
+        try
+        {
+            await releaseLockUnsafeAsync(lockId).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>. Split out because <see cref="DisposeAsync"/> releases every held
+    /// lock in a loop and SemaphoreSlim is not reentrant -- going back through the public method would
+    /// deadlock against the gate this method's caller already holds.
+    /// </summary>
+    private async Task releaseLockUnsafeAsync(int lockId)
+    {
         if (_conn == null || _conn.State == ConnectionState.Closed)
         {
-            _locks.Remove(lockId);
+            removeId(lockId);
             return;
         }
 
@@ -189,13 +317,11 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
             await _conn.CreateCommand("DELETE FROM wolverine_locks WHERE lock_id = @lockId")
                 .With("lockId", lockId)
                 .ExecuteNonQueryAsync();
-            _locks.Remove(lockId);
+            removeId(lockId);
 
-            if (!_locks.Any())
+            if (!anyIdsHeld())
             {
-                await _conn.CloseAsync().ConfigureAwait(false);
-                await _conn.DisposeAsync().ConfigureAwait(false);
-                _conn = null;
+                await safeCloseConnectionAsync().ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -211,17 +337,24 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
             return;
         }
 
+        if (!await _gate.WaitAsync(CloseBudget).ConfigureAwait(false))
+        {
+            _logger.LogWarning(
+                "Timed out waiting to dispose the advisory lock connection for database {Identifier}; abandoning it",
+                _databaseName);
+            return;
+        }
+
         try
         {
-            foreach (var lockId in _locks.ToList())
+            foreach (var lockId in heldIds())
             {
-                await ReleaseLockAsync(lockId);
+                await releaseLockUnsafeAsync(lockId).ConfigureAwait(false);
             }
 
-            // ReleaseLockAsync nulls _conn once the last lock is released. The
-            // finally block below handles disposal in both paths (released-all
-            // vs released-some); calling Close/Dispose here as well caused a
-            // NullReferenceException on the all-released path.
+            // releaseLockUnsafeAsync nulls _conn once the last lock is released; safeCloseConnectionAsync
+            // no-ops on a null connection, so it covers the released-some path without a second null check.
+            await safeCloseConnectionAsync().ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -230,10 +363,70 @@ internal class SqliteAdvisoryLock : IAdvisoryLock
         }
         finally
         {
-            if (_conn != null)
-            {
-                await _conn.DisposeAsync().ConfigureAwait(false);
-            }
+            _gate.Release();
         }
+    }
+
+    /// <summary>
+    /// Callers MUST hold <c>_gate</c>.
+    /// </summary>
+    private async Task safeCloseConnectionAsync()
+    {
+        // GH-4261: take the connection off the field FIRST, so an abandoned close cannot leave a dead
+        // connection reachable for the next caller.
+        var conn = _conn;
+        _conn = null;
+        if (conn == null) return;
+
+        try
+        {
+            if (conn.State == ConnectionState.Open && !await closeWithinBudgetAsync(conn).ConfigureAwait(false))
+            {
+                // Deliberately no DisposeAsync: that would race the CloseAsync still parked on this
+                // connection. Dropping the reference is enough.
+                return;
+            }
+
+            await conn.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error trying to close advisory lock connection for database {Identifier}",
+                _databaseName);
+        }
+    }
+
+    /// <summary>
+    /// GH-4261. <see cref="DbConnection.CloseAsync"/> takes no <see cref="CancellationToken"/>, so a
+    /// caller's shutdown budget cannot reach it. The gate above should stop a connection ever getting
+    /// into a state where the close does not return; this makes it survivable if one ever does. Returns
+    /// false when the close was abandoned.
+    /// </summary>
+    private async Task<bool> closeWithinBudgetAsync(DbConnection conn)
+    {
+        var closing = conn.CloseAsync();
+
+        using var delay = new CancellationTokenSource();
+        var finished = await Task.WhenAny(closing, Task.Delay(CloseBudget, delay.Token)).ConfigureAwait(false);
+        await delay.CancelAsync().ConfigureAwait(false);
+
+        if (!ReferenceEquals(finished, closing))
+        {
+            _logger.LogWarning(
+                "Timed out after {Budget} closing the advisory lock connection for database {Identifier}; abandoning it",
+                CloseBudget, _databaseName);
+
+            // Observe the abandoned close, so that if it eventually faults the exception cannot resurface
+            // as an UnobservedTaskException on the finalizer thread long after anyone could act on it.
+            _ = closing.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return false;
+        }
+
+        // Surface a genuine close failure to the caller's catch rather than swallowing it here.
+        await closing.ConfigureAwait(false);
+        return true;
     }
 }


### PR DESCRIPTION
Closes #4261.

Every `AdvisoryLock` implementation — Postgres, SQL Server, MySQL, Oracle and SQLite — kept one long-lived connection and synchronised access to it with **nothing at all**: no semaphore, no lock, no `Interlocked`. `HasLock` runs *synchronous* I/O on that connection for the GH-2602 liveness ping while `TryAttainLockAsync`, `ReleaseLockAsync` and `DisposeAsync` run *asynchronous* I/O on the same field, and no ADO.NET provider supports concurrent use of one connection.

## The second caller is observable, not inferred

The reporter was careful to mark which caller won the race as inferred rather than observed. It can be named:

- `writeHeartbeats` and `executeHealthChecks` (`WolverineRuntime.Agents.cs:340-341`) run on the runtime-wide `Cancellation` token.
- `shutdownAsync` only cancels that token **after** `teardownAgentsAsync()` returns (`WolverineRuntime.HostService.cs:514-516`).
- `teardownAgentsAsync` "stops" both loops with `_heartbeatLoop?.SafeDispose()` — which disposes the `Task` object and does nothing whatsoever to the loop still running.

So a health check already past its own cancellation guard reaches `ejectStaleNodes` → `HasLeadershipLock()` → the synchronous ping, at the same moment teardown reaches `NodeAgentController.StopAsync` → `ReleaseLeadershipLockAsync`. Fresh ticks *are* latched by the `_cancellation` guards at the top of `WriteHeartbeatAsync` and `DoHealthChecksAsync`; a tick already inside one is not.

## Two costs, both covered by tests

**Where the driver noticed** the concurrent use it threw, and `HasLock`'s catch reads *any* exception as "the server dropped our session": it cleared every held lock id and returned `false`. `DoHealthChecksInternalAsync:209` reads that `false` as lost leadership and answers with `stepDownAsync` — precisely the churn GH-2602 and GH-3604 were fighting.

**Where the driver did not notice**, the protocol desynced and shutdown parked forever inside `NpgsqlConnection.CloseAsync()`, which takes no `CancellationToken` and so is beyond the reach of `HostOptions.ShutdownTimeout` even though that timeout is correctly threaded all the way down to `WolverineRuntime.StopAsync`. The symptom is distinctive: every test passes and is counted, then the process never exits, because the hang lives in fixture disposal after the last test has already reported.

Neither is subtle. Two of the three new tests fail against unfixed Postgres in **212 ms**.

## The fix

Each implementation now serialises every touch of its connection behind a `SemaphoreSlim`, with the held lock ids under their own monitor so the one path that must not wait — `HasLock`, which is synchronous and sits on the health-check tick — can still read them. Lock ordering is always gate-then-ids and never the reverse; no id section does I/O.

`TryAttainLockAsync`, and the SQLite and Oracle release loops inside `DisposeAsync`, go through `*Unsafe` variants: `SemaphoreSlim` is not reentrant, so the public methods would deadlock against the gate their own caller already holds.

**When `HasLock` finds the connection busy it reports the last state it actually established rather than `false`,** and skips the ping for that tick. A busy connection means another advisory-lock operation is in flight *on this node*, which is no evidence at all that the server dropped the session — and answering `false` there is exactly what fires the spurious stepdown.

**Every close is additionally bounded and abandoned on timeout.** This is not merely belt-and-braces on top of the gate: `ReleaseLockAsync` already cancels its `pg_advisory_unlock` at one second and then goes straight into `CloseAsync`, which is a *single-threaded* route to the same orphaned-reader state the dumps showed. The gate cannot help there; the bound can. An abandoned close leaves its connection unreachable rather than disposed — disposing would race the `CloseAsync` still parked on it — and its task is observed so a later fault cannot resurface as an `UnobservedTaskException`.

Oracle is included even though it keeps a connection *per lock* rather than one shared: `HasLock` pings `held.conn` while `ReleaseLockAsync`/`DisposeAsync` roll back that same transaction and close that same connection, and `_locks`/`_heldLocks` are a plain `List` and `Dictionary` mutated from both.

## Verification

| Suite | Result |
|---|---|
| `PostgresqlTests` (full) | 543 passed |
| `SqlServerTests` (full) | 409 passed |
| `MySqlTests` (full) | 184 passed |
| `SqliteTests` (full) | 217 passed |
| `PostgresqlTests.LeaderElection` | 15/15 |
| `OracleTests.LeaderElection` | 15/15 |
| `SqlServerTests.LeaderElection` | 15/15 × 3 runs |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

Two red results came up during verification and both were run down against **pristine `origin/main`** rather than assumed:

- `MySqlTests.LeaderElection`'s `take_over_leader_ship_if_leader_becomes_stale` and `..._with_racing_nodes` fail identically on main today. Pre-existing, and almost certainly the advisory-lock stacking bug fixed for Postgres and SQL Server but never ported to MySQL — `MySqlAdvisoryLock.TryAttainLockAsync` is the only one of the five with no "already holds it" short-circuit, and MySQL's `GET_LOCK` stacks. Filed separately; deliberately **not** fixed here.
- `SqlServerTests.LeaderElection.singular_agent_is_only_running_on_one` failed once on this branch and passed 3/3 on re-run; main was green. A flake. Same for one `ExclusiveListenerRecoveryCompliance` failure in a `PostgresqlTests` run that was green on the repeat and green on main.

⚠️ The new tests are stress tests against a real Postgres. They cannot prove a race absent, and the iteration counts are deliberately generous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
