### PR TITLE
Note the migration hazard when adopting an ASB system queue prefix

### DIFF
--- a/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
+++ b/docs/guide/messaging/transports/azureservicebus/deadletterqueues.md
@@ -106,7 +106,9 @@ await host.StartAsync();
 ## Overriding the Default Dead Letter Queue Name <Badge type="tip" text="6.34" />
 
 `wolverine-dead-letter-queue` is fine for a single application, but it carries no service name at all, so several
-applications sharing one Azure Service Bus namespace all dead letter into the same queue. Rather than repeating
+applications sharing one Azure Service Bus namespace all dead letter into the same queue. If those applications also
+have dead letter queue recovery turned on, whichever one drains a given message first records it in *its* durable
+storage — so a failure belonging to one service ends up filed against another. Rather than repeating
 `ConfigureDeadLetterQueue(...)` on every endpoint, override the default for the whole transport in one call — this is
 the Azure Service Bus counterpart of RabbitMQ's `CustomizeDeadLetterQueueing()` and of SQS's method of the same name:
 

--- a/docs/guide/messaging/transports/azureservicebus/index.md
+++ b/docs/guide/messaging/transports/azureservicebus/index.md
@@ -264,6 +264,30 @@ A dead letter queue that you name yourself is taken as fully qualified and is ne
 [`DefaultDeadLetterQueueName("x")`](/guide/messaging/transports/azureservicebus/deadletterqueues#overriding-the-default-dead-letter-queue-name)
 across the transport.
 
+::: warning Adopting a prefix in an existing application orphans the queues you already have
+A prefix changes the names Wolverine uses, so an application that has been running without one starts using four new
+queues and stops using the four it had.
+
+Three of those are self-healing and need nothing from you. The control queue carries `AutoDeleteOnIdle`, so Azure
+reaps the old one within minutes, and the response and retry queues hold no lasting state.
+
+The **dead letter queue is the exception**, because it is the one that holds messages somebody wanted. Whatever is
+sitting in `wolverine-dead-letter-queue` stays there, and nothing points at it any more — if you are using
+[dead letter queue recovery](/guide/messaging/transports/azureservicebus/deadletterqueues), the recovery listener
+resolves its sources from the names that resolve *now*, so those older dead letters stop being drained into durable
+storage and disappear from your monitoring.
+
+Before you adopt a prefix in an application that is already running, do one of these:
+
+* let the existing dead letter queue drain first, so there is nothing to strand; or
+* keep pointing at it by name with
+  [`DefaultDeadLetterQueueName("wolverine-dead-letter-queue")`](/guide/messaging/transports/azureservicebus/deadletterqueues#overriding-the-default-dead-letter-queue-name),
+  which is taken as fully qualified and is never prefixed. The control, response, and retry queues still get the
+  prefix, which is where the collisions actually are.
+
+None of this applies to a new application, or to one that has never enabled dead letter queue recovery.
+:::
+
 Order does not matter with respect to `EnableWolverineControlQueues()`. The control queue has to be built eagerly at
 configuration time, because Wolverine's message stores and node agent read it long before the transports initialize, so
 calling `SystemQueuePrefix()` afterwards rebuilds the control queue under the prefixed name and discards the unprefixed


### PR DESCRIPTION
Follow-up to #4263. Docs only — no code, no snippet changes.

#4263's documentation is thorough: the `PrefixIdentifiers()` distinction, the never-prefixed explicit dead letter queue names, and the `EnableWolverineControlQueues()` ordering are all covered well. One thing isn't, and it is the thing a reader finds out afterwards.

## Adopting a prefix in a running application orphans the queues it already has

Renaming means four new queues and four abandoned ones. Three are self-healing and need nothing from the reader — the control queue carries `AutoDeleteOnIdle` so Azure reaps it within minutes, and the response and retry queues hold no lasting state.

The **dead letter queue is the exception**, and it is the one holding messages somebody wanted. Whatever is sitting in `wolverine-dead-letter-queue` stays there with nothing pointing at it, and the recovery listener resolves its sources from the names that resolve *now* — so those older dead letters silently stop reaching durable storage and drop out of monitoring.

That is inherent to renaming rather than a defect in #4263, which is exactly why it belongs in the docs. The new warning gives the two ways through it:

* let the existing dead letter queue drain first; or
* keep pointing at it with `DefaultDeadLetterQueueName("wolverine-dead-letter-queue")`, which is taken as fully qualified and never prefixed — so the control, response and retry queues still get isolated, which is where the collisions actually are.

It also says plainly that none of this applies to a new application, or to one that never enabled recovery, so nobody is scared off the feature unnecessarily.

## Sharpens the dead letter page

That page already said several applications sharing a namespace "all dead letter into the same queue". With recovery enabled the consequence is worse than sharing: whichever application drains a given message first records it in *its* durable storage, so a failure belonging to one service is filed against another — and shows up in the wrong service's monitoring. Two sentences, same section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
