### PR TITLE
Recurring cron-scheduled messages (opts.Schedules)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,6 +83,11 @@
     <PackageVersion Include="MQTTnet.Server" Version="5.2.0.1603" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
     <PackageVersion Include="NATS.Net" Version="2.8.2" />
+    <!-- The cron EXPRESSION PARSER behind opts.Schedules (recurring messages). A parser, not a
+         scheduling engine — Wolverine's own scheduled-message machinery is the engine. MIT, zero
+         transitive dependencies, correct DST handling. In core by explicit decision (CritterWatch
+         planning 2026-09-04) rather than a satellite package. -->
+    <PackageVersion Include="Cronos" Version="0.11.0" />
     <PackageVersion Include="NewId" Version="4.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,6 +179,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                     items: [
                         {text: 'Introduction to Messaging', link: '/guide/messaging/introduction'},
                         {text: 'Sending Messages', link: '/guide/messaging/message-bus'},
+                        {text: 'Recurring Messages', link: '/guide/messaging/recurring'},
                         {text: 'Message Routing', link: '/guide/messaging/subscriptions'},
                         {text: 'Listening Endpoints', link: '/guide/messaging/listeners'},
                         {

--- a/docs/guide/messaging/recurring.md
+++ b/docs/guide/messaging/recurring.md
@@ -34,7 +34,7 @@ builder.UseWolverine(opts =>
     opts.Schedules.RecurringMessage<SendMorningDigest>(nineAmCentral);
 });
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L10-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_recurring_messages' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L37-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_recurring_messages' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The message types are handled like any other message — the cron machinery only decides *when* an
@@ -63,7 +63,7 @@ public static class RecurringSampleHandler
         => Console.WriteLine("Good morning!");
 }
 ```
-<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L40-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_recurring_message_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L67-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_recurring_message_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Registering the first schedule is the feature's opt-in. A host with zero schedules registered
@@ -101,6 +101,77 @@ seconds: durable scheduled messages replay on `DurabilitySettings.ScheduledJobPo
 (5 seconds by default), so a faster schedule cannot be honoured and is refused as unsatisfiable
 rather than accepted and delivered late.
 
+## Durable tracking: record and verify
+
+When the message store supports it (every relational database provider — PostgreSQL, SQL Server,
+MySQL, SQLite), the recurring feature keeps a small tracking table
+(`wolverine_recurring_messages`) beside the inbox: one row per registered schedule, mapping the
+schedule's name to the envelope id(s) of its pre-scheduled next occurrence. The scheduled inbox
+row is still the materialized occurrence — the tracking table is bookkeeping, never a delivery
+path — but it upgrades the agent's guarantee from fire-and-forget to **record and verify**:
+
+* Every publish records the pre-scheduled envelope ids on the schedule's row.
+* The agent's loop periodically confirms those envelopes still sit `Scheduled` in the inbox, and
+  re-publishes the occurrence (same deterministic deduplication id) when something cancelled or
+  lost it out from under the schedule.
+* After a failover or restart, the successor agent *adopts* its predecessor's verified pending
+  occurrence off the row instead of blindly re-publishing it.
+* Management tooling can see which schedule owns which pending envelope — and cancel or
+  reschedule an occurrence through the ordinary scheduled-message surface — without parsing
+  deduplication-id strings.
+
+The table is provisioned only on the main message store and only when at least one schedule is
+registered, so the opt-in stays schema-neutral: a host with zero schedules migrates exactly as it
+did before the feature existed.
+
+## Pausing and resuming a schedule
+
+Pause/resume is the one piece of runtime-mutable state the feature has — schedule *definitions*
+stay code-first. `IRecurringScheduleControl` is registered in the container alongside the first
+schedule:
+
+<!-- snippet: sample_pausing_and_resuming_recurring_messages -->
+<a id='snippet-sample_pausing_and_resuming_recurring_messages'></a>
+```cs
+// Registered alongside the first schedule — resolve it straight
+// from the container
+var control = host.Services.GetRequiredService<IRecurringScheduleControl>();
+
+// Pause: marks the schedule's durable tracking row AND eagerly cancels
+// the pre-scheduled next occurrence, so nothing fires in the gap before
+// the scheduling agent's next pass — even when this code runs on a
+// different node than the agent
+await control.PauseAsync("daily-report");
+
+// Resume: the next occurrence is computed strictly after "now".
+// The paused window is never back-filled
+await control.ResumeAsync("daily-report");
+
+// The tracking rows themselves: which schedule owns which pending
+// envelope, next fire times, pause state
+var schedules = await control.QueryAsync();
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L12-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pausing_and_resuming_recurring_messages' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The semantics, precisely:
+
+* **Pause marks the durable tracking row and eagerly cancels the pending pre-scheduled
+  envelope.** The caller may be on a different node than the scheduling agent, so nothing is
+  allowed to fire in the gap before the agent's next pass — the mark and the cancel happen in one
+  database transaction. Occurrences already *executing* are unaffected.
+* **Resume schedules strictly after now.** The first occurrence after a resume is the next one
+  the cron computes from the resume instant; the paused window is never back-filled.
+* **Pause survives restarts and failovers** — it lives on the row, not in agent memory.
+* Pausing or resuming a name that was never registered throws; pausing an already-paused schedule
+  is a no-op that keeps the original pause timestamp.
+
+On a message store *without* the tracking extension (including no store at all), pause and resume
+degrade to the local agent's memory: they only take effect when the running agent is in the same
+process, are lost on restart, and cannot cancel an occurrence that is already pre-scheduled —
+that one will still fire. This is a documented degradation of the same kind as the
+[no-message-store mode](#running-without-a-message-store) below.
+
 ## Failure semantics
 
 All of these are deliberate, and worth knowing before relying on the feature:
@@ -113,6 +184,10 @@ All of these are deliberate, and worth knowing before relying on the feature:
 * **Failover and restart are harmless.** The agent's working state is in-memory; re-publishing
   the same occurrence produces the same deduplication id.
 * **A failed publish logs and retries on the next tick.** It never kills the scheduling loop.
+* **An occurrence with no subscribers or handlers is not a publish.** The agent logs a warning
+  (once per schedule) and keeps retrying each pass, so a subscription that appears later — or a
+  routing table that was still warming up — still gets the occurrence on time rather than
+  silently skipping it.
 
 ## Running without a message store
 

--- a/docs/guide/messaging/recurring.md
+++ b/docs/guide/messaging/recurring.md
@@ -16,11 +16,11 @@ builder.UseWolverine(opts =>
     // Simplest possible usage: a message type with a public, no-argument
     // constructor, published on a cron schedule. The schedule's name defaults
     // to the message type's name
-    opts.Schedules.RecurringMessage<RunNightlyRollup>("0 2 * * *");
+    opts.Schedules.ScheduleRecurring<RunNightlyRollup>("0 2 * * *");
 
     // Or build the message per occurrence — the factory is handed the
     // occurrence time, so a message can describe the window it covers
-    opts.Schedules.RecurringMessage(
+    opts.Schedules.ScheduleRecurring(
         "daily-report",
         "0 9 * * *",
         occurrence => new BuildDailyReport(occurrence.AddDays(-1), occurrence));
@@ -31,7 +31,7 @@ builder.UseWolverine(opts =>
         "0 9 * * *",
         TimeZoneInfo.FindSystemTimeZoneById("America/Chicago"));
 
-    opts.Schedules.RecurringMessage<SendMorningDigest>(nineAmCentral);
+    opts.Schedules.ScheduleRecurring<SendMorningDigest>(nineAmCentral);
 });
 ```
 <sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L37-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_recurring_messages' title='Start of snippet'>anchor</a></sup>

--- a/docs/guide/messaging/recurring.md
+++ b/docs/guide/messaging/recurring.md
@@ -172,6 +172,23 @@ process, are lost on restart, and cannot cancel an occurrence that is already pr
 that one will still fire. This is a documented degradation of the same kind as the
 [no-message-store mode](#running-without-a-message-store) below.
 
+## Diagnostics
+
+Registered schedules surface in three places, all populated from the registrations themselves —
+there is no parallel configuration surface to keep in sync:
+
+* **The service capabilities snapshot** (`ServiceCapabilities.RecurringSchedules`) carries one
+  typed descriptor per schedule — name, cron expression, time zone, message type, plus the live
+  pause state and pending next occurrence read from the tracking extension — so monitoring
+  consoles (CritterWatch) can render and manage schedules without parsing deduplication-id
+  strings. The read is best-effort: an unreachable database costs the snapshot the runtime
+  fields, never the schedule definitions.
+* **`wolverine describe`** renders a Recurring Messages table (name, cron, time zone, message
+  type, computed next occurrence).
+* **The Event Model**: a slice whose command type has a registered schedule is triggered by the
+  job scheduler — the same treatment `TimeoutMessage` gets — with the cron expression as the
+  trigger origin's label.
+
 ## Failure semantics
 
 All of these are deliberate, and worth knowing before relying on the feature:

--- a/docs/guide/messaging/recurring.md
+++ b/docs/guide/messaging/recurring.md
@@ -1,0 +1,133 @@
+# Recurring Messages <Badge type="tip" text="6.34" />
+
+Wolverine has long supported [scheduled message delivery](/guide/messaging/message-bus#scheduling-message-delivery-or-execution)
+for one-off, "run this later" messages. `opts.Schedules` builds recurring, cron-driven messages on
+top of exactly that machinery: a single agent per cluster keeps the *next* occurrence of every
+registered schedule pre-scheduled through the ordinary scheduled-message pipeline, and everything
+else — delivery, durability, replay after a crash, management tooling — is the infrastructure that
+already ships.
+
+<!-- snippet: sample_registering_recurring_messages -->
+<a id='snippet-sample_registering_recurring_messages'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.UseWolverine(opts =>
+{
+    // Simplest possible usage: a message type with a public, no-argument
+    // constructor, published on a cron schedule. The schedule's name defaults
+    // to the message type's name
+    opts.Schedules.RecurringMessage<RunNightlyRollup>("0 2 * * *");
+
+    // Or build the message per occurrence — the factory is handed the
+    // occurrence time, so a message can describe the window it covers
+    opts.Schedules.RecurringMessage(
+        "daily-report",
+        "0 9 * * *",
+        occurrence => new BuildDailyReport(occurrence.AddDays(-1), occurrence));
+
+    // Cron expressions parse into a first class value type that you can
+    // construct, hold, and reuse — including with an explicit time zone
+    var nineAmCentral = new CronSchedule(
+        "0 9 * * *",
+        TimeZoneInfo.FindSystemTimeZoneById("America/Chicago"));
+
+    opts.Schedules.RecurringMessage<SendMorningDigest>(nineAmCentral);
+});
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L10-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_recurring_messages' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The message types are handled like any other message — the cron machinery only decides *when* an
+occurrence is published, never how it is processed:
+
+<!-- snippet: sample_recurring_message_types -->
+<a id='snippet-sample_recurring_message_types'></a>
+```cs
+// Recurring messages are handled like any other message — the cron machinery
+// only decides WHEN they are published, never how they are processed
+public record RunNightlyRollup;
+
+public record BuildDailyReport(DateTimeOffset From, DateTimeOffset To);
+
+public record SendMorningDigest;
+
+public static class RecurringSampleHandler
+{
+    public static void Handle(RunNightlyRollup message)
+        => Console.WriteLine("Rolling up!");
+
+    public static void Handle(BuildDailyReport message)
+        => Console.WriteLine($"Reporting on {message.From} to {message.To}");
+
+    public static void Handle(SendMorningDigest message)
+        => Console.WriteLine("Good morning!");
+}
+```
+<sup><a href='https://github.com/JasperFx/wolverine/blob/main/src/Samples/DocumentationSamples/RecurringMessageSamples.cs#L40-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_recurring_message_types' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Registering the first schedule is the feature's opt-in. A host with zero schedules registered
+behaves — and migrates its message store — exactly as it did before this feature existed. The first
+registration wires three things:
+
+1. **The recurring-message agent**, a [singular agent](/tutorials/leader-election) that runs on
+   exactly one node in the cluster and moves on failover. Its whole job is a guarantee: the next
+   occurrence of each schedule is published with a `ScheduledTime`, so the envelope sits in the
+   same place every other scheduled message sits (the durable inbox when a message store is
+   configured) and fires through the same poller.
+2. **Occurrence deduplication.** Every occurrence carries a deterministic
+   [logical deduplication id](/guide/durability/idempotency) of the form
+   `"{scheduleName}:{occurrenceUtc}"` — identical on any node and after any restart — and the
+   deduplication middleware is applied to the handler chains of exactly the cron-scheduled message
+   types. An agent failover or restart that re-publishes the same occurrence is collapsed at
+   consumption rather than executed twice. (The requirement is deliberately non-strict: publishing
+   the same message type by hand, without an id, passes through untouched.)
+3. **Trace attribution.** Each occurrence carries its schedule's name in a `recurring-schedule`
+   envelope header, surfaced on the handler's OpenTelemetry activity as the
+   `wolverine.schedule.name` tag, so trace consumers can attribute work to the cron job that
+   caused it.
+
+## Cron expressions
+
+`CronSchedule` accepts the standard 5-field cron grammar, or 6 fields where the leading field is
+seconds, parsed by [Cronos](https://github.com/HangfireIO/Cronos). Occurrences are computed in the
+schedule's time zone (UTC unless one is supplied), with daylight-saving transitions handled
+correctly: a schedule inside a spring-forward gap fires at the adjusted instant, and a fall-back
+repeat fires once.
+
+An invalid expression throws at the registration call site — a bad schedule is a programming
+error, and it should fail at the line that wrote it. So does a cadence faster than every 5
+seconds: durable scheduled messages replay on `DurabilitySettings.ScheduledJobPollingTime`
+(5 seconds by default), so a faster schedule cannot be honoured and is refused as unsatisfiable
+rather than accepted and delivered late.
+
+## Failure semantics
+
+All of these are deliberate, and worth knowing before relying on the feature:
+
+* **Missed occurrences are skipped, never back-filled.** The one pre-scheduled envelope still
+  fires even with the agent down — it is an ordinary scheduled message — and only occurrences
+  *after* it in an agent-less window are lost. This is the reason for the agent shape over a
+  self-perpetuating message that schedules its own successor, which dies permanently the first
+  time its envelope is discarded. A missed firing is a missed firing, not a dead schedule.
+* **Failover and restart are harmless.** The agent's working state is in-memory; re-publishing
+  the same occurrence produces the same deduplication id.
+* **A failed publish logs and retries on the next tick.** It never kills the scheduling loop.
+
+## Running without a message store
+
+A host with no message store still runs recurring messages — the agent starts directly (there is
+no cluster to coordinate) and occurrences ride the in-process scheduling model. Two things degrade,
+and Wolverine warns about both at startup:
+
+* An occurrence inside a restart window is lost. The *schedule* itself survives — the agent
+  re-establishes the next occurrence from the registrations at startup — but anything that was
+  pending in memory when the process died is gone.
+* There is no store-backed occurrence deduplication, so an agent restart can double-publish an
+  occurrence where a broker's native deduplication does not cover it.
+
+`DurabilityMode.Serverless` and `DurabilityMode.MediatorOnly` are different: those modes run no
+agents at all, so a registered schedule would be accepted and then silently never fire. Wolverine
+**refuses to start** in those modes with schedules registered, naming the schedules in the
+exception — a schedule that quietly never happens is exactly the failure this feature exists to
+avoid.

--- a/src/Persistence/MySql/MySqlTests/recurring_message_compliance.cs
+++ b/src/Persistence/MySql/MySqlTests/recurring_message_compliance.cs
@@ -1,0 +1,15 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.MySql;
+
+namespace MySqlTests;
+
+[Collection("mysql")]
+public class recurring_message_compliance : RecurringMessageCompliance
+{
+    protected override void configurePersistence(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithMySql(Servers.MySqlConnectionString, "recurring_compliance");
+    }
+}

--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -534,6 +534,12 @@ internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
             yield return new DeduplicationTable(SchemaName);
         }
 
+        // Recurring-message tracking — Main store only, behind the opt-in. See the PostgreSQL twin.
+        if (Durability.EnableRecurringMessages && Role == MessageStoreRole.Main)
+        {
+            yield return new RecurringMessagesTable(SchemaName);
+        }
+
         if (Role == MessageStoreRole.Main)
         {
             var nodeTable = new Table(new DbObjectName(SchemaName, DatabaseConstants.NodeTableName));

--- a/src/Persistence/MySql/Wolverine.MySql/Schema/RecurringMessagesTable.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Schema/RecurringMessagesTable.cs
@@ -1,0 +1,29 @@
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.MySql.Schema;
+
+/// <summary>
+/// Tracking table for recurring (cron) message schedules. See the PostgreSQL twin for the full
+/// rationale — one row per registered schedule, bookkeeping beside the inbox and never a delivery
+/// path, provisioned only on the Main store behind the
+/// <see cref="DurabilitySettings.EnableRecurringMessages" /> opt-in.
+/// </summary>
+internal class RecurringMessagesTable : Table
+{
+    public RecurringMessagesTable(string schemaName) : base(
+        new DbObjectName(schemaName, DatabaseConstants.RecurringMessagesTableName))
+    {
+        // 250 chars stays inside InnoDB's 3072-byte index key limit even at utf8mb4's 4 bytes per
+        // character, so this is a legal primary key without a prefix length.
+        AddColumn(DatabaseConstants.ScheduleName, "varchar(250)").NotNull().AsPrimaryKey();
+        AddColumn(DatabaseConstants.CronExpression, "varchar(250)").NotNull();
+        AddColumn(DatabaseConstants.EnvelopeIds, "varchar(2000)").NotNull();
+        AddColumn(DatabaseConstants.DeduplicationId, "varchar(250)").AllowNulls();
+        AddColumn<DateTimeOffset>(DatabaseConstants.NextOccurrence).AllowNulls();
+        AddColumn<bool>(DatabaseConstants.Paused).NotNull();
+        AddColumn<DateTimeOffset>(DatabaseConstants.PausedAt).AllowNulls();
+        AddColumn<DateTimeOffset>(DatabaseConstants.LastUpdated).NotNull();
+    }
+}

--- a/src/Persistence/PersistenceTests/ModularMonoliths/recurring_table_is_main_database_only_in_a_modular_monolith.cs
+++ b/src/Persistence/PersistenceTests/ModularMonoliths/recurring_table_is_main_database_only_in_a_modular_monolith.cs
@@ -1,0 +1,157 @@
+using IntegrationTests;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Weasel.Core;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PersistenceTests.ModularMonoliths;
+
+/// <summary>
+/// The wolverine_recurring_messages tracking table is MAIN-DATABASE-ONLY bookkeeping — in a
+/// modular monolith whose module owns an ancillary store on its own database, the ancillary
+/// database gets its own envelope tables but must NEVER grow the recurring table: the single
+/// cluster-wide recurring agent publishes through the main store, and a second copy of the table
+/// would be tracking rows nothing reads. The "absent on the ancillary database" assertion is
+/// paired with an "envelope tables present there" guard, so an ancillary store that simply failed
+/// to migrate cannot pass this test vacuously.
+/// </summary>
+public class recurring_table_is_main_database_only_in_a_modular_monolith : IAsyncLifetime
+{
+    // Dedicated durability schema so the physical assertions and the pre-clean touch nothing any
+    // other suite provisions in the shared "wolverine" schema.
+    private const string SchemaName = "recurring_mono";
+
+    private IHost _host = null!;
+    private string _ancillaryConnectionString = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new NpgsqlConnection(Servers.PostgresConnectionString))
+        {
+            await conn.OpenAsync();
+
+            var builder = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString);
+            var exists = await conn.DatabaseExists("database1");
+            if (!exists)
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, "database1");
+            }
+
+            builder.Database = "database1";
+            _ancillaryConnectionString = builder.ConnectionString;
+        }
+
+        // Idempotence: stale tables left by an older build must not decide this run.
+        foreach (var connectionString in new[] { Servers.PostgresConnectionString, _ancillaryConnectionString })
+        {
+            await dropSchema(connectionString);
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType(typeof(MonolithRecurringMessageHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.MessageStorageSchemaName = SchemaName;
+
+                // The main store...
+                opts.Services.AddMarten(m =>
+                {
+                    m.Connection(Servers.PostgresConnectionString);
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                // ...and a module's ancillary store on its OWN database, the modular monolith shape.
+                opts.Services.AddMartenStore<IFirstStore>(m =>
+                {
+                    m.Connection(_ancillaryConnectionString);
+                    m.DatabaseSchemaName = "first_recurring";
+                    m.DisableNpgsqlLogging = true;
+                }).IntegrateWithWolverine();
+
+                // The registration is the feature's opt-in — set before any migration runs.
+                opts.Schedules.ScheduleRecurring<MonolithRecurringMessage>(
+                    "monolith-shape", "0 * * * *", _ => new MonolithRecurringMessage());
+            })
+            .ConfigureServices(services => services.AddResourceSetupOnStartup())
+            .StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_table_is_on_main_and_never_on_the_ancillary_database()
+    {
+        // Main database: migrated, and carrying the recurring table.
+        var mainTables = await tablesInSchema(Servers.PostgresConnectionString);
+        mainTables.ShouldContain(DatabaseConstants.IncomingTable);
+        mainTables.ShouldContain(DatabaseConstants.RecurringMessagesTableName);
+
+        // Ancillary database: its own envelope tables exist (the guard that keeps this honest) —
+        // and the recurring table does not.
+        var ancillaryTables = await tablesInSchema(_ancillaryConnectionString);
+        ancillaryTables.ShouldContain(DatabaseConstants.IncomingTable,
+            "the ancillary database was never migrated, so the absence assertion below would be vacuous");
+        ancillaryTables.ShouldNotContain(DatabaseConstants.RecurringMessagesTableName);
+
+        // The runtime agrees: only the main store carries a live recurring tracking store.
+        var runtime = _host.GetRuntime();
+        runtime.Storage.RecurringMessages.Enabled.ShouldBeTrue();
+
+        var ancillary = runtime.Stores.FindAncillaryStore(typeof(IFirstStore));
+        ancillary.ShouldNotBeNull();
+        ancillary.Role.ShouldBe(MessageStoreRole.Ancillary);
+    }
+
+    private static async Task dropSchema(string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await conn.RunSqlAsync($"drop schema if exists {SchemaName} cascade");
+    }
+
+    private static async Task<string[]> tablesInSchema(string connectionString)
+    {
+        var list = new List<string>();
+
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select table_name from information_schema.tables where table_schema = @schema";
+        cmd.Parameters.AddWithValue("schema", SchemaName);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            list.Add(reader.GetString(0));
+        }
+
+        return list.ToArray();
+    }
+}
+
+public class MonolithRecurringMessage;
+
+public static class MonolithRecurringMessageHandler
+{
+    public static void Handle(MonolithRecurringMessage message)
+    {
+    }
+}

--- a/src/Persistence/PostgresqlTests/MultiTenancy/recurring_table_exists_only_on_the_main_database.cs
+++ b/src/Persistence/PostgresqlTests/MultiTenancy/recurring_table_exists_only_on_the_main_database.cs
@@ -1,0 +1,162 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Weasel.Core;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PostgresqlTests.MultiTenancy;
+
+/// <summary>
+/// The wolverine_recurring_messages tracking table is MAIN-DATABASE-ONLY bookkeeping: the single
+/// cluster-wide recurring agent publishes through the main store, so that is the one place the
+/// table may ever exist. A tenant database that grew the table would invite split-brain tracking
+/// rows nothing reads. Every "absent on a tenant" assertion here is paired with an "envelope
+/// tables present on that same tenant" guard, so a tenant database that simply failed to migrate
+/// cannot pass this test vacuously.
+/// </summary>
+public class recurring_table_exists_only_on_the_main_database : PostgresqlContext, IAsyncLifetime
+{
+    // Dedicated schema so the physical-table assertions cannot collide with any other suite's
+    // leftovers in the shared "wolverine" schema — and so the pre-clean drops nothing shared.
+    private const string SchemaName = "recurring_tenancy";
+
+    private IHost _host = null!;
+    private string _tenant1ConnectionString = null!;
+    private string _tenant2ConnectionString = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await conn.OpenAsync();
+
+        _tenant1ConnectionString = await createDatabaseIfNotExists(conn, "db1");
+        _tenant2ConnectionString = await createDatabaseIfNotExists(conn, "db2");
+
+        // Idempotence: a stale recurring table left on a tenant database by an older build must
+        // fail THIS run's product code, not this run's leftovers.
+        foreach (var connectionString in new[]
+                     { Servers.PostgresConnectionString, _tenant1ConnectionString, _tenant2ConnectionString })
+        {
+            await dropSchema(connectionString);
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType(typeof(TenancyRecurringMessageHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, SchemaName)
+                    .RegisterStaticTenants(tenants =>
+                    {
+                        tenants.Register("one", _tenant1ConnectionString);
+                        tenants.Register("two", _tenant2ConnectionString);
+                    });
+
+                // The registration is the feature's opt-in — this is what flips
+                // EnableRecurringMessages before any migration runs.
+                opts.Schedules.ScheduleRecurring<TenancyRecurringMessage>(
+                    "tenancy-shape", "0 * * * *", _ => new TenancyRecurringMessage());
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_table_is_on_main_and_never_on_a_tenant_database()
+    {
+        // Main database: migrated, and carrying the recurring table.
+        var mainTables = await tablesInSchema(Servers.PostgresConnectionString);
+        mainTables.ShouldContain(DatabaseConstants.IncomingTable);
+        mainTables.ShouldContain(DatabaseConstants.RecurringMessagesTableName);
+
+        // Each tenant database: migrated (the guard that keeps this test honest) — and the
+        // recurring table absent.
+        foreach (var tenantConnectionString in new[] { _tenant1ConnectionString, _tenant2ConnectionString })
+        {
+            var tenantTables = await tablesInSchema(tenantConnectionString);
+            tenantTables.ShouldContain(DatabaseConstants.IncomingTable,
+                "tenant database was never migrated, so the absence assertion below would be vacuous");
+            tenantTables.ShouldNotContain(DatabaseConstants.RecurringMessagesTableName);
+        }
+
+        // And the runtime wiring agrees with the physical shape, per role.
+        var stores = await _host.GetRuntime().Stores.FindAllAsync();
+        stores.ShouldNotBeEmpty();
+        foreach (var store in stores)
+        {
+            if (store.Role == MessageStoreRole.Main)
+            {
+                store.RecurringMessages.Enabled.ShouldBeTrue();
+            }
+            else
+            {
+                store.RecurringMessages.Enabled.ShouldBeFalse();
+            }
+        }
+    }
+
+    private static async Task<string> createDatabaseIfNotExists(NpgsqlConnection conn, string databaseName)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(Servers.PostgresConnectionString);
+
+        var exists = await conn.DatabaseExists(databaseName);
+        if (!exists)
+        {
+            await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+        }
+
+        builder.Database = databaseName;
+
+        return builder.ConnectionString;
+    }
+
+    private static async Task dropSchema(string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await conn.RunSqlAsync($"drop schema if exists {SchemaName} cascade");
+    }
+
+    private static async Task<string[]> tablesInSchema(string connectionString)
+    {
+        var list = new List<string>();
+
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select table_name from information_schema.tables where table_schema = @schema";
+        cmd.Parameters.AddWithValue("schema", SchemaName);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            list.Add(reader.GetString(0));
+        }
+
+        return list.ToArray();
+    }
+}
+
+public class TenancyRecurringMessage;
+
+public static class TenancyRecurringMessageHandler
+{
+    public static void Handle(TenancyRecurringMessage message)
+    {
+    }
+}

--- a/src/Persistence/PostgresqlTests/recurring_message_compliance.cs
+++ b/src/Persistence/PostgresqlTests/recurring_message_compliance.cs
@@ -1,0 +1,14 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Postgresql;
+
+namespace PostgresqlTests;
+
+public class recurring_message_compliance : RecurringMessageCompliance
+{
+    protected override void configurePersistence(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "recurring_compliance");
+    }
+}

