### PR TITLE
MySQL leadership stacked its own named lock until failover was impossible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@
   spurious stepdown. Every close is additionally bounded and abandoned on timeout, so a connection that
   somehow still desyncs costs seconds rather than the process.
 
+- **MySQL leadership no longer stacks its own named lock until failover is impossible.** MySQL named
+  locks stack -- `GET_LOCK` on a name the session already holds succeeds and increments that session's
+  hold count, and the manual is explicit that a lock obtained a second time must be released twice.
+  `MySqlAdvisoryLock.TryAttainLockAsync` was the only one of the five implementations without an
+  "already holds this lock" short-circuit: Postgres, SQL Server and SQLite all return early, MySQL went
+  straight to `GET_LOCK`.
+
+  Since `a84d6a262`, `NodeAgentController.DoHealthChecksInternalAsync` calls
+  `TryAttainLeadershipLockAsync` on *every* tick, including ticks where this node is already the
+  leader. So the leader's hold count grew by one per heartbeat, while the single
+  `ReleaseLeadershipLockAsync` during `stepDownAsync` / `DisableAgentsAsync` called `RELEASE_LOCK` once
+  and removed one duplicate id -- leaving the lock held server-side, and `_locks` non-empty, so the
+  connection was never closed either. A would-be new leader could then never attain, and the election
+  stalled with nothing logged. `MySqlTests.LeaderElection` was red on `main` for exactly this:
+  `take_over_leader_ship_if_leader_becomes_stale` and its racing-nodes twin both failed.
+
+  `TryAttainLockAsync` is now idempotent against a lock this session already holds, matching the
+  Postgres and SQL Server behaviour it had been missing.
 
 - **Node record descriptions no longer overflow the column and fail the insert.** (closes
   [#4246](https://github.com/JasperFx/wolverine/issues/4246)) An `AssignmentChanged` record's

--- a/src/Persistence/MySql/MySqlTests/Bug_advisory_lock_stacking_blocks_failover.cs
+++ b/src/Persistence/MySql/MySqlTests/Bug_advisory_lock_stacking_blocks_failover.cs
@@ -1,0 +1,81 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Shouldly;
+using Wolverine.MySql;
+
+namespace MySqlTests;
+
+/// <summary>
+/// MySQL companion to <c>Bug_advisory_lock_stacking_blocks_failover</c> in
+/// PostgresqlTests and SqlServerTests. MySQL named locks stack: calling
+/// <c>GET_LOCK</c> on a name the session already holds succeeds and
+/// increments that session's hold count, and the docs are explicit that
+/// "if a lock is obtained a second time, it must be released twice."
+/// Probed against the mysql:8.0 image this repo's docker-compose runs —
+/// three <c>GET_LOCK</c> calls followed by one <c>RELEASE_LOCK</c> leave
+/// <c>IS_FREE_LOCK</c> reporting 0.
+///
+/// The heartbeat-renewal change in <c>a84d6a262</c> calls
+/// <c>TryAttainLeadershipLockAsync</c> on every tick, including ticks where
+/// this node is already the leader, so the leader's hold count grows by one
+/// per heartbeat. The single <c>ReleaseLeadershipLockAsync</c> call during
+/// <c>DisableAgentsAsync</c> / <c>stepDownAsync</c> only decrements once,
+/// leaving the lock held server-side — and <c>_locks</c> non-empty, so the
+/// connection is never closed either. A would-be new leader can then never
+/// attain, which is
+/// <c>leader_election.take_over_leader_ship_if_leader_becomes_stale</c>
+/// failing. The fix makes
+/// <see cref="MySqlAdvisoryLock.TryAttainLockAsync"/> idempotent against
+/// re-entrant calls on a still-held lock.
+/// </summary>
+public class Bug_advisory_lock_stacking_blocks_failover
+{
+    [Fact]
+    public async Task repeated_TryAttainLockAsync_does_not_stack_so_one_release_actually_releases()
+    {
+        const int lockId = unchecked((int)0xDEADBEEF);
+
+        await using var source = new MySqlDataSourceBuilder(Servers.MySqlConnectionString).Build();
+
+        var holder = new MySqlAdvisoryLock(source, NullLogger.Instance, "stacking-test");
+        try
+        {
+            // Simulate ten heartbeat ticks on the same leader: every
+            // DoHealthChecksAsync now calls TryAttainLeadershipLockAsync.
+            // Pre-fix this stacked the MySQL named lock ten times.
+            for (var i = 0; i < 10; i++)
+            {
+                (await holder.TryAttainLockAsync(lockId, CancellationToken.None))
+                    .ShouldBeTrue($"holder must still report success on tick {i}");
+            }
+
+            holder.HasLock(lockId).ShouldBeTrue();
+
+            // The leader steps down or is disabled — exactly ONE release
+            // call, matching DisableAgentsAsync / stepDownAsync semantics.
+            await holder.ReleaseLockAsync(lockId);
+
+            // A would-be new leader on a different connection tries to
+            // attain. Pre-fix this returned false because the holder's
+            // session still held nine stacked locks; post-fix it succeeds.
+            var contender = new MySqlAdvisoryLock(source, NullLogger.Instance, "contender");
+            try
+            {
+                (await contender.TryAttainLockAsync(lockId, CancellationToken.None))
+                    .ShouldBeTrue(
+                        "A single ReleaseLockAsync after repeated TryAttainLockAsync calls on the same session " +
+                        "must fully release the MySQL named lock so a different node can take over.");
+            }
+            finally
+            {
+                await contender.ReleaseLockAsync(lockId);
+                await contender.DisposeAsync();
+            }
+        }
+        finally
+        {
+            await holder.DisposeAsync();
+        }
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlAdvisoryLock.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlAdvisoryLock.cs
@@ -155,6 +155,24 @@ internal class MySqlAdvisoryLock : IAdvisoryLock
 
         try
         {
+            // Idempotent against repeated calls on the same session. MySQL named locks stack:
+            // GET_LOCK on a name this session already holds succeeds and increments the session's
+            // hold count, and the docs are explicit that "if a lock is obtained a second time, it
+            // must be released twice." The a84d6a262 heartbeat-renewal change calls
+            // TryAttainLeadershipLockAsync every tick — including ticks where the leader already
+            // holds the lock — so without this short-circuit the leader's hold count grows by one
+            // per heartbeat. The single ReleaseLeadershipLockAsync call during DisableAgentsAsync
+            // or stepDownAsync then only decrements once, leaving the lock still held server-side
+            // and _locks non-empty, so the connection is never closed either. Failover stalls
+            // silently: no error logged, just an election a new leader can never win.
+            //
+            // GH-4261: hasLockUnsafe, not HasLock — we already hold the gate, and SemaphoreSlim is
+            // not reentrant.
+            if (hasLockUnsafe(lockId))
+            {
+                return true;
+            }
+
             if (_conn == null)
             {
                 _conn = _source.CreateConnection();


### PR DESCRIPTION
`MySqlTests.LeaderElection` was **red on `main`** — 13/15, with
`take_over_leader_ship_if_leader_becomes_stale` and its racing-nodes twin both failing,
reproducible on a pristine checkout. This is the fix.

## The mechanism

MySQL named locks **stack**. `GET_LOCK` on a name the session already holds succeeds and
increments that session's hold count, and the manual is explicit that a lock obtained a
second time must be released twice. Probed against the `mysql:8.0` image docker-compose
runs, rather than inferred:

```
get1 1   get2 1   get3 1
release_once 1  ->  is_free_after_one_release  0
release2 1      ->  is_free_after_two          0
release3 1      ->  is_free_after_three        1
```

`MySqlAdvisoryLock.TryAttainLockAsync` was the only one of the five implementations with
no "already holds this lock" short-circuit. Postgres, SQL Server and SQLite all return
early; MySQL went straight to `GET_LOCK`.

Since `a84d6a262`, `NodeAgentController.DoHealthChecksInternalAsync` calls
`TryAttainLeadershipLockAsync` on *every* tick, including ticks where this node is already
the leader. So the leader's hold count grew by one per heartbeat, while the single
`ReleaseLeadershipLockAsync` during `stepDownAsync` / `DisableAgentsAsync` called
`RELEASE_LOCK` once and removed one duplicate id — leaving the lock held server-side, and
`_locks` non-empty, so the connection was never closed either. A would-be new leader could
then never attain, and the election stalled with nothing logged.

## The fix

One short-circuit, the same shape #4266 gave SQLite and SQL Server. It sits **inside** the
GH-4261 gate and calls `hasLockUnsafe`, not `HasLock` — `SemaphoreSlim` is not reentrant,
so the public method would deadlock against the gate its caller already holds.

Plus a MySQL twin of `Bug_advisory_lock_stacking_blocks_failover`, alongside the existing
Postgres and SQL Server ones.

## Verification

| Check | Before | After |
|---|---|---|
| `MySqlTests.LeaderElection` | 13/15 | **15/15**, two consecutive runs |
| `MySqlTests` (full) | — | 185/185 |
| New stacking twin | FAIL 138ms | PASS 105ms |
| `wolverine.slnx -c Release -f net9.0` | — | 0 warnings, 0 errors |

Rebased onto `main` after #4266 merged, and re-verified there rather than on the
pre-merge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)