### PR TITLE
GH-4288: sharded database queues no longer double-store globally partitioned envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### WolverineFx (core)
 
+- **Global partitioning over sharded database queues executes messages again.** (closes
+  [#4288](https://github.com/JasperFx/wolverine/issues/4288)) With `GlobalPartitioned` +
+  `UseShardedSqlServerQueues` (and the PostgreSQL twin), any message that actually round-tripped through a
+  shard queue table -- the exclusive slot listener on another node, or not yet accepting on this one, so
+  the companion-local-queue shortcut did not apply -- was **never executed**. A durable database-backed
+  queue moves each envelope into the inbox as part of the dequeue itself, and the
+  `GlobalPartitionedReceiverBridge` then forwarded it to the companion local queue's `DurableReceiver`,
+  which is not database-backed and stored it a **second** time: a `DuplicateIncomingEnvelopeException` per
+  message, and every envelope permanently parked in `wolverine_incoming_envelopes` as an `Incoming` row
+  owned by a live node that no recovery pass would ever touch. The bridge now marks envelopes a durable
+  database-backed dequeue already persisted -- and everything routed to a bridged listener through
+  store-driven recovery (inbox recovery, DLQ replay, scheduled firing), which is persisted by definition --
+  and `DurableReceiver` skips the second store for a marked envelope while still settling and executing
+  it. Broker-backed topologies (RabbitMQ etc.) are unaffected: their bridge still leaves persistence to
+  the local receiver.
+
 - **`FindForTenantAsync` answers for a single-database deployment.** (closes
   [#4273](https://github.com/JasperFx/wolverine/issues/4273)) The method became public API in #4268 without
   the `_onlyOneDatabase` guard that `FindAllAsync` and `FindDatabasesAsync` both open with, so on a

--- a/src/Persistence/PostgresqlTests/Transport/Bug_4288_sharded_global_partitioning_round_trip.cs
+++ b/src/Persistence/PostgresqlTests/Transport/Bug_4288_sharded_global_partitioning_round_trip.cs
@@ -1,0 +1,131 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+
+namespace PostgresqlTests.Transport;
+
+/// <summary>
+/// GH-4288, the PostgreSQL twin of the SQL Server defect. When a globally partitioned message
+/// actually round-trips through a sharded PostgreSQL queue -- no local companion-queue shortcut --
+/// the durable dequeue moves the envelope into the inbox, and the GlobalPartitionedReceiverBridge
+/// then forwarded it to the companion local queue's DurableReceiver, which stored it AGAIN. Every
+/// message threw DuplicateIncomingEnvelopeException and sat permanently parked in
+/// wolverine_incoming_envelopes. This test defeats the local shortcut by sending straight to the
+/// slot endpoint, forcing the full queue-table round trip.
+/// </summary>
+public class Bug_4288_sharded_global_partitioning_round_trip : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        B4288PgHandler.Received.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UsePostgresqlPersistenceAndTransport(Servers.PostgresConnectionString, "b4288_pg",
+                        transportSchema: "b4288_pg_queues")
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(B4288PgHandler));
+
+                opts.MessagePartitioning.ByMessage<IB4288PgMessage>(x => x.Id.ToString());
+
+                opts.MessagePartitioning.GlobalPartitioned(topology =>
+                {
+                    topology.UseShardedPostgresqlQueues("b4288pg", 2);
+                    topology.MessagesImplementing<IB4288PgMessage>();
+                });
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task messages_sent_through_the_sharded_queue_are_executed_and_do_not_wedge_the_inbox()
+    {
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+        // Send straight to one slot endpoint so the message cannot take the companion local queue
+        // shortcut -- it has to go through the sharded queue table and the durable dequeue that
+        // moves it into the inbox
+        Func<IMessageContext, Task> sendThroughTheShardQueue = async bus =>
+        {
+            foreach (var id in ids)
+            {
+                await bus.EndpointFor(new Uri("postgresql://b4288pg1")).SendAsync(new B4288PgWork(id));
+            }
+        };
+
+        var tracked = await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(120.Seconds())
+            .ExecuteAndWaitAsync(sendThroughTheShardQueue);
+
+        // Before the fix nothing was ever executed -- the local companion queue's DurableReceiver
+        // stored each envelope a second time and DuplicateIncomingEnvelopeException swallowed it.
+        // Scope to this run's ids: startup recovery may also (correctly) execute envelopes a
+        // previous failed run left stuck in the inbox.
+        tracked.Executed.Envelopes()
+            .Count(x => x.Message is B4288PgWork work && ids.Contains(work.Id)).ShouldBe(ids.Length);
+
+        foreach (var id in ids)
+        {
+            B4288PgHandler.Received.ShouldContain(id);
+        }
+
+        // ...and the reported wedge state: rows parked as 'Incoming' that no recovery pass will
+        // ever touch because they are owned by a live node. Mark-as-handled can be coalesced, so
+        // give the status flip a few seconds rather than asserting one snapshot.
+        var cancellation = TestContext.Current.CancellationToken;
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        var stuck = long.MaxValue;
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (stuck > 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            stuck = (long)(await conn
+                .CreateCommand(
+                    "select count(*) from b4288_pg.wolverine_incoming_envelopes where status = 'Incoming'")
+                .ExecuteScalarAsync(cancellation))!;
+
+            if (stuck > 0)
+            {
+                await Task.Delay(250.Milliseconds(), cancellation);
+            }
+        }
+
+        stuck.ShouldBe(0);
+    }
+}
+
+public interface IB4288PgMessage
+{
+    Guid Id { get; }
+}
+
+public record B4288PgWork(Guid Id) : IB4288PgMessage;
+
+public static class B4288PgHandler
+{
+    public static readonly ConcurrentBag<Guid> Received = new();
+
+    public static void Handle(B4288PgWork message) => Received.Add(message.Id);
+}

--- a/src/Persistence/SqlServerTests/Transport/Bug_4288_sharded_global_partitioning_round_trip.cs
+++ b/src/Persistence/SqlServerTests/Transport/Bug_4288_sharded_global_partitioning_round_trip.cs
@@ -1,0 +1,132 @@
+using System.Collections.Concurrent;
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Weasel.Core;
+using Wolverine;
+using Wolverine.SqlServer;
+using Wolverine.Tracking;
+
+namespace SqlServerTests.Transport;
+
+/// <summary>
+/// GH-4288. When a globally partitioned message actually round-trips through a sharded SQL Server
+/// queue -- the exclusive slot listener is on another node, or has not started accepting yet, so the
+/// local companion-queue shortcut does not apply -- the durable dequeue moves the envelope into the
+/// inbox, and the GlobalPartitionedReceiverBridge then forwarded it to the companion local queue's
+/// DurableReceiver, which stored it AGAIN. Every message threw DuplicateIncomingEnvelopeException,
+/// was never executed, and sat permanently parked in wolverine_incoming_envelopes as an 'Incoming'
+/// row owned by a live node. This test defeats the local shortcut by sending straight to the slot
+/// endpoint, forcing the full queue-table round trip.
+/// </summary>
+public class Bug_4288_sharded_global_partitioning_round_trip : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        B4288SqlHandler.Received.Clear();
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, "b4288_sql",
+                        transportSchema: "b4288_sql_queues")
+                    .AutoProvision()
+                    .AutoPurgeOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(B4288SqlHandler));
+
+                opts.MessagePartitioning.ByMessage<IB4288SqlMessage>(x => x.Id.ToString());
+
+                opts.MessagePartitioning.GlobalPartitioned(topology =>
+                {
+                    topology.UseShardedSqlServerQueues("b4288sql", 2);
+                    topology.MessagesImplementing<IB4288SqlMessage>();
+                });
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task messages_sent_through_the_sharded_queue_are_executed_and_do_not_wedge_the_inbox()
+    {
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+        // Send straight to one slot endpoint so the message cannot take the companion local queue
+        // shortcut -- it has to go through the sharded queue table and the durable dequeue that
+        // moves it into the inbox
+        Func<IMessageContext, Task> sendThroughTheShardQueue = async bus =>
+        {
+            foreach (var id in ids)
+            {
+                await bus.EndpointFor(new Uri("sqlserver://b4288sql1")).SendAsync(new B4288SqlWork(id));
+            }
+        };
+
+        var tracked = await _host
+            .TrackActivity()
+            .IncludeExternalTransports()
+            .Timeout(120.Seconds())
+            .ExecuteAndWaitAsync(sendThroughTheShardQueue);
+
+        // Before the fix nothing was ever executed -- the local companion queue's DurableReceiver
+        // stored each envelope a second time and DuplicateIncomingEnvelopeException swallowed it.
+        // Scope to this run's ids: startup recovery may also (correctly) execute envelopes a
+        // previous failed run left stuck in the inbox.
+        tracked.Executed.Envelopes()
+            .Count(x => x.Message is B4288SqlWork work && ids.Contains(work.Id)).ShouldBe(ids.Length);
+
+        foreach (var id in ids)
+        {
+            B4288SqlHandler.Received.ShouldContain(id);
+        }
+
+        // ...and the reported wedge state: rows parked as 'Incoming' with attempts = 0 that no
+        // recovery pass will ever touch because they are owned by a live node. Mark-as-handled can
+        // be coalesced, so give the status flip a few seconds rather than asserting one snapshot.
+        var cancellation = TestContext.Current.CancellationToken;
+        await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync(cancellation);
+
+        var stuck = int.MaxValue;
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (stuck > 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            stuck = (int)(await conn
+                .CreateCommand(
+                    "select count(*) from b4288_sql.wolverine_incoming_envelopes where status = 'Incoming'")
+                .ExecuteScalarAsync(cancellation))!;
+
+            if (stuck > 0)
+            {
+                await Task.Delay(250.Milliseconds(), cancellation);
+            }
+        }
+
+        stuck.ShouldBe(0);
+    }
+}
+
+public interface IB4288SqlMessage
+{
+    Guid Id { get; }
+}
+
+public record B4288SqlWork(Guid Id) : IB4288SqlMessage;
+
+public static class B4288SqlHandler
+{
+    public static readonly ConcurrentBag<Guid> Received = new();
+
+    public static void Handle(B4288SqlWork message) => Received.Add(message.Id);
+}