--- a/src/Persistence/SqlServerTests/Persistence/recurring_message_compliance.cs
+++ b/src/Persistence/SqlServerTests/Persistence/recurring_message_compliance.cs
@@ -1,0 +1,14 @@
+using IntegrationTests;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.SqlServer;
+
+namespace SqlServerTests.Persistence;
+
+public class recurring_message_compliance : RecurringMessageCompliance
+{
+    protected override void configurePersistence(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "recurring_compliance");
+    }
+}

--- a/src/Persistence/SqliteTests/recurring_message_compliance.cs
+++ b/src/Persistence/SqliteTests/recurring_message_compliance.cs
@@ -1,0 +1,24 @@
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Sqlite;
+
+namespace SqliteTests;
+
+[Collection("sqlite")]
+public class recurring_message_compliance : RecurringMessageCompliance, IAsyncLifetime
+{
+    // One file for the whole class so the restart facts (pause survives, adoption) see the same
+    // database from their second host.
+    private readonly SqliteTestDatabase _database = Servers.CreateDatabase(nameof(recurring_message_compliance));
+
+    protected override void configurePersistence(WolverineOptions opts)
+    {
+        opts.PersistMessagesWithSqlite(_database.ConnectionString);
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await base.DisposeAsync();
+        _database.Dispose();
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -916,6 +916,14 @@ join pg_catalog.pg_namespace n on n.oid = c.relnamespace and n.nspname = '{Schem
             yield return new DeduplicationTable(SchemaName);
         }
 
+        // Recurring-message tracking — Main store only (the single cluster-wide agent publishes
+        // through the main store), and only behind the opt-in so a schedule-less upgrade
+        // migrates nothing.
+        if (Durability.EnableRecurringMessages && Role == MessageStoreRole.Main)
+        {
+            yield return new RecurringMessagesTable(SchemaName);
+        }
+
         foreach (var table in _externalTables)
         {
             yield return table;

--- a/src/Persistence/Wolverine.Postgresql/Schema/RecurringMessagesTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Schema/RecurringMessagesTable.cs
@@ -1,0 +1,35 @@
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.Postgresql.Schema;
+
+/// <summary>
+/// Tracking table for recurring (cron) message schedules — one row per registered schedule,
+/// mapping the schedule name to the envelope id(s) of its pre-scheduled next occurrence plus its
+/// pause state. Bookkeeping beside the inbox, never a delivery path: the scheduled inbox row IS
+/// the materialized next occurrence. Provisioned only on the Main store and only when
+/// <see cref="DurabilitySettings.EnableRecurringMessages" /> is set (i.e. at least one schedule
+/// is registered through <c>opts.Schedules</c>).
+/// </summary>
+internal class RecurringMessagesTable : Table
+{
+    public RecurringMessagesTable(string schemaName) : base(
+        new DbObjectName(schemaName, DatabaseConstants.RecurringMessagesTableName))
+    {
+        // 250 matches the deduplication-id convention; a schedule name is an identity meant to be
+        // legible in the database, not a payload.
+        AddColumn(DatabaseConstants.ScheduleName, "varchar(250)").NotNull().AsPrimaryKey();
+        AddColumn(DatabaseConstants.CronExpression, "varchar(250)").NotNull();
+
+        // Comma-joined envelope ids ("N" format) — usually one, more when the message type routes
+        // to multiple durable subscribers; empty while paused or before the first publish. 2000
+        // characters holds ~60 ids, far past any plausible subscriber count for one message type.
+        AddColumn(DatabaseConstants.EnvelopeIds, "varchar(2000)").NotNull();
+        AddColumn(DatabaseConstants.DeduplicationId, "varchar(250)").AllowNulls();
+        AddColumn<DateTimeOffset>(DatabaseConstants.NextOccurrence).AllowNulls();
+        AddColumn<bool>(DatabaseConstants.Paused).NotNull();
+        AddColumn<DateTimeOffset>(DatabaseConstants.PausedAt).AllowNulls();
+        AddColumn<DateTimeOffset>(DatabaseConstants.LastUpdated).NotNull();
+    }
+}

--- a/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
@@ -80,6 +80,24 @@ public class DatabaseConstants
 
     public const string Expires = "expires";
 
+    /// <summary>
+    /// Tracking table for recurring (cron) message schedules — one row per registered schedule,
+    /// mapping the schedule name to the envelope id(s) of its pre-scheduled next occurrence plus
+    /// pause state. Bookkeeping beside the inbox, never a delivery path: the scheduled inbox row
+    /// IS the materialized next occurrence. Provisioned only on the Main store and only when
+    /// <c>DurabilitySettings.EnableRecurringMessages</c> is set (i.e. at least one schedule is
+    /// registered), so an upgrade forces no migration on applications without the feature.
+    /// </summary>
+    public const string RecurringMessagesTableName = "wolverine_recurring_messages";
+
+    public const string ScheduleName = "schedule_name";
+    public const string CronExpression = "cron_expression";
+    public const string EnvelopeIds = "envelope_ids";
+    public const string NextOccurrence = "next_occurrence";
+    public const string Paused = "paused";
+    public const string PausedAt = "paused_at";
+    public const string LastUpdated = "last_updated";
+
     public static readonly string IncomingFields =
         $"{Body}, {Id}, {Status}, {OwnerId}, {ExecutionTime}, {Attempts}, {MessageType}, {ReceivedAt}, {KeepUntil}";
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Admin.cs
@@ -308,6 +308,16 @@ public abstract partial class MessageDatabase<T>
 
             if (_settings.Role == MessageStoreRole.Main)
             {
+                // Recurring-message tracking rows are Main-only bookkeeping (the table only
+                // exists when the feature's opt-in flag is set). A surviving row would let a
+                // later test adopt a previous test's "pending occurrence" or inherit its pause.
+                if (Durability.EnableRecurringMessages)
+                {
+                    await tx.CreateCommand(
+                            $"delete from {QuotedTableNameFor(DatabaseConstants.RecurringMessagesTableName)}")
+                        .ExecuteNonQueryAsync(_cancellation);
+                }
+
                 await tx.CreateCommand($"delete from {QuotedTableNameFor(DatabaseConstants.AgentRestrictionsTableName)}")
                     .ExecuteNonQueryAsync(_cancellation);
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -18,6 +18,7 @@ using Wolverine.Runtime;
 using Wolverine.Runtime.Agents;
 using Wolverine.Transports;
 using Wolverine.RDBMS.Deduplication;
+using Wolverine.RDBMS.Recurring;
 using Wolverine.RDBMS.DynamicListeners;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
 
@@ -108,6 +109,17 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
             // ReSharper disable once VirtualMemberCallInConstructor
             Deduplication = BuildDeduplicationStore();
         }
+
+        // Recurring-message tracking (see IRecurringMessageStore) — Main store only, like the
+        // listener registry: the single cluster-wide recurring agent publishes through the main
+        // store, so that is where the bookkeeping beside its inbox lives. Gated on the opt-in
+        // flag (flipped by registering the first schedule) so existing apps see no schema
+        // migration churn on upgrade.
+        if (settings.EnableRecurringMessages && Role == MessageStoreRole.Main)
+        {
+            // ReSharper disable once VirtualMemberCallInConstructor
+            RecurringMessages = BuildRecurringMessageStore();
+        }
     }
 
     /// <summary>
@@ -126,6 +138,25 @@ public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
 
     /// <inheritdoc />
     public IDeduplicationStore Deduplication { get; private set; } = NullDeduplicationStore.Instance;
+
+    /// <summary>
+    /// Factory hook for the per-database <see cref="IRecurringMessageStore" /> when
+    /// <see cref="DurabilitySettings.EnableRecurringMessages" /> is set on a
+    /// <see cref="MessageStoreRole.Main" /> store. The default returns
+    /// <see cref="RdbmsRecurringMessageStore" />, portable across every provider that uses
+    /// <c>@</c>-prefixed bind variables and <see cref="DbDataSource" />-driven command creation
+    /// (Postgres, SqlServer, MySQL, SQLite).
+    /// </summary>
+    protected virtual IRecurringMessageStore BuildRecurringMessageStore()
+    {
+        return new RdbmsRecurringMessageStore(_dataSource,
+            QuotedTableNameFor(DatabaseConstants.RecurringMessagesTableName),
+            QuotedTableNameFor(DatabaseConstants.IncomingTable),
+            IsUniqueConstraintViolation);
+    }
+
+    /// <inheritdoc />
+    public IRecurringMessageStore RecurringMessages { get; private set; } = NullRecurringMessageStore.Instance;
 
     /// <summary>
     /// Factory hook for constructing the per-database <see cref="IListenerStore"/> when

--- a/src/Persistence/Wolverine.RDBMS/Recurring/RdbmsRecurringMessageStore.cs
+++ b/src/Persistence/Wolverine.RDBMS/Recurring/RdbmsRecurringMessageStore.cs
@@ -1,0 +1,323 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Weasel.Core;
+using Wolverine.Persistence.Durability;
+
+namespace Wolverine.RDBMS.Recurring;
+
+/// <summary>
+/// Cross-provider <see cref="IRecurringMessageStore" /> backed by the single
+/// <c>wolverine_recurring_messages</c> table — one row per registered recurring schedule, keyed by
+/// the schedule name.
+///
+/// <para>
+/// Plain parameterized INSERT / UPDATE / DELETE only, no per-provider UPSERT or MERGE syntax, so
+/// the same implementation serves PostgreSQL, SQL Server, MySQL and SQLite unchanged (the
+/// <see cref="Deduplication.RdbmsDeduplicationStore" /> precedent). The upsert is
+/// update-then-insert with the provider's duplicate-key classifier arbitrating the one real race
+/// — the single cluster-wide agent writing a schedule's first row while an operator pauses it.
+/// </para>
+///
+/// <para>
+/// <see cref="PauseAsync" /> runs its two effects — marking the row paused and cancelling the
+/// tracked pre-scheduled inbox envelopes — in ONE transaction, which is the point of the
+/// extension living beside the inbox in the same database: nothing may fire in the gap between
+/// the mark and the cancel, and a half-applied pause cannot survive a crash.
+/// </para>
+/// </summary>
+internal sealed class RdbmsRecurringMessageStore : IRecurringMessageStore
+{
+    private readonly DbDataSource _dataSource;
+    private readonly string _incomingTable;
+    private readonly Func<Exception, bool> _isUniqueConstraintViolation;
+
+    private readonly string _loadSql;
+    private readonly string _loadAllSql;
+    private readonly string _selectIdsSql;
+    private readonly string _updatePublishSql;
+    private readonly string _insertSql;
+    private readonly string _markPausedSql;
+    private readonly string _resumeSql;
+    private readonly string _cancelScheduledEnvelopeSql;
+
+    /// <param name="recurringTable">
+    /// The fully rendered storage identifier for the recurring-messages table, as produced by
+    /// <see cref="MessageDatabase{T}.QuotedTableNameFor" /> — schema-qualified on engines that
+    /// have schemas, a prefixed single identifier on SQLite (GH-3943).
+    /// </param>
+    /// <param name="incomingTable">
+    /// The rendered identifier for the incoming-envelopes table, for the eager cancel and the
+    /// still-scheduled verification count.
+    /// </param>
+    public RdbmsRecurringMessageStore(
+        DbDataSource dataSource,
+        string recurringTable,
+        string incomingTable,
+        Func<Exception, bool> isUniqueConstraintViolation)
+    {
+        _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        _incomingTable = incomingTable ?? throw new ArgumentNullException(nameof(incomingTable));
+        _isUniqueConstraintViolation = isUniqueConstraintViolation
+                                       ?? throw new ArgumentNullException(nameof(isUniqueConstraintViolation));
+
+        var selectFields =
+            $"{DatabaseConstants.ScheduleName}, {DatabaseConstants.CronExpression}, {DatabaseConstants.EnvelopeIds}, " +
+            $"{DatabaseConstants.DeduplicationId}, {DatabaseConstants.NextOccurrence}, {DatabaseConstants.Paused}, " +
+            $"{DatabaseConstants.PausedAt}, {DatabaseConstants.LastUpdated}";
+
+        _loadSql =
+            $"select {selectFields} from {recurringTable} where {DatabaseConstants.ScheduleName} = @name";
+
+        _loadAllSql =
+            $"select {selectFields} from {recurringTable} order by {DatabaseConstants.ScheduleName}";
+
+        _selectIdsSql =
+            $"select {DatabaseConstants.EnvelopeIds} from {recurringTable} where {DatabaseConstants.ScheduleName} = @name";
+
+        // Preserves paused/paused_at on purpose: the agent's record of a publish is never
+        // permission to un-pause.
+        _updatePublishSql =
+            $"update {recurringTable} set {DatabaseConstants.CronExpression} = @cron, " +
+            $"{DatabaseConstants.EnvelopeIds} = @ids, {DatabaseConstants.DeduplicationId} = @dedup, " +
+            $"{DatabaseConstants.NextOccurrence} = @next, {DatabaseConstants.LastUpdated} = @updated " +
+            $"where {DatabaseConstants.ScheduleName} = @name";
+
+        _insertSql =
+            $"insert into {recurringTable} ({DatabaseConstants.ScheduleName}, {DatabaseConstants.CronExpression}, " +
+            $"{DatabaseConstants.EnvelopeIds}, {DatabaseConstants.DeduplicationId}, {DatabaseConstants.NextOccurrence}, " +
+            $"{DatabaseConstants.Paused}, {DatabaseConstants.PausedAt}, {DatabaseConstants.LastUpdated}) " +
+            "values (@name, @cron, @ids, @dedup, @next, @paused, @pausedat, @updated)";
+
+        // COALESCE keeps the original pause instant on a double-pause; ResumeAsync nulls it, so
+        // the column doubles as the transition marker.
+        _markPausedSql =
+            $"update {recurringTable} set {DatabaseConstants.Paused} = @paused, " +
+            $"{DatabaseConstants.PausedAt} = coalesce({DatabaseConstants.PausedAt}, @pausedat), " +
+            $"{DatabaseConstants.EnvelopeIds} = @ids, {DatabaseConstants.NextOccurrence} = @next, " +
+            $"{DatabaseConstants.LastUpdated} = @updated " +
+            $"where {DatabaseConstants.ScheduleName} = @name";
+
+        _resumeSql =
+            $"update {recurringTable} set {DatabaseConstants.Paused} = @paused, " +
+            $"{DatabaseConstants.PausedAt} = @pausedat, {DatabaseConstants.LastUpdated} = @updated " +
+            $"where {DatabaseConstants.ScheduleName} = @name";
+
+        // The same delete IScheduledMessages.CancelAsync issues — a scheduled envelope's
+        // cancellation IS its removal from the inbox. The status predicate keeps a race with the
+        // durability poller honest: an envelope already claimed for execution is not cancelled.
+        _cancelScheduledEnvelopeSql =
+            $"delete from {incomingTable} where {DatabaseConstants.Id} = @id " +
+            $"and {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}'";
+    }
+
+    public async Task RecordPublishedAsync(RecurringMessageRecord record, CancellationToken token = default)
+    {
+        if (record.Name.IsEmpty()) throw new ArgumentOutOfRangeException(nameof(record), "Name is required");
+
+        if (await tryUpdatePublishAsync(record, token)) return;
+
+        try
+        {
+            await using var insert = _dataSource.CreateCommand(_insertSql)
+                .With("name", record.Name)
+                .With("cron", record.CronExpression)
+                .With("ids", joinIds(record.EnvelopeIds))
+                .With("dedup", (object?)record.DeduplicationId ?? DBNull.Value)
+                .With("next", (object?)record.NextOccurrence ?? DBNull.Value)
+                .With("paused", false)
+                .With("pausedat", DBNull.Value)
+                .With("updated", record.LastUpdated);
+
+            await insert.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        catch (Exception e) when (_isUniqueConstraintViolation(e))
+        {
+            // Lost the first-row race (an operator's pause upserted it between our update and
+            // insert). The row exists now, so the update applies.
+            await tryUpdatePublishAsync(record, token);
+        }
+    }
+
+    private async Task<bool> tryUpdatePublishAsync(RecurringMessageRecord record, CancellationToken token)
+    {
+        await using var update = _dataSource.CreateCommand(_updatePublishSql)
+            .With("cron", record.CronExpression)
+            .With("ids", joinIds(record.EnvelopeIds))
+            .With("dedup", (object?)record.DeduplicationId ?? DBNull.Value)
+            .With("next", (object?)record.NextOccurrence ?? DBNull.Value)
+            .With("updated", record.LastUpdated)
+            .With("name", record.Name);
+
+        return await update.ExecuteNonQueryAsync(token).ConfigureAwait(false) > 0;
+    }
+
+    public async Task<RecurringMessageRecord?> LoadAsync(string name, CancellationToken token = default)
+    {
+        await using var cmd = _dataSource.CreateCommand(_loadSql).With("name", name);
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+        return await reader.ReadAsync(token).ConfigureAwait(false)
+            ? await readRecordAsync(reader, token)
+            : null;
+    }
+
+    public async Task<IReadOnlyList<RecurringMessageRecord>> LoadAllAsync(CancellationToken token = default)
+    {
+        var list = new List<RecurringMessageRecord>();
+
+        await using var cmd = _dataSource.CreateCommand(_loadAllSql);
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            list.Add(await readRecordAsync(reader, token));
+        }
+
+        return list;
+    }
+
+    public async Task<int> CountStillScheduledAsync(Guid[] envelopeIds, CancellationToken token = default)
+    {
+        if (envelopeIds.Length == 0) return 0;
+
+        // An explicit parameter list rather than a provider array bind — N is the subscriber
+        // count of one message type, effectively always a handful.
+        var placeholders = string.Join(", ", envelopeIds.Select((_, i) => $"@id{i}"));
+        var sql =
+            $"select count(*) from {_incomingTable} where {DatabaseConstants.Status} = '{EnvelopeStatus.Scheduled}' " +
+            $"and {DatabaseConstants.Id} in ({placeholders})";
+
+        await using var cmd = _dataSource.CreateCommand(sql);
+        for (var i = 0; i < envelopeIds.Length; i++)
+        {
+            cmd.With($"id{i}", envelopeIds[i]);
+        }
+
+        var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+        return Convert.ToInt32(result);
+    }
+
+    public async Task PauseAsync(string name, DateTimeOffset pausedAt, CancellationToken token = default)
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(token).ConfigureAwait(false);
+        await using var tx = await conn.BeginTransactionAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            // Read the tracked envelopes before the mark clears them off the row.
+            Guid[] pending = [];
+            var load = tx.CreateCommand(_selectIdsSql).With("name", name);
+            await using (load)
+            {
+                var raw = await load.ExecuteScalarAsync(token).ConfigureAwait(false);
+                if (raw is string text)
+                {
+                    pending = parseIds(text);
+                }
+            }
+
+            var mark = tx.CreateCommand(_markPausedSql)
+                .With("paused", true)
+                .With("pausedat", pausedAt)
+                .With("ids", string.Empty)
+                .With("next", DBNull.Value)
+                .With("updated", pausedAt)
+                .With("name", name);
+
+            int marked;
+            await using (mark)
+            {
+                marked = await mark.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            }
+
+            if (marked == 0)
+            {
+                // No row yet — the schedule has never published (or been paused). A paused-only
+                // row makes pausing-before-the-first-publish work; the agent honours it and
+                // never publishes. No unique-violation retry needed: the writes to this table
+                // are this transaction and the single cluster-wide agent, and the agent's own
+                // insert path retries into an update on exactly this collision.
+                var insert = tx.CreateCommand(_insertSql)
+                    .With("name", name)
+                    .With("cron", string.Empty)
+                    .With("ids", string.Empty)
+                    .With("dedup", DBNull.Value)
+                    .With("next", DBNull.Value)
+                    .With("paused", true)
+                    .With("pausedat", pausedAt)
+                    .With("updated", pausedAt);
+
+                await using (insert)
+                {
+                    await insert.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                }
+            }
+
+            // The eager cancel — in the SAME transaction as the mark, so nothing fires in the gap
+            // and a crash cannot leave the schedule paused with its occurrence still live.
+            foreach (var id in pending)
+            {
+                var cancel = tx.CreateCommand(_cancelScheduledEnvelopeSql).With("id", id);
+                await using (cancel)
+                {
+                    await cancel.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                }
+            }
+
+            await tx.CommitAsync(token).ConfigureAwait(false);
+        }
+        catch
+        {
+            await tx.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task ResumeAsync(string name, CancellationToken token = default)
+    {
+        await using var cmd = _dataSource.CreateCommand(_resumeSql)
+            .With("paused", false)
+            .With("pausedat", DBNull.Value)
+            .With("updated", DateTimeOffset.UtcNow)
+            .With("name", name);
+
+        // UPDATE of a missing or already-running row affects 0 rows — resume is naturally
+        // idempotent, and unknown-name validation belongs to the layer that knows the
+        // registrations (IRecurringScheduleControl).
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    private static string joinIds(Guid[] ids)
+    {
+        return ids.Length == 0 ? string.Empty : string.Join(",", ids.Select(x => x.ToString("N")));
+    }
+
+    private static Guid[] parseIds(string text)
+    {
+        return text.IsEmpty()
+            ? []
+            : text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(Guid.Parse).ToArray();
+    }
+
+    private static async Task<RecurringMessageRecord> readRecordAsync(DbDataReader reader, CancellationToken token)
+    {
+        return new RecurringMessageRecord
+        {
+            Name = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false),
+            CronExpression = await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false),
+            EnvelopeIds = parseIds(await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false)),
+            DeduplicationId = await reader.IsDBNullAsync(3, token).ConfigureAwait(false)
+                ? null
+                : await reader.GetFieldValueAsync<string>(3, token).ConfigureAwait(false),
+            NextOccurrence = await reader.IsDBNullAsync(4, token).ConfigureAwait(false)
+                ? null
+                : await reader.GetFieldValueAsync<DateTimeOffset>(4, token).ConfigureAwait(false),
+            Paused = await reader.GetFieldValueAsync<bool>(5, token).ConfigureAwait(false),
+            PausedAt = await reader.IsDBNullAsync(6, token).ConfigureAwait(false)
+                ? null
+                : await reader.GetFieldValueAsync<DateTimeOffset>(6, token).ConfigureAwait(false),
+            LastUpdated = await reader.GetFieldValueAsync<DateTimeOffset>(7, token).ConfigureAwait(false)
+        };
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -638,7 +638,13 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
         {
             yield return new DeduplicationTable(SchemaName);
         }
-        
+
+        // Recurring-message tracking — Main store only, behind the opt-in. See the PostgreSQL twin.
+        if (Durability.EnableRecurringMessages && Role == MessageStoreRole.Main)
+        {
+            yield return new RecurringMessagesTable(SchemaName);
+        }
+
         foreach (var table in _externalTables)
         {
             yield return table;

--- a/src/Persistence/Wolverine.SqlServer/Schema/RecurringMessagesTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Schema/RecurringMessagesTable.cs
@@ -1,0 +1,27 @@
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.SqlServer.Schema;
+
+/// <summary>
+/// Tracking table for recurring (cron) message schedules. See the PostgreSQL twin for the full
+/// rationale — one row per registered schedule, bookkeeping beside the inbox and never a delivery
+/// path, provisioned only on the Main store behind the
+/// <see cref="DurabilitySettings.EnableRecurringMessages" /> opt-in.
+/// </summary>
+internal class RecurringMessagesTable : Table
+{
+    public RecurringMessagesTable(string schemaName) : base(
+        new DbObjectName(schemaName, DatabaseConstants.RecurringMessagesTableName))
+    {
+        AddColumn(DatabaseConstants.ScheduleName, "varchar(250)").NotNull().AsPrimaryKey();
+        AddColumn(DatabaseConstants.CronExpression, "varchar(250)").NotNull();
+        AddColumn(DatabaseConstants.EnvelopeIds, "varchar(2000)").NotNull();
+        AddColumn(DatabaseConstants.DeduplicationId, "varchar(250)").AllowNulls();
+        AddColumn<DateTimeOffset>(DatabaseConstants.NextOccurrence).AllowNulls();
+        AddColumn<bool>(DatabaseConstants.Paused).NotNull();
+        AddColumn<DateTimeOffset>(DatabaseConstants.PausedAt).AllowNulls();
+        AddColumn<DateTimeOffset>(DatabaseConstants.LastUpdated).NotNull();
+    }
+}

--- a/src/Persistence/Wolverine.Sqlite/Schema/RecurringMessagesTable.cs
+++ b/src/Persistence/Wolverine.Sqlite/Schema/RecurringMessagesTable.cs
@@ -1,0 +1,30 @@
+using Weasel.Sqlite;
+using Weasel.Sqlite.Tables;
+using Wolverine.RDBMS;
+
+namespace Wolverine.Sqlite.Schema;
+
+/// <summary>
+/// Tracking table for recurring (cron) message schedules. See the PostgreSQL twin for the full
+/// rationale — one row per registered schedule, bookkeeping beside the inbox and never a delivery
+/// path, provisioned only on the Main store behind the
+/// <see cref="DurabilitySettings.EnableRecurringMessages" /> opt-in.
+/// </summary>
+internal class RecurringMessagesTable : Table
+{
+    public RecurringMessagesTable(string schemaName) : base(
+        new SqliteObjectName(TablePrefixing.Apply(schemaName, DatabaseConstants.RecurringMessagesTableName)))
+    {
+        // GH-3943: a SQLite "schema" is a table-name prefix, not a namespace, hence TablePrefixing
+        // above. DateTimeOffsets ride as TEXT and the pause flag as INTEGER 0/1, matching how
+        // Microsoft.Data.Sqlite binds and reads those CLR types on every other Wolverine table.
+        AddColumn(DatabaseConstants.ScheduleName, "TEXT").NotNull().AsPrimaryKey();
+        AddColumn(DatabaseConstants.CronExpression, "TEXT").NotNull();
+        AddColumn(DatabaseConstants.EnvelopeIds, "TEXT").NotNull();
+        AddColumn(DatabaseConstants.DeduplicationId, "TEXT").AllowNulls();
+        AddColumn(DatabaseConstants.NextOccurrence, "TEXT").AllowNulls();
+        AddColumn(DatabaseConstants.Paused, "INTEGER").NotNull();
+        AddColumn(DatabaseConstants.PausedAt, "TEXT").AllowNulls();
+        AddColumn(DatabaseConstants.LastUpdated, "TEXT").NotNull();
+    }
+}

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -519,6 +519,12 @@ internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
             yield return new DeduplicationTable(SchemaName);
         }
 
+        // Recurring-message tracking — Main store only, behind the opt-in. See the PostgreSQL twin.
+        if (Durability.EnableRecurringMessages && Role == MessageStoreRole.Main)
+        {
+            yield return new RecurringMessagesTable(SchemaName);
+        }
+
         foreach (var table in _externalTables)
         {
             yield return table;

--- a/src/Samples/DocumentationSamples/RecurringMessageSamples.cs
+++ b/src/Samples/DocumentationSamples/RecurringMessageSamples.cs
@@ -42,11 +42,11 @@ public class RecurringMessageSamples
             // Simplest possible usage: a message type with a public, no-argument
             // constructor, published on a cron schedule. The schedule's name defaults
             // to the message type's name
-            opts.Schedules.RecurringMessage<RunNightlyRollup>("0 2 * * *");
+            opts.Schedules.ScheduleRecurring<RunNightlyRollup>("0 2 * * *");
 
             // Or build the message per occurrence — the factory is handed the
             // occurrence time, so a message can describe the window it covers
-            opts.Schedules.RecurringMessage(
+            opts.Schedules.ScheduleRecurring(
                 "daily-report",
                 "0 9 * * *",
                 occurrence => new BuildDailyReport(occurrence.AddDays(-1), occurrence));
@@ -57,7 +57,7 @@ public class RecurringMessageSamples
                 "0 9 * * *",
                 TimeZoneInfo.FindSystemTimeZoneById("America/Chicago"));
 
-            opts.Schedules.RecurringMessage<SendMorningDigest>(nineAmCentral);
+            opts.Schedules.ScheduleRecurring<SendMorningDigest>(nineAmCentral);
         });
 
         #endregion

