### PR TITLE
GH-4282: a configurable prefix for the queues SQS names for itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,30 @@
   six attains against a pool of three: unfixed, it spends fifteen seconds queueing on an empty pool;
   fixed, it finishes in well under one.
 
+### WolverineFx.AmazonSqs
+
+- **A configurable prefix for the queues SQS names for itself.** (closes
+  [#4282](https://github.com/JasperFx/wolverine/issues/4282)) The node control queue was composed as
+  `wolverine.control.{node}` with no service name in it, and the default dead letter queue is
+  `wolverine-dead-letter-queue`, so two unrelated applications sharing one AWS account and region -- both
+  running as node 1 -- claimed the same queues. For the dead letter queue that is damaging rather than
+  untidy: `SqsDeadLetterQueueListener` drains broker-side dead letters into the Wolverine message store, so
+  whichever application won the race recorded another service's failure in *its* store, against the wrong
+  service, in the wrong database.
+
+  `SystemQueuePrefix("my-project")` prepends a prefix, joined with the SQS identifier delimiter (`-`), to
+  the response queue, the node control queue, and the default dead letter queue. Without a prefix -- the
+  default -- every name is byte for byte what it has always been. A dead letter queue you name yourself,
+  through either `ConfigureDeadLetterQueue(...)` or `DefaultDeadLetterQueueName(...)`, is taken as fully
+  qualified and is never prefixed.
+
+  Distinct from `PrefixIdentifiers()`, which renames the *application* queues and deliberately leaves the
+  system queues alone -- cooperating applications that message each other cannot rename those. The two
+  compose. `DefaultDeadLetterQueueName` now resolves on read rather than being assigned in the constructor,
+  so bootstrap call order does not matter; and calling `SystemQueuePrefix()` after
+  `EnableWolverineControlQueues()` rebuilds the control queue under the prefixed name, since that queue has
+  to be built eagerly for `NodeControlEndpoint`.
+
 ### WolverineFx.Http
 
 - **A Static-mode endpoint type mismatch is now reported as itself.** (closes

--- a/src/Transports/AWS/Wolverine.AmazonSqs.Tests/system_queue_prefix.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs.Tests/system_queue_prefix.cs
@@ -1,0 +1,121 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.AmazonSqs.Internal;
+using Wolverine.Runtime;
+using Xunit;
+
+namespace Wolverine.AmazonSqs.Tests;
+
+/// <summary>
+/// GH-4282, the Amazon SQS counterpart of #4263. The node control queue is composed as
+/// <c>"wolverine.control." + node</c> with no service name in it, so two unrelated Wolverine applications
+/// sharing one AWS account and region — both running as node 1 — both claim the same queue. The default dead
+/// letter queue has the same problem, and there it is damaging rather than untidy: <c>SqsDeadLetterQueueListener</c>
+/// drains broker-side dead letters into the Wolverine message store, so whichever application wins the race
+/// records another service's failure in <em>its</em> store.
+///
+/// <para>The response queue was already safe — SQS puts the service name in it — and stays that way.</para>
+/// </summary>
+public class system_queue_prefix
+{
+    private static AmazonSqsTransport transportFor(Action<AmazonSqsTransportConfiguration> configure)
+    {
+        var options = new WolverineOptions { ServiceName = "Orders" };
+        var configuration = options.UseAmazonSqsTransportLocally();
+        configure(configuration);
+
+        return options.Transports.GetOrCreate<AmazonSqsTransport>();
+    }
+
+    [Fact]
+    public void without_a_prefix_every_name_is_unchanged()
+    {
+        // The whole safety property: an application that does not opt in must see byte-for-byte the names
+        // it has always seen.
+        var transport = transportFor(_ => { });
+
+        transport.PrefixSystemQueueName("wolverine.control.1").ShouldBe("wolverine.control.1");
+        transport.DefaultDeadLetterQueueName.ShouldBe(AmazonSqsTransport.DeadLetterQueueName);
+    }
+
+    [Fact]
+    public void the_prefix_joins_with_the_sqs_identifier_delimiter()
+    {
+        // '-', not '.', because that is what SQS names allow and what IdentifierDelimiter already says.
+        var transport = transportFor(x => x.SystemQueuePrefix("my-project"));
+
+        transport.PrefixSystemQueueName("wolverine.control.1").ShouldBe("my-project-wolverine.control.1");
+    }
+
+    [Fact]
+    public void the_default_dead_letter_queue_picks_up_the_prefix()
+    {
+        var transport = transportFor(x => x.SystemQueuePrefix("my-project"));
+
+        transport.DefaultDeadLetterQueueName
+            .ShouldBe($"my-project-{AmazonSqsTransport.DeadLetterQueueName}");
+    }
+
+    [Fact]
+    public void an_explicitly_named_default_dead_letter_queue_is_never_prefixed()
+    {
+        // A name you typed is a name you meant.
+        var transport = transportFor(x => x
+            .SystemQueuePrefix("my-project")
+            .DefaultDeadLetterQueueName("orders-errors"));
+
+        transport.DefaultDeadLetterQueueName.ShouldBe("orders-errors");
+    }
+
+    [Fact]
+    public void the_prefix_is_applied_whichever_order_the_two_calls_are_made_in()
+    {
+        // DefaultDeadLetterQueueName resolves on read, so bootstrap call order cannot matter.
+        var before = transportFor(x => x.SystemQueuePrefix("my-project").DefaultDeadLetterQueueName("errors"));
+        var after = transportFor(x => x.DefaultDeadLetterQueueName("errors").SystemQueuePrefix("my-project"));
+
+        before.DefaultDeadLetterQueueName.ShouldBe(after.DefaultDeadLetterQueueName);
+    }
+
+    [Fact]
+    public void a_prefix_set_after_the_control_queue_rebuilds_it()
+    {
+        // The control queue has to be built eagerly, because NodeControlEndpoint is read by the message
+        // stores and the node agent long before transports initialize. Calling SystemQueuePrefix()
+        // afterwards therefore has to rebuild it, and take the stale one back out so nothing provisions
+        // and listens to a queue nothing points at.
+        var options = new WolverineOptions { ServiceName = "Orders" };
+        var configuration = options.UseAmazonSqsTransportLocally();
+        configuration.EnableWolverineControlQueues();
+
+        var transport = options.Transports.GetOrCreate<AmazonSqsTransport>();
+        var unprefixed = transport.ControlQueue!.QueueName;
+
+        configuration.SystemQueuePrefix("my-project");
+
+        var prefixed = transport.ControlQueue!.QueueName;
+        prefixed.ShouldNotBe(unprefixed);
+        prefixed.ShouldStartWith("my-project-");
+
+        // The stale entry is gone, and the node control endpoint points at the new one.
+        transport.Queues.Any(x => x.QueueName == unprefixed).ShouldBeFalse();
+        options.Transports.NodeControlEndpoint!.Uri.ShouldBe(transport.ControlQueue.Uri);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void an_empty_prefix_is_refused(string prefix)
+    {
+        Should.Throw<ArgumentException>(() => transportFor(x => x.SystemQueuePrefix(prefix)));
+    }
+
+    [Fact]
+    public void a_prefix_with_no_usable_characters_is_refused()
+    {
+        // Better than silently producing a queue named "_-wolverine...".
+        Should.Throw<ArgumentException>(() => transportFor(x => x.SystemQueuePrefix("...")));
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransport.cs
@@ -24,13 +24,21 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>, IAsyncDisposa
     private const string LastActiveTagKey = "wolverine:last-active";
 
     internal readonly List<AmazonSqsQueue> SystemQueues = new();
+
+    /// <summary>
+    /// GH-4282. The node control queue built eagerly by
+    /// <see cref="AmazonSqsTransportConfiguration.EnableWolverineControlQueues" />, tracked here rather than
+    /// on the configuration object because one transport can be reached through more than one
+    /// configuration instance. Kept so a later <c>SystemQueuePrefix()</c> call can rebuild it under the
+    /// prefixed name.
+    /// </summary>
+    internal AmazonSqsQueue? ControlQueue { get; set; }
     private Task? _keepAliveTask;
 
     public AmazonSqsTransport(string protocol) : base(protocol, "Amazon SQS", ["aws", "sqs"])
     {
         Queues = new LightweightCache<string, AmazonSqsQueue>(name => new AmazonSqsQueue(name, this));
         IdentifierDelimiter = "-";
-        DefaultDeadLetterQueueName = DeadLetterQueueName;
     }
 
     public AmazonSqsTransport() : this("sqs")
@@ -129,7 +137,41 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>, IAsyncDisposa
     /// win over this default; <c>DisableAllNativeDeadLetterQueues()</c> disables the
     /// whole DLQ surface regardless of what's configured here.
     /// </summary>
-    public string? DefaultDeadLetterQueueName { get; set; }
+    private string? _defaultDeadLetterQueueName;
+
+    public string? DefaultDeadLetterQueueName
+    {
+        // GH-4282: resolved on READ rather than assigned in the constructor, so a SystemQueuePrefix set at
+        // any point during bootstrap reaches the default dead letter queue. An explicitly assigned name is
+        // taken as given and is never prefixed.
+        get => _defaultDeadLetterQueueName ?? PrefixSystemQueueName(DeadLetterQueueName);
+        set => _defaultDeadLetterQueueName = value;
+    }
+
+    /// <summary>
+    /// GH-4282. Optional prefix prepended to the names of the queues Wolverine creates for its own use --
+    /// the response queue, the node control queue, and the default dead letter queue -- so that several
+    /// unrelated applications can share one AWS account and region without colliding. Null or empty (the
+    /// default) leaves those names exactly as they have always been.
+    ///
+    /// <para>Separate from <c>PrefixIdentifiers()</c>, which renames the APPLICATION queues and
+    /// deliberately leaves the system queues alone. The two compose: this one only ever touches names
+    /// Wolverine chooses for itself.</para>
+    /// </summary>
+    public string? SystemQueuePrefix { get; set; }
+
+    /// <summary>
+    /// GH-4282. Prepend <see cref="SystemQueuePrefix" /> to a Wolverine system queue name using the SQS
+    /// identifier delimiter ('-'). Returns the name untouched when no prefix is configured, so the default
+    /// naming is byte for byte what it was before the prefix existed. The result still goes through
+    /// <see cref="SanitizeSqsName" /> at the call sites, which is what enforces the SQS character set.
+    /// </summary>
+    public string PrefixSystemQueueName(string name)
+    {
+        if (SystemQueuePrefix.IsEmpty()) return name;
+
+        return $"{SystemQueuePrefix}{IdentifierDelimiter}{name}";
+    }
 
     /// <summary>
     /// Is this transport connection allowed to build and use response and control queues
@@ -260,7 +302,7 @@ public class AmazonSqsTransport : BrokerTransport<AmazonSqsQueue>, IAsyncDisposa
             ? runtime.Options.UniqueNodeId.ToString("N")
             : runtime.DurabilitySettings.AssignedNodeNumber.ToString();
         var responseName = SanitizeSqsName(
-            $"wolverine.response.{runtime.Options.ServiceName}.{responseNode}")
+            PrefixSystemQueueName($"wolverine.response.{runtime.Options.ServiceName}.{responseNode}"))
             .ToLowerInvariant();
 
         var queue = Queues[responseName];

--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransportConfiguration.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/AmazonSqsTransportConfiguration.cs
@@ -247,6 +247,64 @@ public class AmazonSqsTransportConfiguration : BrokerExpression<AmazonSqsTranspo
     /// <returns></returns>
     public AmazonSqsTransportConfiguration EnableWolverineControlQueues()
     {
+        buildControlQueue();
+
+        return this;
+    }
+
+    /// <summary>
+    /// GH-4282. Prepend a prefix to the names of the queues Wolverine creates for its own use -- the
+    /// response queue, the node control queue, and the default dead letter queue -- so several unrelated
+    /// applications can share one AWS account and region without colliding. Without a prefix (the default)
+    /// those names are exactly what they have always been.
+    ///
+    /// <para>Only queues Wolverine names for itself are affected. A dead letter queue you name yourself,
+    /// through either <c>ConfigureDeadLetterQueue("x")</c> on an endpoint or
+    /// <see cref="DefaultDeadLetterQueueName" /> on the transport, is taken as fully qualified and is never
+    /// prefixed.</para>
+    ///
+    /// <para>This is a separate concept from <c>PrefixIdentifiers()</c>, which renames the *application*
+    /// queues and deliberately does not reach Wolverine's system queues. Use that when every application
+    /// queue should be renamed too, and this when cooperating applications must keep sharing the same
+    /// application queue names while still each owning their own control, response and dead letter
+    /// queues.</para>
+    ///
+    /// <para>Order does not matter with respect to <see cref="EnableWolverineControlQueues" />: calling
+    /// this afterwards rebuilds the control queue under the prefixed name.</para>
+    /// </summary>
+    /// <param name="prefix">The prefix. Sanitized to legal SQS name characters.</param>
+    public AmazonSqsTransportConfiguration SystemQueuePrefix(string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            throw new ArgumentException("The system queue prefix must be a non-empty value", nameof(prefix));
+        }
+
+        var sanitized = AmazonSqsTransport.SanitizeSqsName(prefix.Trim()).Trim('-', '_').ToLowerInvariant();
+        if (sanitized.IsEmpty())
+        {
+            throw new ArgumentException(
+                $"'{prefix}' does not leave any usable Amazon SQS queue name characters to use as a system queue prefix",
+                nameof(prefix));
+        }
+
+        Transport.SystemQueuePrefix = sanitized;
+
+        // The control queue is built eagerly (see below), so if it already exists under the unprefixed
+        // name, rebuild it here under the new one.
+        if (Transport.ControlQueue != null)
+        {
+            buildControlQueue();
+        }
+
+        return this;
+    }
+
+    // Built here and now rather than in tryBuildSystemEndpoints, because Options.Transports
+    // .NodeControlEndpoint is read by the message stores and the node agent before the transports ever
+    // initialize.
+    private void buildControlQueue()
+    {
         Transport.SystemQueuesEnabled = true;
 
         // Lowercase to match URI normalization (see tryBuildSystemEndpoints comment). In Solo mode the
@@ -256,8 +314,17 @@ public class AmazonSqsTransportConfiguration : BrokerExpression<AmazonSqsTranspo
             ? Options.UniqueNodeId.ToString("N")
             : Options.Durability.AssignedNodeNumber.ToString();
         var queueName = AmazonSqsTransport.SanitizeSqsName(
-            "wolverine.control." + controlNode)
+            Transport.PrefixSystemQueueName("wolverine.control." + controlNode))
             .ToLowerInvariant();
+
+        // SystemQueuePrefix() can be called after EnableWolverineControlQueues(), in which case the control
+        // queue already exists under the unprefixed name. Take it back out so the transport does not go on
+        // to provision and listen to a queue nothing points at any more.
+        if (Transport.ControlQueue != null && Transport.ControlQueue.QueueName != queueName)
+        {
+            Transport.Queues.Remove(Transport.ControlQueue.QueueName);
+            Transport.SystemQueues.Remove(Transport.ControlQueue);
+        }
 
         var queue = Transport.Queues[queueName];
         queue.Mode = EndpointMode.BufferedInMemory;
@@ -270,10 +337,9 @@ public class AmazonSqsTransportConfiguration : BrokerExpression<AmazonSqsTranspo
         queue.Configuration.Attributes["MessageRetentionPeriod"] = "300";
 
         Options.Transports.NodeControlEndpoint = queue;
+        Transport.ControlQueue = queue;
 
         Transport.SystemQueues.Add(queue);
-
-        return this;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #4282. The Amazon SQS counterpart of #4263.

## The bug

The node control queue is composed as `"wolverine.control." + node` with no service name in it, and the default dead letter queue is `wolverine-dead-letter-queue`. Two unrelated Wolverine applications sharing one AWS account and region — both running as node 1 — claim the same queues.

For the dead letter queue that is **damaging rather than untidy**. `SqsDeadLetterQueueListener` drains broker-side dead letters into the Wolverine message store, so whichever application wins the race records another service's failure in *its* store: attributed to the wrong service, in the wrong database, and shown under the wrong name in monitoring.

The response queue was already safe — SQS puts the service name in it — and is unchanged apart from riding the same prefix.

## The change

`SystemQueuePrefix("my-project")` prepends a prefix to the response queue, the node control queue, and the default dead letter queue.

**The delimiter is `-`, not the `.` Azure Service Bus uses** — that is what SQS names allow, and what `IdentifierDelimiter` already said on this transport. Without a prefix (the default) every name is byte for byte what it has always been, which the first test pins.

Only the prefix half was missing here: `AmazonSqsTransport` already had `DefaultDeadLetterQueueName` with the same tri-state resolution — it is what #4263 was modelled on. That property now resolves **on read** rather than being assigned in the constructor, so a prefix set at any point during bootstrap reaches it and call order stops mattering. An explicitly assigned name is taken as fully qualified and is never prefixed.

The control queue has to be built eagerly, because `NodeControlEndpoint` is read by the message stores and the node agent long before transports initialize — so calling `SystemQueuePrefix()` afterwards rebuilds it under the prefixed name and takes the stale entry out of both `Queues` and `SystemQueues`. `ControlQueue` is tracked on the transport rather than the configuration object, because one transport can be reached through more than one configuration instance.

## Deliberately not hoisted into `BrokerTransport`

My analysis on #4263 said to hoist when a second transport needed it, and that is now — two transports with real requirements, including the differing delimiters and character sets. I have still not done it here, because it touches public shared API and would want the Azure Service Bus implementation revisited to use it. That is worth its own change with its own review rather than riding along inside a bug fix.

## Verification

Nine tests, including the one that matters most (`without_a_prefix_every_name_is_unchanged`) and the eager-control-queue rebuild.

Under Bobcat supervision, `./build.sh CIAWSSqs`: **257 passed, 0 retries, no flaky tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
