### PR TITLE
GH-4261 follow-up: a failed attain on the Oracle advisory lock leaked its connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,22 @@
   with the size stripped off, so a widened `varchar` was invisible to it and an existing table kept
   the narrow column forever.
 
+### WolverineFx.Oracle
+
+- **A failed attempt on the advisory lock gives its connection back.** `OracleAdvisoryLock` is the one
+  implementation that opens a connection per lock rather than keeping a single shared one, and
+  `TryAttainLockAsync` only released that connection on two of its exits: success, where the connection
+  is retained to hold the row lock, and `ORA-00054` contention, which closes and disposes it. Every
+  other failure fell through to the outer `catch`, logged, and returned false with the connection --
+  and, past `BeginTransactionAsync`, an open transaction on it -- owned by nobody.
+
+  That is not a once-per-process cost. `TryAttainLeadershipLockAsync` fires on every health-check tick,
+  so a failure mode that persists rather than resolving -- the lock table's schema missing, credentials
+  expired, a RAC node gone -- leaked one connection per tick until the pool was exhausted, at which
+  point the node could no longer open a connection for anything else either. The regression test drives
+  six attains against a pool of three: unfixed, it spends fifteen seconds queueing on an empty pool;
+  fixed, it finishes in well under one.
+
 ### WolverineFx.Http
 
 - **DataAnnotations validation works with `ServiceLocationPolicy.NotAllowed`.** (closes

--- a/src/Persistence/Oracle/OracleTests/Agents/Bug_4261_failed_attain_returns_its_connection.cs
+++ b/src/Persistence/Oracle/OracleTests/Agents/Bug_4261_failed_attain_returns_its_connection.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+
+namespace OracleTests.Agents;
+
+/// <summary>
+/// GH-4261 follow-up. <c>OracleAdvisoryLock.TryAttainLockAsync</c> opens a connection and only gave it
+/// back on two of its exits: the success path, where the connection is retained in <c>_heldLocks</c>,
+/// and the ORA-00054 contention path, which closes and disposes it. Every other failure fell through to
+/// the outer <c>catch</c>, which logged and returned false with the connection -- and, once
+/// <c>BeginTransactionAsync</c> had run, an open transaction on it -- still held by nobody.
+///
+/// <para>That is not a once-per-process cost. <c>TryAttainLeadershipLockAsync</c> fires on every
+/// health-check tick, so any failure mode that persists rather than resolving -- the lock table's schema
+/// missing, credentials expired, a RAC node gone -- leaks one connection per tick until the pool is
+/// exhausted, at which point the node cannot open a connection for anything else either.</para>
+///
+/// <para>The pool ceiling here is deliberately tiny so the leak has to show. Against the unfixed code
+/// the fourth attain finds the pool empty and blocks until <c>Connection Timeout</c>; against the fix
+/// every attain gets a pooled connection straight back.</para>
+/// </summary>
+public class Bug_4261_failed_attain_returns_its_connection : OracleContext
+{
+    private const int LockId = unchecked((int)0xB0BCA7);
+    private const string SchemaName = "WOLVERINE";
+
+    // Comfortably more attains than the pool can hold, so a leak cannot be absorbed.
+    private const int PoolCeiling = 3;
+    private const int Attempts = 6;
+    private static readonly TimeSpan PoolWait = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task a_failing_attain_does_not_leak_its_connection()
+    {
+        var builder = new OracleConnectionStringBuilder(Servers.OracleConnectionString)
+        {
+            Pooling = true,
+            MinPoolSize = 0,
+            MaxPoolSize = PoolCeiling,
+            ConnectionTimeout = (int)PoolWait.TotalSeconds
+        };
+
+        await using var dataSource = new OracleDataSource(builder.ConnectionString);
+
+        // Nothing has ever created this schema, so the FOR UPDATE NOWAIT raises ORA-00942 -- not
+        // ORA-00054 -- and lands in the outer catch. Any other durable failure gets there the same way;
+        // a missing schema is just the one a test can arrange without breaking the server.
+        var advisoryLock = new OracleAdvisoryLock(dataSource, NullLogger.Instance, "gh4261_no_such_schema");
+
+        var stopwatch = Stopwatch.StartNew();
+
+        for (var i = 0; i < Attempts; i++)
+        {
+            (await advisoryLock.TryAttainLockAsync(LockId, CancellationToken.None))
+                .ShouldBeFalse($"attain {i} was against a schema that does not exist");
+        }
+
+        stopwatch.Stop();
+
+        // A leaked connection is not returned, so from attempt PoolCeiling on, OpenConnectionAsync sits
+        // on an empty pool for the whole ConnectionTimeout before throwing. Finishing well inside even
+        // one of those waits is the evidence that no attempt ever queued for a connection.
+        stopwatch.Elapsed.ShouldBeLessThan(PoolWait,
+            $"{Attempts} failed attains against a pool of {PoolCeiling} only stay this quick if each one gave its connection back");
+
+        // And the pool still has everything it started with: this would time out and throw against the
+        // leak, whatever the timings above happened to measure.
+        var connections = new List<OracleConnection>();
+        try
+        {
+            for (var i = 0; i < PoolCeiling; i++)
+            {
+                connections.Add(await dataSource.OpenConnectionAsync(CancellationToken.None));
+            }
+        }
+        finally
+        {
+            foreach (var connection in connections)
+            {
+                await connection.DisposeAsync();
+            }
+        }
+
+        connections.Count.ShouldBe(PoolCeiling);
+
+        await advisoryLock.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task an_attained_lock_keeps_its_connection()
+    {
+        // The other half of the same change: on success rememberId takes ownership, and the discard must
+        // not touch what it now holds. HasLock only answers true by pinging that retained connection, so
+        // a lock disposed out from under itself would report false here.
+        await using var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.OracleConnectionString,
+            SchemaName = SchemaName,
+            Role = MessageStoreRole.Main
+        };
+
+        await using var store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<OracleMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await store.Admin.MigrateAsync();
+
+        var advisoryLock = new OracleAdvisoryLock(dataSource, NullLogger.Instance, SchemaName);
+
+        try
+        {
+            (await advisoryLock.TryAttainLockAsync(LockId, CancellationToken.None)).ShouldBeTrue();
+            advisoryLock.HasLock(LockId).ShouldBeTrue();
+
+            // Not asserted here: the renewal TryAttainLeadershipLockAsync drives on every tick answers
+            // FALSE on Oracle, because the row lock the first attain took on its own connection blocks
+            // the second attain's SELECT ... FOR UPDATE NOWAIT with ORA-00054. That path disposes its
+            // connection correctly, so it is not this leak -- but it is a real difference from the
+            // sibling providers, where the renewal is re-entrant and reports true.
+        }
+        finally
+        {
+            await advisoryLock.DisposeAsync();
+        }
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
@@ -175,9 +175,19 @@ internal class OracleAdvisoryLock : IAdvisoryLock
     {
         await _gate.WaitAsync(token).ConfigureAwait(false);
 
+        // GH-4261 follow-up. Only two paths out of the try below hand these off to somebody else: the
+        // success path, where rememberId retains them, and the ORA-00054 contention path, which tears
+        // them down itself. Every other failure -- a missing schema, expired credentials, a RAC node
+        // going away -- used to fall through to the outer catch and drop the locals on the floor with
+        // the connection still open and, past BeginTransactionAsync, a transaction open on it. Attains
+        // run on the health-check tick, so a failure mode that persists leaks one connection per tick
+        // until the pool is gone. Held in locals so the catch can finish what the try started.
+        OracleConnection? conn = null;
+        OracleTransaction? tx = null;
+
         try
         {
-            var conn = await _source.OpenConnectionAsync(token);
+            conn = await _source.OpenConnectionAsync(token);
 
             // Ensure lock row exists
             await using var ensureCmd = conn.CreateCommand(
@@ -196,7 +206,7 @@ internal class OracleAdvisoryLock : IAdvisoryLock
             }
 
             // Start a transaction to hold the row lock
-            var tx = (OracleTransaction)await conn.BeginTransactionAsync(token);
+            tx = (OracleTransaction)await conn.BeginTransactionAsync(token);
 
             await using var lockCmd = conn.CreateCommand(
                 $"SELECT lock_id FROM {_schemaName}.{LockTable.TableName} WHERE lock_id = :lockId FOR UPDATE NOWAIT");
@@ -220,11 +230,78 @@ internal class OracleAdvisoryLock : IAdvisoryLock
         catch (Exception e)
         {
             _logger.LogError(e, "Error trying to attain advisory lock {LockId}", lockId);
+
+            // Reached only when the lock was NOT attained: the success and ORA-00054 paths both return
+            // from inside the try. If the ORA-00054 teardown was itself what threw, this finishes it --
+            // discardFailedAttainAsync is defensive about being handed something already torn down.
+            await discardFailedAttainAsync(lockId, conn, tx).ConfigureAwait(false);
             return false;
         }
         finally
         {
             _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// GH-4261 follow-up. Give back the connection -- and the transaction, if
+    /// <c>BeginTransactionAsync</c> got that far -- that a failed attain opened. Callers MUST hold
+    /// <c>_gate</c>, and MUST NOT call this once <see cref="rememberId"/> has taken ownership. Nothing
+    /// in here is allowed to throw: it runs from a catch block whose whole job is to answer false.
+    /// </summary>
+    private async Task discardFailedAttainAsync(int lockId, OracleConnection? conn, OracleTransaction? tx)
+    {
+        if (conn == null) return;
+
+        if (tx != null)
+        {
+            try
+            {
+                // Bounded like releaseLockUnsafeAsync's rollback, and for the same reason: we are
+                // already on a failure path and cannot afford a second unbounded wait on a connection
+                // that has just misbehaved.
+                using var cancellation = new CancellationTokenSource();
+                cancellation.CancelAfter(1.Seconds());
+
+                await tx.RollbackAsync(cancellation.Token);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e,
+                    "Error rolling back the transaction of a failed attain of advisory lock {LockId} in schema {Schema}",
+                    lockId, _schemaName);
+            }
+
+            try
+            {
+                await tx.DisposeAsync();
+            }
+            catch
+            {
+                // Already broken, and the connection is going with it regardless.
+            }
+        }
+
+        try
+        {
+            await closeWithinBudgetAsync(conn).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e,
+                "Error closing the connection of a failed attain of advisory lock {LockId} in schema {Schema}",
+                lockId, _schemaName);
+        }
+
+        try
+        {
+            await conn.DisposeAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e,
+                "Error disposing the connection of a failed attain of advisory lock {LockId} in schema {Schema}",
+                lockId, _schemaName);
         }
     }
 


### PR DESCRIPTION
Stacked on #4266 — it needs that PR's `_gate` and `closeWithinBudgetAsync`, so it cannot sit on `main`. **This means it gets no CI checks until #4266 merges and this is retargeted**; `dotnet.yml` only triggers on PRs to `main`.

## What was wrong

`OracleAdvisoryLock` is the one implementation that opens a connection **per lock** rather than keeping a single shared one, and `TryAttainLockAsync` only gave that connection back on two of its exits:

- **success** — retained in `_heldLocks` to hold the row lock, correct;
- **`ORA-00054` contention** — closed and disposed, correct.

Every other failure fell through to the outer `catch`, logged `"Error trying to attain advisory lock {LockId}"`, and returned `false` with the connection still open and — past `BeginTransactionAsync` — an open transaction on it, owned by nobody.

That is not a once-per-process cost. `TryAttainLeadershipLockAsync` fires on **every health-check tick**, so a failure mode that persists rather than resolving — the lock table's schema missing, credentials expired, a RAC node gone — leaks one connection per tick until the pool is exhausted, at which point the node cannot open a connection for anything else either.

## The fix

The connection and transaction now live in locals so the `catch` can finish what the `try` started. `discardFailedAttainAsync` rolls back within the same one-second bound `releaseLockUnsafeAsync` uses, then closes through `closeWithinBudgetAsync` and disposes. Nothing in it is allowed to throw — it runs from a catch whose whole job is to answer `false`.

It is reached **only when the lock was not attained**: both the success path and the `ORA-00054` path return from inside the `try`, so it can never tear down what `rememberId` has taken ownership of. It is also defensive about being handed something already torn down, which covers the one case that does reach it holding a connection — an `ORA-00054` teardown that itself threw.

## Verification

Red baseline established against this branch's parent with the production change reverted, not assumed:

| | unfixed | fixed |
|---|---|---|
| six attains against a missing schema, pool ceiling 3 | **15.2s** (fourth attain blocks the full 5s connection timeout on an empty pool, three times over) | **621ms** |
| pool can still hand out 3 connections afterwards | no | yes |

- `OracleTests` full suite: **166/166 green**.
- `dotnet build wolverine.slnx -c Release -f net9.0`: 0 warnings, 0 errors.

## Noted, not fixed here

While writing the test: on Oracle the **renewal** attain the heartbeat drives on every tick answers `false` for a lock this node already holds. The row lock the first attain took on its own connection blocks the second attain's `SELECT ... FOR UPDATE NOWAIT` with `ORA-00054` — confirmed by probe (`first=True hasAfterFirst=True second=False hasAfterSecond=True`, with an empty log, which is the signature of the silent ORA-00054 branch).

That path disposes its connection correctly, so it is not this leak. But it is a real difference from the sibling providers, where the renewal is re-entrant on the shared connection and reports `true` — and it is the same `TryAttainLeadershipLockAsync` return value that #4266's Postgres tests assert must stay `true` across renewals. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)