### PR TITLE
GH-4314: postprocessor [FromQuery]/[FromHeader] parameters bind from the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,21 @@
 
 ### WolverineFx.Http
 
+- **A postprocessor `[FromQuery]`/`[FromHeader]` parameter binds from the wire instead of whatever
+  same-typed variable was lying around.** (closes
+  [#4314](https://github.com/JasperFx/wolverine/issues/4314)) Postprocessors (`After`/`AfterAsync`/
+  `PostProcess`) are deliberately not run through the HTTP parameter-matching strategies, so nothing
+  produced a variable for a `[FromQuery]` or `[FromHeader]` parameter that didn't collide with a route
+  segment — and JasperFx's `FindVariable` fallback then resolved it by name-then-type to any unrelated
+  variable already in the chain. Concretely: `After([FromQuery] string? audit)` on an endpoint returning
+  `string` compiled cleanly and silently received the endpoint's *response body* as `audit`. GH-4313
+  made codegen honor the route's claim on a postprocessor parameter; this is the query/header half of
+  the same contract the OpenAPI description has published since GH-3601. The binding pass creates its
+  read frames directly (reusing the main method's variable when it already reads the same value) without
+  registering into the description-feeding collections, so the rendered OpenAPI description stays
+  independent of when the chain compiles. Complex `[FromQuery]` types — the flattening shape the
+  description side also declines to describe on a postprocessor — are left alone.
+
 - **A Static-mode endpoint type mismatch is now reported as itself.** (closes
   [#4156](https://github.com/JasperFx/wolverine/issues/4156)) GH-4151 gave handler chains a startup assertion
   that every pre-generated type really is in `WolverineOptions.ApplicationAssembly`, because `codegen write`

--- a/src/Http/Wolverine.Http.Tests/postprocessor_query_header_binding_4314.cs
+++ b/src/Http/Wolverine.Http.Tests/postprocessor_query_header_binding_4314.cs
@@ -1,0 +1,47 @@
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests;
+
+// GH-4314: a postprocessor [FromQuery]/[FromHeader] parameter that does not collide with a route
+// segment must bind from the query string / header, exactly as the OpenAPI description has claimed
+// since GH-3601. Before the fix nothing produced a variable for these parameters, and JasperFx's
+// name-then-type fallback silently bound `audit` to the endpoint's response body (the only other
+// string in the chain) — it compiled, so nothing caught it.
+public class postprocessor_query_header_binding_4314 : IntegrationContext
+{
+    public postprocessor_query_header_binding_4314(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task postprocessor_from_query_and_from_header_parameters_bind_from_the_wire()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/postprocessor-query-header?audit=abc&attempts=3");
+            x.WithRequestHeader("x-trace", "t-42");
+        });
+
+        recorder.Actions.ShouldHaveTheSameElementsAs("After: audit=abc, attempts=3, trace=t-42");
+    }
+
+    [Fact]
+    public async Task absent_values_stay_absent_instead_of_binding_to_an_unrelated_variable()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        // The regression: with no query string at all, the old fallback handed `audit` the
+        // endpoint's response body, so this used to record audit=ok
+        await Scenario(x => x.Get.Url("/middleware/postprocessor-query-header"));
+
+        recorder.Actions.ShouldHaveTheSameElementsAs("After: audit=null, attempts=0, trace=null");
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -226,18 +226,20 @@ public partial class HttpChain
             yield return new RecordEndpointCausationFrame(origin, Method.HandlerType.FullNameInCode());
         }
 
-        // GH-4308: postprocessors are deliberately NOT run through the full parameter-matching
-        // strategies (see the middleware-only loop in this chain's constructor and the GH-3601 notes
-        // in HttpChain.ApiDescription), but a parameter the ROUTE claims — an explicit [FromRoute],
-        // or a name collision with a route-template segment on a route-bindable type — still has to
-        // resolve to the route value, or codegen dies in FindVariable (an UnResolvableVariableException
-        // for a parsed type like long). The OpenAPI side already makes exactly this claim in
-        // isBoundFromRouteValue, rendering only the Path parameter; this is the codegen half of that
-        // decision, matched case-sensitively through FindRouteVariable(ParameterInfo) so the two
-        // halves cannot diverge (GH-3586).
+        // GH-4308 / GH-4314: postprocessors are deliberately NOT run through the full
+        // parameter-matching strategies (see the middleware-only loop in this chain's constructor and
+        // the GH-3601 notes in HttpChain.ApiDescription), but any parameter the OpenAPI description
+        // side claims an HTTP binding for still has to actually get that binding, or JasperFx's
+        // FindVariable falls back to name-then-type resolution and either dies (an
+        // UnResolvableVariableException for a parsed type like long) or, worse, silently hands the
+        // parameter an unrelated variable of the same type — e.g. the endpoint's response body into a
+        // [FromQuery] string. The claims mirrored here are exactly the description side's: a route
+        // claim (explicit [FromRoute], or a name collision with a route-template segment on a
+        // route-bindable type, matched case-sensitively per GH-3586), then simple-typed
+        // [FromQuery]/[FromHeader] per tryDescribePostprocessorBinding.
         foreach (var call in Postprocessors.OfType<MethodCall>().Concat(PostCommitPostprocessors.OfType<MethodCall>()))
         {
-            tryApplyRouteVariablesToPostprocessor(call);
+            tryApplyHttpBindingsToPostprocessor(call);
         }
 
         foreach (var frame in Postprocessors) yield return frame;
@@ -246,7 +248,7 @@ public partial class HttpChain
         foreach (var frame in PostCommitPostprocessors) yield return frame;
     }
 
-    private void tryApplyRouteVariablesToPostprocessor(MethodCall call)
+    private void tryApplyHttpBindingsToPostprocessor(MethodCall call)
     {
         var parameters = call.Method.GetParameters();
         for (var i = 0; i < call.Arguments.Length; i++)
@@ -268,11 +270,101 @@ public partial class HttpChain
                 continue;
             }
 
+            // GH-4314: [FromQuery]/[FromHeader] bind from the query string / header — unless the
+            // route claims the name (isBoundFromRouteValue, the same case-sensitive test the
+            // description side uses), in which case the route wins below exactly as the description
+            // renders only the Path parameter. A complex [FromQuery] is the flattening shape the
+            // description side also refuses to describe on a postprocessor, so it is deliberately
+            // left alone here.
+            if (!isBoundFromRouteValue(parameter))
+            {
+                if (parameter.TryGetAttribute<FromQueryAttribute>(out var fromQuery))
+                {
+                    if (!FromQueryAttributeUsage.IsComplexQueryStringType(parameter.ParameterType))
+                    {
+                        var key = fromQuery.Name.IsNotEmpty() ? fromQuery.Name! : parameter.Name!;
+                        if (tryFindOrCreatePostprocessorQuerystringValue(parameter.ParameterType,
+                                parameter.Name!, key, out var queryValue))
+                        {
+                            call.Arguments[i] = queryValue;
+                        }
+                    }
+
+                    continue;
+                }
+
+                if (parameter.TryGetAttribute<FromHeaderAttribute>(out var fromHeader))
+                {
+                    var headerName = fromHeader.Name.IsNotEmpty() ? fromHeader.Name! : parameter.Name!;
+                    call.Arguments[i] = findOrCreatePostprocessorHeaderValue(parameter, headerName);
+                    continue;
+                }
+            }
+
             if (FindRouteVariable(parameter, out var variable))
             {
                 call.Arguments[i] = variable;
             }
         }
