### PR TITLE
GH-4310: a bare SubscribeToEvent<T>() is a bootstrap error, not silence

### DIFF
--- a/src/Persistence/FisherTests/subscribe_to_event_requires_completion.cs
+++ b/src/Persistence/FisherTests/subscribe_to_event_requires_completion.cs
@@ -1,0 +1,78 @@
+using Fisher;
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Fisher;
+
+namespace FisherTests;
+
+// GH-4310 (mirrored from Wolverine.Marten): SubscribeToEvent<T>() only opens a transformation — a
+// bare call used to register nothing at all, leaving a "subscription" that silently never delivered
+// anything. It is now a bootstrap-time configuration error unless event forwarding is enabled or the
+// transformation is completed with TransformedTo().
+public class subscribe_to_event_requires_completion
+{
+    private static IHostBuilder hostFor(FisherTestDatabase database, Action<FisherIntegration> integration)
+        => Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddFisher(m =>
+                    {
+                        m.Connection(database.ConnectionString);
+                        m.AutoCreateSchemaObjects = AutoCreate.All;
+                    })
+                    .IntegrateWithWolverine(integration);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Durability.Mode = DurabilityMode.Solo;
+            });
+
+    [Fact]
+    public async Task a_bare_subscribe_to_event_with_no_forwarding_fails_at_bootstrap_naming_the_fix()
+    {
+        using var database = Servers.CreateDatabase("subscribe_bare");
+
+        var failure = await Should.ThrowAsync<InvalidOperationException>(
+            () => hostFor(database, m => m.SubscribeToEvent<SomethingHappened>()).StartAsync(TestContext.Current.CancellationToken));
+
+        failure.Message.ShouldContain(nameof(SomethingHappened));
+        failure.Message.ShouldContain(nameof(FisherIntegration.UseFastEventForwarding));
+        failure.Message.ShouldContain("TransformedTo");
+    }
+
+    [Fact]
+    public async Task a_bare_subscribe_to_event_is_allowed_when_forwarding_is_on()
+    {
+        using var database = Servers.CreateDatabase("subscribe_forwarding");
+
+        using var host = await hostFor(database, m =>
+        {
+            m.UseFastEventForwarding = true;
+            m.SubscribeToEvent<SomethingHappened>();
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_completed_transformation_is_allowed_without_forwarding()
+    {
+        using var database = Servers.CreateDatabase("subscribe_transformed");
+
+        // TransformedTo also serves events published by strictly-ordered subscriptions, so a
+        // completed transformation without fast forwarding stays legal.
+        using var host = await hostFor(database, m =>
+        {
+            m.SubscribeToEvent<SomethingHappened>()
+                .TransformedTo(e => new SomethingTranslated(e.Data.Name));
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    public record SomethingHappened(string Name);
+
+    public record SomethingTranslated(string Name);
+}

--- a/src/Persistence/MartenTests/subscribe_to_event_requires_completion.cs
+++ b/src/Persistence/MartenTests/subscribe_to_event_requires_completion.cs
@@ -1,0 +1,71 @@
+using IntegrationTests;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+
+namespace MartenTests;
+
+// GH-4310: SubscribeToEvent<T>() only opens a transformation — a bare call used to register
+// nothing at all, leaving a "subscription" that silently never delivered anything. It is now a
+// bootstrap-time configuration error unless event forwarding is enabled or the transformation is
+// completed with TransformedTo().
+public class subscribe_to_event_requires_completion : PostgresqlContext
+{
+    private static IHostBuilder hostFor(Action<MartenIntegration> integration)
+        => Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DisableNpgsqlLogging = true;
+                    })
+                    .IntegrateWithWolverine(integration);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Durability.Mode = DurabilityMode.Solo;
+            });
+
+    [Fact]
+    public async Task a_bare_subscribe_to_event_with_no_forwarding_fails_at_bootstrap_naming_the_fix()
+    {
+        var failure = await Should.ThrowAsync<InvalidOperationException>(
+            () => hostFor(m => m.SubscribeToEvent<SomethingHappened>()).StartAsync(TestContext.Current.CancellationToken));
+
+        failure.Message.ShouldContain(nameof(SomethingHappened));
+        failure.Message.ShouldContain(nameof(MartenIntegration.UseFastEventForwarding));
+        failure.Message.ShouldContain("TransformedTo");
+    }
+
+    [Fact]
+    public async Task a_bare_subscribe_to_event_is_allowed_when_forwarding_is_on()
+    {
+        using var host = await hostFor(m =>
+        {
+            m.UseFastEventForwarding = true;
+            m.SubscribeToEvent<SomethingHappened>();
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_completed_transformation_is_allowed_without_forwarding()
+    {
+        // TransformedTo also serves events published by strictly-ordered subscriptions, so a
+        // completed transformation without fast forwarding stays legal.
+        using var host = await hostFor(m =>
+        {
+            m.SubscribeToEvent<SomethingHappened>()
+                .TransformedTo(e => new SomethingTranslated(e.Data.Name));
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    public record SomethingHappened(string Name);
+
+    public record SomethingTranslated(string Name);
+}

--- a/src/Persistence/PolecatTests/subscribe_to_event_requires_completion.cs
+++ b/src/Persistence/PolecatTests/subscribe_to_event_requires_completion.cs
@@ -1,0 +1,70 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Shouldly;
+using Wolverine;
+using Wolverine.Polecat;
+
+namespace PolecatTests;
+
+// GH-4310 (mirrored from Wolverine.Marten): SubscribeToEvent<T>() only opens a transformation — a
+// bare call used to register nothing at all, leaving a "subscription" that silently never delivered
+// anything. It is now a bootstrap-time configuration error unless event forwarding is enabled or the
+// transformation is completed with TransformedTo().
+public class subscribe_to_event_requires_completion
+{
+    private static IHostBuilder hostFor(Action<PolecatIntegration> integration)
+        => Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "pc_subscribe_completion";
+                }).IntegrateWithWolverine(integration);
+
+                opts.Discovery.DisableConventionalDiscovery();
+                opts.Durability.Mode = DurabilityMode.Solo;
+            });
+
+    [Fact]
+    public async Task a_bare_subscribe_to_event_with_no_forwarding_fails_at_bootstrap_naming_the_fix()
+    {
+        var failure = await Should.ThrowAsync<InvalidOperationException>(
+            () => hostFor(m => m.SubscribeToEvent<SomethingHappened>()).StartAsync(TestContext.Current.CancellationToken));
+
+        failure.Message.ShouldContain(nameof(SomethingHappened));
+        failure.Message.ShouldContain(nameof(PolecatIntegration.UseFastEventForwarding));
+        failure.Message.ShouldContain("TransformedTo");
+    }
+
+    [Fact]
+    public async Task a_bare_subscribe_to_event_is_allowed_when_forwarding_is_on()
+    {
+        using var host = await hostFor(m =>
+        {
+            m.UseFastEventForwarding = true;
+            m.SubscribeToEvent<SomethingHappened>();
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_completed_transformation_is_allowed_without_forwarding()
+    {
+        // TransformedTo also serves events published by strictly-ordered subscriptions, so a
+        // completed transformation without fast forwarding stays legal.
+        using var host = await hostFor(m =>
+        {
+            m.SubscribeToEvent<SomethingHappened>()
+                .TransformedTo(e => new SomethingTranslated(e.Data.Name));
+        }).StartAsync(TestContext.Current.CancellationToken);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    public record SomethingHappened(string Name);
+
+    public record SomethingTranslated(string Name);
+}

--- a/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherIntegration.cs
@@ -36,6 +36,20 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
 
     public void Configure(WolverineOptions options)
     {
+        // GH-4310 (mirrored from Wolverine.Marten): a bare SubscribeToEvent<T>() registers
+        // nothing — it only opens a transformation that TransformedTo() has to finish. Left alone
+        // without event forwarding, the "subscription" is silently dead: no forwarding occurs, the
+        // handler never fires, and nothing anywhere says so. Fail at bootstrap with the two real
+        // options instead.
+        if (EventRouter.BareSubscriptions.Any() && !UseFastEventForwarding)
+        {
+            var names = EventRouter.BareSubscriptions.Select(x => x.Name).Join(", ");
+            throw new InvalidOperationException(
+                $"SubscribeToEvent<T>() was called for [{names}] but nothing completes the subscription, so these events would never reach a handler. " +
+                $"SubscribeToEvent<T>() only defines a transformation of a forwarded event — either finish it with .TransformedTo(...), " +
+                $"or, to simply have Wolverine handlers receive the event after commit, set {nameof(UseFastEventForwarding)} = true on this integration instead.");
+        }
+
         // Duplicate incoming messages. SQLite reports a unique / primary-key violation through
         // SqliteException.SqliteExtendedErrorCode as SQLITE_CONSTRAINT_PRIMARYKEY (1555) or
         // SQLITE_CONSTRAINT_UNIQUE (2067). The SQL Server 2627 / 2601 pair the Polecat twin tests for
@@ -145,8 +159,17 @@ public class FisherIntegration : IWolverineExtension, IEventForwarding
         }
     }
 
+    /// <summary>
+    /// Define a <em>transformation</em> of a forwarded event: complete the returned builder with
+    /// <see cref="EventForwardingTransform{TSource}.TransformedTo{TDestination}"/> to publish the
+    /// transformed message under Wolverine's normal routing rules. ⚠️ This is not an on-switch for
+    /// event forwarding, and a bare call registers nothing (GH-4310 — the bootstrap rejects it):
+    /// to simply have Wolverine handlers receive an event after commit, set
+    /// <see cref="UseFastEventForwarding"/> = true instead.
+    /// </summary>
     public EventForwardingTransform<T> SubscribeToEvent<T>() where T : notnull
     {
+        EventRouter.BareSubscriptions.Add(typeof(T));
         return new EventForwardingTransform<T>(EventRouter);
     }
 }
@@ -229,6 +252,13 @@ internal class FisherEventRouter : IMessageRouteSource
 
     public bool IsAdditive => false;
     public List<IMessageTransformation> Transformers { get; } = [];
+
+    /// <summary>
+    /// GH-4310: SubscribeToEvent&lt;T&gt;() calls whose transformation was never completed with
+    /// TransformedTo(). Checked at bootstrap — bare entries with no event forwarding enabled are
+    /// a configuration error, because nothing would ever deliver those events.
+    /// </summary>
+    internal List<Type> BareSubscriptions { get; } = [];
 }
 
 internal class EventUnwrappingMessageRoute<T> : TransformedMessageRoute<IEvent<T>, T> where T : notnull
@@ -264,6 +294,9 @@ public class EventForwardingTransform<TSource> where TSource : notnull
 
     public void TransformedTo<TDestination>(Func<IEvent<TSource>, TDestination> transformer)
     {
+        // The subscription is now completed — see FisherEventRouter.BareSubscriptions (GH-4310).
+        _eventRouter.BareSubscriptions.Remove(typeof(TSource));
+
         var transformation = new MessageTransformation<IEvent<TSource>, TDestination>(transformer);
         _eventRouter.Transformers.Add(transformation);
     }

--- a/src/Persistence/Wolverine.Marten/MartenIntegration.cs
+++ b/src/Persistence/Wolverine.Marten/MartenIntegration.cs
@@ -50,6 +50,20 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
 
     public void Configure(WolverineOptions options)
     {
+        // GH-4310: a bare SubscribeToEvent<T>() registers nothing — it only opens a
+        // transformation that TransformedTo() has to finish. Left alone without event
+        // forwarding, the "subscription" is silently dead: no forwarding occurs, the handler
+        // never fires, and nothing anywhere says so. Fail at bootstrap with the two real
+        // options instead.
+        if (EventRouter.BareSubscriptions.Any() && !UseFastEventForwarding)
+        {
+            var names = EventRouter.BareSubscriptions.Select(x => x.Name).Join(", ");
+            throw new InvalidOperationException(
+                $"SubscribeToEvent<T>() was called for [{names}] but nothing completes the subscription, so these events would never reach a handler. " +
+                $"SubscribeToEvent<T>() only defines a transformation of a forwarded event — either finish it with .TransformedTo(...), " +
+                $"or, to simply have Wolverine handlers receive the event after commit, set {nameof(UseFastEventForwarding)} = true on this integration instead.");
+        }
+
         // Duplicate incoming messages
         options.OnException<MartenCommandException>(e =>
             {
@@ -188,8 +202,17 @@ public class MartenIntegration : IWolverineExtension, IEventForwarding
     /// </summary>
     public AutoCreate? AutoCreate { get; set; }
 
+    /// <summary>
+    /// Define a <em>transformation</em> of a forwarded event: complete the returned builder with
+    /// <see cref="EventForwardingTransform{TSource}.TransformedTo{TDestination}"/> to publish the
+    /// transformed message under Wolverine's normal routing rules. ⚠️ This is not an on-switch for
+    /// event forwarding, and a bare call registers nothing (GH-4310 — the bootstrap rejects it):
+    /// to simply have Wolverine handlers receive an event after commit, set
+    /// <see cref="UseFastEventForwarding"/> = true instead.
+    /// </summary>
     public EventForwardingTransform<T> SubscribeToEvent<T>() where T : notnull
     {
+        EventRouter.BareSubscriptions.Add(typeof(T));
         return new EventForwardingTransform<T>(EventRouter);
     }
 }
@@ -327,6 +350,13 @@ internal class MartenEventRouter : IMessageRouteSource
 
     public bool IsAdditive => false;
     public List<IMessageTransformation> Transformers { get; } = [];
+
+    /// <summary>
+    /// GH-4310: SubscribeToEvent&lt;T&gt;() calls whose transformation was never completed with
+    /// TransformedTo(). Checked at bootstrap — bare entries with no event forwarding enabled are
+    /// a configuration error, because nothing would ever deliver those events.
+    /// </summary>
+    internal List<Type> BareSubscriptions { get; } = [];
 }
 
 internal class EventUnwrappingMessageRoute<T> : TransformedMessageRoute<IEvent<T>, T> where T : notnull
@@ -362,6 +392,9 @@ public class EventForwardingTransform<TSource> where TSource : notnull
 
     public void TransformedTo<TDestination>(Func<IEvent<TSource>, TDestination> transformer)
     {
+        // The subscription is now completed — see MartenEventRouter.BareSubscriptions (GH-4310).
+        _martenEventWrapper.BareSubscriptions.Remove(typeof(TSource));
+
         var transformation = new MessageTransformation<IEvent<TSource>, TDestination>(transformer);
         _martenEventWrapper.Transformers.Add(transformation);
     }

--- a/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatIntegration.cs
@@ -41,6 +41,20 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
 
     public void Configure(WolverineOptions options)
     {
+        // GH-4310 (mirrored from Wolverine.Marten): a bare SubscribeToEvent<T>() registers
+        // nothing — it only opens a transformation that TransformedTo() has to finish. Left alone
+        // without event forwarding, the "subscription" is silently dead: no forwarding occurs, the
+        // handler never fires, and nothing anywhere says so. Fail at bootstrap with the two real
+        // options instead.
+        if (EventRouter.BareSubscriptions.Any() && !UseFastEventForwarding)
+        {
+            var names = EventRouter.BareSubscriptions.Select(x => x.Name).Join(", ");
+            throw new InvalidOperationException(
+                $"SubscribeToEvent<T>() was called for [{names}] but nothing completes the subscription, so these events would never reach a handler. " +
+                $"SubscribeToEvent<T>() only defines a transformation of a forwarded event — either finish it with .TransformedTo(...), " +
+                $"or, to simply have Wolverine handlers receive the event after commit, set {nameof(UseFastEventForwarding)} = true on this integration instead.");
+        }
+
         // Duplicate incoming messages - SQL Server uses unique constraint violations
         options.OnException<Microsoft.Data.SqlClient.SqlException>(e =>
             {
@@ -165,8 +179,17 @@ public class PolecatIntegration : IWolverineExtension, IEventForwarding
         }
     }
 
+    /// <summary>
+    /// Define a <em>transformation</em> of a forwarded event: complete the returned builder with
+    /// <see cref="EventForwardingTransform{TSource}.TransformedTo{TDestination}"/> to publish the
+    /// transformed message under Wolverine's normal routing rules. ⚠️ This is not an on-switch for
+    /// event forwarding, and a bare call registers nothing (GH-4310 — the bootstrap rejects it):
+    /// to simply have Wolverine handlers receive an event after commit, set
+    /// <see cref="UseFastEventForwarding"/> = true instead.
+    /// </summary>
     public EventForwardingTransform<T> SubscribeToEvent<T>() where T : notnull
     {
+        EventRouter.BareSubscriptions.Add(typeof(T));
         return new EventForwardingTransform<T>(EventRouter);
     }
 }
@@ -258,6 +281,13 @@ internal class PolecatEventRouter : IMessageRouteSource
 
     public bool IsAdditive => false;
     public List<IMessageTransformation> Transformers { get; } = [];
+
+    /// <summary>
+    /// GH-4310: SubscribeToEvent&lt;T&gt;() calls whose transformation was never completed with
+    /// TransformedTo(). Checked at bootstrap — bare entries with no event forwarding enabled are
+    /// a configuration error, because nothing would ever deliver those events.
+    /// </summary>
+    internal List<Type> BareSubscriptions { get; } = [];
 }
 
 internal class EventUnwrappingMessageRoute<T> : TransformedMessageRoute<IEvent<T>, T> where T : notnull
@@ -293,6 +323,9 @@ public class EventForwardingTransform<TSource> where TSource : notnull
 
     public void TransformedTo<TDestination>(Func<IEvent<TSource>, TDestination> transformer)
     {
+        // The subscription is now completed — see PolecatEventRouter.BareSubscriptions (GH-4310).
+        _eventRouter.BareSubscriptions.Remove(typeof(TSource));
+
         var transformation = new MessageTransformation<IEvent<TSource>, TDestination>(transformer);
         _eventRouter.Transformers.Add(transformation);
     }


### PR DESCRIPTION
Closes #4310.

Found dogfooding the CritterCrush sample (JasperFx/CritterStackSamples#13): `IntegrateWithWolverine(m => m.SubscribeToEvent<DogLiked>())` reads like event forwarding but registers nothing — `SubscribeToEvent<T>()` only opens a transformation that `TransformedTo(...)` has to finish. Called bare, the builder is constructed and discarded, no forwarding occurs, the handler never fires, and nothing anywhere says so. The actual switch for plain forwarding is `UseFastEventForwarding`, which nothing in the name or signature points at.

## The fix

Per the issue's middle option, a bare `SubscribeToEvent<T>()` is now a **bootstrap-time configuration error**: the integration tracks event types whose transformation was never completed, and `Configure` throws an `InvalidOperationException` naming the event types and both real options — finish with `.TransformedTo(...)`, or set `UseFastEventForwarding = true`. A completed transformation without fast forwarding stays legal, since `TransformedTo` also serves events published by strictly-ordered subscriptions. `SubscribeToEvent`'s XML docs now say explicitly that it is transformation-only and not an on-switch for forwarding.

`PolecatIntegration` and `FisherIntegration` carry verbatim copies of the same `IEventForwarding`/`EventForwardingTransform` surface with the identical trap, so the guard and docs are mirrored into both.

## Verification

- New `subscribe_to_event_requires_completion` in MartenTests, PolecatTests, and FisherTests, three cases each: bare call throws with a message naming the event type, `TransformedTo`, and `UseFastEventForwarding`; bare call plus fast forwarding boots; completed transformation without forwarding boots. All 9 green.
- Marten `event_streaming`/`event_forwarding` regression sweep green (7 tests).
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)