### PR TITLE
GH-4267: share and throttle the tenant database list refresh behind FindAllAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### WolverineFx (core)
 
+- **Concurrent callers share one tenant database list refresh.** (closes
+  [#4267](https://github.com/JasperFx/wolverine/issues/4267)) `MessageStoreCollection.FindAllAsync()`
+  re-enumerated a `DynamicMultiple` tenancy source on every call, and it sits on paths that are *retried on
+  failure* -- listener inbox recovery, listener drain, the durability sweeps. With Marten's sharded tenancy
+  that enumeration is a round trip to the tenant registry, so the retry for a connection failure opened
+  another connection to look the databases up again, and concurrent callers each opened their own. On a
+  512-database fleet one 26-minute process logged 233 give-ups over 176 Npgsql connect timeouts and three
+  pool exhaustions, while the master database sat at 0.5% CPU with 150 of its 3600 connections in use -- it
+  is the client-side data source that runs dry, and the retry then asks it for another connection.
+
+  Concurrent callers now join a single in-flight refresh. That sharing is not configurable and is the half
+  that closes the storm: the cost was the fan-out, not the frequency.
+
+  `DurabilitySettings.TenantDatabaseListStaleTime` additionally bounds how often that one refresh happens,
+  and **defaults to zero, so no existing behaviour changes**. Raise it on a large fleet. A non-zero value
+  only ever affects *bulk* enumeration -- a lookup that misses (`FindDatabaseAsync`) always forces past the
+  window, because it is refreshing precisely on account of not having found the database, and answering it
+  from a list the window is vouching for would defeat the call. Forcing skips the freshness check, never the
+  single-flight guard.
+
+
 - **A node no longer sweeps up its own in-flight stop as a wedged shard.** (closes
   [#4240](https://github.com/JasperFx/wolverine/issues/4240)) An event-subscription agent could end up
   running on two nodes at once while `wolverine_nodes` credited only one of them, so nothing in the

--- a/src/Testing/CoreTests/Persistence/throttling_the_tenant_database_list_refresh.cs
+++ b/src/Testing/CoreTests/Persistence/throttling_the_tenant_database_list_refresh.cs
@@ -79,6 +79,55 @@ public class throttling_the_tenant_database_list_refresh
     }
 
     [Fact]
+    public async Task a_lookup_that_misses_forces_past_the_stale_window()
+    {
+        // GH-4267 follow-up. FindDatabaseAsync refreshes precisely BECAUSE it could not find the database,
+        // so a list the window is vouching for is the one answer it must not accept: the caller is asking
+        // about a database that, by construction, is not in that list. Left throttled, a tenant database
+        // provisioned moments ago is invisible to a single-database lookup until the window elapses -- and
+        // BuildAgentAsync turns that null into "No database with Uri ... supports a durability agent".
+        theRuntime.Options.Durability.TenantDatabaseListStaleTime = 30.Seconds();
+        theSource.RefreshAsync().Returns(Task.CompletedTask);
+
+        // Opens the window.
+        await theStores.FindAllAsync();
+        await theSource.Received(1).RefreshAsync();
+
+        // Well inside it, and a miss.
+        (await theStores.FindDatabaseAsync(new Uri("wolverinedb://fake/provisioned-a-moment-ago")))
+            .ShouldBeNull();
+
+        await theSource.Received(2).RefreshAsync();
+    }
+
+    [Fact]
+    public async Task a_forced_lookup_still_joins_a_refresh_already_under_way()
+    {
+        // Forcing skips the freshness check, NOT the single-flight guard. That guard is the half that
+        // closes the connection storm -- every concurrent caller and every retry opening its own
+        // connection to the registry -- so a miss must never be a licence to open another one.
+        theRuntime.Options.Durability.TenantDatabaseListStaleTime = 30.Seconds();
+
+        var refreshIsRunning = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        theSource.RefreshAsync().Returns(refreshIsRunning.Task);
+
+        var enumerating = theStores.FindAllAsync();
+        var missing = Enumerable
+            .Range(0, 12)
+            .Select(i => theStores.FindDatabaseAsync(new Uri($"wolverinedb://fake/missing-{i}")).AsTask())
+            .ToArray();
+
+        await theSource.Received(1).RefreshAsync();
+
+        refreshIsRunning.SetResult();
+
+        await enumerating;
+        await Task.WhenAll(missing);
+
+        await theSource.Received(1).RefreshAsync();
+    }
+
+    [Fact]
     public async Task a_failed_refresh_is_retried_by_the_next_caller()
     {
         theRuntime.Options.Durability.TenantDatabaseListStaleTime = 30.Seconds();

--- a/src/Testing/CoreTests/Persistence/throttling_the_tenant_database_list_refresh.cs
+++ b/src/Testing/CoreTests/Persistence/throttling_the_tenant_database_list_refresh.cs
@@ -1,0 +1,96 @@
+using CoreTests.Runtime;
+using JasperFx.Core;
+using JasperFx.Descriptors;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+// GH-4267. Every FindAllAsync() used to re-enumerate the tenant database list, and the paths that call it
+// are retried on failure, so on a large tenant fleet the retry for a connection failure opened another
+// connection to the tenant registry to look the databases up again.
+public class throttling_the_tenant_database_list_refresh
+{
+    private readonly MockWolverineRuntime theRuntime = new();
+    private readonly ITenantedMessageSource theSource = Substitute.For<ITenantedMessageSource>();
+    private readonly MessageStoreCollection theStores;
+
+    public throttling_the_tenant_database_list_refresh()
+    {
+        theSource.Cardinality.Returns(DatabaseCardinality.DynamicMultiple);
+        theSource.AllActive().Returns(Array.Empty<IMessageStore>());
+
+        var main = Substitute.For<IMessageStore>();
+        main.Uri.Returns(new Uri("wolverinedb://fake/main"));
+        main.Role.Returns(MessageStoreRole.Main);
+
+        var multiTenanted = new MultiTenantedMessageStore(main, theRuntime, theSource);
+
+        theStores = new MessageStoreCollection(theRuntime, [multiTenanted], []);
+    }
+
+    [Fact]
+    public async Task concurrent_callers_share_a_single_refresh()
+    {
+        var refreshIsRunning = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        theSource.RefreshAsync().Returns(refreshIsRunning.Task);
+
+        // The first caller starts the refresh and blocks on it; the rest arrive while it is still running
+        // and have to join it rather than start their own.
+        var first = theStores.FindAllAsync();
+        var joiners = Enumerable.Range(0, 19).Select(_ => theStores.FindAllAsync().AsTask()).ToArray();
+
+        await theSource.Received(1).RefreshAsync();
+
+        refreshIsRunning.SetResult();
+
+        await first;
+        await Task.WhenAll(joiners);
+
+        await theSource.Received(1).RefreshAsync();
+    }
+
+    [Fact]
+    public async Task a_second_enumeration_inside_the_stale_window_does_not_ask_again()
+    {
+        theRuntime.Options.Durability.TenantDatabaseListStaleTime = 30.Seconds();
+        theSource.RefreshAsync().Returns(Task.CompletedTask);
+
+        await theStores.FindAllAsync();
+        await theStores.FindAllAsync();
+        await theStores.FindAllAsync();
+
+        await theSource.Received(1).RefreshAsync();
+    }
+
+    [Fact]
+    public async Task the_list_is_refreshed_again_once_the_stale_time_has_elapsed()
+    {
+        theRuntime.Options.Durability.TenantDatabaseListStaleTime = TimeSpan.Zero;
+        theSource.RefreshAsync().Returns(Task.CompletedTask);
+
+        await theStores.FindAllAsync();
+        await theStores.FindAllAsync();
+
+        await theSource.Received(2).RefreshAsync();
+    }
+
+    [Fact]
+    public async Task a_failed_refresh_is_retried_by_the_next_caller()
+    {
+        theRuntime.Options.Durability.TenantDatabaseListStaleTime = 30.Seconds();
+        theSource.RefreshAsync().Returns(
+            Task.FromException(new TimeoutException("the operation has timed out")),
+            Task.CompletedTask);
+
+        await Should.ThrowAsync<TimeoutException>(async () => await theStores.FindAllAsync());
+
+        // A failure leaves the list unknown, so the window must not have opened.
+        await theStores.FindAllAsync();
+
+        await theSource.Received(2).RefreshAsync();
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -84,17 +84,32 @@ public class DurabilitySettings : IDescribeMyself
     public bool TenantRegistryRequired { get; set; }
 
     /// <summary>
-    ///     How long a tenant database list discovered from a dynamic tenancy source stays current
-    ///     before the next bulk enumeration re-reads it. Concurrent callers always share one refresh
-    ///     regardless of this value. The default is 5 seconds; zero refreshes on every call.
+    ///     How long a tenant database list discovered from a dynamic tenancy source stays current before
+    ///     the next bulk enumeration re-reads it. <b>Defaults to zero — every bulk enumeration re-reads
+    ///     the list, exactly as it always has.</b> Raise it to bound how often a large tenant fleet goes
+    ///     back to the tenant registry.
     /// </summary>
     /// <remarks>
-    ///     Only applies to <see cref="DatabaseCardinality.DynamicMultiple" /> sources, where discovery
-    ///     is a round trip to the tenant registry. A lookup that misses still forces an immediate
-    ///     refresh, so a newly provisioned tenant database is never invisible for this long: the window
-    ///     only bounds how often the paths that enumerate <em>every</em> database go asking.
+    ///     <para>
+    ///     Concurrent callers always share one refresh regardless of this value, and that sharing is not
+    ///     opt-in. It is also the half that actually closes the connection storm this exists for: the cost
+    ///     was every concurrent caller and every retry opening its own connection to the registry, not the
+    ///     frequency of a single refresh.
+    ///     </para>
+    ///     <para>
+    ///     Only applies to <see cref="DatabaseCardinality.DynamicMultiple" /> sources, where discovery is a
+    ///     round trip to the tenant registry. A lookup that misses — <c>FindDatabaseAsync</c> — always
+    ///     forces past this window, so a newly provisioned tenant database is never invisible to a
+    ///     single-database lookup for this long.
+    ///     </para>
+    ///     <para>
+    ///     A non-zero value does mean a database provisioned moments ago can be missing from a BULK
+    ///     enumeration (<c>FindAllAsync</c>) until the window elapses. That is fine for the durability
+    ///     sweeps, which is what the value is for; it is not fine for an application that provisions a
+    ///     tenant and immediately expects to enumerate it, which is why zero is the default.
+    ///     </para>
     /// </remarks>
-    public TimeSpan TenantDatabaseListStaleTime { get; set; } = 5.Seconds();
+    public TimeSpan TenantDatabaseListStaleTime { get; set; } = TimeSpan.Zero;
 
     /// <summary>
     /// If set, this establishes a default database schema name for all registered message

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -84,6 +84,19 @@ public class DurabilitySettings : IDescribeMyself
     public bool TenantRegistryRequired { get; set; }
 
     /// <summary>
+    ///     How long a tenant database list discovered from a dynamic tenancy source stays current
+    ///     before the next bulk enumeration re-reads it. Concurrent callers always share one refresh
+    ///     regardless of this value. The default is 5 seconds; zero refreshes on every call.
+    /// </summary>
+    /// <remarks>
+    ///     Only applies to <see cref="DatabaseCardinality.DynamicMultiple" /> sources, where discovery
+    ///     is a round trip to the tenant registry. A lookup that misses still forces an immediate
+    ///     refresh, so a newly provisioned tenant database is never invisible for this long: the window
+    ///     only bounds how often the paths that enumerate <em>every</em> database go asking.
+    /// </remarks>
+    public TimeSpan TenantDatabaseListStaleTime { get; set; } = 5.Seconds();
+
+    /// <summary>
     /// If set, this establishes a default database schema name for all registered message
     /// storage databases. Use this with a modular monolith approach where all modules target the same physical database. The default is null.
     /// </summary>

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -35,6 +35,7 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
 
     private readonly IWolverineRuntime _runtime;
     private readonly List<MultiTenantedMessageStore> _multiTenanted = new();
+    private readonly Dictionary<MultiTenantedMessageStore, ThrottledTenantRefresh> _tenantRefreshes = new();
     private ImHashMap<Uri, IMessageStore> _services = ImHashMap<Uri, IMessageStore>.Empty;
     private ImHashMap<Type, IMessageStore> _ancillaryStores = ImHashMap<Type, IMessageStore>.Empty;
     private bool _onlyOneDatabase;
@@ -48,6 +49,9 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
             if (store is MultiTenantedMessageStore multiTenanted)
             {
                 _multiTenanted.Add(multiTenanted);
+                _tenantRefreshes[multiTenanted] =
+                    new ThrottledTenantRefresh(multiTenanted.Source,
+                        () => _runtime.Options.Durability.TenantDatabaseListStaleTime);
                 categorizeStore(multiTenanted.Main);
             }
             else
@@ -236,7 +240,10 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
 
     private async ValueTask refreshTenantedDatabaseList(MultiTenantedMessageStore tenantedMessageStore)
     {
-        await tenantedMessageStore.Source.RefreshAsync();
+        // GH-4267. Throttled, because every FindAllAsync() lands here and some of those callers are
+        // retried. Categorizing below is not throttled: it is in-memory, and a store the source
+        // created for a single-tenant lookup has to reach _services either way.
+        await _tenantRefreshes[tenantedMessageStore].MaybeRefreshAsync();
 
         foreach (var store in tenantedMessageStore.Source.AllActive())
         {

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -238,12 +238,17 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
         return _services.Enumerate().Select(x => x.Value).OfType<T>().ToList();
     }
 
-    private async ValueTask refreshTenantedDatabaseList(MultiTenantedMessageStore tenantedMessageStore)
+    private async ValueTask refreshTenantedDatabaseList(MultiTenantedMessageStore tenantedMessageStore,
+        bool force = false)
     {
         // GH-4267. Throttled, because every FindAllAsync() lands here and some of those callers are
         // retried. Categorizing below is not throttled: it is in-memory, and a store the source
         // created for a single-tenant lookup has to reach _services either way.
-        await _tenantRefreshes[tenantedMessageStore].MaybeRefreshAsync();
+        //
+        // force=true comes from FindDatabaseAsync, which only refreshes BECAUSE a lookup missed -- see
+        // MaybeRefreshAsync. It still joins an in-flight refresh; it only declines to be answered from a
+        // list the window is vouching for.
+        await _tenantRefreshes[tenantedMessageStore].MaybeRefreshAsync(force);
 
         foreach (var store in tenantedMessageStore.Source.AllActive())
         {
@@ -258,12 +263,13 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
             return service;
         }
 
-        // Force dynamic tenanted databases to refresh
+        // Force dynamic tenanted databases to refresh. Genuinely forced: this is the path where a newly
+        // provisioned tenant database has to be found now, and the staleness window must not answer for it.
         foreach (var tenantedMessageStore in _multiTenanted)
         {
             if (tenantedMessageStore.Source.Cardinality == DatabaseCardinality.DynamicMultiple)
             {
-                await refreshTenantedDatabaseList(tenantedMessageStore);
+                await refreshTenantedDatabaseList(tenantedMessageStore, force: true);
             }
         }
         

--- a/src/Wolverine/Persistence/ThrottledTenantRefresh.cs
+++ b/src/Wolverine/Persistence/ThrottledTenantRefresh.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using Wolverine.Persistence.Durability;
+
+namespace Wolverine.Persistence;
+
+/// <summary>
+///     Guards the tenant database discovery behind a dynamic tenancy source: concurrent callers share one
+///     refresh, and a refresh that has just succeeded is not repeated until the configured stale time has
+///     elapsed.
+/// </summary>
+/// <remarks>
+///     <para>
+///         GH-4267. Discovery is a round trip to the tenant registry, and
+///         <see cref="MessageStoreCollection.FindAllAsync()" /> sits on paths that are retried on failure —
+///         listener inbox recovery, listener drain, the durability sweeps. Without a guard each retry and
+///         each concurrent caller opens its own connection to the registry, so on a large tenant fleet the
+///         thing that ran out of connections is called again by the retry for the failure it caused.
+///     </para>
+///     <para>
+///         Freshness is not what those callers need: <see cref="MessageStoreCollection.FindDatabaseAsync" />
+///         forces a refresh whenever a lookup misses, which is the path where a newly provisioned tenant
+///         database has to be found right now. A bulk enumeration that is a few seconds stale costs nothing
+///         — the next sweep sees the database.
+///     </para>
+/// </remarks>
+internal sealed class ThrottledTenantRefresh
+{
+    private readonly object _locker = new();
+    private readonly ITenantedMessageSource _source;
+    private readonly Func<TimeSpan> _staleTime;
+
+    private Task? _inFlight;
+    private long _refreshedAt;
+    private bool _hasRefreshed;
+
+    public ThrottledTenantRefresh(ITenantedMessageSource source, Func<TimeSpan> staleTime)
+    {
+        _source = source;
+        _staleTime = staleTime;
+    }
+
+    public Task MaybeRefreshAsync()
+    {
+        TaskCompletionSource completion;
+
+        lock (_locker)
+        {
+            if (_hasRefreshed && Stopwatch.GetElapsedTime(_refreshedAt) < _staleTime())
+            {
+                return Task.CompletedTask;
+            }
+
+            // A refresh already under way covers this caller too. Joining it instead of starting a second
+            // one is the whole point of this class.
+            if (_inFlight is { IsCompleted: false })
+            {
+                return _inFlight;
+            }
+
+            completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _inFlight = completion.Task;
+        }
+
+        _ = refreshAsync(completion);
+
+        return completion.Task;
+    }
+
+    private async Task refreshAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await _source.RefreshAsync().ConfigureAwait(false);
+
+            // Only a successful refresh opens the window. A failed one leaves the source unknown, so the
+            // next caller retries it — one at a time, because the guard above still holds.
+            lock (_locker)
+            {
+                _refreshedAt = Stopwatch.GetTimestamp();
+                _hasRefreshed = true;
+            }
+
+            completion.SetResult();
+        }
+        catch (Exception e)
+        {
+            completion.SetException(e);
+        }
+    }
+}

--- a/src/Wolverine/Persistence/ThrottledTenantRefresh.cs
+++ b/src/Wolverine/Persistence/ThrottledTenantRefresh.cs
@@ -39,13 +39,20 @@ internal sealed class ThrottledTenantRefresh
         _staleTime = staleTime;
     }
 
-    public Task MaybeRefreshAsync()
+    /// <param name="force">
+    /// Skip the staleness window and go to the source, while still joining a refresh that is already under
+    /// way rather than starting a second one. This is what a LOOKUP THAT MISSED needs:
+    /// <see cref="MessageStoreCollection.FindDatabaseAsync" /> refreshes precisely because it could not find
+    /// a database, so answering it from a list this class already knows is stale-by-assumption defeats the
+    /// call. The single-flight guard is the half that closes the connection storm and is kept either way.
+    /// </param>
+    public Task MaybeRefreshAsync(bool force = false)
     {
         TaskCompletionSource completion;
 
         lock (_locker)
         {
-            if (_hasRefreshed && Stopwatch.GetElapsedTime(_refreshedAt) < _staleTime())
+            if (!force && _hasRefreshed && Stopwatch.GetElapsedTime(_refreshedAt) < _staleTime())
             {
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
Closes #4267.

## The problem

`MessageStoreCollection.FindAllAsync()` re-enumerated a `DynamicMultiple` tenancy source on every
call. With Marten's sharded tenancy that is a round trip to the tenant registry
(`ShardedTenancy.BuildDatabases()` opens a connection to the master database and reads
`mt_database_pool` + `mt_tenant_assignments`), and `FindAllAsync()` sits on paths that are **retried
on failure**: listener inbox recovery, listener drain via
`DelegatingMessageInbox.ReleaseIncomingAsync`, the durability sweeps, database discovery.

So the retry for a connection failure opened another connection to look the databases up again, and
concurrent callers each opened their own. On our fleet — 512 tenant databases, ~2 550 tenants, 20 462
async shards over 3 nodes — one 26-minute process lifetime logged 233 × *"Database operation at {Uri}
failed after {Attempts} attempts; giving up"* over 176 Npgsql timeouts raised inside
`NpgsqlConnector.ConnectAsync` and 3 × *"the connection pool has been exhausted"*, while the master
database itself sat at 0.5% CPU with ~150 of its 3 600 connections in use. It is the client-side data
source that runs dry, and the retry then asks it for another connection.

## The change

Concurrent callers join one refresh, and a refresh that has just succeeded is not repeated until
`DurabilitySettings.TenantDatabaseListStaleTime` has elapsed — 5 seconds by default, `TimeSpan.Zero`
for the old per-call behaviour.

Three things deliberately left as they were:

- **Only a successful refresh opens the window.** A failure leaves the list unknown, so the next
  caller retries it — one at a time, because the single-flight guard still holds.
- **Categorizing the active stores is not throttled.** It is in-memory, and a store the source built
  for a single-tenant lookup has to reach the collection either way.
- **`FindDatabaseAsync` still forces a refresh on a miss.** That is the path where a newly
  provisioned tenant database has to be found immediately; the window only bounds how often the
  callers that enumerate *every* database go asking.

Single-database and `StaticMultiple` deployments are untouched — `FindAllAsync` returns early for the
first and never entered this branch for the second.

## Tests

`CoreTests.Persistence.throttling_the_tenant_database_list_refresh`, four cases: concurrent callers
share one refresh; a second enumeration inside the window does not ask again; the list is refreshed
once the window has elapsed; a failed refresh is retried by the next caller. First two are red
without the fix, last two guard against over-caching. Committed red first, then the fix.

- `CoreTests` on net10.0: 2 768 passed, 0 failed, 2 skipped.
- `PostgresqlTests.MultiTenancy` per class on net10.0: `exclusive_listener_recovery_across_tenant_databases`,
  `multi_node_tenant_database_connections`, `queue_counts_across_tenant_databases` and
  `clear_all_wolverine_storage_across_tenant_databases` all green.
- `static_multi_tenancy` fails 1 of 6 for me (`have_all_the_correct_durability_agents`, a Shouldly
  compare on the agent list) — it fails identically on unmodified `main` in the same environment, and
  that class uses `StaticMultiple`, which this change does not touch.

## Open questions

- **Is 5 seconds the right default?** It is the same order as the other polling knobs in
  `DurabilitySettings`. Happy to make it shorter, or to leave the default at zero so nobody's
  behaviour changes without opting in.
- **`RefreshAsync()` vs `RefreshLiteAsync()`.** The throttle calls `RefreshAsync()`, so behaviour is
  unchanged, but the parameterless one passes `withMigration: true` and `RefreshLiteAsync` looks like
  what a hot path actually wants. Left alone here because it is a separate decision.
- `DelegatingMessageInbox.ReleaseIncomingAsync(ownerId, receivedAt)` still walks every store
  serially, so one listener drain is 512 round trips. Not touched — say the word and I will look at
  it in a follow-up.