--- a/src/Samples/DocumentationSamples/RecurringMessageSamples.cs
+++ b/src/Samples/DocumentationSamples/RecurringMessageSamples.cs
@@ -1,10 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine;
+using Wolverine.Runtime.Recurring;
 
 namespace DocumentationSamples;
 
 public class RecurringMessageSamples
 {
+    public static async Task pause_and_resume(IHost host)
+    {
+        #region sample_pausing_and_resuming_recurring_messages
+
+        // Registered alongside the first schedule — resolve it straight
+        // from the container
+        var control = host.Services.GetRequiredService<IRecurringScheduleControl>();
+
+        // Pause: marks the schedule's durable tracking row AND eagerly cancels
+        // the pre-scheduled next occurrence, so nothing fires in the gap before
+        // the scheduling agent's next pass — even when this code runs on a
+        // different node than the agent
+        await control.PauseAsync("daily-report");
+
+        // Resume: the next occurrence is computed strictly after "now".
+        // The paused window is never back-filled
+        await control.ResumeAsync("daily-report");
+
+        // The tracking rows themselves: which schedule owns which pending
+        // envelope, next fire times, pause state
+        var schedules = await control.QueryAsync();
+
+        #endregion
+    }
+
     public static async Task configure()
     {
         #region sample_registering_recurring_messages

--- a/src/Samples/DocumentationSamples/RecurringMessageSamples.cs
+++ b/src/Samples/DocumentationSamples/RecurringMessageSamples.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Hosting;
+using Wolverine;
+
+namespace DocumentationSamples;
+
+public class RecurringMessageSamples
+{
+    public static async Task configure()
+    {
+        #region sample_registering_recurring_messages
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseWolverine(opts =>
+        {
+            // Simplest possible usage: a message type with a public, no-argument
+            // constructor, published on a cron schedule. The schedule's name defaults
+            // to the message type's name
+            opts.Schedules.RecurringMessage<RunNightlyRollup>("0 2 * * *");
+
+            // Or build the message per occurrence — the factory is handed the
+            // occurrence time, so a message can describe the window it covers
+            opts.Schedules.RecurringMessage(
+                "daily-report",
+                "0 9 * * *",
+                occurrence => new BuildDailyReport(occurrence.AddDays(-1), occurrence));
+
+            // Cron expressions parse into a first class value type that you can
+            // construct, hold, and reuse — including with an explicit time zone
+            var nineAmCentral = new CronSchedule(
+                "0 9 * * *",
+                TimeZoneInfo.FindSystemTimeZoneById("America/Chicago"));
+
+            opts.Schedules.RecurringMessage<SendMorningDigest>(nineAmCentral);
+        });
+
+        #endregion
+    }
+}
+
+#region sample_recurring_message_types
+
+// Recurring messages are handled like any other message — the cron machinery
+// only decides WHEN they are published, never how they are processed
+public record RunNightlyRollup;
+
+public record BuildDailyReport(DateTimeOffset From, DateTimeOffset To);
+
+public record SendMorningDigest;
+
+public static class RecurringSampleHandler
+{
+    public static void Handle(RunNightlyRollup message)
+        => Console.WriteLine("Rolling up!");
+
+    public static void Handle(BuildDailyReport message)
+        => Console.WriteLine($"Reporting on {message.From} to {message.To}");
+
+    public static void Handle(SendMorningDigest message)
+        => Console.WriteLine("Good morning!");
+}
+
+#endregion

--- a/src/Testing/CoreTests/Runtime/Recurring/CronScheduleTests.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/CronScheduleTests.cs
@@ -1,0 +1,137 @@
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace CoreTests.Runtime.Recurring;
+
+public class CronScheduleTests
+{
+    // A real DST-observing zone, spelled per-platform. The DST cases are the entire reason the
+    // schedule carries a TimeZoneInfo, so they must run against a zone that actually transitions.
+    private static readonly TimeZoneInfo Chicago = TimeZoneInfo.FindSystemTimeZoneById(
+        OperatingSystem.IsWindows() ? "Central Standard Time" : "America/Chicago");
+
+    [Fact]
+    public void computes_the_next_occurrence_in_utc_by_default()
+    {
+        var schedule = new CronSchedule("0 9 * * *");
+
+        var next = schedule.NextOccurrence(new DateTimeOffset(2026, 1, 15, 10, 0, 0, TimeSpan.Zero));
+
+        next.ShouldBe(new DateTimeOffset(2026, 1, 16, 9, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void the_occurrence_is_strictly_after_the_supplied_instant()
+    {
+        var schedule = new CronSchedule("0 9 * * *");
+
+        // Exactly 09:00 asks for the NEXT one — the agent computes "after now", and an inclusive
+        // answer would re-publish the occurrence that is firing right now.
+        var next = schedule.NextOccurrence(new DateTimeOffset(2026, 1, 15, 9, 0, 0, TimeSpan.Zero));
+
+        next.ShouldBe(new DateTimeOffset(2026, 1, 16, 9, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void computes_in_the_supplied_time_zone()
+    {
+        // Mid-January: Chicago is CST (UTC-6), no DST anywhere near.
+        var schedule = new CronSchedule("0 9 * * *", Chicago);
+
+        var next = schedule.NextOccurrence(new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero));
+
+        next.ShouldBe(new DateTimeOffset(2026, 1, 15, 15, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void a_six_field_expression_carries_seconds()
+    {
+        var schedule = new CronSchedule("30 0 9 * * *");
+
+        var next = schedule.NextOccurrence(new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero));
+
+        next.ShouldBe(new DateTimeOffset(2026, 1, 15, 9, 0, 30, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void spring_forward_a_job_in_the_skipped_hour_fires_at_the_adjusted_instant()
+    {
+        // 2026-03-08: Chicago springs forward at 02:00 CST -> 03:00 CDT, so 02:30 does not exist.
+        // Cronos fires the job at the moment the transition completes rather than dropping it:
+        // 03:00 CDT = 08:00 UTC.
+        var schedule = new CronSchedule("30 2 * * *", Chicago);
+
+        var next = schedule.NextOccurrence(new DateTimeOffset(2026, 3, 8, 6, 0, 0, TimeSpan.Zero));
+
+        next.ShouldBe(new DateTimeOffset(2026, 3, 8, 8, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void fall_back_a_job_in_the_repeated_hour_fires_once_not_twice()
+    {
+        // 2026-11-01: Chicago falls back at 02:00 CDT -> 01:00 CST, so 01:30 local happens twice
+        // (06:30 UTC as CDT, then 07:30 UTC as CST). The job fires for the FIRST and the next
+        // occurrence is the following day — never the repeat.
+        var schedule = new CronSchedule("30 1 * * *", Chicago);
+
+        var first = schedule.NextOccurrence(new DateTimeOffset(2026, 11, 1, 0, 0, 0, TimeSpan.Zero));
+        first.ShouldBe(new DateTimeOffset(2026, 11, 1, 6, 30, 0, TimeSpan.Zero));
+
+        var second = schedule.NextOccurrence(first!.Value);
+        second.ShouldBe(new DateTimeOffset(2026, 11, 2, 7, 30, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void an_invalid_expression_throws_at_the_construction_site()
+    {
+        Should.Throw<ArgumentException>(() => new CronSchedule("not cron at all"))
+            .Message.ShouldContain("not cron at all");
+
+        Should.Throw<ArgumentException>(() => new CronSchedule(" "));
+    }
+
+    [Fact]
+    public void an_unsatisfiably_fast_cadence_is_refused()
+    {
+        // Every second can never be honoured through the durable path (the poller replays on a 5s
+        // cadence), so it is refused at the line that wrote it rather than delivered late forever.
+        Should.Throw<ArgumentException>(() => new CronSchedule("* * * * * *"))
+            .Message.ShouldContain("cannot be honoured");
+    }
+
+    [Fact]
+    public void try_parse_mirrors_the_constructor()
+    {
+        CronSchedule.TryParse("0 9 * * *", null, out var schedule).ShouldBeTrue();
+        schedule.Expression.ShouldBe("0 9 * * *");
+
+        CronSchedule.TryParse("nope", null, out _).ShouldBeFalse();
+        CronSchedule.TryParse("* * * * * *", null, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_default_struct_value_fails_loudly_not_with_a_null_reference()
+    {
+        // default(CronSchedule) always exists — the value-type analogue of a null reference.
+        Should.Throw<InvalidOperationException>(() => default(CronSchedule).NextOccurrence(DateTimeOffset.UtcNow));
+        default(CronSchedule).ToString().ShouldBe("(default CronSchedule)");
+    }
+
+    [Fact]
+    public void the_occurrence_deduplication_id_is_time_zone_independent()
+    {
+        var message = new WolverineOptions().Schedules
+            .RecurringMessage<SampleRecurringMessage>("0 9 * * *", Chicago);
+
+        // The same instant, spelled in two offsets, must produce ONE id — this is what makes a
+        // failover re-publish collapse instead of double-firing.
+        var asLocal = new DateTimeOffset(2026, 1, 15, 9, 0, 0, TimeSpan.FromHours(-6));
+        var asUtc = new DateTimeOffset(2026, 1, 15, 15, 0, 0, TimeSpan.Zero);
+
+        message.DeduplicationIdFor(asLocal).ShouldBe(message.DeduplicationIdFor(asUtc));
+        message.DeduplicationIdFor(asUtc).ShouldStartWith("SampleRecurringMessage:");
+    }
+}
+
+public class SampleRecurringMessage;

--- a/src/Testing/CoreTests/Runtime/Recurring/CronScheduleTests.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/CronScheduleTests.cs
@@ -122,7 +122,7 @@ public class CronScheduleTests
     public void the_occurrence_deduplication_id_is_time_zone_independent()
     {
         var message = new WolverineOptions().Schedules
-            .RecurringMessage<SampleRecurringMessage>("0 9 * * *", Chicago);
+            .ScheduleRecurring<SampleRecurringMessage>("0 9 * * *", Chicago);
 
         // The same instant, spelled in two offsets, must produce ONE id — this is what makes a
         // failover re-publish collapse instead of double-firing.

--- a/src/Testing/CoreTests/Runtime/Recurring/RecurringMessageCollectionTests.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/RecurringMessageCollectionTests.cs
@@ -30,7 +30,7 @@ public class RecurringMessageCollectionTests
     {
         var options = new WolverineOptions();
 
-        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+        options.Schedules.ScheduleRecurring<SampleRecurringMessage>("0 9 * * *");
 
         options.Durability.EnableMessageDeduplication.ShouldBeTrue();
         options.Services.Count(x =>
@@ -45,8 +45,8 @@ public class RecurringMessageCollectionTests
     {
         var options = new WolverineOptions();
 
-        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
-        options.Schedules.RecurringMessage("second", "0 2 * * *", _ => new OtherRecurringMessage());
+        options.Schedules.ScheduleRecurring<SampleRecurringMessage>("0 9 * * *");
+        options.Schedules.ScheduleRecurring("second", "0 2 * * *", _ => new OtherRecurringMessage());
 
         options.Schedules.Count.ShouldBe(2);
         options.Services.Count(x => x.ImplementationType == typeof(RecurringMessageAgent)).ShouldBe(1);
@@ -58,7 +58,7 @@ public class RecurringMessageCollectionTests
     {
         var options = new WolverineOptions();
 
-        var message = options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+        var message = options.Schedules.ScheduleRecurring<SampleRecurringMessage>("0 9 * * *");
 
         message.Name.ShouldBe(nameof(SampleRecurringMessage));
         message.MessageType.ShouldBe(typeof(SampleRecurringMessage));
@@ -68,12 +68,12 @@ public class RecurringMessageCollectionTests
     public void a_duplicate_name_is_refused_at_the_registration_site()
     {
         var options = new WolverineOptions();
-        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+        options.Schedules.ScheduleRecurring<SampleRecurringMessage>("0 9 * * *");
 
         // Names feed the occurrence dedup id — two schedules sharing one would dedupe against
         // each other and silently drop the second's occurrences.
         Should.Throw<ArgumentException>(() =>
-                options.Schedules.RecurringMessage<SampleRecurringMessage>("0 10 * * *"))
+                options.Schedules.ScheduleRecurring<SampleRecurringMessage>("0 10 * * *"))
             .Message.ShouldContain(nameof(SampleRecurringMessage));
     }
 
@@ -83,7 +83,7 @@ public class RecurringMessageCollectionTests
         var options = new WolverineOptions();
 
         Should.Throw<ArgumentException>(() =>
-            options.Schedules.RecurringMessage<SampleRecurringMessage>("every day at nine"));
+            options.Schedules.ScheduleRecurring<SampleRecurringMessage>("every day at nine"));
 
         // Nothing half-registered: the failed call opted into nothing.
         options.Schedules.Any().ShouldBeFalse();
@@ -96,14 +96,14 @@ public class RecurringMessageCollectionTests
         var options = new WolverineOptions();
 
         Should.Throw<ArgumentNullException>(() =>
-            options.Schedules.RecurringMessage<SampleRecurringMessage>("named", "0 9 * * *", null!));
+            options.Schedules.ScheduleRecurring<SampleRecurringMessage>("named", "0 9 * * *", null!));
     }
 
     [Fact]
     public void the_factory_overload_hands_the_creator_the_occurrence_time()
     {
         var options = new WolverineOptions();
-        var message = options.Schedules.RecurringMessage(
+        var message = options.Schedules.ScheduleRecurring(
             "windowed", "0 2 * * *", occurrence => new WindowedMessage(occurrence.AddDays(-1), occurrence));
 
         var at = new DateTimeOffset(2026, 1, 15, 2, 0, 0, TimeSpan.Zero);
@@ -117,7 +117,7 @@ public class RecurringMessageCollectionTests
     public void schedules_are_findable_by_name()
     {
         var options = new WolverineOptions();
-        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+        options.Schedules.ScheduleRecurring<SampleRecurringMessage>("0 9 * * *");
 
         options.Schedules.FindByName(nameof(SampleRecurringMessage)).ShouldNotBeNull();
         options.Schedules.FindByName("nope").ShouldBeNull();

--- a/src/Testing/CoreTests/Runtime/Recurring/RecurringMessageCollectionTests.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/RecurringMessageCollectionTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Recurring;
+using Xunit;
+
+namespace CoreTests.Runtime.Recurring;
+
+/// <summary>
+/// The registration surface is the feature's OPT-IN, so what these pin is the boundary: a host
+/// with zero schedules registers nothing and flips nothing, and the first registration wires
+/// everything exactly once.
+/// </summary>
+public class RecurringMessageCollectionTests
+{
+    [Fact]
+    public void a_host_with_no_schedules_opts_into_nothing()
+    {
+        var options = new WolverineOptions();
+
+        options.Schedules.Any().ShouldBeFalse();
+        options.Durability.EnableMessageDeduplication.ShouldBeFalse();
+        options.Services.Any(x => x.ImplementationType == typeof(RecurringMessageAgent)).ShouldBeFalse();
+        options.RegisteredPolicies.OfType<RecurringDeduplicationPolicy>().Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void registering_the_first_schedule_is_the_opt_in()
+    {
+        var options = new WolverineOptions();
+
+        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+
+        options.Durability.EnableMessageDeduplication.ShouldBeTrue();
+        options.Services.Count(x =>
+                x.ServiceType == typeof(IAgentFamily) &&
+                x.ImplementationType == typeof(RecurringMessageAgent))
+            .ShouldBe(1);
+        options.RegisteredPolicies.OfType<RecurringDeduplicationPolicy>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public void further_registrations_do_not_stack_agents_or_policies()
+    {
+        var options = new WolverineOptions();
+
+        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+        options.Schedules.RecurringMessage("second", "0 2 * * *", _ => new OtherRecurringMessage());
+
+        options.Schedules.Count.ShouldBe(2);
+        options.Services.Count(x => x.ImplementationType == typeof(RecurringMessageAgent)).ShouldBe(1);
+        options.RegisteredPolicies.OfType<RecurringDeduplicationPolicy>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public void the_no_argument_overload_names_the_schedule_after_the_message_type()
+    {
+        var options = new WolverineOptions();
+
+        var message = options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+
+        message.Name.ShouldBe(nameof(SampleRecurringMessage));
+        message.MessageType.ShouldBe(typeof(SampleRecurringMessage));
+    }
+
+    [Fact]
+    public void a_duplicate_name_is_refused_at_the_registration_site()
+    {
+        var options = new WolverineOptions();
+        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+
+        // Names feed the occurrence dedup id — two schedules sharing one would dedupe against
+        // each other and silently drop the second's occurrences.
+        Should.Throw<ArgumentException>(() =>
+                options.Schedules.RecurringMessage<SampleRecurringMessage>("0 10 * * *"))
+            .Message.ShouldContain(nameof(SampleRecurringMessage));
+    }
+
+    [Fact]
+    public void a_bad_cron_expression_fails_at_the_registration_site()
+    {
+        var options = new WolverineOptions();
+
+        Should.Throw<ArgumentException>(() =>
+            options.Schedules.RecurringMessage<SampleRecurringMessage>("every day at nine"));
+
+        // Nothing half-registered: the failed call opted into nothing.
+        options.Schedules.Any().ShouldBeFalse();
+        options.Durability.EnableMessageDeduplication.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_null_creator_is_refused()
+    {
+        var options = new WolverineOptions();
+
+        Should.Throw<ArgumentNullException>(() =>
+            options.Schedules.RecurringMessage<SampleRecurringMessage>("named", "0 9 * * *", null!));
+    }
+
+    [Fact]
+    public void the_factory_overload_hands_the_creator_the_occurrence_time()
+    {
+        var options = new WolverineOptions();
+        var message = options.Schedules.RecurringMessage(
+            "windowed", "0 2 * * *", occurrence => new WindowedMessage(occurrence.AddDays(-1), occurrence));
+
+        var at = new DateTimeOffset(2026, 1, 15, 2, 0, 0, TimeSpan.Zero);
+        var body = message.Creator(at).ShouldBeOfType<WindowedMessage>();
+
+        body.From.ShouldBe(at.AddDays(-1));
+        body.To.ShouldBe(at);
+    }
+
+    [Fact]
+    public void schedules_are_findable_by_name()
+    {
+        var options = new WolverineOptions();
+        options.Schedules.RecurringMessage<SampleRecurringMessage>("0 9 * * *");
+
+        options.Schedules.FindByName(nameof(SampleRecurringMessage)).ShouldNotBeNull();
+        options.Schedules.FindByName("nope").ShouldBeNull();
+    }
+}
+
+public class OtherRecurringMessage;
+
+public record WindowedMessage(DateTimeOffset From, DateTimeOffset To);

--- a/src/Testing/CoreTests/Runtime/Recurring/pause_and_resume_on_a_storeless_host.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/pause_and_resume_on_a_storeless_host.cs
@@ -26,7 +26,7 @@ public class pause_and_resume_on_a_storeless_host
             {
                 // See recurring_messages_on_a_storeless_host for why the assembly pin matters (GH-3521).
                 opts.ApplicationAssembly = typeof(pause_and_resume_on_a_storeless_host).Assembly;
-                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                opts.Schedules.ScheduleRecurring<PendingRecurringMessage>("0 9 * * *");
             }).StartAsync(TestContext.Current.CancellationToken);
 
         var runtime = (WolverineRuntime)host.GetRuntime();

--- a/src/Testing/CoreTests/Runtime/Recurring/pause_and_resume_on_a_storeless_host.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/pause_and_resume_on_a_storeless_host.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Recurring;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime.Recurring;
+
+/// <summary>
+/// The agent-memory half of pause/resume — what <see cref="IRecurringScheduleControl" /> does on a
+/// host whose message store has no recurring tracking extension. The durable half (eager cancel,
+/// pause surviving restart, resume strictly-after-now against a real inbox) lives in the message
+/// store compliance tier; what is pinned here is the documented DEGRADED behaviour: pause reaches
+/// only the local agent's memory, stops future publishes, deliberately keeps the already-pending
+/// occurrence's bookkeeping (an uncancellable envelope must not be re-published on resume), and
+/// unknown names throw at the control surface regardless of store.
+/// </summary>
+public class pause_and_resume_on_a_storeless_host
+{
+    private static async Task<(IHost host, RecurringMessageAgent agent, IRecurringScheduleControl control)>
+        buildAsync()
+    {
+        var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // See recurring_messages_on_a_storeless_host for why the assembly pin matters (GH-3521).
+                opts.ApplicationAssembly = typeof(pause_and_resume_on_a_storeless_host).Assembly;
+                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = (WolverineRuntime)host.GetRuntime();
+        var agent = runtime.InMemoryRecurringAgent.ShouldBeOfType<RecurringMessageAgent>();
+        var control = host.Services.GetRequiredService<IRecurringScheduleControl>();
+
+        // The startup publish of the (pending, daily) next occurrence.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (agent.OccurrencesPublished == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        agent.OccurrencesPublished.ShouldBe(1);
+        return (host, agent, control);
+    }
+
+    [Fact]
+    public async Task pause_stops_future_publishes_and_resume_restores_them()
+    {
+        var (host, agent, control) = await buildAsync();
+        using var _ = host;
+
+        await control.PauseAsync(nameof(PendingRecurringMessage), TestContext.Current.CancellationToken);
+
+        // Two days pass — an unpaused schedule would compute a NEW next occurrence and publish it.
+        var clock = new FrozenClock(DateTimeOffset.UtcNow.AddDays(2));
+        agent.TimeProvider = clock;
+
+        await agent.TickAsync(TestContext.Current.CancellationToken);
+        agent.OccurrencesPublished.ShouldBe(1); // paused: nothing new
+
+        await control.ResumeAsync(nameof(PendingRecurringMessage), TestContext.Current.CancellationToken);
+
+        await agent.TickAsync(TestContext.Current.CancellationToken);
+        agent.OccurrencesPublished.ShouldBe(2); // resumed: the occurrence strictly after "now"
+    }
+
+    [Fact]
+    public async Task in_memory_pause_keeps_the_pending_occurrence_bookkeeping()
+    {
+        var (host, agent, control) = await buildAsync();
+        using var _ = host;
+
+        await control.PauseAsync(nameof(PendingRecurringMessage), TestContext.Current.CancellationToken);
+        await control.ResumeAsync(nameof(PendingRecurringMessage), TestContext.Current.CancellationToken);
+
+        // With no store, the pending occurrence could not be cancelled by the pause — so a
+        // pause/resume round trip before it fires must NOT publish it a second time (there is no
+        // store-backed deduplication here to collapse the duplicate).
+        await agent.TickAsync(TestContext.Current.CancellationToken);
+        agent.OccurrencesPublished.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task unknown_schedule_names_throw_at_the_control_surface()
+    {
+        var (host, _, control) = await buildAsync();
+        using var _1 = host;
+
+        var ex = await Should.ThrowAsync<UnknownRecurringScheduleException>(
+            () => control.PauseAsync("nope", TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("nope");
+        ex.Message.ShouldContain(nameof(PendingRecurringMessage));
+
+        await Should.ThrowAsync<UnknownRecurringScheduleException>(
+            () => control.ResumeAsync("nope", TestContext.Current.CancellationToken));
+    }
+
+    private sealed class FrozenClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Recurring/recurring_messages_on_a_storeless_host.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/recurring_messages_on_a_storeless_host.cs
@@ -1,0 +1,209 @@
+using JasperFx;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Wolverine.Tracking;
+using Wolverine.Runtime.Recurring;
+using Xunit;
+
+namespace CoreTests.Runtime.Recurring;
+
+/// <summary>
+/// No message store is a SUPPORTED mode for recurring messages, not a refusal: with no cluster to
+/// coordinate, "one agent per cluster" is satisfied by starting the agent directly, and
+/// occurrences ride the in-memory scheduled model. These pin that mode end to end — the agent
+/// actually runs, the pre-scheduled occurrence actually fires carrying the schedule header and the
+/// deterministic dedup id, ticks are idempotent while the next occurrence is pending, and the two
+/// modes that CANNOT run the agent at all (Serverless / MediatorOnly) refuse the registrations at
+/// startup instead of accepting schedules that would silently never fire.
+/// </summary>
+public class recurring_messages_on_a_storeless_host
+{
+    [Fact]
+    public async Task the_next_occurrence_is_pre_scheduled_and_fires_with_its_identity()
+    {
+        StorelessRecurringMessageHandler.Reset();
+
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The application assembly is process-pinned by whichever host starts FIRST in a
+                // test run (GH-3521) — left implicit, another suite's host can pin it elsewhere and
+                // this host then never discovers the handlers below, so the occurrence has no route
+                // and silently never arrives. Pin it, per the divergence warning's own advice.
+                opts.ApplicationAssembly = typeof(recurring_messages_on_a_storeless_host).Assembly;
+                // Every five seconds — the minimum legal cadence — so this is a REAL end-to-end
+                // run: the agent pre-schedules the next occurrence, the local queue's in-memory
+                // scheduler fires it at its time, and the handler receives it, within seconds.
+                opts.Schedules.RecurringMessage<StorelessRecurringMessage>("*/5 * * * * *");
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = (WolverineRuntime)host.GetRuntime();
+
+        var agent = runtime.InMemoryRecurringAgent.ShouldBeOfType<RecurringMessageAgent>();
+        agent.Status.ShouldBe(AgentStatus.Running);
+
+        // Generous by design: this is the one wall-clock-dependent assertion in the class, and a
+        // full CoreTests run keeps ~40 hosts busy — thread-pool starvation near the end of a run
+        // has been observed to delay the in-memory scheduler's firing well past the cron instant.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(90);
+        while (StorelessRecurringMessageHandler.Last == null && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        var envelope = StorelessRecurringMessageHandler.Last;
+        envelope.ShouldNotBeNull(
+            $"No occurrence was handled within 90s; the agent reports {agent.OccurrencesPublished} publish(es)");
+
+        // The occurrence carries its schedule's identity as a header (what the OTel tag reads)...
+        envelope.Headers[RecurringMessage.HeaderKey].ShouldBe(nameof(StorelessRecurringMessage));
+
+        // ...and the deterministic occurrence dedup id — identical on any node and after any
+        // restart, which is the entire failover-safety story. ScheduledTime itself is cleared by
+        // the scheduled machinery at fire time, so the id is ALSO the durable record of which
+        // occurrence this was: parse it back and check it names a real firing instant of this
+        // cron, at most a minute away.
+        var prefix = $"{nameof(StorelessRecurringMessage)}:";
+        envelope.DeduplicationId.ShouldNotBeNull();
+        envelope.DeduplicationId.ShouldStartWith(prefix);
+
+        var occurrence = DateTimeOffset.Parse(envelope.DeduplicationId![prefix.Length..]);
+        (occurrence.UtcDateTime.Second % 5).ShouldBe(0);
+        occurrence.Offset.ShouldBe(TimeSpan.Zero);
+        Math.Abs((occurrence - DateTimeOffset.UtcNow).TotalSeconds).ShouldBeLessThan(60);
+    }
+
+    [Fact]
+    public async Task ticks_are_idempotent_while_the_next_occurrence_is_still_pending()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The application assembly is process-pinned by whichever host starts FIRST in a
+                // test run (GH-3521) — left implicit, another suite's host can pin it elsewhere and
+                // this host then never discovers the handlers below, so the occurrence has no route
+                // and silently never arrives. Pin it, per the divergence warning's own advice.
+                opts.ApplicationAssembly = typeof(recurring_messages_on_a_storeless_host).Assembly;
+                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = (WolverineRuntime)host.GetRuntime();
+        var agent = runtime.InMemoryRecurringAgent.ShouldBeOfType<RecurringMessageAgent>();
+
+        // The startup tick publishes the (daily, hence still-pending) next occurrence once.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (agent.OccurrencesPublished == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+
+        agent.OccurrencesPublished.ShouldBe(1);
+
+        // "Only the NEXT occurrence is ever in flight": extra ticks while it is still pending are
+        // pure no-ops, however often the loop wakes.
+        await agent.TickAsync(TestContext.Current.CancellationToken);
+        await agent.TickAsync(TestContext.Current.CancellationToken);
+
+        agent.OccurrencesPublished.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task the_tick_asks_to_sleep_until_the_next_occurrence_bounded_by_the_maximum()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // The application assembly is process-pinned by whichever host starts FIRST in a
+                // test run (GH-3521) — left implicit, another suite's host can pin it elsewhere and
+                // this host then never discovers the handlers below, so the occurrence has no route
+                // and silently never arrives. Pin it, per the divergence warning's own advice.
+                opts.ApplicationAssembly = typeof(recurring_messages_on_a_storeless_host).Assembly;
+                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = (WolverineRuntime)host.GetRuntime();
+        var agent = runtime.InMemoryRecurringAgent.ShouldBeOfType<RecurringMessageAgent>();
+
+        // A daily schedule is always further away than the maximum tick interval, so the loop
+        // sleeps the bounded maximum rather than a day — the cap on how stale its picture gets.
+        var delay = await agent.TickAsync(TestContext.Current.CancellationToken);
+        delay.ShouldBe(agent.MaximumTickInterval);
+    }
+
+    [Fact]
+    public async Task serverless_mode_refuses_registered_schedules_at_startup()
+    {
+        // Serverless runs no agents, so a registered schedule would be accepted and then silently
+        // never fire — the exact quiet failure the feature exists to avoid. Refusal, not warning.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.Serverless;
+                    opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                }).StartAsync(TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain(nameof(PendingRecurringMessage));
+        ex.Message.ShouldContain(nameof(DurabilityMode.Serverless));
+    }
+
+    [Fact]
+    public async Task mediator_only_mode_refuses_registered_schedules_at_startup()
+    {
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Durability.Mode = DurabilityMode.MediatorOnly;
+                    opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                }).StartAsync(TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain(nameof(DurabilityMode.MediatorOnly));
+    }
+
+    [Fact]
+    public async Task a_host_with_no_schedules_starts_no_recurring_agent()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = (WolverineRuntime)host.GetRuntime();
+        runtime.InMemoryRecurringAgent.ShouldBeNull();
+    }
+}
+
+public class StorelessRecurringMessage;
+
+/// <summary>Never fired in these tests — the pending-occurrence cases need a schedule that stays pending.</summary>
+public class PendingRecurringMessage;
+
+public static class StorelessRecurringMessageHandler
+{
+    public static volatile Envelope? Last;
+
+    public static void Reset()
+    {
+        Last = null;
+    }
+
+    // The occurrence has to route somewhere for the publish to schedule anything at all — an
+    // unroutable message is discarded before it ever reaches the in-memory scheduler.
+    public static void Handle(StorelessRecurringMessage message, Envelope envelope)
+    {
+        Last = envelope;
+    }
+}
+
+public static class PendingRecurringMessageHandler
+{
+    public static void Handle(PendingRecurringMessage message)
+    {
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Recurring/recurring_messages_on_a_storeless_host.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/recurring_messages_on_a_storeless_host.cs
@@ -37,7 +37,7 @@ public class recurring_messages_on_a_storeless_host
                 // Every five seconds — the minimum legal cadence — so this is a REAL end-to-end
                 // run: the agent pre-schedules the next occurrence, the local queue's in-memory
                 // scheduler fires it at its time, and the handler receives it, within seconds.
-                opts.Schedules.RecurringMessage<StorelessRecurringMessage>("*/5 * * * * *");
+                opts.Schedules.ScheduleRecurring<StorelessRecurringMessage>("*/5 * * * * *");
             }).StartAsync(TestContext.Current.CancellationToken);
 
         var runtime = (WolverineRuntime)host.GetRuntime();
@@ -87,7 +87,7 @@ public class recurring_messages_on_a_storeless_host
                 // this host then never discovers the handlers below, so the occurrence has no route
                 // and silently never arrives. Pin it, per the divergence warning's own advice.
                 opts.ApplicationAssembly = typeof(recurring_messages_on_a_storeless_host).Assembly;
-                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                opts.Schedules.ScheduleRecurring<PendingRecurringMessage>("0 9 * * *");
             }).StartAsync(TestContext.Current.CancellationToken);
 
         var runtime = (WolverineRuntime)host.GetRuntime();
@@ -121,7 +121,7 @@ public class recurring_messages_on_a_storeless_host
                 // this host then never discovers the handlers below, so the occurrence has no route
                 // and silently never arrives. Pin it, per the divergence warning's own advice.
                 opts.ApplicationAssembly = typeof(recurring_messages_on_a_storeless_host).Assembly;
-                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                opts.Schedules.ScheduleRecurring<PendingRecurringMessage>("0 9 * * *");
             }).StartAsync(TestContext.Current.CancellationToken);
 
         var runtime = (WolverineRuntime)host.GetRuntime();
@@ -144,7 +144,7 @@ public class recurring_messages_on_a_storeless_host
                 .UseWolverine(opts =>
                 {
                     opts.Durability.Mode = DurabilityMode.Serverless;
-                    opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                    opts.Schedules.ScheduleRecurring<PendingRecurringMessage>("0 9 * * *");
                 }).StartAsync(TestContext.Current.CancellationToken);
         });
 
@@ -161,7 +161,7 @@ public class recurring_messages_on_a_storeless_host
                 .UseWolverine(opts =>
                 {
                     opts.Durability.Mode = DurabilityMode.MediatorOnly;
-                    opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                    opts.Schedules.ScheduleRecurring<PendingRecurringMessage>("0 9 * * *");
                 }).StartAsync(TestContext.Current.CancellationToken);
         });
 

--- a/src/Testing/CoreTests/Runtime/Recurring/recurring_schedules_in_capabilities_and_event_model.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/recurring_schedules_in_capabilities_and_event_model.cs
@@ -28,8 +28,8 @@ public class recurring_schedules_in_capabilities_and_event_model : IAsyncLifetim
                 opts.ApplicationAssembly = typeof(recurring_schedules_in_capabilities_and_event_model).Assembly;
                 opts.ServiceName = "recurring-capabilities";
 
-                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
-                opts.Schedules.RecurringMessage("nightly", "0 2 * * *",
+                opts.Schedules.ScheduleRecurring<PendingRecurringMessage>("0 9 * * *");
+                opts.Schedules.ScheduleRecurring("nightly", "0 2 * * *",
                     _ => new NightlyCapabilityMessage(), TimeZoneInfo.Utc);
             }).StartAsync(TestContext.Current.CancellationToken);
     }

--- a/src/Testing/CoreTests/Runtime/Recurring/recurring_schedules_in_capabilities_and_event_model.cs
+++ b/src/Testing/CoreTests/Runtime/Recurring/recurring_schedules_in_capabilities_and_event_model.cs
@@ -1,0 +1,110 @@
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration.Capabilities;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Runtime.Recurring;
+
+/// <summary>
+/// The diagnostics half of the recurring-message feature: registered schedules surface as a
+/// first-class ServiceCapabilities section (typed fields, so a monitoring console never parses
+/// deduplication-id strings, and a schedule change participates in capability change detection),
+/// and a cron-triggered slice on the Event Model is triggered by the job scheduler with the cron
+/// expression as its origin label — populated from the registration, never a parallel surface.
+/// </summary>
+public class recurring_schedules_in_capabilities_and_event_model : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                // See recurring_messages_on_a_storeless_host for why the assembly pin matters (GH-3521).
+                opts.ApplicationAssembly = typeof(recurring_schedules_in_capabilities_and_event_model).Assembly;
+                opts.ServiceName = "recurring-capabilities";
+
+                opts.Schedules.RecurringMessage<PendingRecurringMessage>("0 9 * * *");
+                opts.Schedules.RecurringMessage("nightly", "0 2 * * *",
+                    _ => new NightlyCapabilityMessage(), TimeZoneInfo.Utc);
+            }).StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_capabilities_snapshot_carries_the_recurring_schedules_section()
+    {
+        var capabilities = await ServiceCapabilities.ReadFrom(_host.GetRuntime(), null,
+            TestContext.Current.CancellationToken);
+
+        capabilities.RecurringSchedules.Count.ShouldBe(2);
+
+        // Ordered by name (ordinal), so the snapshot is stable across emits
+        var nightly = capabilities.RecurringSchedules.Single(x => x.Name == "nightly");
+        nightly.Name.ShouldBe("nightly");
+        nightly.CronExpression.ShouldBe("0 2 * * *");
+        nightly.TimeZoneId.ShouldBe(TimeZoneInfo.Utc.Id);
+        nightly.MessageType.Name.ShouldBe(nameof(NightlyCapabilityMessage));
+        nightly.Paused.ShouldBeFalse();
+        nightly.PausedAt.ShouldBeNull();
+
+        // On a storeless host there is no tracking row, so the pending occurrence falls back to
+        // the computed next firing instant — a real 02:00 UTC in the future.
+        nightly.NextOccurrence.ShouldNotBeNull();
+        nightly.NextOccurrence.Value.ShouldBeGreaterThan(DateTimeOffset.UtcNow);
+        nightly.NextOccurrence.Value.UtcDateTime.Hour.ShouldBe(2);
+
+        var daily = capabilities.RecurringSchedules.Single(x => x.Name == nameof(PendingRecurringMessage));
+        daily.CronExpression.ShouldBe("0 9 * * *");
+        daily.MessageType.FullName.ShouldBe(typeof(PendingRecurringMessage).FullName);
+    }
+
+    [Fact]
+    public async Task cron_scheduled_slices_are_job_scheduler_triggered_with_the_cron_as_origin_label()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services,
+            token: TestContext.Current.CancellationToken);
+
+        var slice = model!.Slices.Single(x => x.Name == nameof(NightlyCapabilityMessage));
+        slice.TriggerKind.ShouldBe(TriggerKind.JobScheduler);
+        slice.TriggerOrigin.ShouldNotBeNull();
+        slice.TriggerOrigin.Label.ShouldBe("0 2 * * *");
+    }
+
+    [Fact]
+    public async Task a_host_without_schedules_reports_an_empty_section_and_plain_triggers()
+    {
+        using var plain = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(recurring_schedules_in_capabilities_and_event_model).Assembly;
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var capabilities = await ServiceCapabilities.ReadFrom(plain.GetRuntime(), null,
+            TestContext.Current.CancellationToken);
+        capabilities.RecurringSchedules.ShouldBeEmpty();
+
+        var model = await WolverineEventModelExport.AssembleAsync(plain.Services,
+            token: TestContext.Current.CancellationToken);
+        model!.Slices.Single(x => x.Name == nameof(NightlyCapabilityMessage))
+            .TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+    }
+}
+
+public class NightlyCapabilityMessage;
+
+public static class NightlyCapabilityMessageHandler
+{
+    public static void Handle(NightlyCapabilityMessage message)
+    {
+    }
+}

--- a/src/Testing/Wolverine.ComplianceTests/RecurringMessageCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/RecurringMessageCompliance.cs
@@ -167,7 +167,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
     {
         var host = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("hourly-compliance", "0 * * * *",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("hourly-compliance", "0 * * * *",
                 _ => new RecurringComplianceMessage());
         });
 
@@ -204,7 +204,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
     {
         var host = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("verified-compliance", "0 * * * *",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("verified-compliance", "0 * * * *",
                 _ => new RecurringComplianceMessage());
         });
 
@@ -252,7 +252,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
     {
         var host = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("paused-compliance", "0 * * * *",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("paused-compliance", "0 * * * *",
                 _ => new RecurringComplianceMessage());
         });
 
@@ -294,7 +294,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
         // be durable state, not agent memory.
         var first = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("restartable-compliance", "0 * * * *",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("restartable-compliance", "0 * * * *",
                 _ => new RecurringComplianceMessage());
         });
 
@@ -312,7 +312,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
         // honours the row, nothing is ever even scheduled.
         var second = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("restartable-compliance",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("restartable-compliance",
                 "*/10 * * * * *", _ => new RecurringComplianceMessage());
         }, clean: false);
 
@@ -360,7 +360,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
         // Phase 1: publish an occurrence on a 15s cadence, remember its envelope ids, stop.
         var first = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("adopted-compliance",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("adopted-compliance",
                 "*/15 * * * * *", _ => new RecurringComplianceMessage());
         });
 
@@ -373,7 +373,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
         // row rather than double-publish, and the occurrence must actually fire.
         var second = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("adopted-compliance",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("adopted-compliance",
                 "*/15 * * * * *", _ => new RecurringComplianceMessage());
         }, clean: false);
 
@@ -397,7 +397,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
     {
         var host = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("known-compliance", "0 * * * *",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("known-compliance", "0 * * * *",
                 _ => new RecurringComplianceMessage());
         });
 
@@ -437,7 +437,7 @@ public abstract class RecurringMessageCompliance : IAsyncLifetime
         // provisions both.
         var with = await buildHost(opts =>
         {
-            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("neutrality-compliance", "0 * * * *",
+            opts.Schedules.ScheduleRecurring<RecurringComplianceMessage>("neutrality-compliance", "0 * * * *",
                 _ => new RecurringComplianceMessage());
         });
 

--- a/src/Testing/Wolverine.ComplianceTests/RecurringMessageCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/RecurringMessageCompliance.cs
@@ -1,0 +1,515 @@
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using JasperFx.Resources;
+using Shouldly;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.ScheduledMessageManagement;
+using Wolverine.RDBMS;
+using Wolverine.Runtime.Agents;
+using Wolverine.Runtime.Recurring;
+using Xunit;
+
+namespace Wolverine.ComplianceTests;
+
+/// <summary>
+/// Compliance facts for the recurring (cron) message tracking extension
+/// (<see cref="IRecurringMessageStore" />) — every RDBMS-backed message store inherits these by
+/// subclassing and supplying its persistence configuration. Anything asserting against a store
+/// lives here rather than in a provider-specific suite, so a provider cannot quietly diverge.
+///
+/// <para>
+/// The agent/loop logic itself (tick idempotence, skipped occurrences, storeless mode, the
+/// Serverless/MediatorOnly refusals) is pinned in CoreTests; these facts cover what only a real
+/// store can prove — the tracking row, verification against the durable inbox, durable
+/// pause/resume, and the opt-in's schema neutrality.
+/// </para>
+/// </summary>
+public abstract class RecurringMessageCompliance : IAsyncLifetime
+{
+    private readonly List<IHost> _hosts = [];
+    private readonly List<RecurringMessageAgent> _agents = [];
+    private readonly System.Collections.Concurrent.ConcurrentQueue<string> _logProblems = new();
+
+    /// <summary>Wire this provider's message persistence into the options.</summary>
+    protected abstract void configurePersistence(WolverineOptions opts);
+
+    public ValueTask InitializeAsync()
+    {
+        RecurringComplianceMessageHandler.Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var host in _hosts)
+        {
+            try
+            {
+                await host.StopAsync();
+            }
+            finally
+            {
+                host.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Build (and track for disposal) a Solo-mode host against this provider's store.
+    /// <paramref name="clean" /> resets all resource state — pass false for the second host of a
+    /// restart scenario, where surviving state is the thing under test.
+    /// </summary>
+    protected async Task<IHost> buildHost(Action<WolverineOptions> configure, bool clean = true)
+    {
+        if (clean)
+        {
+            // The recurring agent starts publishing the moment the real host starts, so any reset
+            // must complete BEFORE that host exists — a reset issued after StartAsync races the
+            // startup publish and wipes it out from under the agent's in-memory picture, which
+            // then (correctly) refuses to publish the same occurrence again. A schedule-less
+            // pre-flight host owns the reset; the durability flags are forced by hand so its
+            // store knows about (provisions, migrates, clears) the recurring + deduplication
+            // tables the real host is about to use.
+            using var preFlight = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    opts.Discovery.DisableConventionalDiscovery();
+                    opts.Durability.Mode = DurabilityMode.Solo;
+                    opts.Durability.EnableRecurringMessages = true;
+                    opts.Durability.EnableMessageDeduplication = true;
+                    configurePersistence(opts);
+                }).StartAsync(TestContext.Current.CancellationToken);
+
+            await preFlight.ResetResourceState();
+            await preFlight.StopAsync(TestContext.Current.CancellationToken);
+        }
+
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.AddProvider(new ProblemCapturingLoggerProvider(_logProblems)))
+            .UseWolverine(opts =>
+            {
+                // Explicit inclusion rather than scanning: the compliance assembly carries
+                // handlers for OTHER compliance suites (StorageActionCompliance's Todo handlers
+                // among them) whose persistence this host deliberately does not configure, and
+                // explicit inclusion is also immune to the GH-3521 first-host-wins assembly pin.
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Discovery.IncludeType(typeof(RecurringComplianceMessageHandler));
+
+                // Solo assigns every agent to this node immediately, so the recurring agent's
+                // first tick is not waiting on a leadership election. Failover of the singular
+                // agent belongs to the leadership-election compliance tier, not here.
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Durability.ScheduledJobPollingTime = 1.Seconds();
+
+                // The tracking extension records only envelopes that land in the DURABLE inbox as
+                // Scheduled — a buffered local queue keeps its scheduled occurrences in memory,
+                // where nothing can verify or cancel them. Durable local queues are also what any
+                // production host wanting durable recurring messages would run.
+                opts.Policies.UseDurableLocalQueues();
+
+                configurePersistence(opts);
+                configure(opts);
+            }).Build();
+
+        // Tighten the loop BEFORE the host starts: the agent computes each sleep from these at
+        // the END of a tick, so a knob tightened after startup only takes effect once the
+        // already-running (up to 30s) sleep expires — which is exactly a test timeout.
+        var agent = host.Services.GetServices<IAgentFamily>().OfType<RecurringMessageAgent>()
+            .SingleOrDefault();
+        if (agent != null)
+        {
+            agent.MaximumTickInterval = 1.Seconds();
+            agent.VerificationInterval = 2.Seconds();
+            _agents.Add(agent);
+        }
+
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        _hosts.Add(host);
+
+        return host;
+    }
+
+    private async Task<RecurringMessageRecord> waitForTrackedPublishAsync(IMessageStore store, string name,
+        TimeSpan? timeout = null)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout ?? 30.Seconds());
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var row = await store.RecurringMessages.LoadAsync(name, TestContext.Current.CancellationToken);
+            if (row is { EnvelopeIds.Length: > 0 })
+            {
+                return row;
+            }
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        var agentDump = string.Join(" | ",
+            _agents.Select(a => $"status={a.Status} published={a.OccurrencesPublished}"));
+        var rows = await store.RecurringMessages.LoadAllAsync(TestContext.Current.CancellationToken);
+        var rowDump = rows.Count == 0
+            ? "none"
+            : string.Join(" | ", rows.Select(r =>
+                $"{r.Name}: ids={r.EnvelopeIds.Length} next={r.NextOccurrence:O} paused={r.Paused} cron='{r.CronExpression}' updated={r.LastUpdated:O}"));
+        var counts = await store.Admin.FetchCountsAsync();
+        throw new TimeoutException(
+            $"No tracked publish for schedule '{name}' appeared in time. Agents: [{agentDump}]. " +
+            $"Rows: [{rowDump}]. Counts: scheduled={counts.Scheduled} incoming={counts.Incoming}. " +
+            $"Log problems: {string.Join(" || ", _logProblems)}");
+    }
+
+    [Fact]
+    public async Task publishing_upserts_the_tracking_row_and_the_envelope_is_really_scheduled()
+    {
+        var host = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("hourly-compliance", "0 * * * *",
+                _ => new RecurringComplianceMessage());
+        });
+
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        store.RecurringMessages.Enabled.ShouldBeTrue();
+
+        var row = await waitForTrackedPublishAsync(store, "hourly-compliance");
+
+        row.CronExpression.ShouldBe("0 * * * *");
+        row.Paused.ShouldBeFalse();
+        row.PausedAt.ShouldBeNull();
+
+        // The pending occurrence is a real top-of-hour instant in the future...
+        row.NextOccurrence.ShouldNotBeNull();
+        row.NextOccurrence.Value.ShouldBeGreaterThan(DateTimeOffset.UtcNow);
+        row.NextOccurrence.Value.UtcDateTime.Minute.ShouldBe(0);
+
+        // ...the row carries the occurrence's deterministic dedup id as its stable secondary key...
+        row.DeduplicationId.ShouldBe($"hourly-compliance:{row.NextOccurrence.Value.ToUniversalTime():O}");
+
+        // ...and the tracked envelope ids point at rows that really sit Scheduled in the inbox —
+        // both by the extension's own verification count and by the ScheduledMessages surface
+        // management tooling reads.
+        (await store.RecurringMessages.CountStillScheduledAsync(row.EnvelopeIds,
+            TestContext.Current.CancellationToken)).ShouldBe(row.EnvelopeIds.Length);
+
+        var scheduled = await store.ScheduledMessages.QueryAsync(
+            new ScheduledMessageQuery { MessageIds = row.EnvelopeIds }, TestContext.Current.CancellationToken);
+        scheduled.Messages.Count.ShouldBe(row.EnvelopeIds.Length);
+    }
+
+    [Fact]
+    public async Task verification_detects_a_cancelled_envelope_and_republishes_it()
+    {
+        var host = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("verified-compliance", "0 * * * *",
+                _ => new RecurringComplianceMessage());
+        });
+
+        var store = host.Services.GetRequiredService<IMessageStore>();
+
+        var original = await waitForTrackedPublishAsync(store, "verified-compliance");
+
+        // Cancel the pre-scheduled occurrence out from under the schedule, exactly the way an
+        // operator (or the console) would — through the ScheduledMessages surface on the
+        // TRACKED id, which is also the fact that the tracked id is the real, cancellable one.
+        await store.ScheduledMessages.CancelAsync(
+            new ScheduledMessageQuery { MessageIds = original.EnvelopeIds },
+            TestContext.Current.CancellationToken);
+
+        (await store.RecurringMessages.CountStillScheduledAsync(original.EnvelopeIds,
+            TestContext.Current.CancellationToken)).ShouldBe(0);
+
+        // Record-and-verify: the agent notices the loss and re-publishes the SAME occurrence
+        // under fresh envelope ids, re-recording them on the row.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        RecurringMessageRecord? republished = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var row = await store.RecurringMessages.LoadAsync("verified-compliance",
+                TestContext.Current.CancellationToken);
+            if (row is { EnvelopeIds.Length: > 0 } && !row.EnvelopeIds.Intersect(original.EnvelopeIds).Any())
+            {
+                republished = row;
+                break;
+            }
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        republished.ShouldNotBeNull("the cancelled occurrence was never re-published");
+        republished.NextOccurrence.ShouldBe(original.NextOccurrence);
+        republished.DeduplicationId.ShouldBe(original.DeduplicationId);
+
+        (await store.RecurringMessages.CountStillScheduledAsync(republished.EnvelopeIds,
+            TestContext.Current.CancellationToken)).ShouldBe(republished.EnvelopeIds.Length);
+    }
+
+    [Fact]
+    public async Task pause_marks_the_row_and_eagerly_cancels_the_pending_envelope()
+    {
+        var host = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("paused-compliance", "0 * * * *",
+                _ => new RecurringComplianceMessage());
+        });
+
+        var store = host.Services.GetRequiredService<IMessageStore>();
+        var control = host.Services.GetRequiredService<IRecurringScheduleControl>();
+
+        var before = await waitForTrackedPublishAsync(store, "paused-compliance");
+
+        await control.PauseAsync("paused-compliance", TestContext.Current.CancellationToken);
+
+        // The cancel is EAGER — the pending envelope is gone the moment the pause returns, not
+        // at the agent's next tick (the caller may be on a different node than the agent).
+        (await store.RecurringMessages.CountStillScheduledAsync(before.EnvelopeIds,
+            TestContext.Current.CancellationToken)).ShouldBe(0);
+
+        var row = await store.RecurringMessages.LoadAsync("paused-compliance",
+            TestContext.Current.CancellationToken);
+        row.ShouldNotBeNull();
+        row.Paused.ShouldBeTrue();
+        row.PausedAt.ShouldNotBeNull();
+        row.EnvelopeIds.ShouldBeEmpty();
+        row.NextOccurrence.ShouldBeNull();
+
+        // Double-pause is a no-op that keeps the original pause instant.
+        var firstPausedAt = row.PausedAt;
+        await control.PauseAsync("paused-compliance", TestContext.Current.CancellationToken);
+        var again = await store.RecurringMessages.LoadAsync("paused-compliance",
+            TestContext.Current.CancellationToken);
+        again!.Paused.ShouldBeTrue();
+        again.PausedAt.ShouldBe(firstPausedAt);
+    }
+
+    [Fact]
+    public async Task pause_survives_restart_nothing_fires_while_paused_and_resume_is_strictly_after_now()
+    {
+        RecurringComplianceMessageHandler.Reset();
+
+        // Phase 1: pause the schedule under an hourly cron, then stop the host — the pause has to
+        // be durable state, not agent memory.
+        var first = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("restartable-compliance", "0 * * * *",
+                _ => new RecurringComplianceMessage());
+        });
+
+        var firstStore = first.Services.GetRequiredService<IMessageStore>();
+        await waitForTrackedPublishAsync(firstStore, "restartable-compliance");
+        await first.Services.GetRequiredService<IRecurringScheduleControl>()
+            .PauseAsync("restartable-compliance", TestContext.Current.CancellationToken);
+        var pausedAt = (await firstStore.RecurringMessages.LoadAsync("restartable-compliance",
+            TestContext.Current.CancellationToken))!.PausedAt;
+        await first.StopAsync(TestContext.Current.CancellationToken);
+
+        // Phase 2: SAME schedule name, but now firing every ten seconds, against the same
+        // database with no reset. Deterministic by construction: the durable pause was in place
+        // before this host ever existed, so there is no publish/pause race to lose — if the agent
+        // honours the row, nothing is ever even scheduled.
+        var second = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("restartable-compliance",
+                "*/10 * * * * *", _ => new RecurringComplianceMessage());
+        }, clean: false);
+
+        var store = second.Services.GetRequiredService<IMessageStore>();
+
+        // Let several would-be occurrences pass.
+        await Task.Delay(12.Seconds(), TestContext.Current.CancellationToken);
+
+        RecurringComplianceMessageHandler.Received.ShouldBeEmpty();
+        var row = await store.RecurringMessages.LoadAsync("restartable-compliance",
+            TestContext.Current.CancellationToken);
+        row!.Paused.ShouldBeTrue("the pause did not survive the restart");
+        row.PausedAt.ShouldBe(pausedAt);
+        row.EnvelopeIds.ShouldBeEmpty();
+
+        // Phase 3: resume. The next occurrence is strictly after the resume instant — the paused
+        // window is never back-filled — and the schedule actually fires end to end.
+        var resumedAt = DateTimeOffset.UtcNow;
+        await second.Services.GetRequiredService<IRecurringScheduleControl>()
+            .ResumeAsync("restartable-compliance", TestContext.Current.CancellationToken);
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(60);
+        while (RecurringComplianceMessageHandler.Received.Count == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        var envelope = RecurringComplianceMessageHandler.Received.FirstOrDefault();
+        envelope.ShouldNotBeNull("the resumed schedule never fired");
+
+        // The occurrence instant rides in the deterministic dedup id; parse it back and prove
+        // no part of the paused window was replayed.
+        var prefix = "restartable-compliance:";
+        envelope.DeduplicationId.ShouldNotBeNull();
+        envelope.DeduplicationId.ShouldStartWith(prefix);
+        var occurrence = DateTimeOffset.Parse(envelope.DeduplicationId![prefix.Length..]);
+        occurrence.ShouldBeGreaterThan(resumedAt);
+    }
+
+    [Fact]
+    public async Task a_restarted_host_adopts_the_predecessors_pending_occurrence_and_it_still_fires()
+    {
+        RecurringComplianceMessageHandler.Reset();
+
+        // Phase 1: publish an occurrence on a 15s cadence, remember its envelope ids, stop.
+        var first = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("adopted-compliance",
+                "*/15 * * * * *", _ => new RecurringComplianceMessage());
+        });
+
+        var firstStore = first.Services.GetRequiredService<IMessageStore>();
+        var tracked = await waitForTrackedPublishAsync(firstStore, "adopted-compliance");
+        await first.StopAsync(TestContext.Current.CancellationToken);
+
+        // Phase 2: a successor against the same database. The pre-scheduled occurrence survived
+        // the restart in the durable inbox; the successor's agent must ADOPT it off the tracking
+        // row rather than double-publish, and the occurrence must actually fire.
+        var second = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("adopted-compliance",
+                "*/15 * * * * *", _ => new RecurringComplianceMessage());
+        }, clean: false);
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(60);
+        while (RecurringComplianceMessageHandler.Received.Count == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        var envelope = RecurringComplianceMessageHandler.Received.FirstOrDefault();
+        envelope.ShouldNotBeNull("the predecessor's pre-scheduled occurrence never fired after the restart");
+
+        // The envelope that fired is the PREDECESSOR's — restart durability and adoption in one
+        // assertion. (The dedupe layer would collapse a double-publish at consumption anyway;
+        // adoption means the duplicate is never even created.)
+        tracked.EnvelopeIds.ShouldContain(envelope.Id);
+    }
+
+    [Fact]
+    public async Task pausing_an_unknown_schedule_throws()
+    {
+        var host = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("known-compliance", "0 * * * *",
+                _ => new RecurringComplianceMessage());
+        });
+
+        var control = host.Services.GetRequiredService<IRecurringScheduleControl>();
+
+        var ex = await Should.ThrowAsync<UnknownRecurringScheduleException>(
+            () => control.PauseAsync("no-such-schedule", TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("no-such-schedule");
+        ex.Message.ShouldContain("known-compliance");
+
+        await Should.ThrowAsync<UnknownRecurringScheduleException>(
+            () => control.ResumeAsync("no-such-schedule", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task the_opt_in_is_schema_neutral_for_hosts_without_schedules()
+    {
+        // A host that never registers a schedule must migrate EXACTLY as it did before the
+        // feature existed: no recurring tracking table, no deduplication table (that flag rides
+        // the same registration), and the null store on the extension point.
+        var without = await buildHost(_ => { });
+
+        var store = without.Services.GetRequiredService<IMessageStore>();
+        store.RecurringMessages.Enabled.ShouldBeFalse();
+        store.RecurringMessages.ShouldBeSameAs(NullRecurringMessageStore.Instance);
+
+        // EndsWith rather than equality because SQLite folds the "schema" into a table-name
+        // prefix (GH-3943), so the rendered identifier is prefixed on that provider.
+        var objects = ((Weasel.Core.Migrations.IDatabase)store).AllObjects()
+            .Select(x => x.Identifier.Name).ToArray();
+        objects.Any(x => x.EndsWith(DatabaseConstants.RecurringMessagesTableName)).ShouldBeFalse();
+        objects.Any(x => x.EndsWith(DatabaseConstants.DeduplicationTableName)).ShouldBeFalse();
+
+        await without.StopAsync(TestContext.Current.CancellationToken);
+
+        // And the registration IS the whole opt-in: the same persistence with one schedule
+        // provisions both.
+        var with = await buildHost(opts =>
+        {
+            opts.Schedules.RecurringMessage<RecurringComplianceMessage>("neutrality-compliance", "0 * * * *",
+                _ => new RecurringComplianceMessage());
+        });
+
+        var optedIn = with.Services.GetRequiredService<IMessageStore>();
+        optedIn.RecurringMessages.Enabled.ShouldBeTrue();
+
+        var optedInObjects = ((Weasel.Core.Migrations.IDatabase)optedIn).AllObjects()
+            .Select(x => x.Identifier.Name).ToArray();
+        optedInObjects.Any(x => x.EndsWith(DatabaseConstants.RecurringMessagesTableName)).ShouldBeTrue();
+        optedInObjects.Any(x => x.EndsWith(DatabaseConstants.DeduplicationTableName)).ShouldBeTrue();
+    }
+}
+
+internal class ProblemCapturingLoggerProvider(System.Collections.Concurrent.ConcurrentQueue<string> problems)
+    : Microsoft.Extensions.Logging.ILoggerProvider
+{
+    public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
+        => new ProblemLogger(categoryName, problems);
+
+    public void Dispose()
+    {
+    }
+
+    private class ProblemLogger(string category, System.Collections.Concurrent.ConcurrentQueue<string> problems)
+        : Microsoft.Extensions.Logging.ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+            => logLevel >= Microsoft.Extensions.Logging.LogLevel.Warning;
+
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel)) return;
+            problems.Enqueue($"[{logLevel}] {category}: {formatter(state, exception)} {exception?.Message}");
+        }
+    }
+}
+
+public class RecurringComplianceMessage;
+
+public static class RecurringComplianceMessageHandler
+{
+    private static readonly List<Envelope> _received = [];
+    private static readonly object _lock = new();
+
+    public static IReadOnlyList<Envelope> Received
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _received.ToArray();
+            }
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock)
+        {
+            _received.Clear();
+        }
+    }
+
+    public static void Handle(RecurringComplianceMessage message, Envelope envelope)
+    {
+        lock (_lock)
+        {
+            _received.Add(envelope);
+        }
+    }
+}

