### PR TITLE
GH-4309: a null single-event return is a no-op, not AppendOne(null)

### DIFF
--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/returning_null_event_is_a_no_op.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/returning_null_event_is_a_no_op.cs
@@ -1,0 +1,85 @@
+using IntegrationTests;
+using JasperFx.Events.Projections;
+using JasperFx.Resources;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests.AggregateHandlerWorkflow;
+
+// GH-4309: an aggregate handler that sometimes has nothing to append says so by returning a
+// null event — the exact shape a null cascaded message has always had. Before the fix, the
+// generated code passed the null straight into IEventStream.AppendOne, which throws
+// ArgumentNullException from inside the store.
+public class returning_null_event_is_a_no_op : PostgresqlContext, IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private IDocumentStore theStore = null!;
+    private Guid theStreamId;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.Projections.Snapshot<LetterAggregate>(SnapshotLifecycle.Inline);
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .UseLightweightSessions()
+                    .IntegrateWithWolverine();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(MaybeRaiseAHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services.AddResourceSetupOnStartup();
+            }).StartAsync();
+
+        theStore = theHost.Services.GetRequiredService<IDocumentStore>();
+
+        await using var session = theStore.LightweightSession();
+        theStreamId = session.Events.StartStream<LetterAggregate>(new LetterStarted()).Id;
+        await session.SaveChangesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    [Fact]
+    public async Task a_null_event_return_appends_nothing_and_does_not_blow_up()
+    {
+        await theHost.InvokeMessageAndWaitAsync(new MaybeRaiseA(theStreamId, Emit: false));
+
+        await using var session = theStore.LightweightSession();
+        var aggregate = await session.Events.AggregateStreamAsync<LetterAggregate>(theStreamId, token: TestContext.Current.CancellationToken);
+        aggregate!.ACount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_non_null_event_return_still_appends()
+    {
+        await theHost.InvokeMessageAndWaitAsync(new MaybeRaiseA(theStreamId, Emit: true));
+
+        await using var session = theStore.LightweightSession();
+        var aggregate = await session.Events.AggregateStreamAsync<LetterAggregate>(theStreamId, token: TestContext.Current.CancellationToken);
+        aggregate!.ACount.ShouldBe(1);
+    }
+}
+
+public record MaybeRaiseA(Guid LetterAggregateId, bool Emit);
+
+public static class MaybeRaiseAHandler
+{
+    [AggregateHandler]
+    public static AEvent? Handle(MaybeRaiseA command, LetterAggregate aggregate)
+        => command.Emit ? new AEvent() : null;
+}

--- a/src/Wolverine/Persistence/EventSourcing/EventCaptureFrames.cs
+++ b/src/Wolverine/Persistence/EventSourcing/EventCaptureFrames.cs
@@ -134,13 +134,25 @@ internal class EventCaptureActionSource : IReturnVariableActionSource
         {
             var streamType = typeof(IEventStream<>).MakeGenericType(_aggregateType);
 
-            yield return new MethodCall(streamType, nameof(IEventStream<string>.AppendOne))
+            var append = new MethodCall(streamType, nameof(IEventStream<string>.AppendOne))
             {
                 Arguments =
                 {
                     [0] = _variable
                 }
             };
+
+            // GH-4309: a handler that sometimes has nothing to append says so by returning null —
+            // the same no-op shape a null cascaded message has always had. Guard the append the
+            // way the Events/EventsToAppend path already does with WrapIfNotNull, rather than
+            // letting the null reach IEventStream.AppendOne, which throws ArgumentNullException
+            // from inside the store.
+            yield return couldBeNull(_variable.VariableType) ? append.WrapIfNotNull(_variable) : append;
         }
+
+        // A non-nullable struct event can never be null, and `!= null` against one is not even
+        // legal C# — emit the guard only where a null is representable.
+        private static bool couldBeNull(Type type)
+            => !type.IsValueType || Nullable.GetUnderlyingType(type) is not null;
     }
 }


### PR DESCRIPTION
Closes #4309.

Found dogfooding the CritterCrush sample (JasperFx/CritterStackSamples#13): an automation-style aggregate handler that sometimes has nothing to append says so by returning `null` — the exact no-op shape a null cascaded message has always had. But on the event-returning side, the generated handler passed the null straight into `IEventStream<T>.AppendOne`, which throws `ArgumentNullException: (Parameter 'eventData')` from inside the store at runtime. The nullable-return form compiles cleanly and reads idiomatic, so the asymmetry was a trap.

## The fix

`EventCaptureActionSource.ActionSource.Frames()` (the shared event-capture path for every store integration, per GH-3907) now wraps the single-event `AppendOne` call in the same `WrapIfNotNull` guard the `Events`/`EventsToAppend` return path already uses. The null check is emitted only where a null is representable — reference types and `Nullable<T>` — because `!= null` against a bare struct event isn't legal C#.

## Verification

- New `MartenTests.AggregateHandlerWorkflow.returning_null_event_is_a_no_op`: a `MutualMatchDetected?`-style handler returning null appends nothing and does not throw; returning a real event still appends. Red-baselined: the null case fails with the `AppendOne` `ArgumentNullException` without the fix, green with it.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)