### PR TITLE
GH-4296: inbox recovery can find a tenanted database queue's listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### WolverineFx (core)
 
+- **Inbox recovery finds tenanted database-queue listeners.** (closes
+  [#4296](https://github.com/JasperFx/wolverine/issues/4296)) A PostgreSQL or SQL Server transport queue that is
+  multi-tenanted by database is served by a single `MultiTenantedQueueListener` registered under the bare
+  `postgresql://queue` address, but the per-database listeners it owns each stamp their **own**, more specific
+  `postgresql://queue/database` address into `received_at`. Inbox recovery groups orphaned rows by `received_at`
+  and then asks the endpoint collection for the listener they belong to, so every envelope a dying node left
+  behind was addressed to a listener that had never been registered under that name. The lookup missed, and
+  those rows sat in the tenant database as `owner_id = 0` forever -- not eventually, ever, on a cluster whose
+  listener for that logical queue was very much alive. `FindListenerCircuit` now asks the transport to translate
+  a `received_at` address back to the address its listener is actually registered under before giving up.
+  Sticky (exclusive) per-tenant listeners are untouched: those register the per-database address themselves.
+
 - **Global partitioning over sharded database queues executes messages again.** (closes
   [#4288](https://github.com/JasperFx/wolverine/issues/4288)) With `GlobalPartitioned` +
   `UseShardedSqlServerQueues` (and the PostgreSQL twin), any message that actually round-tripped through a

--- a/src/Persistence/PostgresqlTests/MultiTenancy/tenanted_queue_inbox_recovery_4296.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/tenanted_queue_inbox_recovery_4296.cs
@@ -1,0 +1,268 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Postgresql.Transport;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace PostgresqlTests.MultiTenancy;
+
+/// <summary>
+/// GH-4296. A PostgreSQL transport queue that is multi-tenanted by database is served by a single
+/// <see cref="MultiTenantedQueueListener"/>, registered under the bare "postgresql://queue" address. The
+/// per-database listeners it owns each stamp their OWN, more specific "postgresql://queue/database" address
+/// onto everything they receive, and that is what lands in received_at.
+///
+/// Inbox recovery groups orphaned rows by received_at and then asks the endpoint collection for the listener
+/// they belong to, so those rows were addressed to a listener that had never been registered under that name.
+/// The lookup missed, and the envelopes of any node that died mid-flight sat in the tenant database as
+/// owner_id = 0 forever -- not eventually, ever.
+/// </summary>
+public class tenanted_queue_inbox_recovery_4296 : PostgresqlContext, IAsyncLifetime
+{
+    private const string QueueName = "heavy4296";
+
+    private readonly string theSuffix = Guid.NewGuid().ToString("N")[..8];
+    private readonly string[] theTenants = ["red", "blue", "green"];
+
+    private IHost _host = null!;
+
+    private string MainSchema => $"tq4296_{theSuffix}";
+    private string TenantDatabase(string tenant) => $"w4296_{tenant}_{theSuffix}";
+
+    private static string ConnectionStringFor(string database)
+    {
+        return new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString)
+        {
+            Database = database
+        }.ConnectionString;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+
+            foreach (var tenant in theTenants)
+            {
+                var databaseName = TenantDatabase(tenant);
+                if (!await conn.DatabaseExists(databaseName))
+                {
+                    await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+                }
+            }
+
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.ScheduledJobPollingTime = 250.Milliseconds();
+
+                opts.PersistMessagesWithPostgresql(ConnectionStringFor("postgres"), MainSchema)
+                    .EnableMessageTransport(transport => transport.TransportSchemaName(MainSchema))
+                    .RegisterStaticTenants(tenants =>
+                    {
+                        foreach (var tenant in theTenants)
+                        {
+                            tenants.Register(tenant, ConnectionStringFor(TenantDatabase(tenant)));
+                        }
+                    });
+
+                opts.Services.AddResourceSetupOnStartup();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType<OrphanedQueueMessageHandler>();
+
+                opts.ListenToPostgresqlQueue(QueueName);
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_per_database_address_resolves_back_to_the_registered_listener()
+    {
+        var runtime = _host.GetRuntime();
+        var bare = PostgresqlQueue.ToUri(QueueName, null);
+
+        // This is the address the listening agent is actually registered under
+        runtime.Endpoints.FindListeningAgent(bare)
+            .ShouldNotBeNull("The multi-tenanted queue listener should be running in Solo mode");
+
+        foreach (var store in await tenantStoresAsync(runtime))
+        {
+            var receivedAt = PostgresqlQueue.ToUri(QueueName, store.Name);
+
+            // Nothing is registered under the per-database address -- that is the whole defect
+            runtime.Endpoints.FindListeningAgent(receivedAt).ShouldBeNull();
+
+            // ...but recovery still has to be able to find the circuit these rows belong to
+            var circuit = runtime.Endpoints.FindListenerCircuit(receivedAt);
+            circuit.ShouldNotBeNull($"No listener circuit resolved for the per-database address {receivedAt}");
+            circuit.Endpoint.Uri.ShouldBe(bare);
+        }
+    }
+
+    [Fact]
+    public async Task orphaned_envelopes_in_a_tenant_database_are_recovered()
+    {
+        using var tracking = OrphanedQueueMessages.Track();
+
+        var runtime = _host.GetRuntime();
+
+        var expected = new List<Guid>();
+        foreach (var store in await tenantStoresAsync(runtime))
+        {
+            // received_at exactly as the per-database listener would have stamped it before its node died
+            var receivedAt = PostgresqlQueue.ToUri(QueueName, store.Name);
+            expected.AddRange(await seedAsync(store, runtime, receivedAt, 3));
+        }
+
+        var succeeded = await waitForAsync(() => expected.All(tracking.Contains), 60.Seconds());
+
+        succeeded.ShouldBeTrue(
+            $"Expected all {expected.Count} orphaned envelopes across {theTenants.Length} tenant databases to be " +
+            $"recovered through the multi-tenanted queue listener, but only saw {tracking.Count}");
+    }
+
+    private async Task<IReadOnlyList<IMessageStore>> tenantStoresAsync(IWolverineRuntime runtime)
+    {
+        var stores = runtime.Stores.Main.As<MultiTenantedMessageStore>();
+        var list = new List<IMessageStore>();
+        foreach (var tenant in theTenants)
+        {
+            var store = await stores.Source.FindAsync(tenant);
+            store.ShouldNotBeNull();
+            list.Add(store!);
+        }
+
+        return list;
+    }
+
+    private static async Task<Guid[]> seedAsync(IMessageStore store, IWolverineRuntime runtime, Uri receivedAt,
+        int count)
+    {
+        var serializer = runtime.Options.DefaultSerializer;
+
+        var envelopes = Enumerable.Range(0, count).Select(i =>
+        {
+            var id = Guid.NewGuid();
+            var envelope = new Envelope(new OrphanedQueueMessage(id, i))
+            {
+                Id = id,
+                Destination = receivedAt,
+                Status = EnvelopeStatus.Incoming,
+                OwnerId = TransportConstants.AnyNode,
+                ContentType = serializer.ContentType,
+                MessageType = typeof(OrphanedQueueMessage).ToMessageTypeName(),
+                SentAt = DateTimeOffset.UtcNow
+            };
+
+            envelope.Data = serializer.Write(envelope);
+
+            return envelope;
+        }).ToArray();
+
+        await store.Inbox.StoreIncomingAsync(envelopes);
+
+        return envelopes.Select(x => x.Id).ToArray();
+    }
+
+    private static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition()) return true;
+            await Task.Delay(100.Milliseconds());
+        }
+
+        return condition();
+    }
+}
+
+public record OrphanedQueueMessage(Guid Id, int Index);
+
+public static class OrphanedQueueMessages
+{
+    private static readonly object _lock = new();
+    private static HashSet<Guid>? _received;
+
+    public static Tracker Track()
+    {
+        lock (_lock)
+        {
+            _received = new HashSet<Guid>();
+        }
+
+        return new Tracker();
+    }
+
+    public static void Record(Guid id)
+    {
+        lock (_lock)
+        {
+            _received?.Add(id);
+        }
+    }
+
+    public sealed class Tracker : IDisposable
+    {
+        public bool Contains(Guid id)
+        {
+            lock (_lock)
+            {
+                return _received?.Contains(id) ?? false;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _received?.Count ?? 0;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                _received = null;
+            }
+        }
+    }
+}
+
+public class OrphanedQueueMessageHandler
+{
+    public static void Handle(OrphanedQueueMessage message)
+    {
+        OrphanedQueueMessages.Record(message.Id);
+    }
+}

--- a/src/Persistence/SqlServerTests/MultiTenancy/tenanted_queue_inbox_recovery_4296.cs
+++ b/src/Persistence/SqlServerTests/MultiTenancy/tenanted_queue_inbox_recovery_4296.cs
@@ -1,0 +1,219 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.SqlServer;
+using Wolverine.SqlServer.Transport;
+using Wolverine.Tracking;
+using Wolverine.Transports;
+using Wolverine.Util;
+using Xunit;
+
+namespace SqlServerTests.MultiTenancy;
+
+/// <summary>
+/// GH-4296, the SQL Server twin of the PostgreSQL test of the same name. A database transport queue that is
+/// multi-tenanted by database is served by one <see cref="MultiTenantedQueueListener"/> registered under the
+/// bare "sqlserver://queue" address, while the per-database listeners underneath it stamp their own
+/// "sqlserver://queue/database" address into received_at. Inbox recovery resolves rows back to a listener by
+/// that address, so orphaned envelopes were addressed to a listener nothing had registered.
+/// </summary>
+public class tenanted_queue_inbox_recovery_4296 : MultiTenancyContext
+{
+    private const string QueueName = "heavy4296";
+    private const string SchemaName = "tq4296";
+
+    private readonly string[] theTenants = ["red", "blue", "green"];
+
+    protected override void configureWolverine(WolverineOptions opts)
+    {
+        opts.Durability.Mode = DurabilityMode.Solo;
+        opts.Durability.ScheduledJobPollingTime = 250.Milliseconds();
+
+        opts.UseSqlServerPersistenceAndTransport(Servers.SqlServerConnectionString, SchemaName, SchemaName)
+            .AutoProvision();
+
+        opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, SchemaName)
+            .RegisterStaticTenants(tenants =>
+            {
+                tenants.Register("red", tenant1ConnectionString);
+                tenants.Register("blue", tenant2ConnectionString);
+                tenants.Register("green", tenant3ConnectionString);
+            });
+
+        opts.Services.AddResourceSetupOnStartup();
+
+        opts.Discovery.DisableConventionalDiscovery()
+            .IncludeType<OrphanedSqlServerQueueMessageHandler>();
+
+        opts.ListenToSqlServerQueue(QueueName);
+    }
+
+    [Fact]
+    public async Task the_per_database_address_resolves_back_to_the_registered_listener()
+    {
+        var runtime = theHost.GetRuntime();
+        var bare = SqlServerQueue.ToUri(QueueName, null);
+
+        runtime.Endpoints.FindListeningAgent(bare)
+            .ShouldNotBeNull("The multi-tenanted queue listener should be running in Solo mode");
+
+        foreach (var store in await tenantStoresAsync(runtime))
+        {
+            var receivedAt = SqlServerQueue.ToUri(QueueName, store.Name);
+
+            // Nothing is registered under the per-database address -- that is the whole defect
+            runtime.Endpoints.FindListeningAgent(receivedAt).ShouldBeNull();
+
+            var circuit = runtime.Endpoints.FindListenerCircuit(receivedAt);
+            circuit.ShouldNotBeNull($"No listener circuit resolved for the per-database address {receivedAt}");
+            circuit.Endpoint.Uri.ShouldBe(bare);
+        }
+    }
+
+    [Fact]
+    public async Task orphaned_envelopes_in_a_tenant_database_are_recovered()
+    {
+        using var tracking = OrphanedSqlServerQueueMessages.Track();
+
+        var runtime = theHost.GetRuntime();
+
+        var expected = new List<Guid>();
+        foreach (var store in await tenantStoresAsync(runtime))
+        {
+            var receivedAt = SqlServerQueue.ToUri(QueueName, store.Name);
+            expected.AddRange(await seedAsync(store, runtime, receivedAt, 3));
+        }
+
+        var succeeded = await waitForAsync(() => expected.All(tracking.Contains), 60.Seconds());
+
+        succeeded.ShouldBeTrue(
+            $"Expected all {expected.Count} orphaned envelopes across {theTenants.Length} tenant databases to be " +
+            $"recovered through the multi-tenanted queue listener, but only saw {tracking.Count}");
+    }
+
+    private async Task<IReadOnlyList<IMessageStore>> tenantStoresAsync(IWolverineRuntime runtime)
+    {
+        var stores = runtime.Stores.Main.As<MultiTenantedMessageStore>();
+        var list = new List<IMessageStore>();
+        foreach (var tenant in theTenants)
+        {
+            var store = await stores.Source.FindAsync(tenant);
+            store.ShouldNotBeNull();
+            list.Add(store!);
+        }
+
+        return list;
+    }
+
+    private static async Task<Guid[]> seedAsync(IMessageStore store, IWolverineRuntime runtime, Uri receivedAt,
+        int count)
+    {
+        var serializer = runtime.Options.DefaultSerializer;
+
+        var envelopes = Enumerable.Range(0, count).Select(i =>
+        {
+            var id = Guid.NewGuid();
+            var envelope = new Envelope(new OrphanedSqlServerQueueMessage(id, i))
+            {
+                Id = id,
+                Destination = receivedAt,
+                Status = EnvelopeStatus.Incoming,
+                OwnerId = TransportConstants.AnyNode,
+                ContentType = serializer.ContentType,
+                MessageType = typeof(OrphanedSqlServerQueueMessage).ToMessageTypeName(),
+                SentAt = DateTimeOffset.UtcNow
+            };
+
+            envelope.Data = serializer.Write(envelope);
+
+            return envelope;
+        }).ToArray();
+
+        await store.Inbox.StoreIncomingAsync(envelopes);
+
+        return envelopes.Select(x => x.Id).ToArray();
+    }
+
+    private static async Task<bool> waitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition()) return true;
+            await Task.Delay(100.Milliseconds());
+        }
+
+        return condition();
+    }
+}
+
+public record OrphanedSqlServerQueueMessage(Guid Id, int Index);
+
+public static class OrphanedSqlServerQueueMessages
+{
+    private static readonly object _lock = new();
+    private static HashSet<Guid>? _received;
+
+    public static Tracker Track()
+    {
+        lock (_lock)
+        {
+            _received = new HashSet<Guid>();
+        }
+
+        return new Tracker();
+    }
+
+    public static void Record(Guid id)
+    {
+        lock (_lock)
+        {
+            _received?.Add(id);
+        }
+    }
+
+    public sealed class Tracker : IDisposable
+    {
+        public bool Contains(Guid id)
+        {
+            lock (_lock)
+            {
+                return _received?.Contains(id) ?? false;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _received?.Count ?? 0;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                _received = null;
+            }
+        }
+    }
+}
+
+public class OrphanedSqlServerQueueMessageHandler
+{
+    public static void Handle(OrphanedSqlServerQueueMessage message)
+    {
+        OrphanedSqlServerQueueMessages.Record(message.Id);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlTransport.cs
@@ -121,6 +121,29 @@ public class PostgresqlTransport : BrokerTransport<PostgresqlQueue>, ITransportC
         return identifier.Replace('-', '_').ToLowerInvariant();
     }
 
+    /// <summary>
+    ///     GH-4296. With multi-tenancy by database, the listener registered for a queue is a single
+    ///     <see cref="MultiTenantedQueueListener"/> sitting at the bare "postgresql://queue" address, while the
+    ///     per-database listeners underneath it stamp "postgresql://queue/database" onto every envelope they
+    ///     receive. Map the second shape back to the first so that inbox recovery can find the listener an
+    ///     orphaned row belongs to. Exclusive queues are excluded on purpose: those listen through the sticky
+    ///     per-tenant agents, which DO register the per-database address themselves.
+    /// </summary>
+    public override Uri? TryResolveListenerAddress(Uri receivedAt)
+    {
+        if (Databases == null) return null;
+        if (receivedAt.Scheme != Protocol) return null;
+
+        var queueName = SanitizeIdentifier(receivedAt.Host);
+        if (!Queues.Contains(queueName)) return null;
+
+        var queue = Queues[queueName];
+        if (queue.ListenerScope == ListenerScope.Exclusive) return null;
+
+        // Already the address the queue endpoint itself is registered under, so there is nothing to translate
+        return queue.Uri == receivedAt ? null : queue.Uri;
+    }
+
     protected override PostgresqlQueue findEndpointByUri(Uri uri)
     {
         // A queue reached ONLY by Uri (e.g. ListenForMessagesFrom on "postgresql://my-queue-name")

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerTransport.cs
@@ -103,6 +103,29 @@ public class SqlServerTransport : BrokerTransport<SqlServerQueue>
         return identifier.Replace('-', '_').ToLowerInvariant();
     }
 
+    /// <summary>
+    ///     GH-4296. With multi-tenancy by database, the listener registered for a queue is a single
+    ///     <see cref="MultiTenantedQueueListener"/> sitting at the bare "sqlserver://queue" address, while the
+    ///     per-database listeners underneath it stamp "sqlserver://queue/database" onto every envelope they
+    ///     receive. Map the second shape back to the first so that inbox recovery can find the listener an
+    ///     orphaned row belongs to. Exclusive queues are excluded on purpose: those listen through the sticky
+    ///     per-tenant agents, which DO register the per-database address themselves.
+    /// </summary>
+    public override Uri? TryResolveListenerAddress(Uri receivedAt)
+    {
+        if (Databases == null) return null;
+        if (receivedAt.Scheme != Protocol) return null;
+
+        var queueName = SanitizeIdentifier(receivedAt.Host);
+        if (!Queues.Contains(queueName)) return null;
+
+        var queue = Queues[queueName];
+        if (queue.ListenerScope == ListenerScope.Exclusive) return null;
+
+        // Already the address the queue endpoint itself is registered under, so there is nothing to translate
+        return queue.Uri == receivedAt ? null : queue.Uri;
+    }
+
     protected override SqlServerQueue findEndpointByUri(Uri uri)
     {
         // The fluent API (ListenToSqlServerQueue / ToSqlServerQueue) runs queue names through

--- a/src/Wolverine/Configuration/EndpointCollection.cs
+++ b/src/Wolverine/Configuration/EndpointCollection.cs
@@ -424,8 +424,56 @@ public class EndpointCollection : IEndpointCollection
             return (IListenerCircuit)GetOrBuildSendingAgent(address);
         }
 
-        return FindListeningAgent(address) ??
-               FindListeningAgent(TransportConstants.Durable);
+        var agent = FindListeningAgent(address);
+        if (agent != null)
+        {
+            return agent;
+        }
+
+        // GH-4296. The address on an inbox row is whatever listener stamped it, and that is not always an
+        // address anything is registered under. A database transport that is multi-tenanted by database
+        // registers ONE listening agent for the logical queue and then receives through a per-database
+        // listener that stamps "postgresql://queue/database" -- so every orphaned row from a dead node is
+        // addressed to a listener that does not exist by that name, and inbox recovery walked straight past
+        // it forever. Ask the transport to translate before giving up.
+        var logicalAddress = resolveListenerAddress(address);
+        if (logicalAddress != null)
+        {
+            agent = FindListeningAgent(logicalAddress);
+            if (agent != null)
+            {
+                return agent;
+            }
+        }
+
+        return FindListeningAgent(TransportConstants.Durable);
+    }
+
+    private ImHashMap<Uri, Uri?> _resolvedListenerAddresses = ImHashMap<Uri, Uri?>.Empty;
+
+    // Cached for the same reason IsSingleNodeListener is: this is asked on every durability agent recovery
+    // pass, once per distinct received_at value.
+    private Uri? resolveListenerAddress(Uri address)
+    {
+        if (_resolvedListenerAddresses.TryFind(address, out var resolved))
+        {
+            return resolved;
+        }
+
+        try
+        {
+            resolved = _options.Transports.ForScheme(address.Scheme)?.TryResolveListenerAddress(address);
+        }
+        catch (Exception e)
+        {
+            _runtime.Logger.LogDebug(e, "Unable to resolve a listening address for inbox address {Address}",
+                address);
+            resolved = null;
+        }
+
+        _resolvedListenerAddresses = _resolvedListenerAddresses.AddOrUpdate(address, resolved);
+
+        return resolved;
     }
 
     public async Task StartListenerAsync(Endpoint endpoint, CancellationToken cancellationToken)

