### PR TITLE
GH-3959: capacity-aware agent assignment

### DIFF
--- a/src/Persistence/PostgresqlTests/Agents/capacity_aware_column_is_opt_in.cs
+++ b/src/Persistence/PostgresqlTests/Agents/capacity_aware_column_is_opt_in.cs
@@ -1,0 +1,157 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+
+namespace PostgresqlTests.Agents;
+
+/// <summary>
+/// GH-3959. The load_factor column and every statement naming it are gated on
+/// CapacityAwareAssignment, so upgrading without opting in migrates nothing and reads nothing.
+/// </summary>
+public class capacity_aware_column_is_opt_in : PostgresqlContext
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static Task<IHost> startAsync(string schema, bool capacityAware, AutoCreate autoCreate)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, schema);
+                opts.Durability.CapacityAwareAssignment = capacityAware;
+                opts.AutoBuildMessageStorageOnStartup = autoCreate;
+
+                if (autoCreate != AutoCreate.None)
+                {
+                    opts.Services.AddResourceSetupOnStartup();
+                }
+            }).StartAsync(Ct);
+    }
+
+    private static async Task<long> loadFactorColumnCountAsync(string schema)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(Ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"select count(*) from information_schema.columns where table_schema = '{schema}' and table_name = 'wolverine_nodes' and column_name = 'load_factor'";
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync(Ct));
+    }
+
+    private static async Task dropSchemaAsync(string schema)
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync(Ct);
+        await conn.DropSchemaAsync(schema, ct: Ct);
+    }
+
+    [Fact]
+    public async Task no_column_and_a_working_agent_plane_when_the_flag_is_off()
+    {
+        const string schema = "capacity_off";
+        await dropSchemaAsync(schema);
+
+        var host = await startAsync(schema, capacityAware: false, AutoCreate.CreateOrUpdate);
+
+        try
+        {
+            var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+            (await runtime.Storage.Nodes.MarkHealthCheckAsync(WolverineNode.For(runtime.Options), Ct))
+                .ShouldBeTrue();
+
+            var nodes = await runtime.Storage.Nodes.LoadAllNodesAsync(Ct);
+            nodes.ShouldNotBeEmpty();
+            nodes.ShouldAllBe(x => x.LoadFactor == null);
+
+            await runtime.Storage.Nodes.LoadNodeAgentStateAsync(Ct);
+        }
+        finally
+        {
+            await host.StopAsync(Ct);
+            host.Dispose();
+        }
+
+        (await loadFactorColumnCountAsync(schema)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task the_column_is_provisioned_and_round_trips_a_reading_when_the_flag_is_on()
+    {
+        const string schema = "capacity_on";
+        await dropSchemaAsync(schema);
+
+        var host = await startAsync(schema, capacityAware: true, AutoCreate.CreateOrUpdate);
+
+        try
+        {
+            (await loadFactorColumnCountAsync(schema)).ShouldBe(1);
+
+            var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+            var node = WolverineNode.For(runtime.Options);
+            node.LoadFactor = 42.5;
+            (await runtime.Storage.Nodes.MarkHealthCheckAsync(node, Ct)).ShouldBeTrue();
+
+            var reloaded = await runtime.Storage.Nodes.LoadAllNodesAsync(Ct);
+            reloaded.Single(x => x.NodeId == runtime.Options.UniqueNodeId)
+                .LoadFactor.ShouldBe(42.5);
+        }
+        finally
+        {
+            await host.StopAsync(Ct);
+            host.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The case the gate exists for: an AutoCreate.None deployment that upgrades without opting in
+    /// never gets the column provisioned, and must not be asked for it.
+    /// </summary>
+    [Fact]
+    public async Task auto_create_none_against_a_database_without_the_column()
+    {
+        const string schema = "capacity_none";
+        await dropSchemaAsync(schema);
+
+        // Provision with the column, then drop it: that is exactly the pre-GH-3959 node table.
+        var seed = await startAsync(schema, capacityAware: true, AutoCreate.CreateOrUpdate);
+        await seed.StopAsync(Ct);
+        seed.Dispose();
+
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync(Ct);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"alter table {schema}.wolverine_nodes drop column load_factor";
+            await cmd.ExecuteNonQueryAsync(Ct);
+        }
+
+        var host = await startAsync(schema, capacityAware: false, AutoCreate.None);
+
+        try
+        {
+            var runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+            await runtime.Storage.Nodes.MarkHealthCheckAsync(WolverineNode.For(runtime.Options), Ct);
+            await runtime.Storage.Nodes.LoadAllNodesAsync(Ct);
+            await runtime.Storage.Nodes.LoadNodeAgentStateAsync(Ct);
+        }
+        finally
+        {
+            await host.StopAsync(Ct);
+            host.Dispose();
+        }
+
+        (await loadFactorColumnCountAsync(schema)).ShouldBe(0);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -941,6 +941,13 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
             nodeTable.AddColumn<string>("version");
             nodeTable.AddColumn("capabilities", "text[]").AllowNulls();
 
+            // GH-3959: provisioned only behind the opt-in so an upgrade migrates nothing.
+            // PostgresqlNodePersistence gates every statement naming it on the same flag.
+            if (Durability.CapacityAwareAssignment)
+            {
+                nodeTable.AddColumn(DatabaseConstants.LoadFactor, "double precision").AllowNulls();
+            }
+
             yield return nodeTable;
 
             var assignmentTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeAssignmentsTableName));

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
@@ -26,12 +26,14 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
 
     private readonly DatabaseSettings _settings;
     private readonly DbObjectName _restrictionTable;
+    private readonly DurabilitySettings _durability;
 
     public PostgresqlNodePersistence(DatabaseSettings settings, PostgresqlMessageStore database,
         NpgsqlDataSource dataSource)
     {
         _settings = settings;
         _database = database;
+        _durability = database.Durability;
         _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
         var schemaName = settings.SchemaName ?? "public";
         _nodeTable = new DbObjectName(schemaName, NodeTableName);
@@ -41,6 +43,14 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
 
         _lockId = schemaName.GetDeterministicHashCode();
     }
+
+    // GH-3959: load_factor is only provisioned behind this flag (PostgresqlMessageStore.AllObjects),
+    // so every statement naming it is gated on it too -- otherwise an un-migrated database
+    // (AutoCreate.None, or no DDL rights) fails node startup with a bare 42703. Read live rather than
+    // captured: this is constructed before the flag is reliably set.
+    private bool advertisesLoad => _durability.CapacityAwareAssignment;
+
+    private string nodeColumns => advertisesLoad ? $"{NodeColumns}, {LoadFactor}" : NodeColumns;
 
     public Task ClearAllAsync(CancellationToken cancellationToken)
     {
@@ -85,7 +95,7 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
         var nodes = new List<WolverineNode>();
 
         await using var cmd = _dataSource.CreateCommand(
-            $"select {NodeColumns} from {_nodeTable};select {Id}, {NodeId}, {Started} from {_assignmentTable};");
+            $"select {nodeColumns} from {_nodeTable};select {Id}, {NodeId}, {Started} from {_assignmentTable};");
 
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -151,7 +161,7 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
         var restrictions = new List<AgentRestriction>();
         
         await using var cmd = _dataSource.CreateCommand(
-            $"select {NodeColumns} from {_nodeTable};select {Id}, {NodeId}, {Started} from {_assignmentTable};select id, uri, type, node from {_restrictionTable}");
+            $"select {nodeColumns} from {_nodeTable};select {Id}, {NodeId}, {Started} from {_assignmentTable};select id, uri, type, node from {_restrictionTable}");
         
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -199,7 +209,7 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
         }
 
         await using var cmd = _dataSource.CreateCommand(
-                $"select {NodeColumns} from {_nodeTable} where id = :id;select {Id}, {NodeId}, {Started} from {_assignmentTable} where node_id = :id;")
+                $"select {nodeColumns} from {_nodeTable} where id = :id;select {Id}, {NodeId}, {Started} from {_assignmentTable} where node_id = :id;")
             .With("id", nodeId);
 
         WolverineNode returnValue = default!;