--- a/src/Wolverine/Configuration/Capabilities/RecurringScheduleDescriptor.cs
+++ b/src/Wolverine/Configuration/Capabilities/RecurringScheduleDescriptor.cs
@@ -1,0 +1,50 @@
+using JasperFx.Descriptors;
+
+namespace Wolverine.Configuration.Capabilities;
+
+/// <summary>
+/// Capability shape for one recurring (cron) message schedule registered through
+/// <c>opts.Schedules</c>. Surfaced through <see cref="ServiceCapabilities.RecurringSchedules" />
+/// as a first-class section — rather than an <c>AdditionalCapabilities</c> entry — so external
+/// monitoring tools (CritterWatch in particular) get typed fields, and so a schedule change
+/// participates in capability change detection.
+/// </summary>
+/// <remarks>
+/// Definition fields (name, cron, time zone, message type) come from the code-first
+/// registrations and are always present. Runtime fields (paused state, the pending next
+/// occurrence) come from the message store's recurring tracking extension when it exists; on a
+/// store without it, <see cref="Paused" /> is reported false and <see cref="NextOccurrence" />
+/// falls back to the computed next firing instant.
+/// </remarks>
+public class RecurringScheduleDescriptor
+{
+    public RecurringScheduleDescriptor()
+    {
+    }
+
+    /// <summary>The schedule's registered name — its stable identity (feeds the occurrence
+    /// deduplication id and the <c>wolverine.schedule.name</c> trace tag).</summary>
+    public string Name { get; set; } = null!;
+
+    /// <summary>The cron expression, exactly as registered (5- or 6-field grammar).</summary>
+    public string CronExpression { get; set; } = null!;
+
+    /// <summary>The IANA/Windows id of the time zone occurrences are computed in ("UTC" by default).</summary>
+    public string TimeZoneId { get; set; } = null!;
+
+    /// <summary>The message type each occurrence publishes.</summary>
+    public TypeDescriptor MessageType { get; set; } = null!;
+
+    /// <summary>
+    /// When the next occurrence fires — the pre-scheduled instant off the durable tracking row
+    /// when one exists, otherwise the computed next firing instant. Null while the schedule is
+    /// paused, or when a fixed-date schedule has run out of occurrences.
+    /// </summary>
+    public DateTimeOffset? NextOccurrence { get; set; }
+
+    /// <summary>Is this schedule administratively paused?</summary>
+    public bool Paused { get; set; }
+
+    /// <summary>When the schedule was paused. Null while running.</summary>
+    public DateTimeOffset? PausedAt { get; set; }
+}

