### PR TITLE
Don't throw reading a dead letter that has no content type

### DIFF
--- a/src/Testing/CoreTests/Persistence/dead_letter_envelope_without_a_content_type.cs
+++ b/src/Testing/CoreTests/Persistence/dead_letter_envelope_without_a_content_type.cs
@@ -1,0 +1,76 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+/// <summary>
+/// A message that never crossed a wire is stored with no content type, so reading its dead letter row back
+/// has no serializer to look up. Hydrating it used to throw ArgumentNullException out of
+/// MessageStoreCollection.FetchDeadLetterEnvelopesAsync, which takes the whole page of dead letters with it
+/// -- including every readable row next to it.
+/// </summary>
+public class dead_letter_envelope_without_a_content_type
+{
+    [Fact]
+    public void try_find_serializer_returns_null_for_a_missing_content_type()
+    {
+        var options = new WolverineOptions();
+
+        options.TryFindSerializer(null).ShouldBeNull();
+        options.TryFindSerializer("").ShouldBeNull();
+        options.TryFindSerializer(EnvelopeConstants.JsonContentType).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task try_read_data_does_not_throw()
+    {
+        using var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.Discovery.IncludeType(typeof(ContentTypelessMessageHandler));
+            opts.PublishAllMessages().To("stub://one");
+        }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+        // Both are needed to reach the serializer lookup at all: TryReadData returns early without a
+        // Destination, and only looks for a serializer for a message type that has a handler.
+        var envelope = new Envelope(new ContentTypelessMessage())
+        {
+            Id = Guid.NewGuid(),
+            MessageType = typeof(ContentTypelessMessage).ToMessageTypeName(),
+            Destination = "stub://one".ToUri(),
+            ContentType = null
+        };
+
+        var deadLetter = new DeadLetterEnvelope(
+            envelope.Id,
+            null,
+            envelope,
+            envelope.MessageType!,
+            "stub://one",
+            "test",
+            typeof(InvalidOperationException).FullName!,
+            "boom",
+            DateTimeOffset.UtcNow,
+            false);
+
+        Should.NotThrow(() => deadLetter.TryReadData(runtime));
+
+        // Nothing to deserialize without a serializer, so the row still reads -- it just has no message.
+        deadLetter.Message.ShouldBeNull();
+    }
+}
+
+public record ContentTypelessMessage;
+
+public static class ContentTypelessMessageHandler
+{
+    public static void Handle(ContentTypelessMessage message)
+    {
+    }
+}

