### PR TITLE
GH-4273: FindForTenantAsync answers for a single-database deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### WolverineFx (core)
 
+- **`FindForTenantAsync` answers for a single-database deployment.** (closes
+  [#4273](https://github.com/JasperFx/wolverine/issues/4273)) The method became public API in #4268 without
+  the `_onlyOneDatabase` guard that `FindAllAsync` and `FindDatabasesAsync` both open with, so on a
+  single-database deployment it returned an **empty list for every tenant** rather than the store that
+  actually holds their data. That is the shape of Marten *conjoined* tenancy -- one database, a `tenant_id`
+  column -- because Marten only builds a `MultiTenantedMessageStore` for master-table tenancy, leaving
+  `_multiTenanted` empty. The failure was silent: the method exists so a caller can query one tenant's dead
+  letters without hydrating every message body, and an empty list reads as "this tenant is clean" while its
+  dead letter table is full. Multi-tenanted collections still resolve through the tenancy source unchanged.
+
+
 - **Concurrent callers share one tenant database list refresh.** (closes
   [#4267](https://github.com/JasperFx/wolverine/issues/4267)) `MessageStoreCollection.FindAllAsync()`
   re-enumerated a `DynamicMultiple` tenancy source on every call, and it sits on paths that are *retried on

--- a/src/Testing/CoreTests/Persistence/finding_stores_for_one_tenant.cs
+++ b/src/Testing/CoreTests/Persistence/finding_stores_for_one_tenant.cs
@@ -1,0 +1,82 @@
+using CoreTests.Runtime;
+using JasperFx.Descriptors;
+using NSubstitute;
+using Shouldly;
+using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.Persistence;
+
+/// <summary>
+/// GH-4273. <see cref="MessageStoreCollection.FindForTenantAsync" /> became public API in #4268 without the
+/// <c>_onlyOneDatabase</c> guard that every sibling lookup in the class opens with, so on a single-database
+/// deployment it returned an EMPTY list for every tenant rather than the store holding their data.
+///
+/// <para>That is not an exotic configuration: <c>_onlyOneDatabase</c> is set whenever there is one store and
+/// no <c>MultiTenantedMessageStore</c>, which is the shape of Marten <em>conjoined</em> tenancy -- one
+/// database, a tenant_id column. Marten only builds a MultiTenantedMessageStore for master-table tenancy, so
+/// a conjoined store falls through to a plain message store and <c>_multiTenanted</c> is empty.</para>
+///
+/// <para>The damage was silent. The method exists so a caller can query one tenant's dead letters without
+/// hydrating every message body; an empty list reads as "this tenant has none" while its dead letter table
+/// is full.</para>
+/// </summary>
+public class finding_stores_for_one_tenant
+{
+    private readonly MockWolverineRuntime theRuntime = new();
+
+    private static IMessageStore aStore(string uri, MessageStoreRole role = MessageStoreRole.Main)
+    {
+        var store = Substitute.For<IMessageStore>();
+        store.Uri.Returns(new Uri(uri));
+        store.Role.Returns(role);
+        return store;
+    }
+
+    [Fact]
+    public async Task a_single_database_deployment_answers_with_the_main_store()
+    {
+        // One store, nothing multi-tenanted -- conjoined tenancy, or simply a single-database application.
+        var main = aStore("wolverinedb://fake/main");
+        var collection = new MessageStoreCollection(theRuntime, [main], []);
+
+        var stores = await collection.FindForTenantAsync("acme");
+
+        stores.Select(x => x.Uri).ShouldBe([main.Uri]);
+    }
+
+    [Fact]
+    public async Task the_answer_does_not_depend_on_which_tenant_is_asked_for()
+    {
+        // Every tenant lives in the one database, so every tenant resolves to it -- including one this
+        // process has never seen, which is the case the empty list was most misleading for.
+        var main = aStore("wolverinedb://fake/main");
+        var collection = new MessageStoreCollection(theRuntime, [main], []);
+
+        (await collection.FindForTenantAsync("acme")).ShouldHaveSingleItem();
+        (await collection.FindForTenantAsync("never-seen-before")).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task a_tenanted_deployment_still_resolves_through_the_source()
+    {
+        // The guard must not short-circuit a genuinely multi-tenanted collection: this is the path the
+        // method was written for, and it has to keep working.
+        var source = Substitute.For<ITenantedMessageSource>();
+        source.Cardinality.Returns(DatabaseCardinality.DynamicMultiple);
+        source.AllActive().Returns(Array.Empty<IMessageStore>());
+
+        var tenantStore = aStore("wolverinedb://fake/acme", MessageStoreRole.Ancillary);
+        source.FindAsync("acme").Returns(tenantStore);
+
+        var main = aStore("wolverinedb://fake/main");
+        var multiTenanted = new MultiTenantedMessageStore(main, theRuntime, source);
+        var collection = new MessageStoreCollection(theRuntime, [multiTenanted], []);
+
+        var stores = await collection.FindForTenantAsync("acme");
+
+        stores.Select(x => x.Uri).ShouldBe([tenantStore.Uri]);
+        await source.Received(1).FindAsync("acme");
+    }
+}

--- a/src/Wolverine/Persistence/MessageStoreCollection.cs
+++ b/src/Wolverine/Persistence/MessageStoreCollection.cs
@@ -289,12 +289,24 @@ public class MessageStoreCollection : IAgentFamily, IAsyncDisposable
     /// modular monolith can have a tenanted ancillary store alongside the main one.
     /// </summary>
     /// <remarks>
+    /// On a single-database deployment -- including conjoined tenancy, where every tenant shares one
+    /// database -- this is the main store, exactly as <see cref="FindAllAsync()" /> and
+    /// <see cref="FindDatabasesAsync" /> answer for that case.
+    ///
     /// The tenant-aware counterpart to <see cref="FindDatabaseAsync" />. Callers that want to work against
     /// one tenant's storage directly -- querying its dead letters without hydrating every message body, say
     /// -- would otherwise have to walk <see cref="MultiTenanted" /> and resolve the tenant by hand.
     /// </remarks>
     public async ValueTask<IReadOnlyList<IMessageStore>> FindForTenantAsync(string tenantId)
     {
+        // GH-4273. The same guard FindAllAsync and FindDatabasesAsync open with. Without it this returns an
+        // EMPTY list for every tenant on a single-database deployment -- which is exactly the shape of
+        // conjoined tenancy, where every tenant lives in one database behind a tenant_id column and
+        // _multiTenanted is therefore empty. A caller asking for one tenant's storage got nothing back and
+        // no error: for the dead letter query this method exists to serve, that reads as "this tenant is
+        // clean" while its dead letter table is full.
+        if (_onlyOneDatabase) return [Main];
+
         var list = new List<IMessageStore>();
 
         foreach (var tenantedMessageStore in _multiTenanted)


### PR DESCRIPTION
Closes #4273.

## The bug

`MessageStoreCollection.FindForTenantAsync` became public API in #4268 without the `_onlyOneDatabase` guard that `FindAllAsync` and `FindDatabasesAsync` both open with, so on a single-database deployment it returns an **empty list for every tenant** rather than the store that actually holds their data.

That is not an exotic configuration. `_onlyOneDatabase` is set whenever there is one store and no `MultiTenantedMessageStore` — exactly the shape of Marten **conjoined** tenancy, one database with a `tenant_id` column, because Marten only builds a `MultiTenantedMessageStore` for master-table tenancy (`WolverineOptionsMartenExtensions.cs:284`) and a conjoined store falls through to a plain message store (`:304`). `_multiTenanted` is empty, the `foreach` never runs, and the method returns `[]`.

The failure is silent, which is what makes it worth fixing rather than documenting. The method exists so a caller can query one tenant's dead letters without hydrating every message body — and an empty list reads as *"this tenant is clean"* while its dead letter table is full.

Its own doc comment promised the opposite: *"Find every message store that could hold data for one tenant. There is normally exactly one."*

## Not a regression

`findStoresAsync` behaved this way before #4268 extracted it, so the internal dead-letter-by-tenant path had the same hole. What changed is that the behaviour became **public, documented API**. The remark now states what happens for a single database instead of leaving the reader to discover it.

## Tests

Three, in `CoreTests.Persistence.finding_stores_for_one_tenant`:

* `a_single_database_deployment_answers_with_the_main_store` — **fails without the guard**
* `the_answer_does_not_depend_on_which_tenant_is_asked_for` — **fails without the guard**; covers a tenant this process has never seen, which is the case the empty list was most misleading for
* `a_tenanted_deployment_still_resolves_through_the_source` — passes either way by design. It pins that the guard cannot short-circuit a genuinely multi-tenanted collection, which is the path the method was written for.

## Verification

Under Bobcat supervision, `./build.sh CIPersistence`:

* `PersistenceTests`: **109 passed**, 0 retries
* `PostgresqlTests`: **544 passed**, 0 retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
