### PR TITLE
GH-4287: drop the jasperfx#742 tolerance from the AOT publish smoke

### DIFF
--- a/build/CITargets.cs
+++ b/build/CITargets.cs
@@ -1236,9 +1236,9 @@ partial class Build
             // AOT startup crash in that issue shipped unseen: GetReferencedAssemblies() throwing,
             // the stack walk with no frame metadata, and Activator.CreateInstance over trimmed
             // closed generics all behave fine under the JIT and only fail in a native image. This
-            // one does a REAL PublishAot and executes the produced native binary. See the smoke's
-            // csproj for the tolerated jasperfx#742 upstream blocker and how the assertion deepens
-            // automatically once a fixed JasperFx is pinned.
+            // one does a REAL PublishAot and executes the produced native binary, asserting the
+            // full boot + one dispatched message. The pinned JasperFx (2.63.1+) carries the
+            // jasperfx#742 bootstrap guard, so any regression here fails the lane outright.
             var publishSmoke = RootDirectory / "src" / "Testing" / "Wolverine.AotSmoke.Publish" /
                                "Wolverine.AotSmoke.Publish.csproj";
             var publishSmokeOutput = RootDirectory / "src" / "Testing" / "Wolverine.AotSmoke.Publish" /

--- a/src/Testing/Wolverine.AotSmoke.Publish/Program.cs
+++ b/src/Testing/Wolverine.AotSmoke.Publish/Program.cs
@@ -1,11 +1,6 @@
 // AOT smoke test #3 (GH-4287) — see the csproj header for the full story. Boots a Wolverine host
 // inside a REAL Native AOT binary through the ordinary public UseWolverine path, dispatches one
-// message, and asserts the handler fired. Exit codes:
-//
-//   0  full boot + dispatch succeeded, OR the known upstream JasperFx blocker (jasperfx#742) was
-//      hit — which still proves the Wolverine-side bootstrap fixes hold, since that crash sits
-//      BEHIND them in the startup sequence and is reported loudly as a tolerated blocker.
-//   1  anything else.
+// message, and asserts the handler fired. Exit 0 only on the full boot + dispatch.
 //
 // `codegen write` (or any JasperFx CLI verb) refreshes the committed pre-gen under
 // Internal/Generated/ — run it under plain `dotnet run`, never from the native binary.
@@ -62,21 +57,6 @@ try
     }
 
     Console.WriteLine("OK: Native AOT boot + dispatch smoke passed.");
-    return 0;
-}
-catch (PlatformNotSupportedException e) when (
-    e.StackTrace?.Contains("HasReferenceToJasperFxTool") == true)
-{
-    // jasperfx#742: JasperFx.AddJasperFx unconditionally calls GetReferencedAssemblies(), which
-    // the Native AOT runtime does not implement. This crash sits BEHIND Wolverine's own bootstrap
-    // (the UseWolverine caller-assembly capture and extension discovery), so reaching it proves
-    // the GH-4287 Wolverine-side fixes still hold. Tolerated until a JasperFx release with the
-    // guard is pinned — at which point this handler stops matching and the smoke asserts the
-    // full boot automatically.
-    Console.WriteLine(
-        "KNOWN UPSTREAM BLOCKER (jasperfx#742): JasperFx.AddJasperFx crashed on GetReferencedAssemblies() "
-        + "under Native AOT. The Wolverine-side bootstrap survived to this point, which is what this "
-        + "smoke can assert today. Remove this tolerance once the pinned JasperFx carries the #742 guard.");
     return 0;
 }
 catch (Exception e)

--- a/src/Testing/Wolverine.AotSmoke.Publish/Wolverine.AotSmoke.Publish.csproj
+++ b/src/Testing/Wolverine.AotSmoke.Publish/Wolverine.AotSmoke.Publish.csproj
@@ -23,13 +23,9 @@
         pre-gen under Internal/Generated/), dispatches a message, and asserts
         the handler fired.
 
-        Known upstream blocker: JasperFx.AddJasperFx still crashes under Native
-        AOT (jasperfx#742). Until a JasperFx release with that guard is pinned,
-        the program treats exactly that crash signature as a tolerated,
-        loudly-reported KNOWN BLOCKER and exits 0 — reaching it at all proves
-        the Wolverine-side bootstrap fixes hold, and any OTHER failure exits
-        non-zero. Once the pinned JasperFx moves past #742, the smoke
-        automatically starts asserting the full boot + dispatch.
+        The pinned JasperFx (2.63.1+) carries the jasperfx#742 bootstrap guard,
+        so this smoke asserts the FULL boot + dispatch: any startup crash or a
+        handler that never fires exits non-zero and fails the lane.
 
         Refresh procedure for the committed pre-gen when codegen output drifts
         (from this project's directory):


### PR DESCRIPTION
Cleanup follow-up to #4298 + #4301. With JasperFx 2.63.1 pinned, the tolerated-blocker catch in `Wolverine.AotSmoke.Publish` can never match again — `CIAotSmoke` already passed the **full** Native AOT boot + dispatch assertion on #4301's final run. This deletes the dead catch and the comments describing the staged behavior; the smoke now exits 0 only on a complete boot with the handler observed firing. Verified locally: fresh `PublishAot` against the released 2.63.1 packages prints `OK: Native AOT boot + dispatch smoke passed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)