### PR TITLE
GH-4275: a sitting Oracle leader stops standing down on every tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,24 @@
 
 ### WolverineFx.Oracle
 
+- **A sitting Oracle leader stops standing down on every tick.** (closes
+  [#4275](https://github.com/JasperFx/wolverine/issues/4275)) Since the heartbeat-renewal change in
+  `a84d6a262`, `NodeAgentController` calls `TryAttainLeadershipLockAsync` on every health-check tick,
+  including ticks where this node is already the leader. Oracle holds its row lock in an *uncommitted*
+  transaction on a dedicated connection -- that is how the lock is held -- so the renewal opened a second
+  connection whose `SELECT ... FOR UPDATE NOWAIT` was blocked by the node's own first transaction and raised
+  `ORA-00054`. The renewal answered `false` for a lock the node holds, and a false renewal is how the
+  controller is told leadership was lost, so it called `stepDownAsync` on the very next tick after being
+  elected -- and never reached `EvaluateAssignmentsAsync`, which sits on the `true` branch, so the leader's
+  actual work of evaluating agent assignments never ran.
+
+  `TryAttainLockAsync` now short-circuits on a lock this node already holds, the same way Postgres, SQL
+  Server and SQLite already did. It still pings the retained connection, so a session that really did die is
+  detected exactly as before (GH-2602). The existing leadership compliance suite could not have caught this:
+  every one of its tests is about a *transition*, and a node that steps down re-attains immediately as the
+  only candidate, leaving the end state they assert on untouched.
+
+
 - **A failed attempt on the advisory lock gives its connection back.** `OracleAdvisoryLock` is the one
   implementation that opens a connection per lock rather than keeping a single shared one, and
   `TryAttainLockAsync` only released that connection on two of its exits: success, where the connection

--- a/src/Persistence/Oracle/OracleTests/Agents/Bug_4275_leadership_renewal_is_reentrant.cs
+++ b/src/Persistence/Oracle/OracleTests/Agents/Bug_4275_leadership_renewal_is_reentrant.cs
@@ -1,0 +1,126 @@
+using IntegrationTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+
+namespace OracleTests.Agents;
+
+/// <summary>
+/// GH-4275. The Oracle counterpart of <c>Bug_advisory_lock_stacking_blocks_failover</c>: since the
+/// heartbeat-renewal change in <c>a84d6a262</c>, <c>NodeAgentController.DoHealthChecksInternalAsync</c>
+/// calls <c>TryAttainLeadershipLockAsync</c> on EVERY tick, including ticks where this node is already the
+/// leader.
+///
+/// <para>Oracle holds its row lock in an uncommitted transaction on a dedicated connection — that is how the
+/// lock is held — so the renewal used to open a SECOND connection whose <c>SELECT ... FOR UPDATE NOWAIT</c>
+/// was blocked by this node's own first transaction and raised ORA-00054. The renewal answered
+/// <c>false</c> for a lock the node holds, and the controller reads a false renewal as lost leadership:</para>
+///
+/// <code>
+/// if (IsLeader)
+/// {
+///     await stepDownAsync("the leadership advisory lock could not be renewed");
+/// }
+/// </code>
+///
+/// <para>So a sitting Oracle leader stepped down on the very next tick after being elected, every tick — and
+/// never reached <c>EvaluateAssignmentsAsync</c>, which is only on the <c>true</c> branch, so the leader's
+/// actual work of evaluating agent assignments did not run at all.</para>
+///
+/// <para>The existing leadership compliance suite could not catch this: every one of its tests is about a
+/// TRANSITION — becoming leader, switchover, ejecting a stale node — and none assert that a leader stays
+/// leader across repeated health-check ticks. A node that steps down also usually re-attains immediately,
+/// being the only candidate, so the churn leaves the end state those tests assert on untouched.</para>
+/// </summary>
+public class Bug_4275_leadership_renewal_is_reentrant : OracleContext
+{
+    // A lock id PER TEST. Oracle holds the row lock in an uncommitted transaction, so it is only freed
+    // once the holder's rollback and close have completed -- sharing one id across two tests in this
+    // collection let the second test's first attain race the first test's teardown and hit ORA-00054.
+    // Bobcat caught that as a flaky pass-on-retry rather than a failure.
+    private const int RenewalLockId = unchecked((int)0xB0BCB0);
+    private const int ReleaseLockId = unchecked((int)0xB0BCB1);
+    private const string SchemaName = "WOLVERINE";
+
+    [Fact]
+    public async Task the_renewal_reports_the_lock_still_held()
+    {
+        await using var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        await migrateAsync(dataSource);
+
+        var advisoryLock = new OracleAdvisoryLock(dataSource, NullLogger.Instance, SchemaName);
+
+        try
+        {
+            (await advisoryLock.TryAttainLockAsync(RenewalLockId, CancellationToken.None))
+                .ShouldBeTrue("the first attain elects this node");
+
+            // Ten heartbeat ticks on the same leader. Every one of these used to answer false, and every
+            // false is a stepDownAsync.
+            for (var tick = 0; tick < 10; tick++)
+            {
+                (await advisoryLock.TryAttainLockAsync(RenewalLockId, CancellationToken.None))
+                    .ShouldBeTrue($"the renewal on tick {tick} must report the lock still held");
+
+                advisoryLock.HasLock(RenewalLockId).ShouldBeTrue($"and the lock is still held on tick {tick}");
+            }
+        }
+        finally
+        {
+            await advisoryLock.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task one_release_after_many_renewals_actually_releases()
+    {
+        // The other half, and the reason the short-circuit is the right shape rather than swallowing
+        // ORA-00054: renewals must not accumulate anything a single release cannot undo. A contender has
+        // to be able to take the lock after exactly one ReleaseLockAsync, which is what stepDownAsync and
+        // DisableAgentsAsync issue.
+        await using var dataSource = new OracleDataSource(Servers.OracleConnectionString);
+        await migrateAsync(dataSource);
+
+        var holder = new OracleAdvisoryLock(dataSource, NullLogger.Instance, SchemaName);
+        (await holder.TryAttainLockAsync(ReleaseLockId, CancellationToken.None)).ShouldBeTrue();
+
+        for (var tick = 0; tick < 10; tick++)
+        {
+            await holder.TryAttainLockAsync(ReleaseLockId, CancellationToken.None);
+        }
+
+        await holder.ReleaseLockAsync(ReleaseLockId);
+
+        var contender = new OracleAdvisoryLock(dataSource, NullLogger.Instance, SchemaName);
+        try
+        {
+            (await contender.TryAttainLockAsync(ReleaseLockId, CancellationToken.None))
+                .ShouldBeTrue("a single release after repeated renewals has to free the lock for a new leader");
+        }
+        finally
+        {
+            await contender.DisposeAsync();
+            await holder.DisposeAsync();
+        }
+    }
+
+    private static async Task migrateAsync(OracleDataSource dataSource)
+    {
+        var settings = new DatabaseSettings
+        {
+            ConnectionString = Servers.OracleConnectionString,
+            SchemaName = SchemaName,
+            Role = MessageStoreRole.Main
+        };
+
+        await using var store = new OracleMessageStore(settings, new DurabilitySettings(), dataSource,
+            NullLogger<OracleMessageStore>.Instance, Array.Empty<SagaTableDefinition>());
+
+        await store.Admin.MigrateAsync();
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleAdvisoryLock.cs
@@ -187,6 +187,24 @@ internal class OracleAdvisoryLock : IAdvisoryLock
 
         try
         {
+            // GH-4275. Idempotent against the renewal the heartbeat drives on every tick. Oracle holds its
+            // row lock in an UNCOMMITTED transaction on a dedicated connection -- that is how the lock is
+            // held -- so without this short-circuit the next attain opens a SECOND connection whose
+            // SELECT ... FOR UPDATE NOWAIT is blocked by this node's OWN first transaction and raises
+            // ORA-00054. TryAttainLeadershipLockAsync answered false for a lock this node holds, and
+            // NodeAgentController reads that as lost leadership: a sitting Oracle leader called
+            // stepDownAsync on the very next tick after being elected, every tick, and never reached
+            // EvaluateAssignmentsAsync -- which is only on the true branch.
+            //
+            // hasLockUnsafe, not HasLock: we already hold _gate and SemaphoreSlim is not reentrant. It
+            // pings the retained connection, so this still distinguishes "we hold it" from "our session
+            // died and the row lock evaporated", which is the GH-2602 property that has to survive.
+            // Postgres, SQL Server and SQLite all open with the same short-circuit.
+            if (hasLockUnsafe(lockId))
+            {
+                return true;
+            }
+
             conn = await _source.OpenConnectionAsync(token);
 
             // Ensure lock row exists


### PR DESCRIPTION
Closes #4275.

## The bug

Since the heartbeat-renewal change in `a84d6a262`, `NodeAgentController.DoHealthChecksInternalAsync` calls `TryAttainLeadershipLockAsync` on **every** health-check tick, including ticks where this node is already the leader.

Oracle holds its row lock in an **uncommitted transaction on a dedicated connection** — that is how the lock is held. So the renewal opened a *second* connection whose `SELECT ... FOR UPDATE NOWAIT` was blocked by the node's **own** first transaction and raised `ORA-00054`. The renewal answered `false` for a lock the node holds, and a false renewal is how the controller is told leadership was lost:

```csharp
if (IsLeader)
{
    await stepDownAsync("the leadership advisory lock could not be renewed");
}
```

A sitting Oracle leader therefore stepped down on the very next tick after being elected — every tick. And because `EvaluateAssignmentsAsync` sits on the `true` branch, the leader's actual work of evaluating and rebalancing agent assignments never ran at all.

Verified by probe before any code was written:

```
first=True  hasAfterFirst=True  second=False  hasAfterSecond=True  third=False
```

`HasLock` keeps answering `true` throughout, because it pings the connection retained by the first attain. That is why the earlier `IsLeader && !HasLeadershipLock()` guard never fires and the *renewal* is what reports the loss.

## The fix

`TryAttainLockAsync` short-circuits on a lock this node already holds, the way Postgres, SQL Server and SQLite already do — Oracle and MySQL were the only two without it. It calls `hasLockUnsafe`, not `HasLock`, because `_gate` is already held and `SemaphoreSlim` is not reentrant, and it still pings the retained connection so a session that really did die is detected exactly as before (GH-2602).

## Why the existing suite didn't catch it

Worth stating, because it says what test was actually missing. Every test in `LeadershipElectionCompliance` is about a **transition** — becoming leader, switchover, ejecting a stale node. None assert that a leader *stays* leader across repeated ticks. A node that steps down also re-attains immediately as the only candidate, so the churn leaves the end state those tests assert on untouched.

The two new tests assert the renewal itself, and that one release after many renewals still frees the lock for a contender — the property that makes the short-circuit the right shape rather than swallowing `ORA-00054`. The renewal test fails on tick 0 without the fix.

## Bobcat supervision earned its keep

The first `./build.sh CIOracle` run flagged my **own new test** as `[FLAKY] — passed on attempt 2`, along with five neighbouring `exclusive_listener_recovery_compliance` tests. Raw `dotnet test` would have shown six green ticks.

Both new tests had shared one lock id, so the second test's first attain raced the first test's teardown — an Oracle row lock is only freed once the holder's rollback and close complete — and the uncommitted transaction destabilised anything else touching that schema. A lock id per test fixed all six.

Final: `./build.sh CIOracle` → **168 passed, 0 retries, no flaky tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