+    }
+
+    // Variables bound ONLY for postprocessor parameters (GH-4314). Deliberately kept out of
+    // _querystringVariables/_headerVariables: those collections feed the OpenAPI description, and
+    // this pass runs at codegen time, which is lazy — registering here would change the rendered
+    // description depending on whether the chain compiled before or after the ApiDescription was
+    // read. Postprocessor parameters are instead described straight from the method signature by
+    // tryDescribePostprocessorBinding.
+    private readonly List<HttpElementVariable> _postprocessorQuerystringVariables = [];
+    private readonly List<HttpElementVariable> _postprocessorHeaderVariables = [];
+
+    private bool tryFindOrCreatePostprocessorQuerystringValue(Type parameterType, string parameterName,
+        string key, [NotNullWhen(true)] out Variable? variable)
+    {
+        // When the main method or a middleware method already reads this query string value, reuse
+        // its variable rather than reading the same key into a second, identically-named local
+        var existing = _querystringVariables.FirstOrDefault(x => x.Name == key)
+                       ?? _postprocessorQuerystringVariables.FirstOrDefault(x => x.Name == key);
+
+        if (existing is not null)
+        {
+            if (existing.VariableType != parameterType)
+            {
+                throw new InvalidOperationException(
+                    $"The query string parameter '{key}' cannot be used for multiple target types");
+            }
+
+            variable = existing;
+            return true;
+        }
+
+        var created = createQuerystringValue(parameterType, parameterName, key);
+        if (created is null)
+        {
+            variable = null;
+            return false;
+        }
+
+        _postprocessorQuerystringVariables.Add(created);
+        variable = created;
+        return true;
+    }
+
+    private Variable findOrCreatePostprocessorHeaderValue(ParameterInfo parameter, string headerName)
+    {
+        var existing = _headerVariables
+                           .FirstOrDefault(x => x.Name == headerName && x.VariableType == parameter.ParameterType)
+                       ?? _postprocessorHeaderVariables
+                           .FirstOrDefault(x => x.Name == headerName && x.VariableType == parameter.ParameterType);
+
+        if (existing is not null) return existing;
+
+        var frame = new ReadHttpFrame(BindingSource.Header, parameter.ParameterType, parameter.Name!)
+        {
+            Key = headerName
+        };
+
+        _postprocessorHeaderVariables.Add(frame.Variable);
+        return frame.Variable;
     }
 
     private bool requiresFlush(Frame[] actionsOnOtherReturnValues)