--- a/src/Wolverine/Persistence/Durability/DeadLetterEnvelope.cs
+++ b/src/Wolverine/Persistence/Durability/DeadLetterEnvelope.cs
@@ -64,7 +64,7 @@ public class DeadLetterEnvelope
         {
             var endpoint = runtime.Endpoints.EndpointFor(Envelope.Destination!);
             var serializer = endpoint?.TryFindSerializer(Envelope.ContentType) ??
-                             runtime.Options.TryFindSerializer(Envelope.ContentType!);
+                             runtime.Options.TryFindSerializer(Envelope.ContentType);
 
             if (serializer != null)
             {

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -271,6 +271,44 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         return null;
     }
  
+    /// <summary>
+    /// Find every message store that could hold data for one tenant. There is normally exactly one, but a
+    /// modular monolith can have a tenanted ancillary store alongside the main one.
+    /// </summary>
+    /// <remarks>
+    /// The tenant-aware counterpart to <see cref="FindDatabaseAsync" />. Callers that want to work against
+    /// one tenant's storage directly -- querying its dead letters without hydrating every message body, say
+    /// -- would otherwise have to walk <see cref="MultiTenanted" /> and resolve the tenant by hand.
+    /// </remarks>
+    public async ValueTask<IReadOnlyList<IMessageStore>> FindForTenantAsync(string tenantId)
+    {
+        var list = new List<IMessageStore>();
+
+        foreach (var tenantedMessageStore in _multiTenanted)
+        {
+            var store = await tenantedMessageStore.Source.FindAsync(tenantId);
+            if (store != null)
+            {
+                list.Add(store);
+                continue;
+            }
+
+            // A tenant this process has not seen yet may have been added elsewhere since the last refresh.
+            if (tenantedMessageStore.Source.Cardinality == DatabaseCardinality.DynamicMultiple)
+            {
+                await tenantedMessageStore.Source.RefreshAsync();
+            }
+
+            store = await tenantedMessageStore.Source.FindAsync(tenantId);
+            if (store != null)
+            {
+                list.Add(store);
+            }
+        }
+
+        return list;
+    }
+
     public async ValueTask<IReadOnlyList<IMessageStore>> FindDatabasesAsync(Uri[] uris)
     {
         if (_onlyOneDatabase) return [Main];
@@ -534,26 +572,7 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         }
         else if (request.TenantId != null)
         {
-            foreach (var tenantedMessageStore in _multiTenanted)
-            {
-                var store = await tenantedMessageStore.Source.FindAsync(request.TenantId);
-                if (store != null)
-                {
-                    list.Add(store);
-                    continue;
-                }
-                
-                if (tenantedMessageStore.Source.Cardinality == DatabaseCardinality.DynamicMultiple)
-                {
-                    await tenantedMessageStore.Source.RefreshAsync();
-                }
-            
-                store = await tenantedMessageStore.Source.FindAsync(request.TenantId);
-                if (store != null)
-                {
-                    list.Add(store);
-                }
-            }
+            list.AddRange(await FindForTenantAsync(request.TenantId));
         }
         else
         {

--- a/src/Wolverine/WolverineOptions.Serialization.cs
+++ b/src/Wolverine/WolverineOptions.Serialization.cs
@@ -130,10 +130,18 @@ public sealed partial class WolverineOptions
 
     /// <summary>
     /// Try to resolve a previously-registered serializer by its content-type.
-    /// Returns null when no serializer is registered under the given content-type.
+    /// Returns null when the content-type is missing, or when no serializer is registered under it.
     /// </summary>
-    internal IMessageSerializer? TryFindSerializer(string contentType)
+    internal IMessageSerializer? TryFindSerializer(string? contentType)
     {
+        // Same guard as Endpoint.TryFindSerializer, which delegates here as its fallback. Without it
+        // the dictionary lookup throws ArgumentNullException on an envelope that carries no content
+        // type, which is not something a Try* method should do to its caller.
+        if (contentType.IsEmpty())
+        {
+            return null;
+        }
+
         if (_serializers.TryGetValue(contentType, out var s))
         {
             return s;


### PR DESCRIPTION
Two commits, take either on its own.

## 1. `TryFindSerializer` throws on a null content-type

`WolverineOptions.TryFindSerializer` is documented as returning null when nothing is registered under the
given content-type, but it passes the argument straight into a `Dictionary` lookup:

```csharp
internal IMessageSerializer? TryFindSerializer(string contentType)
{
    if (_serializers.TryGetValue(contentType, out var s)) return s;   // ArgumentNullException
    return null;
}
```

`Endpoint.TryFindSerializer` — which delegates here as its fallback — already takes a `string?` and guards
with `IsEmpty()`. So the pair has the same name and purpose, and only one of them guards. This gives the
other one the same signature and the same guard, and drops the `!` in `DeadLetterEnvelope.TryReadData` that
was hiding it:

```csharp
var serializer = endpoint?.TryFindSerializer(Envelope.ContentType) ??
                 runtime.Options.TryFindSerializer(Envelope.ContentType!);   // <- here
```

**Where it bites.** `MessageStoreCollection.FetchDeadLetterEnvelopesAsync` calls `TryReadData` on every
envelope it returns. An envelope stored without a content type — a durable local queue sets none — reaches
the unguarded lookup and throws *out of the fetch*, so one such row takes the whole page with it: every
readable dead letter beside it, and every store the request would have visited next.

We hit this on a service-desk screen that lists stalled work per tenant and names the failure behind each
item. It returned 500 for every tenant, including one with a single stalled item, because the lookup read
every tenant database and one row somewhere in the fleet had no content type:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at Wolverine.WolverineOptions.TryFindSerializer(String contentType) in WolverineOptions.Serialization.cs:137
   at Wolverine.Persistence.Durability.DeadLetterEnvelope.TryReadData(IWolverineRuntime runtime)
   at Wolverine.Persistence.MessageStoreCollection.FetchDeadLetterEnvelopesAsync(...)
```

`TryReadData` already treats an unreadable body as a non-event — it has a `Destination is null` guard for
the placeholder row, and it logs-and-swallows a failed `ReadFromData`. A missing content-type is the same
kind of "cannot read this one", so it now returns without a message rather than throwing.

Tests in `CoreTests.Persistence.dead_letter_envelope_without_a_content_type`. Verified red on `main`: the
serializer test does not even compile against the non-nullable signature, and with `null!` both fail with
the stack above.

## 2. No public way to resolve a tenant's message store

`MessageStoreCollection` does tenant → store resolution in three places (`findStoresAsync`,
`ReplayDeadLettersAsync(tenantId, ids)`, `DiscardDeadLettersAsync(tenantId, ids)`) but exposes none of it,
while Uri-addressed lookup has `FindDatabaseAsync`/`FindDatabasesAsync` and the unscoped case has
`FindAllAsync`. A caller who wants to work against one tenant's storage has to walk `MultiTenanted` and
resolve by hand.

The case that prompted it: reading one tenant's dead letters through `IDeadLetters.QueryAsync`, which
returns the rows *without* hydrating a message out of every body. `FetchDeadLetterEnvelopesAsync` always
hydrates, and `DeadLetterEnvelopeGetRequest.TenantId` only narrows which stores it visits — so a caller
that needs envelope metadata and nothing from the message is paying multi-megabyte deserialization per row
for data it throws away. (Ours are 2–6 MB, 500 rows a page.)

`FindForTenantAsync` is that resolution extracted from `findStoresAsync` unchanged, refresh-and-retry for
`DynamicMultiple` sources included, with `findStoresAsync` now calling it. Replay and Discard are left
alone deliberately — they refresh *eagerly* rather than on a miss, so folding them in would change their
behaviour and not just their shape. Happy to do that too if you'd rather they were consistent.

Full `CoreTests` on net10.0: 2766 passed, 0 failed, 2 skipped.