--- a/src/Wolverine/Transports/ITransport.cs
+++ b/src/Wolverine/Transports/ITransport.cs
@@ -55,6 +55,19 @@ public interface ITransport
     Endpoint GetOrCreateEndpoint(Uri uri);
     Endpoint? TryGetEndpoint(Uri uri);
 
+    /// <summary>
+    ///     Map an address stamped onto an inbox row as <c>received_at</c> back to the address the listening
+    ///     endpoint is actually registered under, for the transports where the two are not the same thing.
+    ///     The database transports are the case in point: under multi-tenancy by database a single logical
+    ///     queue endpoint listens across every tenant database, and the per-database listener it owns stamps
+    ///     its own, more specific "scheme://queue/database" address onto everything it receives. Inbox
+    ///     recovery groups orphaned rows by <c>received_at</c> and then has to find the listener they belong
+    ///     to, so without this translation those rows are addressed to a listener that was never registered
+    ///     anywhere and are never recovered -- see GH-4296. Return null when the address needs no
+    ///     translation, which is the default and the answer for every broker transport.
+    /// </summary>
+    Uri? TryResolveListenerAddress(Uri receivedAt) => null;
+
     public IEnumerable<Endpoint> Endpoints();
 
     ValueTask InitializeAsync(IWolverineRuntime runtime);