@@ -288,8 +298,20 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
 
     public async Task<bool> MarkHealthCheckAsync(WolverineNode node, CancellationToken token)
     {
-        var count = await _dataSource.CreateCommand($"update {_nodeTable} set health_check = now() where id = :id")
-            .With("id", node.NodeId).ExecuteNonQueryAsync(token);
+        // GH-3959: the load advertisement rides the same single-statement heartbeat write, so the
+        // leader never places agents against a reading older than one HealthCheckPollingTime.
+        var cmd = _dataSource
+            .CreateCommand(advertisesLoad
+                ? $"update {_nodeTable} set health_check = now(), {LoadFactor} = :load where id = :id"
+                : $"update {_nodeTable} set health_check = now() where id = :id")
+            .With("id", node.NodeId);
+
+        if (advertisesLoad)
+        {
+            cmd = cmd.With("load", (object?)node.LoadFactor ?? DBNull.Value);
+        }
+
+        var count = await cmd.ExecuteNonQueryAsync(token);
 
         // GH-3604 / D2: a miss means a peer deleted this still-live node's row; report it to the caller
         // instead of blindly re-inserting a skeleton (fresh node_number, empty capabilities) here.
@@ -302,15 +324,25 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
         // capabilities so the resurrected row matches the identity the process still uses in memory.
         var strings = node.Capabilities.Select(x => x.ToString()).ToArray();
 
-        await _dataSource.CreateCommand(
-                $"insert into {_nodeTable} (id, node_number, uri, capabilities, description, version, health_check) values (:id, :number, :uri, :capabilities, :description, :version, now()) on conflict (id) do update set node_number = :number, uri = :uri, capabilities = :capabilities, description = :description, version = :version, health_check = now()")
+        var loadColumn = advertisesLoad ? $", {LoadFactor}" : string.Empty;
+        var loadValue = advertisesLoad ? ", :load" : string.Empty;
+        var loadUpdate = advertisesLoad ? $", {LoadFactor} = :load" : string.Empty;
+
+        var cmd = _dataSource.CreateCommand(
+                $"insert into {_nodeTable} (id, node_number, uri, capabilities, description, version, health_check{loadColumn}) values (:id, :number, :uri, :capabilities, :description, :version, now(){loadValue}) on conflict (id) do update set node_number = :number, uri = :uri, capabilities = :capabilities, description = :description, version = :version, health_check = now(){loadUpdate}")
             .With("id", node.NodeId)
             .With("number", node.AssignedNodeNumber)
             .With("uri", (node.ControlUri ?? TransportConstants.LocalUri).ToString())
             .With("capabilities", strings)
             .With("description", node.Description)
-            .With("version", node.Version.ToString())
-            .ExecuteNonQueryAsync(token);
+            .With("version", node.Version.ToString());
+
+        if (advertisesLoad)
+        {
+            cmd = cmd.With("load", (object?)node.LoadFactor ?? DBNull.Value);
+        }
+
+        await cmd.ExecuteNonQueryAsync(token);
     }
 
     public Task LogRecordsAsync(params NodeRecord[] records)