--- a/src/Http/Wolverine.Http/HttpChain.cs
+++ b/src/Http/Wolverine.Http/HttpChain.cs
@@ -989,61 +989,9 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         var variable = _querystringVariables.FirstOrDefault(x => x.Name == key);
         if (variable == null)
         {
-            if (parameterType == typeof(string))
+            variable = createQuerystringValue(parameterType, parameterName, key);
+            if (variable != null)
             {
-                variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key).Variable;
-                variable.Name = key;
-
-                if (variable.Usage == "tenantId")
-                {
-                    variable.OverrideName("tenantIdString");
-                }
-                
-                _querystringVariables.Add(variable);
-            }
-
-            if (parameterType == typeof(string[]))
-            {
-                variable = new ParsedArrayQueryStringValue(parameterType, key).Variable;
-                variable.Name = key;
-                _querystringVariables.Add(variable);
-            }
-
-            if (parameterType.IsNullable())
-            {
-                var inner = parameterType.GetInnerTypeFromNullable();
-                if (RouteParameterStrategy.CanParse(inner))
-                {
-                    //variable = new ParsedNullableQueryStringValue(parameterType, parameterName).Variable;
-                    variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key,
-                        rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
-                    variable.Name = key;
-                    _querystringVariables.Add(variable);
-                }
-            }
-
-            if (parameterType.IsArray && RouteParameterStrategy.CanParse(parameterType.GetElementType()!))
-            {
-                variable = new ParsedArrayQueryStringValue(parameterType, key,
-                    rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
-                variable.Name = key;
-                _querystringVariables.Add(variable);
-            }
-
-            if (ParsedCollectionQueryStringValue.CanParse(parameterType))
-            {
-                variable = new ParsedCollectionQueryStringValue(parameterType, key,
-                    rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
-                variable.Name = key;
-                _querystringVariables.Add(variable);
-            }
-
-            if (RouteParameterStrategy.CanParse(parameterType))
-            {
-                //variable = new ParsedQueryStringValue(parameterType, parameterName).Variable;
-                variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, parameterName,
-                    rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
-                variable.Name = key;
                 _querystringVariables.Add(variable);
             }
         }
@@ -1051,6 +999,72 @@ public partial class HttpChain : Chain<HttpChain, ModifyHttpChainAttribute>, ICo
         {
             throw new InvalidOperationException(
                 $"The query string parameter '{key}' cannot be used for multiple target types");
+        }
+
+        return variable;
+    }
+
+    /// <summary>
+    /// Creates the reading frame + variable for a query string value WITHOUT registering it in
+    /// <c>_querystringVariables</c>. GH-4314: the postprocessor binding pass in HttpChain.Codegen.cs
+    /// needs exactly this creation logic, but that pass runs at codegen time, which is lazy — and
+    /// <c>_querystringVariables</c> feeds the OpenAPI description (fillQuerystringParameters), so
+    /// registering from codegen would make the rendered description depend on whether the chain
+    /// happened to compile before or after the ApiDescription was read.
+    /// </summary>
+    private HttpElementVariable? createQuerystringValue(Type parameterType, string parameterName, string key)
+    {
+        HttpElementVariable? variable = null;
+
+        if (parameterType == typeof(string))
+        {
+            variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key).Variable;
+            variable.Name = key;
+
+            if (variable.Usage == "tenantId")
+            {
+                variable.OverrideName("tenantIdString");
+            }
+        }
+
+        if (parameterType == typeof(string[]))
+        {
+            variable = new ParsedArrayQueryStringValue(parameterType, key).Variable;
+            variable.Name = key;
+        }
+
+        if (parameterType.IsNullable())
+        {
+            var inner = parameterType.GetInnerTypeFromNullable();
+            if (RouteParameterStrategy.CanParse(inner))
+            {
+                //variable = new ParsedNullableQueryStringValue(parameterType, parameterName).Variable;
+                variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, key,
+                    rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
+                variable.Name = key;
+            }
+        }
+
+        if (parameterType.IsArray && RouteParameterStrategy.CanParse(parameterType.GetElementType()!))
+        {
+            variable = new ParsedArrayQueryStringValue(parameterType, key,
+                rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
+            variable.Name = key;
+        }
+
+        if (ParsedCollectionQueryStringValue.CanParse(parameterType))
+        {
+            variable = new ParsedCollectionQueryStringValue(parameterType, key,
+                rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
+            variable.Name = key;
+        }
+
+        if (RouteParameterStrategy.CanParse(parameterType))
+        {
+            //variable = new ParsedQueryStringValue(parameterType, parameterName).Variable;
+            variable = new ReadHttpFrame(BindingSource.QueryString, parameterType, parameterName,
+                rejectUnparseableValue: _parent.RejectUnparseableQueryValues).Variable;
+            variable.Name = key;
         }
 
         return variable;

--- a/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
+++ b/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
@@ -110,6 +110,24 @@ public static class PostprocessorRouteCollisionRecordingEndpoint
     }
 }
 