--- a/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
+++ b/src/Wolverine/Configuration/Capabilities/ServiceCapabilities.cs
@@ -11,6 +11,7 @@ using Wolverine.Configuration.EventModeling;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Wolverine.Persistence;
+using Wolverine.Persistence.Durability;
 using Wolverine.Persistence.Sagas;
 using Wolverine.Runtime;
 using Wolverine.Runtime.Handlers;
@@ -105,6 +106,17 @@ public class ServiceCapabilities : OptionsDescription
     /// </summary>
     public List<SagaDescriptor> Sagas { get; set; } = [];
 
+    /// <summary>
+    /// One <see cref="RecurringScheduleDescriptor" /> per recurring (cron) message schedule
+    /// registered through <c>opts.Schedules</c> — name, cron expression, time zone, message
+    /// type, plus the runtime pause state and pending next occurrence read best-effort from the
+    /// message store's recurring tracking extension. First-class rather than an
+    /// <c>AdditionalCapabilities</c> entry so consumers (CritterWatch) get typed fields and a
+    /// schedule change participates in capability change detection. Empty when no schedules are
+    /// registered.
+    /// </summary>
+    public List<RecurringScheduleDescriptor> RecurringSchedules { get; set; } = [];
+
     public List<MessageStore> MessageStores { get; set; } = [];
 
     /// <summary>
@@ -198,6 +210,9 @@ public class ServiceCapabilities : OptionsDescription
         readSection(runtime, nameof(MessagingEndpoints), token, () => readEndpoints(runtime, capabilities, token));
 
         readSection(runtime, nameof(Sagas), token, () => readSagas(runtime, capabilities));
+
+        await readSectionAsync(runtime, nameof(RecurringSchedules), token,
+            () => readRecurringSchedules(runtime, token, capabilities));
 
         readSection(runtime, nameof(AdditionalCapabilities), token,
             () => readAdditionalCapabilities(runtime, capabilities));
