### PR TITLE
Bump JasperFx dependencies to 2.63.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.8.0" />
-    <PackageVersion Include="JasperFx" Version="2.63.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.63.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.63.1" />
+    <PackageVersion Include="JasperFx" Version="2.63.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.63.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.63.2" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.63.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.63.2" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.32.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Moves all four JasperFx line packages together (`JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`) from 2.63.1 to **2.63.2**, released today.

2.63.2 carries [jasperfx#748](https://github.com/JasperFx/jasperfx/pull/748) (closes [jasperfx#747](https://github.com/JasperFx/jasperfx/issues/747)): **a Native AOT publish no longer reports trim/AOT warnings out of JasperFx.**

That is the second half of #4232, whose literal ask was "Build should produce no warnings". Against 2.63.1 a Wolverine `PublishAot` application reports seven IL warnings — two `IL3000` on `Assembly.Location`, three `IL2026`, and the `IL2104`/`IL3053` assembly rollups — every one raised against **JasperFx's** IL rather than the application's, so nothing the app author could act on or suppress. With this pin the publish is clean.

The startup-crash half of #4232 was already closed by #4298 plus the 2.63.1 pin in #4301, and the `Wolverine.AotSmoke.Publish` smoke has since dropped its tolerated-blocker catch and asserts the full native boot + dispatch.

## Verification

- Real `PublishAot --use-current-runtime` of a Wolverine application consuming the **released** packages: **zero IL warnings**, with `-p:TrimmerSingleWarn=false` so nothing hides behind the assembly rollup.
- Full `wolverine.slnx` builds clean at `-c Release -f net9.0`.
- CoreTests: **2786 passed, 0 failed** — the `Bug_4156` order-dependent flake that shadowed recent runs is gone now that #4299 has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)