@@ -396,6 +428,17 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
 
         var capabilities = await reader.GetFieldValueAsync<string[]>(7);
         node.Capabilities.AddRange(capabilities.Select(x => new Uri(x)));
+
+        // GH-3959: resolved by name -- a select that stops appending the column should fail loudly
+        // here rather than read a wrong hard-coded ordinal.
+        if (advertisesLoad)
+        {
+            var loadFactor = reader.GetOrdinal(LoadFactor);
+            if (!await reader.IsDBNullAsync(loadFactor))
+            {
+                node.LoadFactor = await reader.GetFieldValueAsync<double>(loadFactor);
+            }
+        }
 
         return node;
     }

--- a/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
@@ -136,5 +136,11 @@ public class DatabaseConstants
     public static readonly string Started = "started";
     public static readonly string HealthCheck = "health_check";
     public static readonly string Capabilities = "capabilities";
+
+    // GH-3959: per-node load advertisement. Deliberately NOT part of NodeColumns -- every store's
+    // readNode is a positional read over that shared list, and only PostgreSQL persists this column
+    // -- and then only when DurabilitySettings.CapacityAwareAssignment provisioned it.
+    public static readonly string LoadFactor = "load_factor";
+
     public static readonly string NodeColumns = $"{Id}, {NodeNumber}, {Description}, {Uri}, {Started}, {HealthCheck}, {Version}, {Capabilities}";
 }

--- a/src/Testing/CoreTests/Runtime/Agents/capacity_aware_distribution.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/capacity_aware_distribution.cs
@@ -122,6 +122,42 @@ public class capacity_aware_distribution
     }
 
     [Fact]