@@ -527,6 +542,53 @@ public class ServiceCapabilities : OptionsDescription
     {
         capabilities.EventModel =
             await WolverineEventModelExport.AssembleAsync(runtime.Services, runtime.Options.ServiceName, token);
+    }
+
+    /// <summary>
+    /// One descriptor per registered recurring (cron) schedule. Definition data comes straight
+    /// off the code-first registrations; the runtime half (paused, the actually-pending next
+    /// occurrence) is read from the message store's recurring tracking extension with its own
+    /// inner best-effort guard — an unreachable database costs the snapshot the runtime fields,
+    /// never the schedule definitions themselves.
+    /// </summary>
+    private static async Task readRecurringSchedules(IWolverineRuntime runtime, CancellationToken token,
+        ServiceCapabilities capabilities)
+    {
+        var schedules = runtime.Options.Schedules;
+        if (!schedules.Any()) return;
+
+        var rows = new Dictionary<string, RecurringMessageRecord>();
+        try
+        {
+            foreach (var row in await runtime.Storage.RecurringMessages.LoadAllAsync(token))
+            {
+                rows[row.Name] = row;
+            }
+        }
+        catch (Exception e)
+        {
+            token.ThrowIfCancellationRequested();
+            runtime.Logger.LogWarning(e,
+                "Wolverine was unable to read the recurring-message tracking rows for the ServiceCapabilities snapshot. Schedule definitions are still reported; pause state and pending occurrences are not.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var schedule in schedules.OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            var row = rows.GetValueOrDefault(schedule.Name);
+            capabilities.RecurringSchedules.Add(new RecurringScheduleDescriptor
+            {
+                Name = schedule.Name,
+                CronExpression = schedule.Schedule.Expression,
+                TimeZoneId = schedule.Schedule.TimeZone.Id,
+                MessageType = TypeDescriptor.For(schedule.MessageType),
+                Paused = row?.Paused ?? false,
+                PausedAt = row?.PausedAt,
+                NextOccurrence = row?.Paused == true
+                    ? null
+                    : row?.NextOccurrence ?? schedule.Schedule.NextOccurrence(now)
+            });
+        }
     }
 
     private static void readAdditionalCapabilities(IWolverineRuntime runtime, ServiceCapabilities capabilities)

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -76,7 +76,7 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
 
         foreach (var chain in DescribedChains(options))
         {
-            var slice = EventModelRoles.ForHandlerChain(chain);
+            var slice = applyRecurringTrigger(EventModelRoles.ForHandlerChain(chain), chain.MessageType, options);
             slices.Add(slice);
 
             knownTypes.TryAdd(chain.MessageType.FullName!, chain.MessageType);
@@ -108,6 +108,32 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         model = ApplyGrpcTriggers(model, grpc);
         model = ApplyExternalSystems(model, options, stickyEndpoints, knownTypes, includeInbound: true);
         return FinishModel(model);
+    }
+
+    /// <summary>
+    ///     A slice whose message type has a registered recurring (cron) schedule is triggered by the job
+    ///     scheduler, not an ad-hoc message publish — same treatment <see cref="EventModelRoles.ForHandlerChain" />
+    ///     gives <see cref="TimeoutMessage" /> — and the trigger origin's label documents itself as the
+    ///     cron expression, populated from the registration rather than invented as a parallel surface.
+    /// </summary>
+    private static EventModelSliceDescriptor applyRecurringTrigger(EventModelSliceDescriptor slice,
+        Type messageType, WolverineOptions options)
+    {
+        if (!options.Schedules.Any()) return slice;
+
+        var expressions = options.Schedules
+            .Where(x => x.MessageType == messageType)
+            .Select(x => x.Schedule.Expression)
+            .Distinct()
+            .ToArray();
+
+        if (expressions.Length == 0) return slice;
+
+        return slice with
+        {
+            TriggerKind = TriggerKind.JobScheduler,
+            TriggerOrigin = slice.TriggerOrigin ?? new PublisherOrigin { Label = string.Join("; ", expressions) }
+        };
     }
 
     /// <summary>

--- a/src/Wolverine/CronSchedule.cs
+++ b/src/Wolverine/CronSchedule.cs
@@ -1,0 +1,150 @@
+using Cronos;
+
+namespace Wolverine;
+
+/// <summary>
+/// A parsed, immutable cron schedule — the value type behind <c>opts.Schedules</c>. The string
+/// registration overloads are sugar over this: parsing (and therefore refusal of an invalid
+/// expression) happens in the constructor, so direct construction and the string forms fail at the
+/// same place with the same exception.
+///
+/// <para>
+/// Accepts the standard 5-field cron grammar, or 6 fields where the leading field is seconds.
+/// Occurrences are computed in <see cref="TimeZone" /> (UTC unless one is supplied), with DST
+/// handled by Cronos — a schedule inside a spring-forward gap fires at the adjusted instant, and a
+/// fall-back repeat fires once.
+/// </para>
+///
+/// <para>
+/// ⚠️ Being a struct changes the null story rather than removing it: <c>default(CronSchedule)</c>
+/// exists and wraps nothing. Every member guards it with a clear exception rather than a
+/// <see cref="NullReferenceException" /> from the parser internals.
+/// </para>
+/// </summary>
+public readonly struct CronSchedule : IEquatable<CronSchedule>
+{
+    /// <summary>
+    /// The minimum spacing between occurrences a schedule may declare. Durable scheduled messages
+    /// replay on <see cref="DurabilitySettings.ScheduledJobPollingTime" /> (5 seconds by default),
+    /// so a faster cadence cannot be honoured through that path — the registration is refused as
+    /// unsatisfiable rather than accepted and quietly delivered late.
+    /// </summary>
+    public static readonly TimeSpan MinimumCadence = TimeSpan.FromSeconds(5);
+
+    private readonly CronExpression? _expression;
+
+    /// <summary>The raw cron expression this schedule was parsed from.</summary>
+    public string Expression { get; }
+
+    /// <summary>The time zone occurrences are computed in. UTC unless one was supplied.</summary>
+    public TimeZoneInfo TimeZone { get; }
+
+    /// <summary>
+    /// Parse a cron expression (5-field, or 6-field with a leading seconds field) into a schedule.
+    /// Throws <see cref="ArgumentException" /> for an invalid expression or an unsatisfiably fast
+    /// cadence — a bad schedule is a programming error and should fail at the line that wrote it.
+    /// </summary>
+    public CronSchedule(string expression, TimeZoneInfo? timeZone = null)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            throw new ArgumentException("A cron expression is required", nameof(expression));
+        }
+
+        var fieldCount = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+
+        try
+        {
+            _expression = fieldCount == 6
+                ? CronExpression.Parse(expression, CronFormat.IncludeSeconds)
+                : CronExpression.Parse(expression);
+        }
+        catch (CronFormatException e)
+        {
+            throw new ArgumentException(
+                $"'{expression}' is not a valid cron expression: {e.Message}", nameof(expression), e);
+        }
+
+        Expression = expression;
+        TimeZone = timeZone ?? TimeZoneInfo.Utc;
+
+        assertSatisfiableCadence();
+    }
+
+    /// <summary>Parse a cron expression into a schedule. Identical to the constructor.</summary>
+    public static CronSchedule Parse(string expression, TimeZoneInfo? timeZone = null)
+    {
+        return new CronSchedule(expression, timeZone);
+    }
+
+    /// <summary>Try-parse twin of <see cref="Parse" />. False for invalid or unsatisfiable expressions.</summary>
+    public static bool TryParse(string expression, TimeZoneInfo? timeZone, out CronSchedule schedule)
+    {
+        try
+        {
+            schedule = new CronSchedule(expression, timeZone);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            schedule = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The next occurrence strictly after <paramref name="after" />, or null when the expression
+    /// has no further occurrence (possible with fixed-date expressions).
+    /// </summary>
+    public DateTimeOffset? NextOccurrence(DateTimeOffset after)
+    {
+        var expression = _expression ?? throw new InvalidOperationException(
+            "This is the default, uninitialized CronSchedule value. Construct one with an expression.");
+
+        return expression.GetNextOccurrence(after, TimeZone);
+    }
+
+    private void assertSatisfiableCadence()
+    {
+        // Sample the first gap from a fixed anchor. Not a proof over every gap the expression can
+        // produce, but it deterministically catches the every-second / every-other-second shapes
+        // that can never be honoured, at the moment they are written.
+        var anchor = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var first = NextOccurrence(anchor);
+        if (first == null) return;
+
+        var second = NextOccurrence(first.Value);
+        if (second == null) return;
+
+        if (second.Value - first.Value < MinimumCadence)
+        {
+            throw new ArgumentException(
+                $"'{Expression}' fires more often than every {MinimumCadence.TotalSeconds:0} seconds, " +
+                $"which cannot be honoured: durable scheduled messages replay on " +
+                $"{nameof(DurabilitySettings.ScheduledJobPollingTime)} (default 5s), so a faster cadence " +
+                "would be accepted and then quietly delivered late.");
+        }
+    }
+
+    public bool Equals(CronSchedule other)
+    {
+        return Expression == other.Expression && Equals(TimeZone?.Id, other.TimeZone?.Id);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is CronSchedule other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Expression, TimeZone?.Id);
+    }
+
+    // Guarded because this is a struct: default(CronSchedule).Expression is null, and a ToString()
+    // that returns null breaks logging at the worst possible moment.
+    public override string ToString()
+    {
+        return Expression == null ? "(default CronSchedule)" : $"{Expression} ({TimeZone.Id})";
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -355,6 +355,21 @@ public class DurabilitySettings : IDescribeMyself
     public int DeduplicationCleanupBatchSize { get; set; } = 5000;
 
     /// <summary>
+    ///     Is the recurring (cron) message feature active on this application? Flipped by
+    ///     registering the first schedule through <c>opts.Schedules</c> — never set this by hand.
+    ///
+    ///     <para>
+    ///     It exists as a durability setting because the message stores read it: when
+    ///     <see langword="true" />, the main store provisions the <c>wolverine_recurring_messages</c>
+    ///     tracking table and builds a real <see cref="Persistence.Durability.IRecurringMessageStore" />.
+    ///     When <see langword="false" /> — every application that has not registered a schedule —
+    ///     providers return the null store and the schema is byte-identical to a Wolverine version
+    ///     without the feature, so an upgrade forces no migration on anyone who has not asked for it.
+    ///     </para>
+    /// </summary>
+    public bool EnableRecurringMessages { get; set; }
+
+    /// <summary>
     ///     Governs the page size for how many persisted incoming or outgoing messages
     ///     will be loaded at one time for attempted retries or scheduled jobs
     /// </summary>
@@ -773,6 +788,8 @@ public class DurabilitySettings : IDescribeMyself
             desc.AddValue(nameof(DeduplicationWindow), DeduplicationWindow);
             desc.AddValue(nameof(DeduplicationCleanupPollingTime), DeduplicationCleanupPollingTime);
         }
+
+        desc.AddValue(nameof(EnableRecurringMessages), EnableRecurringMessages);
 
         if (OutboxStaleTime.HasValue) desc.AddValue(nameof(OutboxStaleTime), OutboxStaleTime.Value);
         if (InboxStaleTime.HasValue) desc.AddValue(nameof(InboxStaleTime), InboxStaleTime.Value);

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -460,6 +460,14 @@ public partial class Envelope
         {
             activity.SetTag(WolverineTracing.MessageScheduled, true);
         }
+
+        // An occurrence published by opts.Schedules carries its schedule's name in a header;
+        // surfacing it as a tag is what lets trace consumers (CritterWatch among them) attribute
+        // the handler span to the cron job that caused it.
+        if (Headers.TryGetValue(RecurringMessage.HeaderKey, out var scheduleName))
+        {
+            activity.MaybeSetTag(WolverineTracing.ScheduleName, scheduleName);
+        }
     }
 
     internal ValueTask PersistAsync(IEnvelopeTransaction transaction)

--- a/src/Wolverine/Persistence/Durability/IMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStore.cs
@@ -128,6 +128,18 @@ public interface IMessageStore : IAsyncDisposable
     /// </summary>
     IDeduplicationStore Deduplication => NullDeduplicationStore.Instance;
 
+    /// <summary>
+    /// Tracking for recurring (cron) message schedules — schedule name to the envelope id(s) of
+    /// its pre-scheduled next occurrence plus pause state. Opt-in via
+    /// <see cref="DurabilitySettings.EnableRecurringMessages" /> (flipped by registering the first
+    /// schedule through <c>opts.Schedules</c>); providers must return
+    /// <see cref="NullRecurringMessageStore.Instance" /> (and skip provisioning the tracking
+    /// table) when the flag is <c>false</c>, so an upgrade is a no-op for anyone who has not asked
+    /// for the feature. Defaulted rather than abstract for the same reason as
+    /// <see cref="Deduplication" /> — a provider with no answer inherits the graceful no-op.
+    /// </summary>
+    IRecurringMessageStore RecurringMessages => NullRecurringMessageStore.Instance;
+
     IMessageStoreAdmin Admin { get; }
 
     IDeadLetters DeadLetters { get; }

--- a/src/Wolverine/Persistence/Durability/IRecurringMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/IRecurringMessageStore.cs
@@ -1,0 +1,150 @@
+namespace Wolverine.Persistence.Durability;
+
+/// <summary>
+/// One recurring message schedule's durable tracking state — the row behind
+/// <see cref="IRecurringMessageStore" />. The scheduled INBOX row is the materialized next
+/// occurrence (delivery never runs through this table); this record is the bookkeeping beside it
+/// that makes the "next occurrence is up" guarantee verifiable and gives management tooling a
+/// stable handle on what is pending for which schedule.
+/// </summary>
+public class RecurringMessageRecord
+{
+    /// <summary>The schedule's registered name — the primary key.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>The schedule's cron expression, recorded for diagnostics and management surfaces.</summary>
+    public string CronExpression { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The envelope ids of the pre-scheduled inbox rows for the next occurrence. Usually one;
+    /// more when the message type routes to multiple durable subscribers. Empty while the
+    /// schedule is paused, before its first publish, or when no route stored durably.
+    /// </summary>
+    public Guid[] EnvelopeIds { get; init; } = [];
+
+    /// <summary>
+    /// The deterministic occurrence deduplication id of the pending occurrence — the stable
+    /// secondary key that survives even where an envelope id could not be captured.
+    /// </summary>
+    public string? DeduplicationId { get; init; }
+
+    /// <summary>When the pending occurrence fires. Null while paused or never published.</summary>
+    public DateTimeOffset? NextOccurrence { get; init; }
+
+    /// <summary>Is this schedule administratively paused?</summary>
+    public bool Paused { get; init; }
+
+    /// <summary>When the schedule was paused. Null while running.</summary>
+    public DateTimeOffset? PausedAt { get; init; }
+
+    /// <summary>Last time the recurring agent (or a pause/resume) touched this row.</summary>
+    public DateTimeOffset LastUpdated { get; init; }
+}
+
+/// <summary>
+/// Message-store extension tracking recurring (cron) message schedules — one row per registered
+/// schedule, mapping the schedule name to the envelope id(s) of its pre-scheduled next occurrence
+/// plus its pause state. Opt-in exactly like the rest of the recurring feature: registering the
+/// first schedule through <c>opts.Schedules</c> is what makes providers build a real
+/// implementation and provision the backing table; with zero schedules registered they MUST
+/// return <see cref="NullRecurringMessageStore.Instance" /> and leave the schema untouched.
+///
+/// <para>
+/// What the tracking buys, in order of importance: the recurring agent's guarantee becomes
+/// <b>verifiable</b> (it can confirm the tracked envelope still sits <c>Scheduled</c> in the inbox
+/// and re-publish when something cancelled it out from under the schedule); <b>pause/resume</b>
+/// state is durable across restarts and visible to whichever node holds the agent; and management
+/// tooling can interrogate which schedule owns which pending envelope without parsing
+/// deduplication-id strings.
+/// </para>
+///
+/// <para>
+/// Defaulted rather than abstract on <see cref="IMessageStore" /> on purpose (the
+/// <see cref="IMessageStore.Deduplication" /> precedent): a provider with no answer inherits the
+/// no-op, and the feature degrades gracefully — schedules still fire, verification just cannot
+/// see the inbox and pause state is not durable.
+/// </para>
+/// </summary>
+public interface IRecurringMessageStore
+{
+    /// <summary>
+    /// Is this a real, durable store? <see langword="false" /> for
+    /// <see cref="NullRecurringMessageStore" />. The recurring agent checks this before it spends
+    /// any effort on tracking or verification.
+    /// </summary>
+    bool Enabled => true;
+
+    /// <summary>
+    /// Upsert the tracking row for one schedule after publishing its next occurrence. Overwrites
+    /// the publish bookkeeping (cron expression, envelope ids, deduplication id, next occurrence,
+    /// last updated) and MUST preserve the row's pause state — the agent's record of a publish is
+    /// never permission to un-pause.
+    /// </summary>
+    Task RecordPublishedAsync(RecurringMessageRecord record, CancellationToken token = default);
+
+    /// <summary>Load one schedule's tracking row. Null when the schedule has never been recorded.</summary>
+    Task<RecurringMessageRecord?> LoadAsync(string name, CancellationToken token = default);
+
+    /// <summary>Load every schedule's tracking row.</summary>
+    Task<IReadOnlyList<RecurringMessageRecord>> LoadAllAsync(CancellationToken token = default);
+
+    /// <summary>
+    /// How many of these envelope ids still sit in the durable inbox with
+    /// <see cref="EnvelopeStatus.Scheduled" /> status? The verification half of record-and-verify:
+    /// a count short of <paramref name="envelopeIds" />.Length means something cancelled or lost a
+    /// pre-scheduled occurrence, and the agent re-publishes it (same occurrence, same
+    /// deduplication id, so an envelope that actually fired in the gap still collapses to one
+    /// handling).
+    /// </summary>
+    Task<int> CountStillScheduledAsync(Guid[] envelopeIds, CancellationToken token = default);
+
+    /// <summary>
+    /// Pause a schedule: mark its row paused AND eagerly cancel (delete from the inbox) any
+    /// tracked pre-scheduled envelopes — the caller may be on a different node than the agent, and
+    /// nothing may fire in the gap before the agent's next tick. Idempotent: pausing an
+    /// already-paused schedule keeps the original <see cref="RecurringMessageRecord.PausedAt" />
+    /// and is a no-op; a schedule with no row yet gets a paused-only row, so pausing before the
+    /// first publish works.
+    /// </summary>
+    Task PauseAsync(string name, DateTimeOffset pausedAt, CancellationToken token = default);
+
+    /// <summary>
+    /// Resume a paused schedule: clear the pause mark so the agent's next tick pre-schedules the
+    /// occurrence strictly after the resume time. The paused window is never back-filled.
+    /// Idempotent — resuming a running or unknown schedule is a no-op.
+    /// </summary>
+    Task ResumeAsync(string name, CancellationToken token = default);
+}
+
+/// <summary>
+/// Default no-op recurring-message tracking. Returned by
+/// <see cref="IMessageStore.RecurringMessages" /> when no schedules are registered, and by stores
+/// with no durable backing for the extension. Recurring messages still work on this — the agent's
+/// in-memory picture drives publishing — but verification no-ops (<see cref="CountStillScheduledAsync" />
+/// reports everything present so nothing is ever spuriously re-published) and pause state is not
+/// durable or cluster-visible.
+/// </summary>
+public sealed class NullRecurringMessageStore : IRecurringMessageStore
+{
+    public static NullRecurringMessageStore Instance { get; } = new();
+
+    public bool Enabled => false;
+
+    public Task RecordPublishedAsync(RecurringMessageRecord record, CancellationToken token = default)
+        => Task.CompletedTask;
+
+    public Task<RecurringMessageRecord?> LoadAsync(string name, CancellationToken token = default)
+        => Task.FromResult<RecurringMessageRecord?>(null);
+
+    public Task<IReadOnlyList<RecurringMessageRecord>> LoadAllAsync(CancellationToken token = default)
+        => Task.FromResult<IReadOnlyList<RecurringMessageRecord>>([]);
+
+    public Task<int> CountStillScheduledAsync(Guid[] envelopeIds, CancellationToken token = default)
+        => Task.FromResult(envelopeIds.Length);
+
+    public Task PauseAsync(string name, DateTimeOffset pausedAt, CancellationToken token = default)
+        => Task.CompletedTask;
+
+    public Task ResumeAsync(string name, CancellationToken token = default)
+        => Task.CompletedTask;
+}

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -368,6 +368,11 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
     // authoritative for the registry.
     public IListenerStore Listeners => Main.Listeners;
 
+    // Recurring-message tracking is cluster-level bookkeeping owned by the single recurring
+    // agent, which publishes through the main store — same reasoning as the listener registry
+    // above: the master is authoritative, per-tenant rows would be duplicates.
+    public IRecurringMessageStore RecurringMessages => Main.RecurringMessages;
+
     public IMessageStoreAdmin Admin => this;
 
     [UnconditionalSuppressMessage("Trimming", "IL2026",

--- a/src/Wolverine/Runtime/Recurring/RecurringDeduplicationPolicy.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringDeduplicationPolicy.cs
@@ -1,0 +1,55 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using Wolverine.Configuration;
+using Wolverine.Persistence;
+using Wolverine.Runtime.Handlers;
+
+namespace Wolverine.Runtime.Recurring;
+
+/// <summary>
+/// Applies logical message deduplication to the handler chain of every message type that is known
+/// to be cron-scheduled — exactly those, nothing broader. The recurring agent stamps a
+/// deterministic occurrence id (<see cref="RecurringMessage.DeduplicationIdFor" />) on each
+/// publish, so a failover or restart that re-publishes the same occurrence is collapsed at
+/// consumption rather than executed twice.
+///
+/// <para>
+/// The requirement is deliberately <see cref="DeduplicationRequirement.Required" /> = false: a
+/// cron-scheduled message type may legitimately also be published by hand, without an id, and
+/// those sends must pass through rather than be refused. Only setting the requirement here — the
+/// frames themselves are woven by the chain's own compile, after the persistence providers have
+/// settled <c>IsTransactional</c>.
+/// </para>
+/// </summary>
+internal class RecurringDeduplicationPolicy : IHandlerPolicy
+{
+    private readonly RecurringMessageCollection _schedules;
+
+    public RecurringDeduplicationPolicy(RecurringMessageCollection schedules)
+    {
+        _schedules = schedules;
+    }
+
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        // The claim frame is enforcing by design: MessageDeduplicator.TryClaimAsync THROWS on a
+        // store whose IDeduplicationStore.Enabled is false rather than waving duplicates through.
+        // On a host whose store cannot back deduplication (a storeless host most obviously), an
+        // auto-applied requirement would therefore turn every occurrence into an error — strictly
+        // worse than the failover double-fire window it exists to close. Skip, and let the startup
+        // warning name the gap.
+        var runtime = container.GetInstance<IWolverineRuntime>();
+        if (!runtime.Storage.Deduplication.Enabled) return;
+
+        var messageTypes = _schedules.MessageTypes();
+
+        foreach (var chain in chains)
+        {
+            if (!messageTypes.Contains(chain.MessageType)) continue;
+
+            // An explicit [Deduplicated] on the handler wins — the user may have chosen a
+            // different source or strictness, and two requirements cannot both apply.
+            chain.Deduplication ??= new DeduplicationRequirement { Required = false };
+        }
+    }
+}

--- a/src/Wolverine/Runtime/Recurring/RecurringMessage.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringMessage.cs
@@ -1,0 +1,64 @@
+namespace Wolverine;
+
+/// <summary>
+/// One registered recurring message: a named <see cref="CronSchedule" /> plus the factory that
+/// builds the message for each occurrence. Registered through <c>opts.Schedules</c>; executed by
+/// Wolverine's recurring-message agent, which keeps exactly the NEXT occurrence pre-scheduled
+/// through the existing scheduled-message machinery.
+/// </summary>
+public sealed class RecurringMessage
+{
+    /// <summary>
+    /// The envelope header carrying the schedule name on every occurrence this schedule publishes.
+    /// Round-trips on every transport like any other header, and is what stamps the
+    /// <c>wolverine.schedule.name</c> tag onto the handler's OpenTelemetry activity.
+    /// </summary>
+    public const string HeaderKey = "recurring-schedule";
+
+    internal RecurringMessage(string name, CronSchedule schedule, Type messageType,
+        Func<DateTimeOffset, object> creator)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("A recurring message needs a non-empty name", nameof(name));
+        }
+
+        Name = name;
+        Schedule = schedule;
+        MessageType = messageType;
+        Creator = creator;
+    }
+
+    /// <summary>
+    /// The schedule's identity. Feeds the occurrence deduplication id
+    /// (<c>"{Name}:{occurrenceUtc:O}"</c>) and the <see cref="HeaderKey" /> header, so it must be
+    /// stable — renaming a schedule makes its in-flight occurrence look unrelated to its next one.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>When this message fires.</summary>
+    public CronSchedule Schedule { get; }
+
+    /// <summary>The message type each occurrence publishes.</summary>
+    public Type MessageType { get; }
+
+    /// <summary>Builds the message for one occurrence; handed the occurrence time.</summary>
+    internal Func<DateTimeOffset, object> Creator { get; }
+
+    /// <summary>
+    /// The logical deduplication id for one occurrence of this schedule. Time-zone independent
+    /// (the occurrence is normalized to UTC), and deterministic across nodes and restarts — which
+    /// is the whole safety story: an agent failover or restart that re-publishes the same
+    /// occurrence produces the same id, and the landed GH-4180 deduplication machinery collapses
+    /// the duplicate at consumption.
+    /// </summary>
+    public string DeduplicationIdFor(DateTimeOffset occurrence)
+    {
+        return $"{Name}:{occurrence.ToUniversalTime():O}";
+    }
+
+    public override string ToString()
+    {
+        return $"{Name}: {MessageType.Name} at {Schedule}";
+    }
+}