+// GH-4314: a postprocessor [FromQuery]/[FromHeader] parameter that does NOT collide with any route
+// segment must bind from the query string / header, exactly as the OpenAPI description has claimed
+// since GH-3601. Before the fix nothing produced a variable for these parameters at all, and
+// JasperFx's name-then-type fallback silently handed `audit` the endpoint's response body — the only
+// other string in the chain — so user code documented to receive a query value received the response
+// instead. The `string` response return is deliberate bait for that fallback.
+public static class PostprocessorQueryHeaderRecordingEndpoint
+{
+    [WolverineGet("/middleware/postprocessor-query-header")]
+    public static string Get() => "ok";
+
+    public static void After(Recorder recorder, [FromQuery] string? audit, [FromQuery] int attempts,
+        [FromHeader(Name = "x-trace")] string? trace)
+    {
+        recorder.Actions.Add($"After: audit={audit ?? "null"}, attempts={attempts}, trace={trace ?? "null"}");
+    }
+}
+
 public interface IAmAuthenticated
 {
     bool Authenticated { get; set; }


### PR DESCRIPTION
Closes #4314. Follow-up to #4313 (GH-4308), which handled only the route half of the claim.

## The defect

Postprocessors (`After`/`AfterAsync`/`PostProcess`) are deliberately not run through the HTTP parameter-matching strategies — the GH-3601 invariant the OpenAPI description machinery depends on. So a postprocessor `[FromQuery]`/`[FromHeader]` parameter that does **not** collide with a route segment got no produced variable at all, and JasperFx's `MethodFrameArranger.FindVariable` fell back to name-then-type resolution: the parameter could silently bind to any unrelated variable of the same type already in the chain. The concrete instance already in tree (`PostprocessorQueryEndpoint` in `Wolverine.Http.Tests.DifferentAssembly`): OpenAPI describes `audit` as a query parameter, but the generated code passed the endpoint's **response body** (`result_of_Get`, the only `string` in the chain) into `After` as `audit`. It compiled, so nothing caught it.

## The fix

The postprocessor pass in `DetermineFrames` (added by #4313) now mirrors the full claim the description side publishes in `tryDescribePostprocessorBinding`:

1. explicit `[FromRoute(Name = ...)]` and route-claimed parameters — unchanged from #4313, with the query/header branches gated through the same case-sensitive `isBoundFromRouteValue` test the description side uses (GH-3586), so a route-claimed name still binds from the route;
2. a simple-typed `[FromQuery]` parameter gets a query string reading frame under the attribute's name (or the parameter's own);
3. a `[FromHeader]` parameter gets a header reading frame.

Per the GH-3601 compile-order invariant called out on the issue: codegen runs lazily, so the pass creates its read frames **directly**, reusing the main method's variable when it already reads the same value, and never registers into `_querystringVariables`/`_headerVariables` — those feed `fillQuerystringParameters`/`fillKnownHeaderParameters`, and registering there would make the rendered OpenAPI description depend on whether the chain compiled before or after the ApiDescription was read. The query-value creation logic is extracted out of `TryFindOrCreateQuerystringValue` into a shared non-registering helper so the two paths cannot drift. Complex `[FromQuery]` types — the flattening shape the description side also declines to describe on a postprocessor — are deliberately left alone.

## Verification

- New `WolverineWebApi` endpoint keeps `codegen preview` (and the Nuke `CodegenPreviewCommand` target) guarding the shape; the generated code now reads `audit`/`attempts` from the query string and `trace` from the header while the response body flows only to the response.
- New integration tests prove both directions: wire values reach `After`, and absent values stay absent instead of picking up the response body (the old behavior recorded `audit=ok`).
- Full `Wolverine.Http.Tests` suite: 1033 passed / 0 failed locally.
- `dotnet build wolverine.slnx -c Release -f net9.0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)