### PR TITLE
GH-4156: say what a Static-mode type mismatch actually is, for HTTP and gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,30 @@
 
 ### WolverineFx.Http
 
+- **A Static-mode endpoint type mismatch is now reported as itself.** (closes
+  [#4156](https://github.com/JasperFx/wolverine/issues/4156)) GH-4151 gave handler chains a startup assertion
+  that every pre-generated type really is in `WolverineOptions.ApplicationAssembly`, because `codegen write`
+  emits into the *entry* project and the two silently disagree when they are different assemblies. HTTP
+  endpoint chains are a separate `ICodeFileCollection` and were left out of that pass.
+
+  The issue expected the HTTP half to be failing lazily, on the first request to each route. It was not:
+  `HttpChain.BuildEndpoint` already forces the handler build for every chain whenever `TypeLoadMode.Static`,
+  independently of `RouteWarmup`, so the mapping already failed. What it failed *with* was the problem --
+  JasperFx's `ExpectedTypeMissingException` on the first chain it happened to reach, naming one generated
+  code file and the assembly it looked in, and nothing else. No count, no route the operator recognizes, and
+  no mention of the one fact that resolves it. `HttpGraph` now asserts before it builds endpoints, so the
+  whole picture arrives at once: every affected route by its route pattern, the assembly that was searched,
+  and -- when the generated types are sitting in the entry assembly instead -- which assembly they are in and
+  what to do about it.
+
+- **gRPC service chains get the same assertion.** `GrpcGraph.DiscoverServices` forces nothing, so unlike HTTP
+  a missing pre-built type here really did wait for the first RPC to that service, with the host reporting
+  healthy the entire time. It now fails discovery, with the same diagnostic.
+
+  Neither is a behaviour change for a correctly configured application: in `TypeLoadMode.Auto` -- the
+  default -- nothing is asserted, because Auto generates what it cannot load.
+
+
 - **DataAnnotations validation works with `ServiceLocationPolicy.NotAllowed`.** (closes
   [#4238](https://github.com/JasperFx/wolverine/issues/4238)) Under the Wolverine 6 default the
   application threw `InvalidServiceLocationException` at bootstrap and could not start. This was

--- a/src/Http/Wolverine.Http.Tests/Bug_4156_static_mode_endpoint_types.cs
+++ b/src/Http/Wolverine.Http.Tests/Bug_4156_static_mode_endpoint_types.cs
@@ -1,0 +1,81 @@
+using JasperFx.CodeGeneration;
+using Marten;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.Http.Tests.DifferentAssembly.Validation;
+using Wolverine.Marten;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Http.Tests;
+
+/// <summary>
+/// GH-4156. GH-4151 made <c>HandlerGraph</c> assert at startup, in <see cref="TypeLoadMode.Static" />, that
+/// every handler chain's pre-generated type really is in <see cref="WolverineOptions.ApplicationAssembly" />
+/// -- because `codegen write` emits into the ENTRY project, and when ApplicationAssembly points somewhere
+/// else the two disagree with nothing to detect it.
+///
+/// <para>Wolverine.Http's endpoint chains are a separate <c>ICodeFileCollection</c> and were deliberately
+/// out of that PR's scope, with the identical exposure: in Static mode there is no fallback, so a missing
+/// pre-generated endpoint type surfaced on the first HTTP request to that route -- a 500 per request on a
+/// host that had reported healthy since the deploy, with no failure policy able to reach it.</para>
+/// </summary>
+public class Bug_4156_static_mode_endpoint_types
+{
+    [Fact]
+    public async Task static_mode_without_pre_built_endpoint_types_fails_the_mapping()
+    {
+        await using var app = buildHost(TypeLoadMode.Static);
+
+        // No pre-built types were ever generated into DifferentAssembly, which is exactly the state the
+        // entry-project-vs-library split leaves a Static mode app in.
+        var ex = Should.Throw<MissingPreBuiltTypesException>(() => app.MapWolverineEndpoints());
+
+        // Name the assembly that was searched, because "the types are missing" and "the types are in the
+        // other assembly" call for different fixes.
+        ex.Message.ShouldContain(typeof(Validated2Endpoint).Assembly.GetName().Name!);
+
+        // And name the ROUTES, not just the generated type names. An operator reading a failed deploy knows
+        // which routes they have and does not know what codegen called them.
+        ex.Message.ShouldContain("validate2/customer");
+    }
+
+    [Fact]
+    public async Task auto_mode_maps_the_same_endpoints_without_complaint()
+    {
+        // False-positive guard, and the working configuration for this layout: Auto generates what it
+        // cannot load, so the assembly split costs a cold start rather than correctness.
+        await using var app = buildHost(TypeLoadMode.Auto);
+
+        Should.NotThrow(() => app.MapWolverineEndpoints());
+    }
+
+    private static WebApplication buildHost(TypeLoadMode mode)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Development" });
+        builder.WebHost.UseTestServer();
+
+        // "DifferentAssembly" carries Marten aggregate endpoints, so any host discovering it needs Marten
+        // registered to resolve the aggregates' id types. Nothing here starts the host, so point it at an
+        // unreachable database to keep the test free of infrastructure.
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(
+                "Host=localhost;Port=9999;Database=does_not_exist;Username=nobody;Password=nobody;Timeout=2;Command Timeout=2");
+        }).IntegrateWithWolverine();
+
+        builder.Host.UseWolverine(opts =>
+        {
+            // Pin discovery to the small, isolated assembly so the test is deterministic and does not pick
+            // up the rest of the suite's endpoints.
+            opts.ApplicationAssembly = typeof(Validated2Endpoint).Assembly;
+            opts.CodeGeneration.TypeLoadMode = mode;
+        });
+
+        builder.Services.AddWolverineHttp();
+
+        return builder.Build();
+    }
+}

--- a/src/Http/Wolverine.Http/HttpGraph.PreBuiltTypes.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.PreBuiltTypes.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+using JasperFx.CodeGeneration;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Http;
+
+public partial class HttpGraph
+{
+    /// <summary>
+    ///     GH-4156. The Wolverine.Http counterpart to <see cref="HandlerGraph.AssertPreBuiltTypesExist" />.
+    ///     Endpoint chains are a separate <see cref="JasperFx.CodeGeneration.ICodeFileCollection" /> and were
+    ///     deliberately left out of the GH-4151 fix, but they have the identical exposure: in
+    ///     <see cref="TypeLoadMode.Static" /> there is no fallback, so an endpoint whose pre-generated type is
+    ///     not in the application assembly can never be invoked. Until now the miss surfaced on the first HTTP
+    ///     request to that route -- the host reported healthy in the meantime, and the deploy that caused it
+    ///     was long finished. Attach every expected type up front instead, so the misconfiguration is a failed
+    ///     start.
+    /// </summary>
+    /// <remarks>
+    ///     Attaching is not merely a probe. <see cref="HttpChain" /> caches the resolved type in
+    ///     <c>_handlerType</c>, so the types the loader would otherwise resolve one route at a time on their
+    ///     first request are resolved here, which is what Static mode wanted in the first place.
+    /// </remarks>
+    internal void AssertPreBuiltTypesExist()
+    {
+        if (Rules.TypeLoadMode != TypeLoadMode.Static)
+        {
+            return;
+        }
+
+        // `codegen write` runs against an application whose generated types do not exist yet -- that is the
+        // point of running it. Same guard as the registry fast path in DiscoverEndpoints.
+        if (DynamicCodeBuilder.WithinCodegenCommand)
+        {
+            return;
+        }
+
+        var applicationAssembly = Rules.ApplicationAssembly;
+        if (applicationAssembly == null)
+        {
+            return;
+        }
+
+        var collection = (ICodeFileCollection)this;
+        var containingNamespace = collection.ToNamespace(Rules);
+
+        var missing = new List<ICodeFile>();
+        foreach (var file in collection.BuildFiles())
+        {
+            // The pre-generated HttpEndpointRegistry is deliberately not fatal, for the same reason the
+            // handler-side HandlerRegistry is not: its absence only costs the cold-start scan skip in
+            // DiscoverEndpoints, which already falls back to HttpChainSource.FindActions(). No request is
+            // lost over it.
+            if (file is HttpEndpointRegistryCodeFile)
+            {
+                continue;
+            }
+
+            if (!file.AttachTypesSynchronously(Rules, applicationAssembly, Container.Services, containingNamespace))
+            {
+                missing.Add(file);
+            }
+        }
+
+        if (missing.Count == 0)
+        {
+            return;
+        }
+
+        throw new MissingPreBuiltTypesException(describeMissingEndpointTypes(applicationAssembly, missing));
+    }
+
+    private string describeMissingEndpointTypes(Assembly applicationAssembly, List<ICodeFile> missing)
+    {
+        var message = new StringBuilder();
+
+        message.AppendLine(
+            $"Wolverine.Http is running in {nameof(TypeLoadMode)}.{nameof(TypeLoadMode.Static)}, but {missing.Count} expected pre-built HTTP endpoint type(s) could not be loaded from the configured {nameof(WolverineOptions.ApplicationAssembly)} '{applicationAssembly.GetName().Name}':");
+
+        foreach (var chain in missing.OfType<HttpChain>())
+        {
+            // The route, not just the generated type name -- an operator reading a failed deploy knows which
+            // routes they have, and does not know what codegen called them.
+            message.AppendLine($"  * {chain.RoutePattern?.RawText ?? chain.Description} ({chain})");
+        }
+
+        foreach (var file in missing.Where(x => x is not HttpChain))
+        {
+            message.AppendLine("  * " + file);
+        }
+
+        message.AppendLine();
+
+        var elsewhere = findAssemblyHoldingGeneratedEndpointTypes(applicationAssembly);
+        if (elsewhere != null)
+        {
+            message.AppendLine(
+                $"Pre-generated Wolverine HTTP types were found in '{elsewhere.GetName().Name}' instead. 'dotnet run -- codegen write' emits its source into the entry project, while {nameof(TypeLoadMode)}.{nameof(TypeLoadMode.Static)} loads pre-built types from {nameof(WolverineOptions)}.{nameof(WolverineOptions.ApplicationAssembly)}, so the two disagree.");
+            message.AppendLine(
+                $"If {nameof(WolverineOptions.ApplicationAssembly)} was only set so that Wolverine would discover endpoints living in another assembly, use opts.Discovery.{nameof(Configuration.HandlerDiscovery.IncludeAssembly)}(...) for that instead and leave {nameof(WolverineOptions.ApplicationAssembly)} as the entry assembly. Otherwise, point the generated code output at the project that builds '{applicationAssembly.GetName().Name}' with opts.CodeGeneration.{nameof(GenerationRules.GeneratedCodeOutputPath)}.");
+        }
+        else
+        {
+            message.AppendLine(
+                "No pre-generated Wolverine HTTP types could be found in any assembly this application is using. Run 'dotnet run -- codegen write' as part of the build and compile its output into the application assembly, or run in TypeLoadMode.Auto.");
+        }
+
+        message.AppendLine();
+        message.Append("See https://wolverinefx.net/guide/http/codegen.html");
+
+        return message.ToString();
+    }
+
+    // Purely a diagnostic for the exception message above: say where the generated code actually landed,
+    // because "the types are missing" and "the types are in the other assembly" call for different fixes.
+    // The generated HttpEndpointRegistry is the marker -- codegen write always emits exactly one, alongside
+    // the endpoint types, into whichever project it wrote to.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification =
+            "ExportedTypes walk over candidate assemblies to locate misplaced codegen output; runs only on the startup failure path while building an exception message. See AOT guide.")]
+    private Assembly? findAssemblyHoldingGeneratedEndpointTypes(Assembly applicationAssembly)
+    {
+        var candidates = new List<Assembly>();
+
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly != null)
+        {
+            candidates.Add(entryAssembly);
+        }
+
+        candidates.AddRange(_options.Assemblies);
+
+        foreach (var candidate in candidates.Distinct().Where(x => x != applicationAssembly && !x.IsDynamic))
+        {
+            try
+            {
+                if (candidate.ExportedTypes.Any(x => x.Name == HttpEndpointRegistry.GeneratedTypeName))
+                {
+                    return candidate;
+                }
+            }
+            catch (Exception)
+            {
+                // A candidate assembly that cannot be reflected over simply is not a candidate. This probe
+                // exists to make an exception message more useful and must never become the thing that fails.
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Http/Wolverine.Http/HttpGraph.cs
+++ b/src/Http/Wolverine.Http/HttpGraph.cs
@@ -201,6 +201,15 @@ public partial class HttpGraph : EndpointDataSource, ICodeFileCollectionWithServ
 
         foreach (var policy in wolverineHttpOptions.Policies) policy.Apply(_chains, Rules, Container);
 
+        // GH-4156. BEFORE BuildEndpoint, deliberately. In TypeLoadMode.Static BuildEndpoint already forces
+        // the handler build for every chain -- regardless of RouteWarmup -- so a missing pre-built type does
+        // already fail the mapping rather than the first request. What it fails with is the problem: JasperFx
+        // throws ExpectedTypeMissingException on the FIRST chain it reaches, naming one generated code file
+        // and the assembly it looked in, and nothing else. That leaves the operator without the count, the
+        // routes in a form they recognize, or the one fact that actually resolves this -- that the types are
+        // sitting in the entry assembly instead. Assert here so the whole picture is reported at once.
+        AssertPreBuiltTypesExist();
+
         _endpoints.AddRange(_chains.Select(x => x.BuildEndpoint(wolverineHttpOptions.WarmUpRoutes)));
     }
 

--- a/src/Testing/CoreTests/Bugs/Bug_4156_static_mode_with_a_class_library_composition_root.cs
+++ b/src/Testing/CoreTests/Bugs/Bug_4156_static_mode_with_a_class_library_composition_root.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Module1;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// GH-4156, from the report against GH-4151's <c>AssertPreBuiltTypesExist</c>: a class library holds both the
+/// handlers and the composition root, so it is what Wolverine resolves as
+/// <see cref="WolverineOptions.ApplicationAssembly" />, while `codegen write` emits into the ENTRY project --
+/// so the pre-built types land in a different assembly. On 6.30.1 that became a hard startup failure where
+/// 6.29.2 had started cleanly, and it was read as a regression.
+///
+/// <para>It is not. In <see cref="TypeLoadMode.Static" /> there is no fallback: with the two assemblies
+/// disagreeing, not one handler type can be attached, so before the startup assertion the host booted
+/// healthy and then failed per message from inside executor construction -- where no failure policy can
+/// reach, and where the pipeline's last-resort recovery ACKED THE ENVELOPE AWAY. See
+/// <see cref="Bug_4151_executor_build_failure_loses_message" />, which pins both halves of that. The 6.29.2
+/// host in this shape was not working; it was silently discarding every durable message it received.</para>
+///
+/// <para>So these tests pin the diagnosis rather than a fix: the library really is what registers Wolverine,
+/// TypeLoadMode.Auto really is the working configuration for this layout, and Static really must fail loudly.
+/// The fix for an application in this shape is the one the exception message already gives.</para>
+/// </summary>
+public class Bug_4156_static_mode_with_a_class_library_composition_root
+{
+    private static readonly Assembly TheClassLibrary = typeof(CompositionRootInAClassLibrary).Assembly;
+
+    [Fact]
+    public async Task the_class_library_is_what_registers_wolverine()
+    {
+        // The premise of the whole report, and the only half of it that can be asserted deterministically
+        // here. RegistrationCallingAssembly is captured per-options at registration; the ApplicationAssembly
+        // that follows from it is pinned PROCESS-WIDE by whichever host started first
+        // (RememberedApplicationAssembly), so reading that back inside a parallel test suite asserts against
+        // whatever else happened to build a host first -- it resolved to Module1 run alone and to CoreTests
+        // run in the full suite. That is a property of the test process, not of the layout.
+        using var host = CompositionRootInAClassLibrary.BuildHost();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var options = host.Services.GetRequiredService<WolverineOptions>();
+
+        options.RegistrationCallingAssembly!.GetName().Name.ShouldBe(TheClassLibrary.GetName().Name);
+        options.RegistrationCallingAssembly.GetName().Name
+            .ShouldNotBe(typeof(Bug_4156_static_mode_with_a_class_library_composition_root).Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public async Task auto_mode_starts_cleanly_in_this_layout()
+    {
+        // The reporter's passing test, and the working configuration for this shape: Auto generates what it
+        // cannot load, so the assembly split costs a cold start rather than correctness.
+        using var host = CompositionRootInAClassLibrary.BuildHost(opts =>
+        {
+            // Set explicitly rather than left to the process-wide inference, for the reason above. This is
+            // the value that inference produces for this layout; pinning it here is what makes the test
+            // deterministic rather than a race against every other host in the suite.
+            opts.ApplicationAssembly = TheClassLibrary;
+            opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
+        });
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task static_mode_fails_the_start_and_names_the_assembly_it_searched()
+    {
+        var ex = await Should.ThrowAsync<MissingPreBuiltTypesException>(() =>
+            CompositionRootInAClassLibrary.BuildHost(opts =>
+            {
+                opts.ApplicationAssembly = TheClassLibrary;
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Static;
+            }).StartAsync(TestContext.Current.CancellationToken));
+
+        // Naming the assembly is the whole diagnostic value: "30 types could not be loaded" without saying
+        // WHERE it looked leaves the reader no way to see that the library, not the entry project, is what
+        // was searched.
+        ex.Message.ShouldContain(TheClassLibrary.GetName().Name!);
+        ex.Message.ShouldContain(nameof(Bug4156Ping));
+    }
+}

--- a/src/Testing/Module1/CompositionRootInAClassLibrary.cs
+++ b/src/Testing/Module1/CompositionRootInAClassLibrary.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+
+namespace Module1;
+
+/// <summary>
+/// GH-4156. Reconstructs the layout reported against `AssertPreBuiltTypesExist`: a class library holds both
+/// the handlers AND the composition root, so it is the assembly that calls <c>UseWolverine</c> and therefore
+/// the one Wolverine infers as <see cref="WolverineOptions.ApplicationAssembly" />. The entry project is a
+/// separate assembly, and `codegen write` emits its source there -- so with the default conventions the two
+/// are always different assemblies and <c>TypeLoadMode.Static</c> cannot resolve a single pre-built type.
+///
+/// <para>Deliberately in this library rather than in the test assembly: calling <c>UseWolverine</c> from
+/// CoreTests would infer CoreTests, which is the configuration that WORKS and proves nothing.</para>
+/// </summary>
+public static class CompositionRootInAClassLibrary
+{
+    /// <summary>
+    /// Registers AND builds, both inside this library. Both halves matter: UseWolverine on IHostBuilder
+    /// defers its real work into a ConfigureServices callback that only runs during Build(), so the frame
+    /// the application-assembly inference actually sees is the one that called Build(). Splitting them --
+    /// registering here and building in the test assembly -- infers the TEST assembly and reproduces
+    /// nothing.
+    /// </summary>
+    public static IHost BuildHost(Action<WolverineOptions>? configure = null)
+    {
+        return Host.CreateDefaultBuilder().UseWolverine(opts =>
+        {
+            opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(Bug4156PingHandler));
+            configure?.Invoke(opts);
+        }).Build();
+    }
+}
+
+public record Bug4156Ping;
+
+public static class Bug4156PingHandler
+{
+    public static void Handle(Bug4156Ping ping)
+    {
+    }
+}

--- a/src/Wolverine.Grpc.Tests/Bug_4156_static_mode_service_types.cs
+++ b/src/Wolverine.Grpc.Tests/Bug_4156_static_mode_service_types.cs
@@ -1,0 +1,63 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests;
+
+/// <summary>
+/// GH-4156. gRPC service chains are a third <c>ICodeFileCollection</c> alongside handler chains (GH-4151)
+/// and HTTP endpoint chains, with the same exposure and -- unlike HTTP -- the same lazy failure the issue
+/// described. <c>HttpChain.BuildEndpoint</c> already forces the handler build for every chain in
+/// <see cref="TypeLoadMode.Static" />, so HTTP at least failed at mapping (with an unreadable exception).
+/// <c>GrpcGraph.DiscoverServices</c> forces nothing, so a missing pre-built type here really did wait for
+/// the first RPC to that service, with the host reporting healthy the whole time.
+/// </summary>
+public class Bug_4156_static_mode_service_types
+{
+    [Fact]
+    public void static_mode_without_pre_built_service_types_fails_discovery()
+    {
+        var graph = buildGraph(TypeLoadMode.Static);
+
+        var ex = Should.Throw<MissingPreBuiltTypesException>(() => graph.DiscoverServices(new WolverineGrpcOptions()));
+
+        // Name the assembly that was searched, because "the types are missing" and "the types are in the
+        // other assembly" call for different fixes.
+        ex.Message.ShouldContain(typeof(Bug_4156_static_mode_service_types).Assembly.GetName().Name!);
+    }
+
+    [Fact]
+    public void auto_mode_discovers_the_same_services_without_complaint()
+    {
+        // False-positive guard: the assertion must fire on a genuinely missing pre-built type and on
+        // nothing else. Auto generates what it cannot load, so the very same graph is fine.
+        var graph = buildGraph(TypeLoadMode.Auto);
+
+        Should.NotThrow(() => graph.DiscoverServices(new WolverineGrpcOptions()));
+    }
+
+    // Same minimal codegen harness as grpc_direct_mapped_manifest.
+    private static GrpcGraph buildGraph(TypeLoadMode mode)
+    {
+        var registry = new ServiceCollection();
+        registry.AddLogging();
+        registry.AddTransient<IServiceVariableSource>(c =>
+            new ServiceCollectionServerVariableSource((ServiceContainer)c.GetRequiredService<IServiceContainer>()));
+        registry.AddSingleton<IServiceCollection>(registry);
+        registry.AddSingleton<IServiceContainer, ServiceContainer>();
+        registry.AddSingleton<IAssemblyGenerator, JasperFx.RuntimeCompiler.AssemblyGenerator>();
+
+        var container = registry.BuildServiceProvider().GetRequiredService<IServiceContainer>();
+
+        var options = new WolverineOptions { ApplicationAssembly = typeof(Bug_4156_static_mode_service_types).Assembly };
+        options.CodeGeneration.TypeLoadMode = mode;
+
+        return new GrpcGraph(options, container);
+    }
+}

--- a/src/Wolverine.Grpc/GrpcGraph.PreBuiltTypes.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.PreBuiltTypes.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+using JasperFx.CodeGeneration;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Grpc;
+
+public partial class GrpcGraph
+{
+    /// <summary>
+    ///     GH-4156. The Wolverine.Grpc counterpart to <see cref="HandlerGraph.AssertPreBuiltTypesExist" /> and
+    ///     <see cref="Http.HttpGraph.AssertPreBuiltTypesExist" />. All three chain flavors here -- proto-first,
+    ///     code-first and hand-written -- resolve a generated wrapper by name out of the application assembly,
+    ///     and in <see cref="TypeLoadMode.Static" /> there is no fallback when that lookup misses. Without this
+    ///     the miss surfaces on the first RPC to that service, with the host reporting healthy in between.
+    /// </summary>
+    internal void AssertPreBuiltTypesExist()
+    {
+        if (Rules.TypeLoadMode != TypeLoadMode.Static)
+        {
+            return;
+        }
+
+        // `codegen write` runs against an application whose generated types do not exist yet -- that is the
+        // point of running it. Same guard as the registry fast path in DiscoverServices.
+        if (DynamicCodeBuilder.WithinCodegenCommand)
+        {
+            return;
+        }
+
+        var applicationAssembly = Rules.ApplicationAssembly;
+        if (applicationAssembly == null)
+        {
+            return;
+        }
+
+        var collection = (ICodeFileCollection)this;
+        var containingNamespace = collection.ToNamespace(Rules);
+
+        var missing = new List<ICodeFile>();
+        foreach (var file in collection.BuildFiles())
+        {
+            // The pre-generated GrpcServiceRegistry is deliberately not fatal, for the same reason the
+            // handler and HTTP registries are not: its absence only costs the cold-start scan skip in
+            // DiscoverServices, which already falls back to the GetExportedTypes walk. No RPC is lost over it.
+            if (file is GrpcServiceRegistryCodeFile)
+            {
+                continue;
+            }
+
+            if (!file.AttachTypesSynchronously(Rules, applicationAssembly, Container.Services, containingNamespace))
+            {
+                missing.Add(file);
+            }
+        }
+
+        if (missing.Count == 0)
+        {
+            return;
+        }
+
+        throw new MissingPreBuiltTypesException(describeMissingServiceTypes(applicationAssembly, missing));
+    }
+
+    private string describeMissingServiceTypes(Assembly applicationAssembly, List<ICodeFile> missing)
+    {
+        var message = new StringBuilder();
+
+        message.AppendLine(
+            $"Wolverine.Grpc is running in {nameof(TypeLoadMode)}.{nameof(TypeLoadMode.Static)}, but {missing.Count} expected pre-built gRPC service type(s) could not be loaded from the configured {nameof(WolverineOptions.ApplicationAssembly)} '{applicationAssembly.GetName().Name}':");
+
+        foreach (var file in missing)
+        {
+            message.AppendLine("  * " + file);
+        }
+
+        message.AppendLine();
+
+        var elsewhere = findAssemblyHoldingGeneratedServiceTypes(applicationAssembly);
+        if (elsewhere != null)
+        {
+            message.AppendLine(
+                $"Pre-generated Wolverine gRPC types were found in '{elsewhere.GetName().Name}' instead. 'dotnet run -- codegen write' emits its source into the entry project, while {nameof(TypeLoadMode)}.{nameof(TypeLoadMode.Static)} loads pre-built types from {nameof(WolverineOptions)}.{nameof(WolverineOptions.ApplicationAssembly)}, so the two disagree.");
+            message.AppendLine(
+                $"Point the generated code output at the project that builds '{applicationAssembly.GetName().Name}' with opts.CodeGeneration.{nameof(GenerationRules.GeneratedCodeOutputPath)}, or leave {nameof(WolverineOptions.ApplicationAssembly)} as the entry assembly.");
+        }
+        else
+        {
+            message.AppendLine(
+                "No pre-generated Wolverine gRPC types could be found in any assembly this application is using. Run 'dotnet run -- codegen write' as part of the build and compile its output into the application assembly, or run in TypeLoadMode.Auto.");
+        }
+
+        message.AppendLine();
+        message.Append("See https://wolverinefx.net/guide/codegen.html");
+
+        return message.ToString();
+    }
+
+    // Purely a diagnostic for the exception message above: say where the generated code actually landed,
+    // because "the types are missing" and "the types are in the other assembly" call for different fixes.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification =
+            "ExportedTypes walk over candidate assemblies to locate misplaced codegen output; runs only on the startup failure path while building an exception message. See AOT guide.")]
+    private Assembly? findAssemblyHoldingGeneratedServiceTypes(Assembly applicationAssembly)
+    {
+        var candidates = new List<Assembly>();
+
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly != null)
+        {
+            candidates.Add(entryAssembly);
+        }
+
+        candidates.AddRange(_options.Assemblies);
+
+        foreach (var candidate in candidates.Distinct().Where(x => x != applicationAssembly && !x.IsDynamic))
+        {
+            try
+            {
+                if (candidate.ExportedTypes.Any(x => x.Name == GrpcServiceRegistry.GeneratedTypeName))
+                {
+                    return candidate;
+                }
+            }
+            catch (Exception)
+            {
+                // A candidate assembly that cannot be reflected over simply is not a candidate. This probe
+                // exists to make an exception message more useful and must never become the thing that fails.
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Wolverine.Grpc/GrpcGraph.cs
+++ b/src/Wolverine.Grpc/GrpcGraph.cs
@@ -17,7 +17,7 @@ namespace Wolverine.Grpc;
 ///     and plugs their generated wrapper types into the Wolverine code-generation pipeline.
 ///     Mirrors the role of <c>HandlerGraph</c> / <c>HttpGraph</c> for their respective chain types.
 /// </summary>
-public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
+public partial class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
 {
     private readonly List<GrpcServiceChain> _chains = [];
     private readonly List<CodeFirstGrpcServiceChain> _codeFirstChains = [];
@@ -169,6 +169,10 @@ public class GrpcGraph : ICodeFileCollectionWithServices, IDescribeMyself
         {
             policy.Apply(_chains, _codeFirstChains, _handWrittenChains, Rules, Container);
         }
+
+        // GH-4156. Last of the chain-shaping steps, so every chain that will ever exist is checked. In
+        // TypeLoadMode.Static a missing pre-built type used to surface on the first RPC to that service.
+        AssertPreBuiltTypesExist();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #4156.

## The issue's premise holds for gRPC, not for HTTP

4156 says a missing pre-generated endpoint type "surfaces on the first HTTP request to that route rather than at startup, and the host reports healthy in the meantime." It doesn't. `HttpChain.BuildEndpoint` (`HttpChain.EndpointBuilder.cs:85`) already forces the handler build for **every** chain whenever `TypeLoadMode.Static`, independently of `RouteWarmup` — so the mapping already fails.

What it fails *with* is the problem:

```
JasperFx.CodeGeneration.ExpectedTypeMissingException : Could not load expected pre-built types for
code file POST_validate2_customer (POST_validate2_customer) from assembly
Wolverine.Http.Tests.DifferentAssembly, Version=6.33.0.0... You may want to verify that this is the
correct assembly for pre-generated types.
```

One code file — whichever chain it reached first — no count, no route the operator recognizes, and no mention of the one fact that resolves it: that the generated types are sitting in the entry assembly. So for HTTP this is a **diagnostic** fix rather than a timing one, and the assertion has to run *before* `BuildEndpoint` or it never gets a turn.

The same case now reports:

```
Wolverine.Http is running in TypeLoadMode.Static, but 33 expected pre-built HTTP endpoint type(s)
could not be loaded from the configured ApplicationAssembly 'Wolverine.Http.Tests.DifferentAssembly':
  * /validate2/customer (POST_validate2_customer)
  * /shapes/marten/orders/{id}/confirm (POST_shapes_marten_orders_id_confirm)
  ... (31 more)

No pre-generated Wolverine HTTP types could be found in any assembly this application is using. Run
'dotnet run -- codegen write' as part of the build and compile its output into the application
assembly, or run in TypeLoadMode.Auto.
```

**gRPC is the case the issue actually described.** `GrpcGraph.DiscoverServices` forces nothing, so there the miss genuinely waited for the first RPC to that service, host healthy throughout. It gets both the timing and the diagnostic.

Neither is a behaviour change for a correctly configured application: in `TypeLoadMode.Auto` — the default — nothing is asserted, because Auto generates what it cannot load. Both new suites pin that as an explicit false-positive guard.

## The reported "regression" on the handler side is the check working

The comment thread on 4156 reads as though `AssertPreBuiltTypesExist` broke a working app (6.29.2 green, 6.30.1 red). It didn't. Rather than run the attached zip, this reconstructs that layout in the suite — `Module1.CompositionRootInAClassLibrary`, a class library holding both the handler and the composition root, plus `Bug_4156_static_mode_with_a_class_library_composition_root`.

In Static mode there is no fallback, so that host booted healthy and then failed per message inside executor construction — where no failure policy can reach, and where the pipeline's last-resort recovery **acked the envelope away**. `HandlerPipeline.cs:393` says so directly, and `Bug_4151_executor_build_failure_loses_message` pins both halves. That 6.29.2 host was not working; it was silently discarding every durable message it received. `TypeLoadMode.Auto` is the answer for that layout, which is what the exception message already says.

Two things worth knowing, both learned the hard way while building it:

- **The application-assembly inference follows whoever calls `Build()`, not whoever calls `UseWolverine`.** My first attempt registered in Module1 and built in CoreTests, inferred CoreTests, and reproduced nothing. Both halves have to live in the library.
- **`ApplicationAssembly` is pinned process-wide by the first host to start** (`RememberedApplicationAssembly`). Asserting the inferred value inside a parallel suite asserts against whatever else built a host first — it resolved to `Module1` run alone and `CoreTests` run in the full suite, and save/restore around the static is not enough because the clobbering comes from other tests running concurrently. These tests pin `RegistrationCallingAssembly` (per-options, deterministic) and set `ApplicationAssembly` explicitly to the value the inference produces.

## Verification

| Suite | Result |
|---|---|
| `CoreTests` (full) | 2772 passed |
| `Wolverine.Http.Tests` (full) | 1027 passed |
| `Wolverine.Grpc.Tests` (full) | 318 passed |
| `dotnet build wolverine.slnx -c Release -f net9.0` | clean |

`Wolverine.Http.Tests.Bugs.Bug_using_host_stop.wolverine_runtime_stops_when_host_is_{stopped,disposed}(WebApplicationBuilder)` fail in that run. Both fail identically with this change fully reverted (product files removed, new tests removed), so they are pre-existing and unrelated.

## One deliberate non-decision

The message is **uncapped** — 33 routes here, but an application with 500 routes would emit 500 lines into a log. The handler-side message added in #4151 has exactly the same shape, so this matches it rather than diverging. Capping is probably right, but it should change all three messages together, not just HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
