### PR TITLE
GH-4308: codegen makes good on the route's claim to a postprocessor parameter

### DIFF
--- a/src/Http/Wolverine.Http.Tests/postprocessor_route_binding_4308.cs
+++ b/src/Http/Wolverine.Http.Tests/postprocessor_route_binding_4308.cs
@@ -1,0 +1,46 @@
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests;
+
+// GH-4308: a postprocessor [FromQuery] parameter whose name collides with a route segment on a
+// route-bindable type is claimed by the route. The OpenAPI side has said so since GH-3601 (only the
+// Path parameter renders); this proves the generated code makes good on that claim instead of dying
+// at codegen with an UnResolvableVariableException.
+public class postprocessor_route_binding_4308 : IntegrationContext
+{
+    public postprocessor_route_binding_4308(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task a_postprocessor_parameter_claimed_by_the_route_binds_from_the_route_value()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        // The query string carries a conflicting value on the same name: the route's claim has to
+        // win, exactly as the OpenAPI description documents it.
+        await Scenario(x => x.Get.Url("/middleware/postprocessor-route/123?orderId=456"));
+
+        recorder.Actions.ShouldHaveTheSameElementsAs("After: 123");
+    }
+
+    [Fact]
+    public async Task an_unparseable_route_value_is_a_404_before_the_endpoint_runs()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/postprocessor-route/not-a-long");
+            x.StatusCodeShouldBe(404);
+        });
+
+        recorder.Actions.ShouldBeEmpty();
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -226,10 +226,53 @@ public partial class HttpChain
             yield return new RecordEndpointCausationFrame(origin, Method.HandlerType.FullNameInCode());
         }
 
+        // GH-4308: postprocessors are deliberately NOT run through the full parameter-matching
+        // strategies (see the middleware-only loop in this chain's constructor and the GH-3601 notes
+        // in HttpChain.ApiDescription), but a parameter the ROUTE claims — an explicit [FromRoute],
+        // or a name collision with a route-template segment on a route-bindable type — still has to
+        // resolve to the route value, or codegen dies in FindVariable (an UnResolvableVariableException
+        // for a parsed type like long). The OpenAPI side already makes exactly this claim in
+        // isBoundFromRouteValue, rendering only the Path parameter; this is the codegen half of that
+        // decision, matched case-sensitively through FindRouteVariable(ParameterInfo) so the two
+        // halves cannot diverge (GH-3586).
+        foreach (var call in Postprocessors.OfType<MethodCall>().Concat(PostCommitPostprocessors.OfType<MethodCall>()))
+        {
+            tryApplyRouteVariablesToPostprocessor(call);
+        }
+
         foreach (var frame in Postprocessors) yield return frame;
 
         // GH-3975: after EVERY postprocessor, including the persistence provider's commit frame.
         foreach (var frame in PostCommitPostprocessors) yield return frame;
+    }
+
+    private void tryApplyRouteVariablesToPostprocessor(MethodCall call)
+    {
+        var parameters = call.Method.GetParameters();
+        for (var i = 0; i < call.Arguments.Length; i++)
+        {
+            // Never override an argument something else has already bound
+            if (call.Arguments[i] != null) continue;
+
+            var parameter = parameters[i];
+
+            // Mirrors RouteParameterStrategy.TryMatch: an explicit [FromRoute(Name = ...)] names the
+            // route segment directly rather than matching on the parameter's own name
+            if (parameter.TryGetAttribute<FromRouteAttribute>(out var att) && att.Name.IsNotEmpty())
+            {
+                if (FindRouteVariable(parameter.ParameterType, att.Name!, out var named))
+                {
+                    call.Arguments[i] = named;
+                }
+
+                continue;
+            }
+
+            if (FindRouteVariable(parameter, out var variable))
+            {
+                call.Arguments[i] = variable;
+            }
+        }
     }
 
     private bool requiresFlush(Frame[] actionsOnOtherReturnValues)

