### PR TITLE
GH-4286: dead letter expiration never fired on CosmosDb or RavenDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,28 @@
   the prefixed default, then `wolverine-dead-letter-queue` -- and it resolves on read, so the order of
   those calls during bootstrapping does not matter.
 
+### WolverineFx.CosmosDb
+
+- **`DeadLetterQueueExpirationEnabled` actually deletes expired dead letters now.** (closes
+  [#4286](https://github.com/JasperFx/wolverine/issues/4286)) The recovery loop's hourly throttle
+  reset its own timestamp at the top of every iteration and compared against it a few statements
+  later, so the expired dead letter sweep could only ever fire if a single recovery tick took more
+  than an hour — in practice never, and dead letters accumulated without bound with the feature
+  turned on. The throttle now lives outside the loop and is stamped after each sweep, so the first
+  recovery tick sweeps immediately (matching the relational providers, whose expiration timer first
+  fires a minute after startup) and hourly after that.
+
+### WolverineFx.RavenDb
+
+- **`DeadLetterQueueExpirationEnabled` actually deletes expired dead letters now.** (closes
+  [#4286](https://github.com/JasperFx/wolverine/issues/4286)) Same throttle defect as the CosmosDb
+  entry above — the hourly guard compared against a timestamp taken in the same loop iteration, so
+  the sweep never fired. Fixing the throttle also unmasked a second defect on this provider: the
+  sweep was a `DeleteByQueryOperation` against an index named `DeadLetterMessages` that Wolverine
+  never creates, so the first sweep that actually ran would have thrown
+  `IndexDoesNotExistException` and still deleted nothing. The sweep is now a dynamic query in
+  batches of `RecoveryBatchSize`, the same shape the scheduled-message poller already uses.
+
 ### Dependencies
 
 - JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator and JasperFx.SourceGenerator to

--- a/src/Persistence/CosmosDbTests/Bug_4286_dead_letter_expiration.cs
+++ b/src/Persistence/CosmosDbTests/Bug_4286_dead_letter_expiration.cs
@@ -1,0 +1,70 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.CosmosDb;
+
+namespace CosmosDbTests;
+
+// GH-4286: the recovery loop's hourly throttle reset its own timestamp at the top of every
+// iteration and compared against it a few statements later, so the expired dead letter sweep
+// could only ever fire if a single recovery tick took more than an hour — with
+// DeadLetterQueueExpirationEnabled on, dead letters accumulated without bound. The throttle
+// now lives outside the loop, so the FIRST recovery tick sweeps.
+[Collection("cosmosdb")]
+public class Bug_4286_dead_letter_expiration
+{
+    private readonly AppFixture _fixture;
+
+    public Bug_4286_dead_letter_expiration(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task expired_dead_letters_are_swept_by_the_recovery_loop()
+    {
+        await _fixture.ClearAll();
+        var store = _fixture.BuildMessageStore();
+
+        // Seed the dead letter queue BEFORE the host starts so the first recovery tick sees both
+        var expired = ObjectMother.Envelope();
+        expired.DeliverBy = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await store.Inbox.MoveToDeadLetterStorageAsync(expired, new InvalidOperationException("expired"));
+
+        var keeper = ObjectMother.Envelope();
+        keeper.DeliverBy = DateTimeOffset.UtcNow.AddDays(1);
+        await store.Inbox.MoveToDeadLetterStorageAsync(keeper, new InvalidOperationException("keeper"));
+
+        (await store.Admin.FetchCountsAsync()).DeadLetter.ShouldBe(2);
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.DeadLetterQueueExpirationEnabled = true;
+                opts.Durability.ScheduledJobFirstExecution = 0.Seconds();
+                opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+                opts.UseCosmosDbPersistence(AppFixture.DatabaseName);
+                opts.Services.AddSingleton(_fixture.Client);
+                opts.ServiceName = "dlq-expiration";
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var counts = await store.Admin.FetchCountsAsync();
+            if (counts.DeadLetter <= 1) break;
+
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+
+        (await store.Admin.FetchCountsAsync()).DeadLetter.ShouldBe(1);
+        (await store.DeadLetters.DeadLetterEnvelopeByIdAsync(keeper.Id)).ShouldNotBeNull();
+        (await store.DeadLetters.DeadLetterEnvelopeByIdAsync(expired.Id)).ShouldBeNull();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Persistence/RavenDbTests/Bug_4286_dead_letter_expiration.cs
+++ b/src/Persistence/RavenDbTests/Bug_4286_dead_letter_expiration.cs
@@ -1,0 +1,80 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.RavenDb;
+using Wolverine.RavenDb.Internals;
+
+namespace RavenDbTests;
+
+// GH-4286: the recovery loop's hourly throttle reset its own timestamp at the top of every
+// iteration and compared against it a few statements later, so the expired dead letter sweep
+// could only ever fire if a single recovery tick took more than an hour — with
+// DeadLetterQueueExpirationEnabled on, dead letters accumulated without bound. The throttle
+// now lives outside the loop, so the FIRST recovery tick sweeps.
+[Collection("raven")]
+public class Bug_4286_dead_letter_expiration
+{
+    private readonly DatabaseFixture _fixture;
+
+    public Bug_4286_dead_letter_expiration(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task expired_dead_letters_are_swept_by_the_recovery_loop()
+    {
+        var documentStore = _fixture.StartRavenStore();
+        var store = new RavenDbMessageStore(documentStore, new WolverineOptions());
+
+        // Seed the dead letter queue BEFORE the host starts so the first recovery tick sees both
+        var expired = ObjectMother.Envelope();
+        expired.DeliverBy = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await store.Inbox.MoveToDeadLetterStorageAsync(expired, new InvalidOperationException("expired"));
+
+        var keeper = ObjectMother.Envelope();
+        keeper.DeliverBy = DateTimeOffset.UtcNow.AddDays(1);
+        await store.Inbox.MoveToDeadLetterStorageAsync(keeper, new InvalidOperationException("keeper"));
+
+        // Prime the ExpirationTime auto index and wait until both seeded documents are queryable,
+        // so the sweep's own dynamic query on the first recovery tick is not racing a stale index
+        using (var session = documentStore.OpenAsyncSession())
+        {
+            var seeded = await session.Query<DeadLetterMessage>()
+                .Customize(x => x.WaitForNonStaleResults())
+                .Where(x => x.ExpirationTime < DateTimeOffset.UtcNow.AddDays(2))
+                .CountAsync(TestContext.Current.CancellationToken);
+            seeded.ShouldBe(2);
+        }
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.DeadLetterQueueExpirationEnabled = true;
+                opts.Durability.ScheduledJobFirstExecution = 0.Seconds();
+                opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+                opts.Services.AddSingleton<IDocumentStore>(documentStore);
+                opts.UseRavenDbPersistence();
+                opts.ServiceName = "dlq-expiration";
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await store.DeadLetters.DeadLetterEnvelopeByIdAsync(expired.Id) == null) break;
+
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+
+        (await store.DeadLetters.DeadLetterEnvelopeByIdAsync(expired.Id)).ShouldBeNull();
+        (await store.DeadLetters.DeadLetterEnvelopeByIdAsync(keeper.Id)).ShouldNotBeNull();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/Durability/CosmosDbDurabilityAgent.cs
@@ -70,10 +70,14 @@ public partial class CosmosDbDurabilityAgent : IAgent
             await Task.Delay(recoveryStart, _combined.Token);
             using var timer = new PeriodicTimer(_settings.ScheduledJobPollingTime);
 
+            // GH-4286: this throttle lives OUTSIDE the loop — reset per iteration, the hourly guard
+            // below could only fire if a single recovery tick took more than an hour, so expired dead
+            // letters were never deleted. MinValue makes the first tick sweep immediately, matching the
+            // RDBMS providers' expiration timer that first fires a minute after startup.
+            var lastExpiredTime = DateTimeOffset.MinValue;
+
             while (!_combined.IsCancellationRequested)
             {
-                var lastExpiredTime = DateTimeOffset.UtcNow;
-
                 try
                 {
                     await tryRecoverIncomingMessages();
@@ -81,10 +85,12 @@ public partial class CosmosDbDurabilityAgent : IAgent
 
                     if (_settings.DeadLetterQueueExpirationEnabled)
                     {
+                        // Crudely just doing this every hour
                         var now = DateTimeOffset.UtcNow;
                         if (now > lastExpiredTime.AddHours(1))
                         {
                             await tryDeleteExpiredDeadLetters();
+                            lastExpiredTime = now;
                         }
                     }
 

--- a/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/Durability/RavenDbDurabilityAgent.cs
@@ -72,10 +72,14 @@ public partial class RavenDbDurabilityAgent : IAgent
             await Task.Delay(recoveryStart, _combined.Token);
             using var timer = new PeriodicTimer(_settings.ScheduledJobPollingTime);
 
+            // GH-4286: this throttle lives OUTSIDE the loop — reset per iteration, the hourly guard
+            // below could only fire if a single recovery tick took more than an hour, so expired dead
+            // letters were never deleted. MinValue makes the first tick sweep immediately, matching the
+            // RDBMS providers' expiration timer that first fires a minute after startup.
+            var lastExpiredTime = DateTimeOffset.MinValue;
+
             while (!_combined.IsCancellationRequested)
             {
-                var lastExpiredTime = DateTimeOffset.UtcNow;
-
                 try
                 {
                     await tryRecoverIncomingMessages();
@@ -88,6 +92,7 @@ public partial class RavenDbDurabilityAgent : IAgent
                         if (now > lastExpiredTime.AddHours(1))
                         {
                             await tryDeleteExpiredDeadLetters();
+                            lastExpiredTime = now;
                         }
                     }
 
@@ -148,13 +153,37 @@ public partial class RavenDbDurabilityAgent : IAgent
 
     private async Task tryDeleteExpiredDeadLetters()
     {
+        // GH-4286: this used to be a DeleteByQueryOperation against an index named "DeadLetterMessages"
+        // that Wolverine never creates, so once the throttle defect above was fixed and the sweep could
+        // actually fire, it threw IndexDoesNotExistException instead of deleting. A dynamic query builds
+        // its own auto index, the same way runScheduledJobs queries IncomingMessage.
         var now = DateTimeOffset.UtcNow;
-        using var session = _store.OpenAsyncSession();
-        var op =
-            await _store.Operations.SendAsync(
-                new DeleteByQueryOperation<DeadLetterMessage>("DeadLetterMessages", x => x.ExpirationTime < now));
- 
-        await op.WaitForCompletionAsync();
+
+        while (!_combined.IsCancellationRequested)
+        {
+            using var session = _store.OpenAsyncSession();
+            var expired = await session.Query<DeadLetterMessage>()
+                .Where(x => x.ExpirationTime < now)
+                .Take(_settings.RecoveryBatchSize)
+                .ToListAsync(_combined.Token);
+
+            if (!expired.Any())
+            {
+                return;
+            }
+
+            foreach (var message in expired)
+            {
+                session.Delete(message);
+            }
+
+            await session.SaveChangesAsync(_combined.Token);
+
+            if (expired.Count < _settings.RecoveryBatchSize)
+            {
+                return;
+            }
+        }
     }
 
 


### PR DESCRIPTION
Closes #4286

## The throttle defect (both providers)

Exactly as diagnosed in the issue: both `CosmosDbDurabilityAgent` and `RavenDbDurabilityAgent` reset `lastExpiredTime` at the **top of every recovery loop iteration** and compared it against `DateTimeOffset.UtcNow` a few statements later, so `tryDeleteExpiredDeadLetters()` could only fire if a single recovery tick took more than an hour — in practice never. With `DeadLetterQueueExpirationEnabled = true`, dead letters accumulated without bound on both providers.

The fix is the one suggested in the issue: the throttle now lives **outside** the loop, initialized to `DateTimeOffset.MinValue` so the first recovery tick sweeps immediately — matching the RDBMS providers, whose dedicated expiration timer first fires a minute after startup — and stamped after each sweep, hourly thereafter.

## The second defect the throttle was masking (RavenDb only)

With the throttle fixed, the RavenDb sweep still deleted nothing: it was a `DeleteByQueryOperation<DeadLetterMessage>("DeadLetterMessages", ...)` against an index named `DeadLetterMessages` **that Wolverine never creates**, so the first sweep that actually ran threw `IndexDoesNotExistException` into the recovery loop's catch-and-log and the dead letters stayed put. The new integration test caught this immediately. The sweep is now a dynamic session query deleting in `RecoveryBatchSize` batches — the same shape `runScheduledJobs` already uses to query `IncomingMessage`, so it builds its own auto index.

## Testing

New `Bug_4286_dead_letter_expiration` on **both** providers: seed one already-expired dead letter (past `DeliverBy`) and one live one, start a `Solo` host with `DeadLetterQueueExpirationEnabled` and fast recovery timings, and require the first sweep to delete exactly the expired one while the live one survives. The RavenDb test primes the `ExpirationTime` auto index before the host starts so the sweep isn't racing a stale index.

- Both tests red against the old code (30s timeout, dead letters untouched), green with the fix.
- Full suites green: CosmosDbTests 108/108, RavenDbTests 225/225.
- Full-solution build gate clean: `dotnet build wolverine.slnx -c Release -f net9.0`.

Note: #4293 (GH-4285) also adds a `### WolverineFx.CosmosDb` CHANGELOG section under Unreleased, so whichever of the two merges second will need a trivial CHANGELOG conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)