### PR TITLE
GH-4285: stop concurrent CosmosDb node startup from assigning duplicate node numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,19 @@
   the prefixed default, then `wolverine-dead-letter-queue` -- and it resolves on read, so the order of
   those calls during bootstrapping does not matter.
 
+### WolverineFx.CosmosDb
+
+- **Concurrent node startup no longer assigns duplicate node numbers.** (closes
+  [#4285](https://github.com/JasperFx/wolverine/issues/4285)) `PersistAsync` allocated
+  `AssignedNodeNumber` with an unguarded read-modify-write on the shared sequence document, so two
+  nodes starting at the same moment -- initial creation of a multi-replica deployment, a simultaneous
+  restart -- both read count `N` and both wrote `N + 1`, ending up with the same number. The number is
+  more than a label: it becomes the envelope owner id, and shutdown releases ownership *by number*, so
+  one duplicate's clean exit released the other still-running node's in-flight envelopes back to
+  `AnyNode` for redelivery while the original owner was still processing them. The increment is now
+  optimistic-concurrency safe: the replace is guarded by the ETag of the read and retried on a 412
+  (a peer bumped the sequence first) or a 409 (a peer created the missing sequence document first).
+
 ### Dependencies
 
 - JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator and JasperFx.SourceGenerator to

--- a/src/Persistence/CosmosDbTests/Bug_4285_concurrent_node_number_assignment.cs
+++ b/src/Persistence/CosmosDbTests/Bug_4285_concurrent_node_number_assignment.cs
@@ -1,0 +1,55 @@
+using Shouldly;
+using Wolverine.Runtime.Agents;
+
+namespace CosmosDbTests;
+
+// GH-4285: two nodes starting at the same moment both read the node sequence document at the
+// same count and both wrote count + 1 back, so both were assigned the same AssignedNodeNumber —
+// and because envelope ownership is released by node number on shutdown, one node's exit
+// released the other still-running node's in-flight envelopes for redelivery.
+[Collection("cosmosdb")]
+public class Bug_4285_concurrent_node_number_assignment
+{
+    private readonly AppFixture _fixture;
+
+    public Bug_4285_concurrent_node_number_assignment(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task concurrently_persisting_nodes_assigns_unique_node_numbers()
+    {
+        await _fixture.ClearAll();
+        var messageStore = _fixture.BuildMessageStore();
+
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nodes = Enumerable.Range(0, 20).Select(_ =>
+        {
+            var id = Guid.NewGuid();
+            return new WolverineNode
+            {
+                NodeId = id,
+                ControlUri = new Uri($"dbcontrol://{id}"),
+                Description = Environment.MachineName,
+                Version = new Version(1, 2, 3, 0)
+            };
+        }).ToArray();
+
+        var tasks = nodes.Select(async node =>
+        {
+            await start.Task;
+            return await messageStore.Nodes.PersistAsync(node, CancellationToken.None);
+        }).ToArray();
+
+        start.SetResult();
+
+        var assignedNodeNumbers = await Task.WhenAll(tasks);
+
+        assignedNodeNumbers.OrderBy(x => x).ShouldBe(Enumerable.Range(1, nodes.Length).ToArray());
+
+        var persisted = await messageStore.Nodes.LoadAllNodesAsync(CancellationToken.None);
+        persisted.Select(x => x.AssignedNodeNumber).OrderBy(x => x)
+            .ShouldBe(assignedNodeNumbers.OrderBy(x => x));
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.NodeAgents.cs
@@ -41,23 +41,52 @@ public partial class CosmosDbMessageStore : INodeAgentPersistence
     public async Task<int> PersistAsync(WolverineNode node, CancellationToken cancellationToken)
     {
         var sequenceId = $"{DocumentTypes.NodeSequence}|sequence";
-        CosmosNodeSequence? sequence;
-        try
-        {
-            var response = await _container.ReadItemAsync<CosmosNodeSequence>(
-                sequenceId, new PartitionKey(DocumentTypes.SystemPartition),
-                cancellationToken: cancellationToken);
-            sequence = response.Resource;
-        }
-        catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
-        {
-            sequence = new CosmosNodeSequence { Id = sequenceId };
-        }
 
-        node.AssignedNodeNumber = ++sequence.Count;
+        // GH-4285: the node number becomes the envelope owner id, and shutdown releases ownership BY
+        // number — so two nodes sharing a number cross-release each other's in-flight envelopes. The
+        // increment must be optimistic-concurrency safe: replace guarded by the ETag of the read, retry
+        // on 412 (a peer bumped the sequence first) or 409 (a peer created the missing document first).
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                CosmosNodeSequence sequence;
+                try
+                {
+                    var response = await _container.ReadItemAsync<CosmosNodeSequence>(
+                        sequenceId, new PartitionKey(DocumentTypes.SystemPartition),
+                        cancellationToken: cancellationToken);
+                    sequence = response.Resource;
+                    sequence.Count++;
 
-        await _container.UpsertItemAsync(sequence, new PartitionKey(DocumentTypes.SystemPartition),
-            cancellationToken: cancellationToken);
+                    await _container.ReplaceItemAsync(sequence, sequenceId,
+                        new PartitionKey(DocumentTypes.SystemPartition),
+                        new ItemRequestOptions { IfMatchEtag = response.ETag },
+                        cancellationToken);
+                }
+                catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
+                {
+                    sequence = new CosmosNodeSequence { Id = sequenceId, Count = 1 };
+                    await _container.CreateItemAsync(sequence, new PartitionKey(DocumentTypes.SystemPartition),
+                        cancellationToken: cancellationToken);
+                }
+
+                node.AssignedNodeNumber = sequence.Count;
+                break;
+            }
+            catch (CosmosException e) when (e.StatusCode is HttpStatusCode.PreconditionFailed
+                                                or HttpStatusCode.Conflict)
+            {
+                if (attempt >= 24)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to assign a node number for node {node.NodeId} after {attempt + 1} attempts because of contention on the node sequence document",
+                        e);
+                }
+
+                await Task.Delay(Random.Shared.Next(5, 25), cancellationToken);
+            }
+        }
 
         var nodeDoc = new CosmosWolverineNode(node);
         await _container.UpsertItemAsync(nodeDoc, new PartitionKey(DocumentTypes.SystemPartition),


### PR DESCRIPTION
Closes #4285

## The defect

`CosmosDbMessageStore.PersistAsync` allocated `AssignedNodeNumber` with an unguarded read-modify-write on the shared `CosmosNodeSequence` document: read the count, increment in memory, `UpsertItemAsync` back with no ETag guard. Two nodes starting at the same moment — initial creation of a multi-replica deployment, a simultaneous restart, a rescheduling event — both read count `N` and both wrote `N + 1`, so both came up with the **same node number**, exactly as reproduced in #4285 with two Aspire replicas.

As the issue lays out, the number is more than a label. It becomes the envelope owner id (`NodeAgentController.StartLocalProcessing` adopts it, and the durability agent stamps incoming envelope ownership with it), and `WolverineRuntime` shutdown releases ownership **by node number**. So one duplicate's clean exit released the other still-running node's in-flight envelopes back to `AnyNode` for redelivery while the original owner was still processing them. `AssignmentGrid.NodeFor(int)` lookups also resolve arbitrarily under duplicates.

## The fix

The suggested fix from the issue, essentially verbatim: the increment is now optimistic-concurrency safe.

- The sequence is read and then replaced via `ReplaceItemAsync` guarded by `IfMatchEtag` from that read.
- A **412 PreconditionFailed** (a peer bumped the sequence between our read and replace) retries with a small jittered delay.
- The not-found path now uses `CreateItemAsync` instead of an upsert, so a **409 Conflict** (a peer created the missing sequence document first) also retries and increments the peer's document instead of clobbering it.
- Contention only exists at node startup, so retries are bounded (25 attempts) before surfacing an `InvalidOperationException` rather than looping forever.

## Testing

New `Bug_4285_concurrent_node_number_assignment` in CosmosDbTests mirrors the existing RavenDb `concurrently_persisting_nodes_assigns_unique_node_numbers` compliance test: 20 gate-released parallel `PersistAsync` calls against the Cosmos emulator must come back numbered exactly 1..20, matching what `LoadAllNodesAsync` then reports.

- Red against the old code (duplicate numbers reproduce readily under the parallel start gate), green with the fix.
- Full CosmosDbTests suite green: 108/108.
- Full-solution build gate clean: `dotnet build wolverine.slnx -c Release -f net9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)