+    public void loads_within_the_same_band_defer_to_the_foreign_count_ordering()
+    {
+        var grid = new AssignmentGrid();
+
+        // node1 reads marginally lighter, but both readings sit in the same 10-point band, so the
+        // GH-3877 foreign-count order still decides — the node carrying other schemes' work loses.
+        var node1 = grid.WithNode(1, Guid.NewGuid()).Running(new Uri("red://1"), new Uri("red://2"));
+        node1.LoadFactor = 41.2;
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+        node2.LoadFactor = 44.7;
+
+        grid.WithAgents(blue1);
+        grid.DistributeEvenly("blue");
+
+        grid.AgentFor(blue1).AssignedNode.ShouldBe(node2);
+    }
+
+    [Fact]
+    public void loads_in_different_bands_outrank_the_foreign_count_ordering()
+    {
+        var grid = new AssignmentGrid();
+
+        // A band's worth of separation means the advertised load wins even against a node
+        // carrying nothing foreign.
+        var node1 = grid.WithNode(1, Guid.NewGuid()).Running(new Uri("red://1"), new Uri("red://2"));
+        node1.LoadFactor = 15;
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+        node2.LoadFactor = 45;
+
+        grid.WithAgents(blue1);
+        grid.DistributeEvenly("blue");
+
+        grid.AgentFor(blue1).AssignedNode.ShouldBe(node1);
+    }
+
+    [Fact]
     public void memory_pressure_monitor_honors_the_0_to_100_contract()
     {
         var monitor = new MemoryPressureLoadMonitor();

--- a/src/Testing/CoreTests/Runtime/Agents/capacity_aware_distribution.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/capacity_aware_distribution.cs
@@ -1,0 +1,137 @@
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+public class capacity_aware_distribution
+{
+    private readonly Uri blue1 = new Uri("blue://1");
+    private readonly Uri blue2 = new Uri("blue://2");
+    private readonly Uri blue3 = new Uri("blue://3");
+    private readonly Uri blue4 = new Uri("blue://4");
+    private readonly Uri blue5 = new Uri("blue://5");
+    private readonly Uri blue6 = new Uri("blue://6");
+
+    [Fact]
+    public void shed_pass_never_detaches_pinned_agents()
+    {
+        var grid = new AssignmentGrid();
+        grid.OverloadShedBatchSize = 2;
+
+        var node1 = grid.WithNode(1, Guid.NewGuid()).Running(blue1, blue2, blue3);
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+
+        node1.IsOverloaded = true;
+        node1.IsAcceptingAgents = false;
+
+        grid.AgentFor(blue1).IsPinned = true;
+        grid.AgentFor(blue2).IsPinned = true;
+
+        grid.DistributeEvenly("blue");
+
+        // Only the unpinned agent may be shed; the pins stay put
+        grid.AgentFor(blue1).AssignedNode.ShouldBe(node1);
+        grid.AgentFor(blue2).AssignedNode.ShouldBe(node1);
+        grid.AgentFor(blue3).AssignedNode.ShouldBe(node2);
+    }
+
+    [Fact]
+    public void ceiling_detach_never_detaches_pinned_agents()
+    {
+        var grid = new AssignmentGrid();
+
+        // 6 agents over 2 nodes -> ceiling of 3, so node1 must give up 2 of its 5.
+        // With 3 of them pinned, the 2 detached must both be unpinned.
+        var node1 = grid.WithNode(1, Guid.NewGuid()).Running(blue1, blue2, blue3, blue4, blue5);
+        var node2 = grid.WithNode(2, Guid.NewGuid()).Running(blue6);
+
+        grid.AgentFor(blue1).IsPinned = true;
+        grid.AgentFor(blue2).IsPinned = true;
+        grid.AgentFor(blue3).IsPinned = true;
+
+        grid.DistributeEvenly("blue");
+
+        grid.AgentFor(blue1).AssignedNode.ShouldBe(node1);
+        grid.AgentFor(blue2).AssignedNode.ShouldBe(node1);
+        grid.AgentFor(blue3).AssignedNode.ShouldBe(node1);
+
+        // The unpinned extras moved to the other node and total load stayed even
+        node1.Agents.Count.ShouldBe(3);
+        node2.Agents.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void overloaded_node_receives_no_placements()
+    {
+        var grid = new AssignmentGrid();
+
+        var node1 = grid.WithNode(1, Guid.NewGuid());
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+
+        node1.IsOverloaded = true;
+        node1.IsAcceptingAgents = false;
+
+        grid.WithAgents(blue1, blue2, blue3, blue4);
+        grid.DistributeEvenly("blue");
+
+        node1.Agents.ShouldBeEmpty();
+        node2.Agents.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public void all_nodes_overloaded_leaves_agents_waiting()
+    {
+        var grid = new AssignmentGrid();
+
+        var node1 = grid.WithNode(1, Guid.NewGuid()).Running(blue1);
+        var node2 = grid.WithNode(2, Guid.NewGuid()).Running(blue2);
+
+        foreach (var node in grid.Nodes)
+        {
+            node.IsOverloaded = true;
+            node.IsAcceptingAgents = false;
+        }
+
+        grid.WithAgents(blue3, blue4);
+        grid.DistributeEvenly("blue");
+
+        // Nothing new is placed anywhere; the unassigned agents wait
+        grid.AgentFor(blue3).AssignedNode.ShouldBeNull();
+        grid.AgentFor(blue4).AssignedNode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void node_in_the_hysteresis_band_neither_sheds_nor_receives()
+    {
+        var grid = new AssignmentGrid();
+
+        // Between the receive line and the shed line: not overloaded, not accepting
+        var node1 = grid.WithNode(1, Guid.NewGuid()).Running(blue1, blue2);
+        var node2 = grid.WithNode(2, Guid.NewGuid());
+
+        node1.IsAcceptingAgents = false;
+
+        grid.WithAgents(blue3, blue4);
+        grid.DistributeEvenly("blue");
+
+        // Keeps what it has, takes nothing new
+        grid.AgentFor(blue1).AssignedNode.ShouldBe(node1);
+        grid.AgentFor(blue2).AssignedNode.ShouldBe(node1);
+        grid.AgentFor(blue3).AssignedNode.ShouldBe(node2);
+        grid.AgentFor(blue4).AssignedNode.ShouldBe(node2);
+    }
+
+    [Fact]
+    public void memory_pressure_monitor_honors_the_0_to_100_contract()
+    {
+        var monitor = new MemoryPressureLoadMonitor();
+
+        var load = monitor.CurrentLoad();
+
+        if (load.HasValue)
+        {
+            load.Value.ShouldBeGreaterThanOrEqualTo(0);
+            load.Value.ShouldBeLessThanOrEqualTo(100);
+        }
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -662,6 +662,19 @@ public class DurabilitySettings : IDescribeMyself
     ///     agents off overloaded nodes, and leaves agents unassigned when no node has headroom.
     ///     Requires a message store that persists the load advertisement (PostgreSQL today). Off by
     ///     default.
+    ///     <para>
+    ///         Scope today: only the even distribution
+    ///         (<see cref="Runtime.Agents.AssignmentGrid.DistributeEvenly(string)" />) honors the
+    ///         overload flags — dynamic, exclusive, and sticky-queue listener agents, plus event
+    ///         subscriptions on clusters with homogeneous capabilities. Group-affinity distribution
+    ///         (multi-database event stores), blue/green distribution across mixed capabilities, and
+    ///         the durability-agent affinity distribution do not yet consult node load.
+    ///     </para>
+    ///     <para>
+    ///         Enabling this provisions a load_factor column on the wolverine_nodes table. With
+    ///         <c>AutoCreate.None</c> — or a process without DDL rights — apply the schema migration
+    ///         before turning this on; otherwise every heartbeat fails against the missing column.
+    ///     </para>
     /// </summary>
     public bool CapacityAwareAssignment { get; set; }
 

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -656,6 +656,35 @@ public class DurabilitySettings : IDescribeMyself
     public int MaxLocalAgentReconciliationsPerTick { get; set; } = 50;
 
     /// <summary>
+    ///     Opt in to capacity-aware agent assignment. Each node advertises its current load (see
+    ///     <see cref="NodeLoadMonitor" />) on every heartbeat; the leader prefers the least-loaded
+    ///     nodes, never places onto a node at or above <see cref="NodeOverloadThreshold" />, sheds
+    ///     agents off overloaded nodes, and leaves agents unassigned when no node has headroom.
+    ///     Requires a message store that persists the load advertisement (PostgreSQL today). Off by
+    ///     default.
+    /// </summary>
+    public bool CapacityAwareAssignment { get; set; }
+
+    /// <summary>
+    ///     Advertised load percentage at or above which a node is considered overloaded: it begins
+    ///     shedding agents, and stops receiving new ones starting 10 points below this value.
+    ///     Default 90.
+    /// </summary>
+    public double NodeOverloadThreshold { get; set; } = 90;
+
+    /// <summary>
+    ///     Maximum number of agents per scheme the leader detaches from an overloaded node in one
+    ///     assignment evaluation. Default 1.
+    /// </summary>
+    public int OverloadShedBatchSize { get; set; } = 1;
+
+    /// <summary>
+    ///     Sampler for this node's own load when <see cref="CapacityAwareAssignment" /> is enabled.
+    ///     Null (the default) uses the built-in memory pressure monitor.
+    /// </summary>
+    public Runtime.Agents.INodeLoadMonitor? NodeLoadMonitor { get; set; }
+
+    /// <summary>
     ///     GH-3970: how many consecutive assignment ticks may fail to <i>build or start</i> an agent on this
     ///     node before the node releases it to a capable peer, using the same embargo as
     ///     <see cref="MaxLocalAgentRestartsBeforeRelease" />.
@@ -854,6 +883,9 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(AssignmentSettleNodeCount), AssignmentSettleNodeCount);
         desc.AddValue(nameof(LocalAgentReconciliationThreshold), LocalAgentReconciliationThreshold);
         desc.AddValue(nameof(MaxLocalAgentReconciliationsPerTick), MaxLocalAgentReconciliationsPerTick);
+        desc.AddValue(nameof(CapacityAwareAssignment), CapacityAwareAssignment);
+        desc.AddValue(nameof(NodeOverloadThreshold), NodeOverloadThreshold);
+        desc.AddValue(nameof(OverloadShedBatchSize), OverloadShedBatchSize);
         desc.AddValue(nameof(TenantCheckPeriod), TenantCheckPeriod);
         desc.AddValue(nameof(UpdateMetricsPeriod), UpdateMetricsPeriod);
         desc.AddValue(nameof(DurabilityMetricsEnabled), DurabilityMetricsEnabled);

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -36,9 +36,41 @@ public partial class AssignmentGrid
             return;
         }
 
-        if (_nodes.Count == 1)
+        // Per-node counts must only consider the agents in this pass — otherwise a filtered pass
+        // would detach or count agents that belong to a different pass of the same scheme.
+        var agentSet = agents.ToHashSet();
+        int countOn(Node node) => node.Agents.Count(agentSet.Contains);
+
+        // GH-3959 shed pass: an overloaded node gives up a bounded number of this pass's agents per
+        // evaluation — gradual on purpose, since pressure is re-sampled every heartbeat. The detached
+        // agents join the missing queue below; if no node has headroom they stay unassigned rather
+        // than overloading a peer. An operator's pin outranks the shed: detaching a pinned agent just
+        // makes ApplyRestrictions pin it right back next evaluation, a permanent shed/pin fight.
+        foreach (var node in _nodes.Where(x => x.IsOverloaded))
         {
-            var node = _nodes.Single();
+            foreach (var agent in node.Agents
+                         .Where(x => agentSet.Contains(x) && !x.IsPinned)
+                         .Take(OverloadShedBatchSize).ToArray())
+            {
+                agent.Detach();
+            }
+        }
+
+        // Only nodes with headroom receive placements — and "headroom" sits a hysteresis band below
+        // the shed line (see Node.IsAcceptingAgents), so a node hovering at the boundary doesn't have
+        // this pass place agents that the next pass sheds. When capacity-aware assignment is off, no
+        // node is ever flagged and this is exactly the full node list (today's behavior).
+        var receiving = _nodes.Where(x => x.IsAcceptingAgents).ToList();
+        if (receiving.Count == 0)
+        {
+            // No node has real headroom: leave the unassigned remainder waiting. The next evaluation
+            // re-reads freshly advertised loads and places them as soon as anyone recovers.
+            return;
+        }
+
+        if (receiving.Count == 1 && _nodes.Count == 1)
+        {
+            var node = receiving.Single();
             foreach (var agent in agents)
             {
                 node.Assign(agent);
@@ -47,12 +79,7 @@ public partial class AssignmentGrid
             return;
         }
 
-        // Per-node counts must only consider the agents in this pass — otherwise a filtered pass
-        // would detach or count agents that belong to a different pass of the same scheme.
-        var agentSet = agents.ToHashSet();
-        int countOn(Node node) => node.Agents.Count(agentSet.Contains);
-
-        var spread = (double)agents.Count / _nodes.Count;
+        var spread = (double)agents.Count / receiving.Count;
         var minimum = (int)Math.Floor(spread);
         var maximum = (int)Math.Ceiling(spread); // this is helpful to reduce the number of assignments
 
@@ -69,15 +96,28 @@ public partial class AssignmentGrid
         // still produces zero commands and this cannot induce reassignment churn. The ordering is a
         // snapshot taken before any assignment, which keeps a single pass filling nodes in blocks rather
         // than round-robining, and AssignedId keeps it deterministic when the foreign load ties.
-        var ordered = _nodes
-            .OrderBy(x => x.Agents.Count(a => !agentSet.Contains(a)))
+        //
+        // GH-3959: advertised load leads the ordering — the least-pressured node with headroom fills
+        // first, Orleans-style. Nodes advertising no load sort as zero, so when capacity-aware
+        // assignment is off this is the original foreign-count/AssignedId ordering unchanged.
+        var ordered = receiving
+            .OrderBy(x => x.LoadFactor ?? 0)
+            .ThenBy(x => x.Agents.Count(a => !agentSet.Contains(a)))
             .ThenBy(x => x.AssignedId)
             .ToList();
 
-        // First, pair down number of running agents if necessary. Might have to steal some later
-        foreach (var node in _nodes)
+        // First, pair down number of running agents if necessary. Might have to steal some later.
+        // Overloaded nodes are exempt: their reduction is the rate-limited shed pass above, not a
+        // ceiling computed over the nodes still accepting work. Pinned agents are never detached —
+        // they count toward the ceiling, so a node carrying pins gives up more of its unpinned
+        // agents instead.
+        foreach (var node in receiving)
         {
-            var extras = node.Agents.Where(agentSet.Contains).Skip(maximum).ToArray();
+            var pinned = node.Agents.Count(x => agentSet.Contains(x) && x.IsPinned);
+            var extras = node.Agents
+                .Where(x => agentSet.Contains(x) && !x.IsPinned)
+                .Skip(Math.Max(0, maximum - pinned))
+                .ToArray();
             foreach (var agent in extras)
             {
                 agent.Detach();

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Distribution.cs
@@ -98,10 +98,15 @@ public partial class AssignmentGrid
         // than round-robining, and AssignedId keeps it deterministic when the foreign load ties.
         //
         // GH-3959: advertised load leads the ordering — the least-pressured node with headroom fills
-        // first, Orleans-style. Nodes advertising no load sort as zero, so when capacity-aware
-        // assignment is off this is the original foreign-count/AssignedId ordering unchanged.
+        // first, Orleans-style — but in 10-point bands, not raw readings. Raw readings almost never
+        // tie exactly, so ordering on them would leave the foreign-count order below deciding nothing
+        // and every family's pass chasing the same marginally-least-loaded node between two
+        // heartbeats: precisely the cross-scheme stacking GH-3877 fixed. Within a band the readings
+        // are treated as equal and the foreign count discriminates. Nodes advertising no load sort in
+        // the lowest band, so when capacity-aware assignment is off this is the original
+        // foreign-count/AssignedId ordering unchanged.
         var ordered = receiving
-            .OrderBy(x => x.LoadFactor ?? 0)
+            .OrderBy(x => Math.Floor((x.LoadFactor ?? 0) / 10))
             .ThenBy(x => x.Agents.Count(a => !agentSet.Contains(a)))
             .ThenBy(x => x.AssignedId)
             .ToList();

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.Node.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.Node.cs
@@ -40,8 +40,29 @@ public partial class AssignmentGrid
 
         public int AssignedId { get; }
         public Guid NodeId { get; }
-        
+
         public bool IsLeader { get; internal set; }
+
+        /// <summary>
+        ///     The load percentage this node advertised on its last heartbeat, or null when it isn't
+        ///     advertising load. See <see cref="WolverineNode.LoadFactor" />.
+        /// </summary>
+        public double? LoadFactor { get; internal set; }
+
+        /// <summary>
+        ///     Whether the leader considers this node overloaded for this evaluation
+        ///     (<see cref="LoadFactor" /> at or above
+        ///     <see cref="DurabilitySettings.NodeOverloadThreshold" />): the distribution methods shed
+        ///     agents off it. Never true unless capacity-aware assignment is enabled.
+        /// </summary>
+        public bool IsOverloaded { get; internal set; }
+
+        /// <summary>
+        ///     Whether this node may receive new agent placements this evaluation. Sits a hysteresis
+        ///     band below the shed line, so a node between the two thresholds neither sheds nor
+        ///     receives. Always true when capacity-aware assignment is off.
+        /// </summary>
+        public bool IsAcceptingAgents { get; internal set; } = true;
 
         public IReadOnlyList<Agent> Agents => _agents;
         public Uri? ControlUri { get; set; }

--- a/src/Wolverine/Runtime/Agents/AssignmentGrid.cs
+++ b/src/Wolverine/Runtime/Agents/AssignmentGrid.cs
@@ -49,6 +49,12 @@ public partial class AssignmentGrid
     /// </summary>
     public DateTimeOffset EvaluationTime { get; internal set; }
 
+    /// <summary>
+    ///     How many agents per scheme the distribution methods detach from an overloaded node in one
+    ///     evaluation. Stamped from <see cref="DurabilitySettings.OverloadShedBatchSize" />.
+    /// </summary>
+    public int OverloadShedBatchSize { get; internal set; } = 1;
+
     public IReadOnlyList<Agent> AgentsForScheme(string scheme)
     {
         return _agents.Values.Where(x => x.Uri.Scheme.EqualsIgnoreCase(scheme)).ToList();
@@ -82,6 +88,7 @@ public partial class AssignmentGrid
     {
         var node = new Node(this, wolverineNode.AssignedNodeNumber, wolverineNode.NodeId, wolverineNode.Capabilities);
         node.ControlUri = wolverineNode.ControlUri;
+        node.LoadFactor = wolverineNode.LoadFactor;
 
         node.IsLeader = wolverineNode.ActiveAgents.Contains(NodeAgentController.LeaderUri);
         

--- a/src/Wolverine/Runtime/Agents/INodeLoadMonitor.cs
+++ b/src/Wolverine/Runtime/Agents/INodeLoadMonitor.cs
@@ -1,0 +1,49 @@
+namespace Wolverine.Runtime.Agents;
+
+/// <summary>
+///     Samples this node's load for capacity-aware agent assignment
+///     (<see cref="DurabilitySettings.CapacityAwareAssignment" />). The value is advertised to the
+///     cluster on every heartbeat.
+/// </summary>
+public interface INodeLoadMonitor
+{
+    /// <summary>
+    ///     The node's current load as a percentage (0–100), or null when there is no usable signal.
+    ///     Called from the heartbeat path, so implementations must be cheap and non-blocking.
+    /// </summary>
+    double? CurrentLoad();
+}
+
+/// <summary>
+///     Default <see cref="INodeLoadMonitor" />: this process's resident memory
+///     (<see cref="Environment.WorkingSet" />) as a percentage of the GC's memory budget, so 100 is
+///     roughly where managed allocations start failing. A rising reading is taken immediately; a
+///     falling one decays gradually, so one lucky GC can't mask sustained pressure.
+/// </summary>
+public class MemoryPressureLoadMonitor : INodeLoadMonitor
+{
+    private double _smoothed;
+
+    public double? CurrentLoad()
+    {
+        var info = GC.GetGCMemoryInfo();
+        if (info.TotalAvailableMemoryBytes <= 0)
+        {
+            return null;
+        }
+
+        // Deliberately WorkingSet against the GC budget (75% of the cgroup limit in a container),
+        // NOT GCMemoryInfo.MemoryLoadBytes: inside a cgroup the latter includes page cache and other
+        // processes, reads above 100% on a healthy node, and barely falls when agents stop.
+        // WorkingSet can exceed the budget (native memory, retained segments), so clamp to the
+        // documented 0-100 range before smoothing -- beyond 100 there is no more information, and
+        // clamping first keeps the decay from starting at a phantom value.
+        var raw = Math.Clamp(100.0 * Environment.WorkingSet / info.TotalAvailableMemoryBytes, 0, 100);
+
+        _smoothed = raw >= _smoothed
+            ? raw
+            : _smoothed * 0.7 + raw * 0.3;
+
+        return Math.Round(_smoothed, 2);
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.Capacity.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.Capacity.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Runtime.Agents;
+
+public partial class NodeAgentController
+{
+    // GH-3959: the node's own load sampler, created lazily so the setting can be assigned any time
+    // before the runtime starts. Null result = not advertising.
+    private INodeLoadMonitor? _loadMonitor;
+
+    private double? sampleLoad()
+    {
+        if (!_runtime.Options.Durability.CapacityAwareAssignment)
+        {
+            return null;
+        }
+
+        _loadMonitor ??= _runtime.Options.Durability.NodeLoadMonitor ?? new MemoryPressureLoadMonitor();
+
+        try
+        {
+            return _loadMonitor.CurrentLoad();
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Error sampling node load; advertising no load this heartbeat");
+            return null;
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.Capacity.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.Capacity.cs
@@ -7,6 +7,7 @@ public partial class NodeAgentController
     // GH-3959: the node's own load sampler, created lazily so the setting can be assigned any time
     // before the runtime starts. Null result = not advertising.
     private INodeLoadMonitor? _loadMonitor;
+    private bool _loadSamplingFailed;
 
     private double? sampleLoad()
     {
@@ -19,11 +20,28 @@ public partial class NodeAgentController
 
         try
         {
-            return _loadMonitor.CurrentLoad();
+            var load = _loadMonitor.CurrentLoad();
+            _loadSamplingFailed = false;
+            return load;
         }
         catch (Exception e)
         {
-            _logger.LogDebug(e, "Error sampling node load; advertising no load this heartbeat");
+            // Advertising no load is not neutral under capacity-aware assignment: the leader treats
+            // this node as always having headroom AND orders it into the lowest load band for new
+            // placements, so a persistently broken sampler makes this node the cluster's preferred
+            // placement target. Warn once per outage (heartbeats would repeat it every second or so),
+            // then stay quiet until sampling recovers.
+            if (!_loadSamplingFailed)
+            {
+                _loadSamplingFailed = true;
+                _logger.LogWarning(e,
+                    "Error sampling node load; advertising no load until sampling recovers, so the leader will treat this node as having unlimited headroom for new agent placements");
+            }
+            else
+            {
+                _logger.LogDebug(e, "Error sampling node load; advertising no load this heartbeat");
+            }
+
             return null;
         }
     }

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.EvaluateAssignments.cs
@@ -103,13 +103,28 @@ public partial class NodeAgentController
         }
         
         var grid = new AssignmentGrid();
+        grid.OverloadShedBatchSize = Math.Max(1, _runtime.Options.Durability.OverloadShedBatchSize);
 
         var capabilities = nodes.SelectMany(x => x.Capabilities).Distinct().ToArray();
         grid.WithAgents(capabilities);
-        
+
+        var capacityAware = _runtime.Options.Durability.CapacityAwareAssignment;
+        var overloadThreshold = _runtime.Options.Durability.NodeOverloadThreshold;
+
         foreach (var node in nodes)
         {
-            grid.WithNode(node);
+            var gridNode = grid.WithNode(node);
+
+            // GH-3959: only the leader flags overload, and only when the feature is on — a node that
+            // advertises no load always counts as having headroom, which keeps stores without load
+            // persistence on today's behavior. The receive line sits a 10-point hysteresis band below
+            // the shed line so placement and shedding never fight around one threshold.
+            gridNode.IsOverloaded = capacityAware
+                                    && gridNode.LoadFactor.HasValue
+                                    && gridNode.LoadFactor.Value >= overloadThreshold;
+            gridNode.IsAcceptingAgents = !capacityAware
+                                         || !gridNode.LoadFactor.HasValue
+                                         || gridNode.LoadFactor.Value < Math.Max(0, overloadThreshold - 10);
         }
 
         // GH-3785: the durability family places each database's agent next to that database's

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -98,6 +98,7 @@ public partial class NodeAgentController
         node.AssignedNodeNumber = _runtime.Options.Durability.AssignedNodeNumber;
         node.Capabilities.AddRange(_capabilities.Where(x => !_releasedAgents.ContainsKey(x)));
         node.AssignAgents(Agents.Keys.ToArray());
+        node.LoadFactor = sampleLoad();
         return node;
     }
 
@@ -112,7 +113,11 @@ public partial class NodeAgentController
         // skeleton and only build the full identity picture (node number, capabilities, every running agent)
         // on the rare miss. buildLocalNode enumerates every agent on the node, so calling it every heartbeat
         // would be a real cost on the thousands-of-agents nodes this whole fix is about.
-        var existed = await _persistence.MarkHealthCheckAsync(WolverineNode.For(_runtime.Options), token);
+        // GH-3959: the load sample rides the skeleton so capacity advertisement refreshes on EVERY
+        // heartbeat — the leader must never place agents against a stale reading.
+        var skeleton = WolverineNode.For(_runtime.Options);
+        skeleton.LoadFactor = sampleLoad();
+        var existed = await _persistence.MarkHealthCheckAsync(skeleton, token);
         if (existed)
         {
             return;

--- a/src/Wolverine/Runtime/Agents/WolverineNode.cs
+++ b/src/Wolverine/Runtime/Agents/WolverineNode.cs
@@ -16,8 +16,15 @@ public class WolverineNode
     public string Description { get; set; } = Environment.MachineName;
 
     public List<Uri> Capabilities { get; set; } = new();
-    
+
     public List<Uri> ActiveAgents { get; set; } = new();
+
+    /// <summary>
+    ///     This node's self-reported load percentage (see <see cref="INodeLoadMonitor" />), refreshed
+    ///     on every heartbeat. Null when the node is not advertising load, in which case the leader
+    ///     treats it as always having headroom.
+    /// </summary>
+    public double? LoadFactor { get; set; }
     public DateTimeOffset Started { get; set; }
     public DateTimeOffset LastHealthCheck { get; set; } = DateTimeOffset.UtcNow;
     


### PR DESCRIPTION
Rebased onto current `main` and narrowed to the capacity work. The node-side reconciliation
sweep this PR originally carried shipped separately in #4404 (hardened in #4408), so nothing
of GH-3987 is left here.

## GH-3959: capacity-aware agent assignment

Opt-in via `CapacityAwareAssignment`, off by default. Each node samples its own load through
`INodeLoadMonitor` — the default reads memory pressure from `Environment.WorkingSet` against
the GC budget — and advertises it on every heartbeat. The leader then:

- prefers the least-loaded nodes;
- never places onto a node at or above `NodeOverloadThreshold` (default 90);
- sheds at most `OverloadShedBatchSize` agents per scheme per evaluation off overloaded nodes,
  never a pinned one;
- leaves agents unassigned when no node has headroom, rather than piling them onto a survivor
  that cannot start them.

Placement stops a 10-point hysteresis band below the shed line, so the two passes cannot
oscillate around one threshold. A node advertising no load always counts as having headroom,
keeping stores without load persistence on today's behavior.

The advertisement persists in a new `wolverine_nodes` column provisioned only when the feature
is on, leaving existing schemas and `AutoCreate` settings untouched. PostgreSQL today; other
stores simply never advertise.

## Why

In the GH-3959 incident shape — three nodes collapsing to one — the survivor accepted every
assignment, ran out of memory starting them, and the leader re-decided forever: ~125
`AssignmentChanged` rows/minute with sustained `OutOfMemoryException`. Now the survivor holds
at its ceiling, the deficit surfaces as waiting agents, and recovery on scale-out is immediate.

All defaults preserve existing behavior.