--- a/src/Wolverine/Transports/TransportBase.cs
+++ b/src/Wolverine/Transports/TransportBase.cs
@@ -77,6 +77,14 @@ public abstract class TransportBase<TEndpoint> : ITransport, ITagged where TEndp
         return findEndpointByUri(uri);
     }
 
+    /// <summary>
+    ///     See <see cref="ITransport.TryResolveListenerAddress"/>. Declared here as a virtual rather than left to
+    ///     the interface's default implementation because a derived transport that does not re-list
+    ///     <see cref="ITransport"/> in its own base list inherits this class's interface map, and a matching method
+    ///     it declares would silently never be called.
+    /// </summary>
+    public virtual Uri? TryResolveListenerAddress(Uri receivedAt) => null;
+
     public virtual bool TryBuildStatefulResource(IWolverineRuntime runtime, out IStatefulResource? resource)
     {
         resource = default;


### PR DESCRIPTION
Closes #4296.

## The defect

A PostgreSQL or SQL Server transport queue that is multi-tenanted by database is served by **one** `MultiTenantedQueueListener`, registered in the endpoint collection under the bare `postgresql://queue` address. The per-database listeners it owns are not registered anywhere, and each of them stamps its own, more specific `postgresql://queue/database` address onto everything it receives — that is the value that lands in `received_at`.

`CheckRecoverableIncomingMessagesOperation` groups orphaned inbox rows by `received_at` and then asks the endpoint collection for the listener circuit those rows belong to. For these rows the answer was always "no such listener", because nothing had ever been registered under the per-database address. So the envelopes a dying node left behind as `owner_id = 0` were invisible to recovery permanently — not eventually, ever — on a cluster whose listener for that logical queue was very much alive.

The reporter isolated this precisely: identical envelope, identical state, identical host, the only variable being the address format. `postgresql://queue/` recovered in ~27s; `postgresql://queue/<tenant db>` never recovered at all.

## The fix

`FindListenerCircuit` now asks the transport to translate a `received_at` address back to the address its listener is actually registered under before falling through to the durable-queue fallback. The translation is a new `ITransport` hook that defaults to `null`, so every broker transport is unaffected. The result is cached per address, like `IsSingleNodeListener` already is, because it is asked once per distinct `received_at` on every recovery pass.

This is deliberately a **lookup-side** fix rather than changing what gets written into `received_at`: the rows already stranded in production databases are recovered by it too, with no migration.

The PostgreSQL and SQL Server implementations decline **exclusive** queues on purpose — those listen through the sticky per-tenant agents, which *do* register the per-database address themselves, so their rows already resolve directly.

### One thing worth calling out

The hook is declared as a `virtual` on `TransportBase`, not left to the interface's default implementation. A derived transport that does not re-list `ITransport` in its own base list inherits `TransportBase`'s interface map, so `PostgresqlTransport`'s matching method would silently never be called. That is not hypothetical — it is what the first run of the new tests caught, with the transport resolving the address correctly when called directly and `FindListenerCircuit` still answering null.

## Tests

`tenanted_queue_inbox_recovery_4296`, one on each provider, each with two facts:

- the per-database address resolves back to the registered listener (and nothing is registered under the per-database address, which pins *why* the direct lookup misses);
- nine orphaned envelopes seeded across three tenant databases, stamped exactly as a dead node's per-database listener would have stamped them, are all recovered and handled.

Both fail against the old behavior — no circuit resolved, 0 of 9 recovered — and pass with the fix.

`dotnet build wolverine.slnx -c Release -f net9.0` is clean. CoreTests: 2784 passed, 1 failed — `Bug_4156_static_mode_with_a_class_library_composition_root`, the known suite-order flake already being fixed in #4299, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)