--- a/src/Wolverine/Runtime/Recurring/RecurringMessageAgent.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringMessageAgent.cs
@@ -1,0 +1,195 @@
+using Microsoft.Extensions.Logging;
+using Wolverine.Runtime.Agents;
+
+namespace Wolverine.Runtime.Recurring;
+
+/// <summary>
+/// The single-per-cluster agent behind <c>opts.Schedules</c>. Its whole job is a guarantee: the
+/// NEXT occurrence of every registered <see cref="RecurringMessage" /> is pre-scheduled through
+/// Wolverine's existing scheduled-message machinery — <see cref="IMessageBus.PublishAsync" /> with
+/// a <see cref="DeliveryOptions.ScheduledTime" /> — and nothing deeper. Delivery, durability,
+/// replay-after-crash and management all belong to the machinery that already ships.
+///
+/// <para>
+/// Failure semantics, all deliberate:
+/// missed occurrences are SKIPPED, never back-filled — the one pre-scheduled envelope still fires
+/// with the agent down, and only occurrences after it in an agent-less window are lost, which is
+/// the reason for this shape over a self-perpetuating message (whose chain dies forever on its
+/// first discarded envelope). A restart or failover loses only in-memory state; re-publishing the
+/// same occurrence produces the same deterministic deduplication id, and the consumption-side
+/// dedupe collapses it. A failed publish logs and retries on the next tick — it never kills the
+/// loop.
+/// </para>
+/// </summary>
+internal class RecurringMessageAgent : SingularAgent
+{
+    public const string SchemeName = "wolverine-recurring";
+
+    private readonly IWolverineRuntime _runtime;
+    private readonly ILogger<RecurringMessageAgent> _logger;
+    private readonly Dictionary<string, DateTimeOffset> _lastPublished = new();
+
+    private CancellationTokenSource? _cancellation;
+    private Task? _loop;
+    private DateTimeOffset _lastTick;
+
+    /// <summary>Total occurrences this agent instance has published. A test seam only.</summary>
+    internal int OccurrencesPublished;
+
+    public RecurringMessageAgent(IWolverineRuntime runtime, ILogger<RecurringMessageAgent> logger)
+        : base(SchemeName)
+    {
+        _runtime = runtime;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Settable purely as a test seam, matching the house pattern on
+    /// <see cref="EventSubscriptionAgent" /> — production code never assigns it.
+    /// </summary>
+    public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+    /// <summary>
+    /// The longest the loop sleeps between looks at the schedule table, even when every next
+    /// occurrence is far away — a bound on how stale the agent's picture can get, and internal so
+    /// tests can tighten it.
+    /// </summary>
+    internal TimeSpan MaximumTickInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    public string Description =>
+        $"Recurring message scheduler ({_runtime.Options.Schedules.Count} schedule(s))";
+
+    protected override Task startAsync(CancellationToken cancellationToken)
+    {
+        _cancellation = new CancellationTokenSource();
+        _lastTick = TimeProvider.GetUtcNow();
+        _loop = Task.Run(() => runAsync(_cancellation.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    protected override async Task stopAsync(CancellationToken cancellationToken)
+    {
+        if (_cancellation != null)
+        {
+            await _cancellation.CancelAsync();
+        }
+
+        if (_loop != null)
+        {
+            try
+            {
+                await _loop.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+            }
+            catch (TimeoutException)
+            {
+                // The loop is only ever between a publish and a delay; abandoning it on a slow
+                // stop is safe because the next start rebuilds all state from the registrations.
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        _cancellation?.Dispose();
+        _cancellation = null;
+        _loop = null;
+    }
+
+    private async Task runAsync(CancellationToken cancellation)
+    {
+        while (!cancellation.IsCancellationRequested)
+        {
+            TimeSpan delay;
+
+            try
+            {
+                delay = await TickAsync(cancellation);
+            }
+            catch (Exception e)
+            {
+                // A tick that fails wholesale (not per-schedule — those are caught inside) should
+                // never kill the loop; the schedule table is static and the next tick retries.
+                _logger.LogError(e, "Error in the recurring message scheduling loop");
+                delay = MaximumTickInterval;
+            }
+
+            try
+            {
+                await Task.Delay(delay, TimeProvider, cancellation);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// One pass over every registered schedule: publish any next occurrence that is not already in
+    /// flight, and return how long to sleep before looking again. Internal (and factored out of
+    /// the loop) purely so tests can drive ticks synchronously against a controlled clock.
+    /// </summary>
+    internal async Task<TimeSpan> TickAsync(CancellationToken cancellation)
+    {
+        var now = TimeProvider.GetUtcNow();
+        _lastTick = now;
+        DateTimeOffset? soonest = null;
+
+        foreach (var message in _runtime.Options.Schedules)
+        {
+            if (cancellation.IsCancellationRequested) break;
+
+            try
+            {
+                var next = message.Schedule.NextOccurrence(now);
+                if (next == null) continue; // no further occurrences — a fixed-date schedule ran out
+
+                if (soonest == null || next < soonest) soonest = next;
+
+                // Only the NEXT occurrence is ever in flight. While it is still in the future the
+                // computation keeps answering the same instant and this stays a no-op; once it
+                // passes, the following occurrence computes and publishes. Restart/failover wipes
+                // this dictionary harmlessly — the re-publish carries the same dedup id.
+                if (_lastPublished.TryGetValue(message.Name, out var last) && last == next) continue;
+
+                await publishOccurrenceAsync(message, next.Value);
+                _lastPublished[message.Name] = next.Value;
+                Interlocked.Increment(ref OccurrencesPublished);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Failed to schedule the next occurrence of recurring message '{Name}'; will retry on the next pass",
+                    message.Name);
+            }
+        }
+
+        if (soonest == null) return MaximumTickInterval;
+
+        var untilNext = soonest.Value - now;
+        if (untilNext > MaximumTickInterval) return MaximumTickInterval;
+        return untilNext < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : untilNext;
+    }
+
+    private Task publishOccurrenceAsync(RecurringMessage message, DateTimeOffset occurrence)
+    {
+        var body = message.Creator(occurrence) ?? throw new InvalidOperationException(
+            $"The creator for recurring message '{message.Name}' returned null");
+
+        _logger.LogDebug("Scheduling occurrence of recurring message '{Name}' for {Occurrence}",
+            message.Name, occurrence);
+
+        var options = new DeliveryOptions
+        {
+            ScheduledTime = occurrence,
+
+            // The deterministic occurrence id — identical across nodes, restarts and time zones —
+            // that lets the GH-4180 dedupe collapse a failover double-publish at consumption.
+            DeduplicationId = message.DeduplicationIdFor(occurrence)
+        };
+        options.Headers[RecurringMessage.HeaderKey] = message.Name;
+
+        IMessageBus bus = new MessageBus(_runtime);
+        return bus.PublishAsync(body, options).AsTask();
+    }
+}

--- a/src/Wolverine/Runtime/Recurring/RecurringMessageAgent.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringMessageAgent.cs
@@ -1,4 +1,8 @@
+using System.Diagnostics;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
+using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Agents;
 
 namespace Wolverine.Runtime.Recurring;
@@ -6,9 +10,20 @@ namespace Wolverine.Runtime.Recurring;
 /// <summary>
 /// The single-per-cluster agent behind <c>opts.Schedules</c>. Its whole job is a guarantee: the
 /// NEXT occurrence of every registered <see cref="RecurringMessage" /> is pre-scheduled through
-/// Wolverine's existing scheduled-message machinery — <see cref="IMessageBus.PublishAsync" /> with
-/// a <see cref="DeliveryOptions.ScheduledTime" /> — and nothing deeper. Delivery, durability,
+/// Wolverine's existing scheduled-message machinery — a routed publish with a
+/// <see cref="DeliveryOptions.ScheduledTime" /> — and nothing deeper. Delivery, durability,
 /// replay-after-crash and management all belong to the machinery that already ships.
+///
+/// <para>
+/// Where the message store carries the recurring tracking extension
+/// (<see cref="IRecurringMessageStore" />), the guarantee is record-and-verify rather than
+/// fire-and-forget: each publish records the pre-scheduled envelope id(s) on the schedule's
+/// tracking row, the loop occasionally confirms those envelopes still sit
+/// <see cref="EnvelopeStatus.Scheduled" /> in the inbox (re-publishing when something cancelled
+/// them out from under the schedule), and a failover successor ADOPTS a predecessor's verified
+/// pending occurrence off the row instead of blindly re-publishing it. The row also carries the
+/// pause flag the loop honours every tick.
+/// </para>
 ///
 /// <para>
 /// Failure semantics, all deliberate:
@@ -28,6 +43,15 @@ internal class RecurringMessageAgent : SingularAgent
     private readonly IWolverineRuntime _runtime;
     private readonly ILogger<RecurringMessageAgent> _logger;
     private readonly Dictionary<string, DateTimeOffset> _lastPublished = new();
+    private readonly Dictionary<string, DateTimeOffset> _lastVerified = new();
+    private readonly HashSet<string> _warnedNoRoutes = new();
+
+    // Only the channel for pause/resume on a store WITHOUT the recurring tracking extension —
+    // with a real store the durable row is the single channel, deliberately (see
+    // RecurringScheduleControl). Locked because the control service writes from caller threads
+    // while the loop reads.
+    private readonly HashSet<string> _locallyPaused = new();
+    private readonly object _pauseLock = new();
 
     private CancellationTokenSource? _cancellation;
     private Task? _loop;
@@ -56,8 +80,48 @@ internal class RecurringMessageAgent : SingularAgent
     /// </summary>
     internal TimeSpan MaximumTickInterval { get; set; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// How often the loop re-confirms that a tracked pre-scheduled envelope still sits Scheduled
+    /// in the inbox. "Occasionally" on purpose: the check is a cheap indexed count, but the thing
+    /// it catches — an occurrence cancelled or lost out from under its schedule — is rare, and a
+    /// re-publish carries the same deduplication id either way. Internal so tests can tighten it.
+    /// </summary>
+    internal TimeSpan VerificationInterval { get; set; } = TimeSpan.FromMinutes(5);
+
     public string Description =>
         $"Recurring message scheduler ({_runtime.Options.Schedules.Count} schedule(s))";
+
+    /// <summary>
+    /// Pause a schedule in THIS instance's memory — the fallback channel when the message store
+    /// has no recurring tracking extension. Does not (cannot) cancel an already-pre-scheduled
+    /// occurrence, so the pending one still fires; only future publishes stop. The in-memory
+    /// last-published bookkeeping is deliberately kept, so a resume before the pending occurrence
+    /// does not double-publish it.
+    /// </summary>
+    internal void MarkPaused(string name)
+    {
+        lock (_pauseLock)
+        {
+            _locallyPaused.Add(name);
+        }
+    }
+
+    /// <summary>The in-memory resume half of <see cref="MarkPaused" />.</summary>
+    internal void MarkResumed(string name)
+    {
+        lock (_pauseLock)
+        {
+            _locallyPaused.Remove(name);
+        }
+    }
+
+    private bool isLocallyPaused(string name)
+    {
+        lock (_pauseLock)
+        {
+            return _locallyPaused.Contains(name);
+        }
+    }
 
     protected override Task startAsync(CancellationToken cancellationToken)
     {
@@ -97,6 +161,22 @@ internal class RecurringMessageAgent : SingularAgent
 
     private async Task runAsync(CancellationToken cancellation)
     {
+        // The agent machinery starts BEFORE the messaging transports, and a RoutingFor answer
+        // computed in that window can come back empty and be cached for the life of the host —
+        // a first-tick publish would then silently go nowhere, forever. Wait for the runtime to
+        // be fully started (transports up, routing cache pre-populated with real routes).
+        if (_runtime is WolverineRuntime runtime)
+        {
+            try
+            {
+                await runtime.FullyStarted.WaitAsync(cancellation);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+
         while (!cancellation.IsCancellationRequested)
         {
             TimeSpan delay;
@@ -125,9 +205,10 @@ internal class RecurringMessageAgent : SingularAgent
     }
 
     /// <summary>
-    /// One pass over every registered schedule: publish any next occurrence that is not already in
-    /// flight, and return how long to sleep before looking again. Internal (and factored out of
-    /// the loop) purely so tests can drive ticks synchronously against a controlled clock.
+    /// One pass over every registered schedule: honour pause flags, verify or adopt tracked
+    /// occurrences, publish any next occurrence that is not already in flight, and return how
+    /// long to sleep before looking again. Internal (and factored out of the loop) purely so
+    /// tests can drive ticks synchronously against a controlled clock.
     /// </summary>
     internal async Task<TimeSpan> TickAsync(CancellationToken cancellation)
     {
@@ -135,26 +216,70 @@ internal class RecurringMessageAgent : SingularAgent
         _lastTick = now;
         DateTimeOffset? soonest = null;
 
+        var store = _runtime.Storage.RecurringMessages;
+        var rows = await tryLoadTrackingRowsAsync(store, cancellation);
+
         foreach (var message in _runtime.Options.Schedules)
         {
             if (cancellation.IsCancellationRequested) break;
 
             try
             {
+                var row = rows?.GetValueOrDefault(message.Name);
+
+                if (row is { Paused: true } || isLocallyPaused(message.Name))
+                {
+                    await honourPauseAsync(store, message.Name, row, now, cancellation);
+                    continue;
+                }
+
                 var next = message.Schedule.NextOccurrence(now);
                 if (next == null) continue; // no further occurrences — a fixed-date schedule ran out
 
                 if (soonest == null || next < soonest) soonest = next;
 
                 // Only the NEXT occurrence is ever in flight. While it is still in the future the
-                // computation keeps answering the same instant and this stays a no-op; once it
-                // passes, the following occurrence computes and publishes. Restart/failover wipes
-                // this dictionary harmlessly — the re-publish carries the same dedup id.
-                if (_lastPublished.TryGetValue(message.Name, out var last) && last == next) continue;
+                // computation keeps answering the same instant; the tracked row lets us verify it
+                // is really pending (and re-publish when it is not), and lets a failover successor
+                // adopt a predecessor's publish instead of duplicating it.
+                if (_lastPublished.TryGetValue(message.Name, out var last) && last == next)
+                {
+                    if (!await isDueForReverificationAsync(store, message, row, next.Value, now, cancellation))
+                    {
+                        continue;
+                    }
 
-                await publishOccurrenceAsync(message, next.Value);
+                    // The tracked envelope is gone — something cancelled or lost it. Fall through
+                    // and re-publish this same occurrence (same deduplication id, so an envelope
+                    // that actually fired in the gap still collapses to one handling).
+                    _lastPublished.Remove(message.Name);
+                    _logger.LogWarning(
+                        "The pre-scheduled occurrence of recurring message '{Name}' at {Occurrence} is no " +
+                        "longer in the inbox; re-publishing it", message.Name, next.Value);
+                }
+                else if (!_lastPublished.ContainsKey(message.Name) &&
+                         await canAdoptTrackedOccurrenceAsync(store, row, next.Value, now, cancellation))
+                {
+                    // Failover/restart: a previous agent instance already pre-scheduled exactly
+                    // this occurrence, and the inbox confirms it is still pending. Adopt it.
+                    _lastPublished[message.Name] = next.Value;
+                    continue;
+                }
+
+                var outgoing = await publishOccurrenceAsync(message, next.Value);
+                if (outgoing.Length == 0)
+                {
+                    // No routes is NOT a publish — marking it as one would silently skip the
+                    // occurrence. Leave the schedule unmarked so the next tick retries; if a
+                    // subscription appears (or routing finishes waking up), the occurrence is
+                    // still scheduled on time.
+                    continue;
+                }
+
                 _lastPublished[message.Name] = next.Value;
                 Interlocked.Increment(ref OccurrencesPublished);
+
+                await recordPublishAsync(store, message, next.Value, now, outgoing, cancellation);
             }
             catch (Exception e)
             {
@@ -171,7 +296,90 @@ internal class RecurringMessageAgent : SingularAgent
         return untilNext < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : untilNext;
     }
 
-    private Task publishOccurrenceAsync(RecurringMessage message, DateTimeOffset occurrence)
+    private async Task<Dictionary<string, RecurringMessageRecord>?> tryLoadTrackingRowsAsync(
+        IRecurringMessageStore store, CancellationToken cancellation)
+    {
+        if (!store.Enabled) return null;
+
+        try
+        {
+            var rows = await store.LoadAllAsync(cancellation);
+            return rows.ToDictionary(x => x.Name);
+        }
+        catch (Exception e)
+        {
+            // Publishing is governed by in-memory state, so the tick can proceed without the
+            // rows; what is lost until the store answers again is pause visibility and
+            // verification, not delivery.
+            _logger.LogError(e, "Unable to load the recurring message tracking rows; continuing without them");
+            return null;
+        }
+    }
+
+    private async Task honourPauseAsync(IRecurringMessageStore store, string name,
+        RecurringMessageRecord? row, DateTimeOffset now, CancellationToken cancellation)
+    {
+        if (!store.Enabled)
+        {
+            // In-memory pause cannot cancel the pending occurrence, so the last-published
+            // bookkeeping is deliberately KEPT — a resume before that occurrence must not
+            // publish it a second time onto a store with no deduplication.
+            return;
+        }
+
+        // Durable pause: the pending envelope was cancelled eagerly by PauseAsync, so forget it.
+        _lastPublished.Remove(name);
+        _lastVerified.Remove(name);
+
+        if (row is { Paused: true, EnvelopeIds.Length: > 0 })
+        {
+            // A publish raced the pause (or the pausing node died mid-cancel), leaving a tracked
+            // envelope pending on a paused schedule. PauseAsync is idempotent — re-running it
+            // finishes the eager cancel.
+            await store.PauseAsync(name, row.PausedAt ?? now, cancellation);
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the tracked envelopes for a pending occurrence are due a check AND that
+    /// check found at least one of them missing from the inbox — i.e. the occurrence needs
+    /// re-publishing. Any other answer (not enabled, not due yet, row does not match, all still
+    /// scheduled) is false: leave the occurrence alone.
+    /// </summary>
+    private async Task<bool> isDueForReverificationAsync(IRecurringMessageStore store,
+        RecurringMessage message, RecurringMessageRecord? row, DateTimeOffset next,
+        DateTimeOffset now, CancellationToken cancellation)
+    {
+        if (!store.Enabled) return false;
+        if (row == null || row.NextOccurrence != next || row.EnvelopeIds.Length == 0) return false;
+
+        if (_lastVerified.TryGetValue(message.Name, out var verified) &&
+            now - verified < VerificationInterval)
+        {
+            return false;
+        }
+
+        var stillScheduled = await store.CountStillScheduledAsync(row.EnvelopeIds, cancellation);
+        _lastVerified[message.Name] = now;
+
+        return stillScheduled < row.EnvelopeIds.Length;
+    }
+
+    private async Task<bool> canAdoptTrackedOccurrenceAsync(IRecurringMessageStore store,
+        RecurringMessageRecord? row, DateTimeOffset next, DateTimeOffset now,
+        CancellationToken cancellation)
+    {
+        if (!store.Enabled) return false;
+        if (row == null || row.NextOccurrence != next || row.EnvelopeIds.Length == 0) return false;
+
+        var stillScheduled = await store.CountStillScheduledAsync(row.EnvelopeIds, cancellation);
+        if (stillScheduled < row.EnvelopeIds.Length) return false;
+
+        _lastVerified[row.Name] = now;
+        return true;
+    }
+
+    private async Task<Envelope[]> publishOccurrenceAsync(RecurringMessage message, DateTimeOffset occurrence)
     {
         var body = message.Creator(occurrence) ?? throw new InvalidOperationException(
             $"The creator for recurring message '{message.Name}' returned null");
@@ -189,7 +397,89 @@ internal class RecurringMessageAgent : SingularAgent
         };
         options.Headers[RecurringMessage.HeaderKey] = message.Name;
 
-        IMessageBus bus = new MessageBus(_runtime);
-        return bus.PublishAsync(body, options).AsTask();
+        // The routed-then-persisted spelling of IMessageBus.PublishAsync, taken apart only
+        // because the public path never surfaces the envelopes (GH-4180's own analysis) and the
+        // tracking row needs their ids. Everything else — routing, correlation stamping, the
+        // persist-or-send decision — is the same machinery PublishAsync runs.
+        var bus = new MessageBus(_runtime);
+        var outgoing = _runtime.RoutingFor(body.GetType()).RouteForPublish(body, options);
+
+        if (outgoing.Length == 0)
+        {
+            // For a registered schedule this is a misconfiguration worth saying out loud — the
+            // cron ticks forever and every occurrence goes nowhere. Once per schedule, since the
+            // tick loop keeps retrying.
+            if (_warnedNoRoutes.Add(message.Name))
+            {
+                _logger.LogWarning(
+                    "The occurrence of recurring message '{Name}' ({MessageType}) has no subscribers or handlers — nothing was scheduled",
+                    message.Name, message.MessageType.FullNameInCode());
+            }
+
+            _runtime.MessageTracking.NoRoutesFor(new Envelope(body));
+            return outgoing;
+        }
+
+        _warnedNoRoutes.Remove(message.Name);
+
+        foreach (var envelope in outgoing)
+        {
+            bus.TrackEnvelopeCorrelation(envelope, Activity.Current);
+        }
+
+        await bus.PersistOrSendAsync(outgoing);
+        return outgoing;
+    }
+
+    private async Task recordPublishAsync(IRecurringMessageStore store, RecurringMessage message,
+        DateTimeOffset occurrence, DateTimeOffset now, Envelope[] outgoing, CancellationToken cancellation)
+    {
+        if (!store.Enabled) return;
+
+        try
+        {
+            // Only envelopes that actually landed in the durable inbox as Scheduled are
+            // verifiable and cancellable; an occurrence riding a broker's native delayed
+            // delivery (or an in-memory queue) is deliberately not tracked — verification
+            // would keep "finding it missing" and re-publish it forever.
+            // Scheduled status alone is not enough: routing stamps it on BUFFERED local queue
+            // envelopes too, whose occurrences live in the in-memory scheduler and never reach
+            // the inbox — recording those would make verification "find them missing" and
+            // re-publish forever. Only a durable sender's scheduled envelope becomes an inbox
+            // row (the durable local queue, or the durable-local wrapper a non-native remote
+            // scheduled send rides in).
+            var scheduledIds = outgoing
+                .Where(x => x is { Status: EnvelopeStatus.Scheduled, Sender.IsDurable: true })
+                .Select(x => x.Id)
+                .ToArray();
+
+            if (scheduledIds.Length == 0)
+            {
+                _logger.LogDebug(
+                    "No occurrence envelope of recurring message '{Name}' landed in the durable inbox " +
+                    "(destinations: {Destinations}; statuses: {Statuses}) — the occurrence will fire, but " +
+                    "cannot be verified or cancelled through the tracking extension",
+                    message.Name,
+                    outgoing.Select(x => x.Destination?.ToString() ?? "?").Join(", "),
+                    outgoing.Select(x => x.Status.ToString()).Join(", "));
+            }
+
+            await store.RecordPublishedAsync(new RecurringMessageRecord
+            {
+                Name = message.Name,
+                CronExpression = message.Schedule.Expression,
+                EnvelopeIds = scheduledIds,
+                DeduplicationId = message.DeduplicationIdFor(occurrence),
+                NextOccurrence = occurrence,
+                LastUpdated = now
+            }, cancellation);
+        }
+        catch (Exception e)
+        {
+            // The publish itself succeeded — a lost record degrades verification and management
+            // visibility for this occurrence, never delivery. The next publish re-records.
+            _logger.LogError(e,
+                "Failed to record the tracking row for recurring message '{Name}'", message.Name);
+        }
     }
 }

--- a/src/Wolverine/Runtime/Recurring/RecurringMessageCollection.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringMessageCollection.cs
@@ -1,0 +1,132 @@
+using System.Collections;
+using Wolverine.Runtime.Recurring;
+
+namespace Wolverine;
+
+/// <summary>
+/// The recurring (cron) message registrations for this application — <c>opts.Schedules</c>.
+///
+/// <para>
+/// Registering the first schedule is the feature's opt-in: it registers the single-per-cluster
+/// recurring-message agent and enables the logical message deduplication that makes agent
+/// failover/restart double-publishes harmless. A host with zero schedules registered behaves —
+/// and migrates its message store — exactly as it did before this feature existed.
+/// </para>
+///
+/// <para>
+/// Registration is code-first and configuration-time only. A bad cron expression or a duplicate
+/// name throws here, at the line that wrote it, never at startup on some other host.
+/// </para>
+/// </summary>
+public sealed class RecurringMessageCollection : IEnumerable<RecurringMessage>
+{
+    private readonly WolverineOptions _parent;
+    private readonly List<RecurringMessage> _messages = [];
+    private bool _agentRegistered;
+
+    internal RecurringMessageCollection(WolverineOptions parent)
+    {
+        _parent = parent;
+    }
+
+    /// <summary>
+    /// Schedule a message with a public no-argument constructor on a cron expression. The schedule
+    /// name defaults to the message type's name.
+    /// </summary>
+    public RecurringMessage RecurringMessage<T>(string cronExpression, TimeZoneInfo? timeZone = null)
+        where T : new()
+    {
+        return RecurringMessage<T>(new CronSchedule(cronExpression, timeZone));
+    }
+
+    /// <summary>
+    /// Schedule a message with a public no-argument constructor on an already-parsed
+    /// <see cref="CronSchedule" />. The schedule name defaults to the message type's name.
+    /// </summary>
+    public RecurringMessage RecurringMessage<T>(CronSchedule schedule) where T : new()
+    {
+        return register(new RecurringMessage(typeof(T).Name, schedule, typeof(T), _ => new T()!));
+    }
+
+    /// <summary>
+    /// Schedule a factory-built message on a cron expression. The factory is handed the occurrence
+    /// time, so a message can describe the window it covers.
+    /// </summary>
+    public RecurringMessage RecurringMessage<T>(string name, string cronExpression,
+        Func<DateTimeOffset, T> creator, TimeZoneInfo? timeZone = null) where T : class
+    {
+        return RecurringMessage(name, new CronSchedule(cronExpression, timeZone), creator);
+    }
+
+    /// <summary>
+    /// Schedule a factory-built message on an already-parsed <see cref="CronSchedule" />.
+    /// </summary>
+    public RecurringMessage RecurringMessage<T>(string name, CronSchedule schedule,
+        Func<DateTimeOffset, T> creator) where T : class
+    {
+        if (creator == null)
+        {
+            throw new ArgumentNullException(nameof(creator));
+        }
+
+        return register(new RecurringMessage(name, schedule, typeof(T), occurrence => creator(occurrence)));
+    }
+
+    /// <summary>Look up a registered schedule by name. Null when none matches.</summary>
+    public RecurringMessage? FindByName(string name)
+    {
+        return _messages.FirstOrDefault(x => x.Name == name);
+    }
+
+    /// <summary>The message types with at least one registered schedule.</summary>
+    internal IReadOnlyList<Type> MessageTypes()
+    {
+        return _messages.Select(x => x.MessageType).Distinct().ToArray();
+    }
+
+    public bool Any()
+    {
+        return _messages.Count != 0;
+    }
+
+    public int Count => _messages.Count;
+
+    private RecurringMessage register(RecurringMessage message)
+    {
+        if (_messages.Any(x => x.Name == message.Name))
+        {
+            throw new ArgumentException(
+                $"A recurring message named '{message.Name}' is already registered. Names are " +
+                "identities (they feed the occurrence deduplication id and the OpenTelemetry tag) — " +
+                "give this schedule an explicit, distinct name.");
+        }
+
+        _messages.Add(message);
+
+        // The occurrence dedup id is only protective if something consumes it: turning the
+        // GH-4180 machinery on and pointing it at exactly the cron-scheduled message types is
+        // part of the registration, never a documented prerequisite the user has to remember.
+        // (Hosts whose store cannot back it get a startup warning, not a broken boot — the
+        // failover double-fire window then matches the pre-deduplication status quo.)
+        _parent.Durability.EnableMessageDeduplication = true;
+
+        if (!_agentRegistered)
+        {
+            _agentRegistered = true;
+            _parent.Services.AddSingularAgent<RecurringMessageAgent>();
+            _parent.RegisteredPolicies.Add(new RecurringDeduplicationPolicy(this));
+        }
+
+        return message;
+    }
+
+    public IEnumerator<RecurringMessage> GetEnumerator()
+    {
+        return _messages.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/src/Wolverine/Runtime/Recurring/RecurringMessageCollection.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringMessageCollection.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Runtime.Recurring;
 
 namespace Wolverine;
@@ -110,10 +111,16 @@ public sealed class RecurringMessageCollection : IEnumerable<RecurringMessage>
         // failover double-fire window then matches the pre-deduplication status quo.)
         _parent.Durability.EnableMessageDeduplication = true;
 
+        // The other half of the opt-in: the main message store reads this flag to provision the
+        // wolverine_recurring_messages tracking table and build a real IRecurringMessageStore,
+        // which is what makes the agent's guarantee verifiable and pause/resume durable.
+        _parent.Durability.EnableRecurringMessages = true;
+
         if (!_agentRegistered)
         {
             _agentRegistered = true;
             _parent.Services.AddSingularAgent<RecurringMessageAgent>();
+            _parent.Services.AddSingleton<IRecurringScheduleControl, RecurringScheduleControl>();
             _parent.RegisteredPolicies.Add(new RecurringDeduplicationPolicy(this));
         }
 

--- a/src/Wolverine/Runtime/Recurring/RecurringMessageCollection.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringMessageCollection.cs
@@ -34,17 +34,17 @@ public sealed class RecurringMessageCollection : IEnumerable<RecurringMessage>
     /// Schedule a message with a public no-argument constructor on a cron expression. The schedule
     /// name defaults to the message type's name.
     /// </summary>
-    public RecurringMessage RecurringMessage<T>(string cronExpression, TimeZoneInfo? timeZone = null)
+    public RecurringMessage ScheduleRecurring<T>(string cronExpression, TimeZoneInfo? timeZone = null)
         where T : new()
     {
-        return RecurringMessage<T>(new CronSchedule(cronExpression, timeZone));
+        return ScheduleRecurring<T>(new CronSchedule(cronExpression, timeZone));
     }
 
     /// <summary>
     /// Schedule a message with a public no-argument constructor on an already-parsed
     /// <see cref="CronSchedule" />. The schedule name defaults to the message type's name.
     /// </summary>
-    public RecurringMessage RecurringMessage<T>(CronSchedule schedule) where T : new()
+    public RecurringMessage ScheduleRecurring<T>(CronSchedule schedule) where T : new()
     {
         return register(new RecurringMessage(typeof(T).Name, schedule, typeof(T), _ => new T()!));
     }
@@ -53,16 +53,16 @@ public sealed class RecurringMessageCollection : IEnumerable<RecurringMessage>
     /// Schedule a factory-built message on a cron expression. The factory is handed the occurrence
     /// time, so a message can describe the window it covers.
     /// </summary>
-    public RecurringMessage RecurringMessage<T>(string name, string cronExpression,
+    public RecurringMessage ScheduleRecurring<T>(string name, string cronExpression,
         Func<DateTimeOffset, T> creator, TimeZoneInfo? timeZone = null) where T : class
     {
-        return RecurringMessage(name, new CronSchedule(cronExpression, timeZone), creator);
+        return ScheduleRecurring(name, new CronSchedule(cronExpression, timeZone), creator);
     }
 
     /// <summary>
     /// Schedule a factory-built message on an already-parsed <see cref="CronSchedule" />.
     /// </summary>
-    public RecurringMessage RecurringMessage<T>(string name, CronSchedule schedule,
+    public RecurringMessage ScheduleRecurring<T>(string name, CronSchedule schedule,
         Func<DateTimeOffset, T> creator) where T : class
     {
         if (creator == null)

--- a/src/Wolverine/Runtime/Recurring/RecurringScheduleControl.cs
+++ b/src/Wolverine/Runtime/Recurring/RecurringScheduleControl.cs
@@ -1,0 +1,124 @@
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime.Agents;
+
+namespace Wolverine.Runtime.Recurring;
+
+/// <summary>
+/// Thrown when a pause/resume names a recurring schedule this application never registered.
+/// Registration is code-first, so an unknown name is a programming (or operator-typo) error —
+/// silently no-op'ing it would report success for a schedule that does not exist.
+/// </summary>
+public class UnknownRecurringScheduleException : Exception
+{
+    public UnknownRecurringScheduleException(string name, IEnumerable<RecurringMessage> known)
+        : base($"No recurring message named '{name}' is registered on this application. " +
+               $"Registered schedule(s): {string.Join(", ", known.Select(x => x.Name).DefaultIfEmpty("none"))}")
+    {
+    }
+}
+
+/// <summary>
+/// Runtime pause/resume/query surface for the recurring (cron) messages registered through
+/// <c>opts.Schedules</c> — the only runtime-mutable state the feature has (schedule definitions
+/// stay code-first). Resolve it from the container; it is registered alongside the first schedule.
+///
+/// <para>
+/// Pausing marks the schedule's durable tracking row AND eagerly cancels the pre-scheduled next
+/// occurrence, so nothing fires in the gap before the agent's next tick — the caller may be on a
+/// different node than the agent. Resuming clears the mark; the agent then pre-schedules the
+/// occurrence strictly after the resume time, never back-filling the paused window.
+/// </para>
+///
+/// <para>
+/// On a message store without the recurring tracking extension the durable half is unavailable:
+/// pause/resume reach only the agent instance in THIS process (effective on a single-node or
+/// storeless host, where the agent is always local), are lost on restart, and an
+/// already-pre-scheduled occurrence cannot be cancelled — it will still fire once.
+/// </para>
+/// </summary>
+public interface IRecurringScheduleControl
+{
+    /// <summary>
+    /// Pause a registered schedule and eagerly cancel its pending pre-scheduled occurrence.
+    /// Idempotent; throws <see cref="UnknownRecurringScheduleException" /> for a name this
+    /// application never registered.
+    /// </summary>
+    Task PauseAsync(string name, CancellationToken token = default);
+
+    /// <summary>
+    /// Resume a paused schedule. The next occurrence is computed strictly after now — the paused
+    /// window is never back-filled. Idempotent; throws
+    /// <see cref="UnknownRecurringScheduleException" /> for an unregistered name.
+    /// </summary>
+    Task ResumeAsync(string name, CancellationToken token = default);
+
+    /// <summary>
+    /// The durable tracking rows — which schedule owns which pending envelope, next fire times,
+    /// pause state. Empty on a store without the recurring tracking extension.
+    /// </summary>
+    Task<IReadOnlyList<RecurringMessageRecord>> QueryAsync(CancellationToken token = default);
+}
+
+internal class RecurringScheduleControl : IRecurringScheduleControl
+{
+    private readonly IWolverineRuntime _runtime;
+    private readonly RecurringMessageAgent? _agent;
+
+    public RecurringScheduleControl(IWolverineRuntime runtime, IEnumerable<IAgentFamily> agentFamilies)
+    {
+        _runtime = runtime;
+
+        // The singular agent is a container singleton on EVERY node; it only RUNS on one. The
+        // local instance is the pause/resume channel exactly when the store cannot be — see below.
+        _agent = agentFamilies.OfType<RecurringMessageAgent>().FirstOrDefault();
+    }
+
+    public async Task PauseAsync(string name, CancellationToken token = default)
+    {
+        assertKnown(name);
+
+        var store = _runtime.Storage.RecurringMessages;
+        if (store.Enabled)
+        {
+            // The durable row is the single channel: the agent reads pause flags off it every
+            // tick, whichever node it runs on. Deliberately NOT also marking the local agent —
+            // a local mark that a resume on another node cannot clear would pause the schedule
+            // forever.
+            await store.PauseAsync(name, DateTimeOffset.UtcNow, token);
+        }
+        else
+        {
+            // No durable channel — agent memory is all there is. Only effective when the running
+            // agent is in this process, and the already-pre-scheduled occurrence still fires.
+            _agent?.MarkPaused(name);
+        }
+    }
+
+    public async Task ResumeAsync(string name, CancellationToken token = default)
+    {
+        assertKnown(name);
+
+        var store = _runtime.Storage.RecurringMessages;
+        if (store.Enabled)
+        {
+            await store.ResumeAsync(name, token);
+        }
+        else
+        {
+            _agent?.MarkResumed(name);
+        }
+    }
+
+    public Task<IReadOnlyList<RecurringMessageRecord>> QueryAsync(CancellationToken token = default)
+    {
+        return _runtime.Storage.RecurringMessages.LoadAllAsync(token);
+    }
+
+    private void assertKnown(string name)
+    {
+        if (_runtime.Options.Schedules.FindByName(name) == null)
+        {
+            throw new UnknownRecurringScheduleException(name, _runtime.Options.Schedules);
+        }
+    }
+}

--- a/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Agents.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Descriptors;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Wolverine.Persistence.Durability;
 using Wolverine.Runtime.Agents;
@@ -234,6 +235,23 @@ public partial class WolverineRuntime : IAgentRuntime
                 Options.Durability.AssignedNodeNumber = 1;
             }
 
+            // With no message store there is no node coordination for the recurring-message agent
+            // to ride — but no cluster to coordinate either, so "single agent per cluster" is
+            // satisfied by starting it directly. Recurring messages then run on the in-memory
+            // scheduled model: the schedule itself survives a restart (the agent re-establishes
+            // the next occurrence from the registrations), but an occurrence inside the restart
+            // window is lost and nothing dedupes — the startup warning in HostService names both.
+            if (Options.Schedules.Any())
+            {
+                InMemoryRecurringAgent = _container.GetAllInstances<IAgentFamily>()
+                    .OfType<Recurring.RecurringMessageAgent>().FirstOrDefault();
+
+                if (InMemoryRecurringAgent != null)
+                {
+                    await ((IHostedService)InMemoryRecurringAgent).StartAsync(_agentCancellation.Token);
+                }
+            }
+
             return;
         }
 
@@ -264,6 +282,12 @@ public partial class WolverineRuntime : IAgentRuntime
     }
 
     internal IAgent? DurableScheduledJobs { get; private set; }
+
+    /// <summary>
+    /// Set only on a storeless host, where the recurring-message agent is started directly rather
+    /// than through node coordination. See the note in <c>startAgentsAsync</c>.
+    /// </summary>
+    internal IAgent? InMemoryRecurringAgent { get; private set; }
 
     private void startNodeAgentController()
     {

--- a/src/Wolverine/Runtime/WolverineRuntime.Disposal.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Disposal.cs
@@ -25,6 +25,13 @@ public partial class WolverineRuntime : IAsyncDisposable
             await DurableScheduledJobs.StopAsync(CancellationToken.None);
         }
 
+        // The recurring-message agent started directly on a storeless host (no node coordination
+        // to own its lifecycle). Null everywhere else — the agent runtime stops it there.
+        if (InMemoryRecurringAgent != null)
+        {
+            await InMemoryRecurringAgent.StopAsync(CancellationToken.None);
+        }
+
         if (ScheduledJobs != null)
         {
             ScheduledJobs.Dispose();

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -28,6 +28,19 @@ public partial class WolverineRuntime
     private bool _hasStarted;
     private Task? _idleAgentCleanupLoop;
 
+    private readonly TaskCompletionSource _fullyStarted =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Completes once StartAsync has finished everything — transports started, the routing cache
+    /// pre-populated — as opposed to <c>_hasStarted</c>, which is deliberately flipped early so
+    /// the agent machinery can use a MessageBus during startup. Background work that ROUTES
+    /// messages (the recurring-message agent's loop) must await this rather than publish into a
+    /// half-started runtime: RoutingFor answers computed before the transports start can come
+    /// back empty and are then CACHED for the life of the host.
+    /// </summary>
+    internal Task FullyStarted => _fullyStarted.Task;
+
     /// <summary>
     /// Detects whether Wolverine is running in a metadata-only CLI mode (codegen, OpenAPI
     /// generation via GetDocument.Insider) where persistence and transport connectivity
@@ -282,6 +295,7 @@ public partial class WolverineRuntime
 
             await Observer.RuntimeIsFullyStarted();
             _hasStarted = true;
+            _fullyStarted.TrySetResult();
 
             // Freeze fault-publishing policy so per-type overrides cannot be silently
             // mutated from runtime code after host startup completes. All bootstrap

--- a/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.HostService.cs
@@ -99,6 +99,44 @@ public partial class WolverineRuntime
                     "Configure a message store (e.g. PersistMessagesWithPostgresql) to make the policy effective.");
             }
 
+            if (Options.Schedules.Any())
+            {
+                // "Silently never fires" is not a degradation, it is a refusal: these modes run no
+                // agents at all, so a registered schedule would be accepted and then simply never
+                // happen — the exact class of quiet failure the recurring feature exists to avoid.
+                if (Options.Durability.Mode is DurabilityMode.Serverless or DurabilityMode.MediatorOnly)
+                {
+                    var names = Options.Schedules.Select(x => x.Name).Join(", ");
+                    throw new InvalidOperationException(
+                        $"Recurring messages are registered ({names}) but Durability.Mode is " +
+                        $"{Options.Durability.Mode}, which runs no agents — the schedules would never " +
+                        "fire. Remove the registrations from this host, or run it in Solo or Balanced mode.");
+                }
+
+                // No message store is a SUPPORTED mode, not a refusal: the agent runs on the
+                // in-memory scheduled model. What degrades — and is deliberately named here rather
+                // than discovered in production — is (a) an occurrence inside a restart window is
+                // lost (the schedule itself survives; the agent re-establishes the next occurrence
+                // from the registrations) and (b) there is no store-backed deduplication, so an
+                // agent restart can double-fire an occurrence where a native broker id does not
+                // cover it.
+                if (Storage is NullMessageStore)
+                {
+                    Logger.LogWarning(
+                        "Recurring messages are registered but no message store is configured, so they run " +
+                        "on the in-memory scheduled model: an occurrence inside a restart window is lost, " +
+                        "and occurrence deduplication is unavailable. Configure a message store to make " +
+                        "recurring messages durable.");
+                }
+                else if (Storage.Deduplication.Enabled == false)
+                {
+                    Logger.LogWarning(
+                        "Recurring messages are registered but the configured message store does not " +
+                        "support logical message deduplication, so an agent restart or failover can " +
+                        "publish the same occurrence twice.");
+                }
+            }
+
             if (!Options.ExternalTransportsAreStubbed)
             {
                 foreach (var configuresRuntime in Options.Transports.OfType<ITransportConfiguresRuntime>().ToArray())

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -176,6 +176,13 @@ public static class WolverineTracing
     public const string MessageScheduled = "wolverine.message.scheduled";
 
     /// <summary>
+    /// The name of the opts.Schedules recurring schedule that published this envelope, carried on
+    /// every activity for an occurrence (and consumed downstream by CritterWatch). Absent for
+    /// everything that is not a recurring-message occurrence.
+    /// </summary>
+    public const string ScheduleName = "wolverine.schedule.name";
+
+    /// <summary>
     /// Activity tag for the saga type full name when processing a saga message
     /// </summary>
     public const string SagaType = "wolverine.saga.type";

--- a/src/Wolverine/Wolverine.csproj
+++ b/src/Wolverine/Wolverine.csproj
@@ -43,6 +43,9 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+        <!-- Cron expression parsing for opts.Schedules (recurring messages). See the note in
+             Directory.Packages.props for why this lives in core rather than a satellite. -->
+        <PackageReference Include="Cronos" />
         <PackageReference Include="NewId" />
         <!--
           Newtonsoft.Json was removed from the core WolverineFx package in 6.0.

--- a/src/Wolverine/WolverineOptions.cs
+++ b/src/Wolverine/WolverineOptions.cs
@@ -410,6 +410,16 @@ public sealed partial class WolverineOptions
     public MessageDeduplicationRules MessageDeduplication { get; } = new();
 
     /// <summary>
+    /// Recurring (cron) message registrations. A single agent per cluster keeps the NEXT occurrence
+    /// of each registered schedule pre-scheduled through the existing scheduled-message machinery;
+    /// registering the first schedule is the feature's opt-in (nothing store-affecting activates on
+    /// a host with zero schedules). See <see cref="RecurringMessageCollection" />.
+    /// </summary>
+    public RecurringMessageCollection Schedules => _schedules ??= new RecurringMessageCollection(this);
+
+    private RecurringMessageCollection? _schedules;
+
+    /// <summary>
     /// List of <see cref="IEnvelopeRule"/> instances applied to every outgoing envelope.
     /// </summary>
     public List<IEnvelopeRule> MetadataRules { get; } = new();

--- a/src/Wolverine/WolverineSystemPart.cs
+++ b/src/Wolverine/WolverineSystemPart.cs
@@ -58,6 +58,8 @@ internal class WolverineSystemPart : SystemPartBase
             AnsiConsole.WriteLine();
             WriteMessageSubscriptions();
             AnsiConsole.WriteLine();
+            WriteRecurringSchedules();
+            AnsiConsole.WriteLine();
             WriteSendingEndpoints();
             AnsiConsole.WriteLine();
             WriteListeners();
@@ -103,6 +105,34 @@ internal class WolverineSystemPart : SystemPartBase
             }
             
 
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    public void WriteRecurringSchedules()
+    {
+        var schedules = _runtime.Options.Schedules;
+        if (!schedules.Any()) return;
+
+        // Static configuration only, deliberately — this runs in description mode, possibly with
+        // no reachable database, so the durable pause/tracking state is out of scope here. The
+        // capabilities snapshot (ServiceCapabilities.RecurringSchedules) carries the live half.
+        var table = new Table
+        {
+            Title = new TableTitle("Recurring Messages") { Style = new Style(decoration: Decoration.Bold) }
+        }.AddColumns("Schedule", "Cron", "Time Zone", "Message Type", "Next Occurrence (UTC)");
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var schedule in schedules.OrderBy(x => x.Name, StringComparer.Ordinal))
+        {
+            var next = schedule.Schedule.NextOccurrence(now);
+            table.AddRow(
+                schedule.Name.EscapeMarkup(),
+                schedule.Schedule.Expression.EscapeMarkup(),
+                schedule.Schedule.TimeZone.Id.EscapeMarkup(),
+                schedule.MessageType.FullNameInCode().EscapeMarkup(),
+                next?.ToUniversalTime().ToString("u").EscapeMarkup() ?? "none");
         }
 
         AnsiConsole.Write(table);


### PR DESCRIPTION
Recurring cron-scheduled messages (`opts.Schedules`), built **on** the existing scheduled-message machinery rather than beside it. Plan of record: [CritterWatch #1200](https://github.com/JasperFx/CritterWatch/issues/1200) (this is the Wolverine half; the CritterWatch console half follows once this ships).

Three stages, one commit each:

## Stage 1 — the core primitive
- `CronSchedule`: immutable value type over **Cronos** (in core by explicit decision — a parser, not a scheduling engine; MIT, zero transitive deps, correct DST). 5/6-field grammar, per-schedule time zone, registration-time refusal of invalid or unsatisfiably fast (&lt;5s) expressions.
- A `SingularAgent` (one per cluster, moves on failover) keeps the **next** occurrence of every schedule pre-scheduled via `PublishAsync` + `ScheduledTime` — delivery, durability, replay and management stay the infrastructure that already ships.
- Registration is the opt-in: zero schedules ⇒ the host behaves and migrates exactly as before. First registration wires the agent, flips `EnableMessageDeduplication`, and applies the GH-4180 dedupe middleware to exactly the cron-scheduled message types. Deterministic occurrence dedup id `{name}:{occurrenceUtc:O}` is the failover story — re-publishing the same occurrence collapses at consumption.
- Missed occurrences are skipped, never back-filled. **No message store is a supported mode** (in-memory, startup warning naming the degradations); Serverless/MediatorOnly + schedules refuses to start — "silently never fires" is the exact quiet failure this feature exists to avoid.
- OTel: occurrences carry a `recurring-schedule` header → `wolverine.schedule.name` activity tag.

## Stage 2 — durable tracking + pause/resume
- `IMessageStore.RecurringMessages`: default interface member with a null implementation (the Deduplication pattern) — no store is forced to implement it, the feature degrades gracefully where absent.
- One shared `RdbmsRecurringMessageStore` + a `wolverine_recurring_messages` Weasel table per provider (Postgresql, SqlServer, MySql, Sqlite), provisioned only on the Main store and only behind the opt-in — zero schedules ⇒ the schema is byte-identical to a Wolverine without the feature (pinned by a compliance fact).
- Record-and-verify: each publish upserts the tracked envelope ids; the loop occasionally confirms they still sit `Scheduled` and re-publishes on loss; a failover successor **adopts** its predecessor's verified pending occurrence instead of double-publishing.
- Pause/resume via `IRecurringScheduleControl`: pause marks the row and eagerly cancels the pending envelopes in one transaction (the caller may be on a different node than the agent); resume schedules strictly after now, never back-filling.
- **Fixes a real startup bug the compliance suite flushed out**: agents start before the messaging transports, and a `RoutingFor` answer computed in that window can come back empty and is cached for the life of the host — so the agent's first tick could publish into a half-started runtime, get "no routes", and mark the occurrence published (schedule silently dead until the next occurrence). Fixed with an internal `WolverineRuntime.FullyStarted` gate awaited by the agent loop, plus no-routes ≠ published (retry + warn once per schedule).

## Stage 3 — the diagnostics surfaces (the CritterWatch seam)
- `ServiceCapabilities.RecurringSchedules`: a first-class typed section (name, cron, time zone, message type, live pause state, pending next occurrence), read through the GH-3740 best-effort guard — an unreachable database costs the runtime fields, never the definitions.
- Event Model: a slice whose command type has a registered schedule is triggered by the **job scheduler** (the `TimeoutMessage` treatment), with the cron expression as the trigger-origin label.
- `wolverine describe`: a Recurring Messages table (static configuration only; the capabilities snapshot carries the live half).

## Testing
- 26 CoreTests for stage 1 (incl. DST spring-forward/fall-back pins and an end-to-end storeless fire); a new `RecurringMessageCompliance` base green 7/7 on all four RDBMS providers (×4 stability runs on SQLite); storeless pause-semantics pins; capabilities/Event Model/describe pins on both schedule-bearing and schedule-free hosts.
- Full CoreTests green modulo the documented wolverine#4304 environmental red (`Bug_4156`, red on clean main in the same worktree, green at the same SHA elsewhere).
- Rebased onto current main (post-JasperFx 2.63.1 bump); core + all four persistence test projects compile clean on the rebase.

## Docs
`docs/guide/messaging/recurring.md` with mdsnippets samples, including "Durable tracking: record and verify" and "Pausing and resuming a schedule".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