--- a/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
+++ b/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json.Serialization;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core;
+using Microsoft.AspNetCore.Mvc;
 using Wolverine.Http;
 
 namespace WolverineWebApi;
@@ -89,6 +90,23 @@ public class BeforeAndAfterEndpoint
     {
         recorder.Actions.Add("Action");
         return "okay";
+    }
+}
+
+// GH-4308: a postprocessor parameter whose name collides with a route segment on a route-bindable
+// type is claimed by the route — OpenAPI renders only the single Path parameter (GH-3601), and the
+// generated code must make the same claim by binding the parameter from the parsed route value. Before
+// the fix this shape didn't compile at all: nothing produced a `long` variable for After's parameter
+// and codegen died with an UnResolvableVariableException (which is what failed `codegen preview` on
+// WolverineWebApi, so this endpoint also keeps the Nuke CodegenPreviewCommand guarding the shape).
+public static class PostprocessorRouteCollisionRecordingEndpoint
+{
+    [WolverineGet("/middleware/postprocessor-route/{orderId:long}")]
+    public static string Get() => "ok";
+
+    public static void After(Recorder recorder, [FromQuery] long orderId)
+    {
+        recorder.Actions.Add($"After: {orderId}");
     }
 }
 


### PR DESCRIPTION
Closes #4308.

`codegen preview` against WolverineWebApi (and therefore the Nuke `CodegenPreviewCommand` → `Commands` → `Test` → `Full` targets) has exited 1 on every commit of `main` since the GH-3601 merge, with `UnResolvableVariableException: unable to resolve a variable of type long` building `GET_shapes_postprocessor_collision_orderId`.

## Root cause

The route-variable pass in `HttpChain` runs over `Middleware` `MethodCall`s only — both the full strategy matching in the constructor and the `RouteParameterStrategy.TryApplyRouteVariables` loop in `DetermineFrames`. Postprocessors (`After`) are deliberately not parameter-matched (that's a documented GH-3601 invariant the OpenAPI description machinery depends on), so nothing ever produced a `long` variable for the `After` method's route-colliding parameter and chain assembly died in JasperFx's type-only `FindVariable`. The description half of GH-3601 (`isBoundFromRouteValue`) claims the route binds that parameter; the codegen half never made good on the claim.

## The fix

`DetermineFrames` now runs a narrow **route-only** pass over `Postprocessors` and `PostCommitPostprocessors` before yielding them: an explicit `[FromRoute(Name = ...)]`, or a parameter the route claims, gets the parsed route-value variable. The claim is matched **case-sensitively** through `FindRouteVariable(ParameterInfo)` — the same comparison `isBoundFromRouteValue` deliberately uses (GH-3586) — so the description and codegen halves can't diverge. Postprocessors stay out of the full strategy list, so no query/header variables are produced and the GH-3601 description invariants are untouched.

## Verification

- `dotnet run --project src/Http/WolverineWebApi ... -- codegen preview` exits 0 (was exit 1 on `main`); the generated `GET_shapes_postprocessor_collision_orderId` parses `orderId` from the route with the standard 404 guard and passes it to `After`.
- New WolverineWebApi endpoint + `postprocessor_route_binding_4308` integration test: with `/middleware/postprocessor-route/123?orderId=456`, `After` receives **123** (the route's value, as OpenAPI documents), not the query string's 456. Red-baselined: fails with the exact `UnResolvableVariableException` from the issue without the fix.
- Full `Wolverine.Http.Tests` suite: 1031 passed, 0 failed.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

## Out of scope, found while fixing

A postprocessor `[FromQuery]`/`[FromHeader]` parameter that does *not* collide with a route segment is still resolved by type only, so it can silently bind to an unrelated variable of the same type (e.g. `After([FromQuery] string? audit)` on an endpoint returning `string` receives the response body). Same root cause, but the fix needs care around the GH-3601 description-source invariants, so it's split out rather than smuggled in here — follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)