--- a/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_tests.cs
+++ b/src/Testing/CoreTests/Runtime/Partitioning/global_partitioning_tests.cs
@@ -413,6 +413,40 @@ public class GlobalPartitionedReceiverBridgeTests
     }
 
     [Fact]
+    public async Task does_not_mark_envelopes_as_persisted_by_default()
+    {
+        // The RabbitMQ/broker case: nothing has touched the inbox yet, so the local
+        // queue's DurableReceiver still has to store the envelope itself
+        var localQueue = Substitute.For<ILocalQueue>();
+        var bridge = new GlobalPartitionedReceiverBridge(localQueue);
+        var listener = Substitute.For<IListener>();
+        var envelope = ObjectMother.Envelope();
+        envelope.WasPersistedInInbox = false;
+
+        await bridge.ReceivedAsync(listener, envelope);
+
+        envelope.WasPersistedInInbox.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task marks_envelopes_as_persisted_when_the_source_endpoint_already_stored_them()
+    {
+        // GH-4288. A durable database-backed queue moves the envelope into the inbox as part of
+        // the dequeue itself, so the bridge has to say so or the companion local queue's
+        // DurableReceiver stores it again and throws DuplicateIncomingEnvelopeException
+        var localQueue = Substitute.For<ILocalQueue>();
+        var bridge = new GlobalPartitionedReceiverBridge(localQueue, envelopesArePersistedInInbox: true);
+        var listener = Substitute.For<IListener>();
+        var envelope = ObjectMother.Envelope();
+        envelope.WasPersistedInInbox = false;
+
+        await bridge.ReceivedAsync(listener, envelope);
+
+        envelope.WasPersistedInInbox.ShouldBeTrue();
+        await localQueue.Received(1).ReceivedAsync(listener, envelope);
+    }
+
+    [Fact]
     public async Task drain_async_returns_completed()
     {
         var localQueue = Substitute.For<ILocalQueue>();

--- a/src/Testing/CoreTests/Runtime/WorkerQueues/durable_receiver_already_persisted_envelope_4288.cs
+++ b/src/Testing/CoreTests/Runtime/WorkerQueues/durable_receiver_already_persisted_envelope_4288.cs
@@ -1,0 +1,53 @@
+using NSubstitute;
+using Wolverine.ComplianceTests;
+using Wolverine.Runtime;
+using Wolverine.Runtime.WorkerQueues;
+using Wolverine.Transports;
+using Wolverine.Transports.Stub;
+using Xunit;
+
+namespace CoreTests.Runtime.WorkerQueues;
+
+/// <summary>
+/// GH-4288. A durable database-backed queue (sharded SQL Server / PostgreSQL slots in a global
+/// partitioned topology) moves each envelope into the inbox as part of the dequeue, then the
+/// GlobalPartitionedReceiverBridge forwards it to a companion local queue whose DurableReceiver is
+/// NOT database-backed. Before the fix that receiver stored the envelope a second time, threw
+/// DuplicateIncomingEnvelopeException on every message, and parked all of them in the inbox
+/// permanently. An envelope arriving with WasPersistedInInbox = true must skip the inbox store and
+/// still be settled and processed.
+/// </summary>
+public class durable_receiver_already_persisted_envelope_4288
+{
+    private readonly Envelope theEnvelope = ObjectMother.Envelope();
+    private readonly IListener theListener = Substitute.For<IListener>();
+    private readonly IHandlerPipeline thePipeline = Substitute.For<IHandlerPipeline>();
+    private readonly DurableReceiver theReceiver;
+    private readonly MockWolverineRuntime theRuntime = new();
+
+    public durable_receiver_already_persisted_envelope_4288()
+    {
+        // A local queue style endpoint, so ShouldPersistBeforeProcessing is true
+        var stubEndpoint = new StubEndpoint("one", new StubTransport());
+        theReceiver = new DurableReceiver(stubEndpoint, theRuntime, thePipeline);
+
+        theEnvelope.WasPersistedInInbox = true;
+    }
+
+    [Fact]
+    public async Task does_not_store_the_envelope_in_the_inbox_a_second_time()
+    {
+        await theReceiver.ReceivedAsync(theListener, theEnvelope);
+
+        await theRuntime.Storage.Inbox.DidNotReceive().StoreIncomingAsync(Arg.Any<Envelope>());
+        await theRuntime.Storage.Inbox.DidNotReceive().StoreIncomingAsync(Arg.Any<IReadOnlyList<Envelope>>());
+    }
+
+    [Fact]
+    public async Task still_settles_the_delivery_with_the_listener()
+    {
+        await theReceiver.ReceivedAsync(theListener, theEnvelope);
+
+        await theListener.Received().CompleteAsync(theEnvelope);
+    }
+}

--- a/src/Wolverine/Runtime/Partitioning/GlobalPartitionedReceiverBridge.cs
+++ b/src/Wolverine/Runtime/Partitioning/GlobalPartitionedReceiverBridge.cs
@@ -11,10 +11,12 @@ namespace Wolverine.Runtime.Partitioning;
 internal class GlobalPartitionedReceiverBridge : IReceiver
 {
     private readonly ILocalQueue _localQueue;
+    private readonly bool _envelopesArePersistedInInbox;
 
-    public GlobalPartitionedReceiverBridge(ILocalQueue localQueue)
+    public GlobalPartitionedReceiverBridge(ILocalQueue localQueue, bool envelopesArePersistedInInbox = false)
     {
         _localQueue = localQueue;
+        _envelopesArePersistedInInbox = envelopesArePersistedInInbox;
     }
 
     public IHandlerPipeline Pipeline => _localQueue.Pipeline;
@@ -29,6 +31,16 @@ internal class GlobalPartitionedReceiverBridge : IReceiver
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
+        // GH-4288. A durable database-backed queue moves each envelope into the incoming
+        // (inbox) table as part of the dequeue itself, so the companion local queue's
+        // DurableReceiver must not store it a second time -- that threw
+        // DuplicateIncomingEnvelopeException on every message and parked all of them in the
+        // inbox as permanently stuck 'Incoming' rows owned by a live node.
+        if (_envelopesArePersistedInInbox)
+        {
+            envelope.WasPersistedInInbox = true;
+        }
+
         // Forward to local queue for sequential processing
         await _localQueue.ReceivedAsync(listener, envelope);
     }

--- a/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/DurableReceiver.cs
@@ -578,7 +578,10 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
     {
         if (_latched)
         {
-            if (!envelope.IsFromLocalDurableQueue())
+            // GH-4288. An envelope already persisted in the inbox (a durable database-backed queue's
+            // dequeue, or store-driven recovery) has a row for the recovery sweeps to find; storing it
+            // again could only throw DuplicateIncomingEnvelopeException to be swallowed below.
+            if (!envelope.IsFromLocalDurableQueue() && !envelope.WasPersistedInInbox)
             {
                 // Persist once as owner id = 0, then get out.
                 await executeWithRetriesAsync(async () =>
@@ -623,7 +626,11 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
             return;
         }
 
-        if (ShouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue())
+        // GH-4288. WasPersistedInInbox: a durable database-backed queue moves the envelope into the
+        // inbox as part of the dequeue, and the GlobalPartitionedReceiverBridge then forwards it to a
+        // companion local queue whose receiver is NOT database-backed -- so the endpoint-level
+        // ShouldPersistBeforeProcessing check alone re-stored an already-persisted row here.
+        if (ShouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue() && !envelope.WasPersistedInInbox)
         {
             try
             {
@@ -880,7 +887,9 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         var survivors = new List<Envelope>(envelopes.Length);
         foreach (var envelope in envelopes)
         {
-            if (ShouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue())
+            // GH-4288. See receiveOneAsync -- WasPersistedInInbox marks an envelope a durable
+            // database-backed dequeue (or store-driven recovery) already put in the inbox.
+            if (ShouldPersistBeforeProcessing && !envelope.IsFromLocalDurableQueue() && !envelope.WasPersistedInInbox)
             {
                 try
                 {
@@ -940,17 +949,25 @@ public class DurableReceiver : ILocalQueue, IChannelCallback, ISupportNativeSche
         }
 
         var batchSucceeded = false;
-        if (ShouldPersistBeforeProcessing)
+
+        // GH-4288. Leave out envelopes a durable database-backed dequeue already moved into the
+        // inbox -- batch-storing them again would throw DuplicateIncomingEnvelopeException for
+        // the whole batch.
+        var toPersist = ShouldPersistBeforeProcessing
+            ? envelopes.Where(x => !x.WasPersistedInInbox).ToArray()
+            : Array.Empty<Envelope>();
+
+        if (toPersist.Length > 0)
         {
             try
             {
-                assignAncillaryStoreIfNeeded(envelopes);
-                await _inbox.StoreIncomingAsync(envelopes).ConfigureAwait(false);
-                foreach (var envelope in envelopes)
+                assignAncillaryStoreIfNeeded(toPersist);
+                await _inbox.StoreIncomingAsync(toPersist).ConfigureAwait(false);
+                foreach (var envelope in toPersist)
                 {
                     envelope.WasPersistedInInbox = true;
                 }
-                
+
                 batchSucceeded = true;
             }
             catch (DuplicateIncomingEnvelopeException)

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -278,6 +278,11 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             // Forward to the companion local queue for sequential processing
             foreach (var envelope in envelopes)
             {
+                // GH-4288. Everything routed through here (inbox recovery, DLQ replay, scheduled
+                // firing) came out of the message store, so the inbox row already exists. Without
+                // this the companion local queue's DurableReceiver re-stored each envelope and the
+                // resulting DuplicateIncomingEnvelopeException kept recovered messages stuck forever.
+                envelope.WasPersistedInInbox = true;
                 await _receiver!.ReceivedAsync(Listener!, envelope);
             }
         }
@@ -480,7 +485,13 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
             var localQueue = _runtime.Endpoints.AgentForLocalQueue(Endpoint.GlobalPartitionLocalQueueUri) as ILocalQueue;
             if (localQueue != null)
             {
-                _receiver = new GlobalPartitionedReceiverBridge(localQueue);
+                // GH-4288. A durable database-backed queue (sharded SQL Server / PostgreSQL slots) moves
+                // each envelope into the inbox as part of the dequeue itself, so the bridge has to mark
+                // the envelopes as already persisted or the companion local queue's DurableReceiver
+                // stores them a second time -- a DuplicateIncomingEnvelopeException per message and
+                // every one of them permanently parked in the inbox instead of executed.
+                var alreadyPersisted = Endpoint is IDatabaseBackedEndpoint && Endpoint.Mode == EndpointMode.Durable;
+                _receiver = new GlobalPartitionedReceiverBridge(localQueue, alreadyPersisted);
             }
         }
         // If there are global partitioned topologies and this is NOT a paired endpoint, intercept matching messages


### PR DESCRIPTION
Closes #4288.

## The defect

With `GlobalPartitioned` + `UseShardedSqlServerQueues` (and the PostgreSQL twin), any message that actually round-tripped through a shard queue table — the exclusive slot listener owned by another node, or not yet accepting on the publishing node, so the companion-local-queue shortcut did not apply — was **never executed**:

1. A durable database-backed queue's dequeue (`TryPopDurablyAsync`) moves each envelope into `wolverine_incoming_envelopes` as part of the pop itself.
2. In a global partitioned topology the slot listener's receiver is a `GlobalPartitionedReceiverBridge`, which forwards to the companion **local** queue's `DurableReceiver`.
3. That receiver decides whether to persist from its *own* endpoint (`ShouldPersistBeforeProcessing = !(endpoint is IDatabaseBackedEndpoint)`) — and a local queue is not database-backed, so it stored the envelope a **second** time.
4. `DuplicateIncomingEnvelopeException` per message, the envelope settled but never enqueued for execution, and the row left parked as `Incoming` owned by a live node — invisible to every recovery sweep, so it never self-heals. Store-driven recovery (`EnqueueDirectlyAsync` → bridge) re-hit the same duplicate, which is why even that could not unstick them.

This is exactly why the issue's controls pass: a plain durable SQL Server queue's own receiver *is* database-backed (no bridge), and RabbitMQ's dequeue does not touch the inbox, so the local receiver's store is the first one.

## The fix

- `GlobalPartitionedReceiverBridge` stamps `Envelope.WasPersistedInInbox` before forwarding when the source endpoint is a durable `IDatabaseBackedEndpoint` (wired in `ListeningAgent`).
- `ListeningAgent.EnqueueDirectlyAsync`'s bridge branch stamps it unconditionally — everything routed there (inbox recovery, DLQ replay, scheduled firing) came out of the message store by definition, so recovery of previously-stuck rows now heals too.
- `DurableReceiver` skips the inbox store for a marked envelope on the single, batch, and latched paths, while still settling the delivery and enqueueing for execution.

Broker-backed topologies are unaffected: their bridge passes `false` and the local receiver keeps doing the first (and only) store.

## Tests

- `Bug_4288_sharded_global_partitioning_round_trip` for **both** SQL Server and PostgreSQL: sends straight to a slot endpoint so the message cannot take the local shortcut and must round-trip through the shard queue table, then asserts execution and that no `Incoming` rows are left wedged. Verified **red without the core fix** (times out with all messages `Sent`, exactly the reported state) and green with it.
- Unit coverage: bridge stamping on/off, and a `DurableReceiver` test that a pre-persisted envelope is not stored again but is still settled.

## Verification

- Full `wolverine.slnx` builds clean with `-c Release -f net9.0`.
- CoreTests: 2784 passed, 1 unrelated pre-existing failure (`Bug_4156_static_mode_with_a_class_library_composition_root`, a suite-order/static-state flake that passes in isolation and is untouched by this diff).
- SqlServerTests.Transport: 97 passed; PostgresqlTests.Transport: 110 passed; RabbitMQ global-partitioning tests: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)