### PR TITLE
BatchedSender.QueuedCount counts up as well as down

### DIFF
--- a/src/Testing/CoreTests/Transports/Sending/BatchedSenderTests.cs
+++ b/src/Testing/CoreTests/Transports/Sending/BatchedSenderTests.cs
@@ -114,6 +114,47 @@ public class BatchedSenderTests
         sw.Elapsed.ShouldBeLessThan(500.Milliseconds());
     }
 
+    // The Channels rewrite of this pipeline kept the per-batch decrement of _queued but lost
+    // the enqueue-side increment, so QueuedCount drifted negative on every batched sender.
+    [Fact]
+    public async Task queued_count_tracks_posted_minus_flushed_envelopes()
+    {
+        var endpoint = new TcpEndpoint(2259)
+        {
+            MessageBatchSize = 100,
+            MessageBatchTimeout = 50.Milliseconds()
+        };
+
+        var gate = new TaskCompletionSource();
+        var protocol = Substitute.For<ISenderProtocol>();
+        protocol.SendBatchAsync(Arg.Any<ISenderCallback>(), Arg.Any<OutgoingMessageBatch>())
+            .Returns(_ => gate.Task);
+
+        using var sender = new BatchedSender(endpoint, protocol, CancellationToken.None, NullLogger.Instance);
+        sender.RegisterCallback(Substitute.For<ISenderCallback>());
+
+        sender.QueuedCount.ShouldBe(0);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await sender.SendAsync(Envelope.ForPing(TransportConstants.LocalUri));
+        }
+
+        // The protocol is gated, so all five envelopes are accepted but none has flushed
+        sender.QueuedCount.ShouldBe(5);
+
+        gate.SetResult();
+
+        var deadline = DateTimeOffset.UtcNow.Add(5.Seconds());
+        while (sender.QueuedCount != 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            sender.QueuedCount.ShouldBeGreaterThanOrEqualTo(0);
+            await Task.Delay(25.Milliseconds(), TestContext.Current.CancellationToken);
+        }
+
+        sender.QueuedCount.ShouldBe(0);
+    }
+
     [Fact]
     public void default_batch_timeout_is_250ms()
     {

--- a/src/Wolverine/Transports/Sending/BatchedSender.cs
+++ b/src/Wolverine/Transports/Sending/BatchedSender.cs
@@ -93,6 +93,9 @@ public class BatchedSender : ISender, ISenderRequiresCallback, IConditionalNativ
             throw new InvalidOperationException("This agent has not been started");
         }
 
+        // Paired with the per-batch decrement in SendBatchAsync's finally, so
+        // QueuedCount reflects envelopes accepted but not yet flushed to the protocol
+        Interlocked.Increment(ref _queued);
         return _serializing.PostAsync(message);
     }
 


### PR DESCRIPTION
## What

`BatchedSender._queued` was decremented per flushed batch in `SendBatchAsync`'s `finally` but never incremented anywhere, so the public `QueuedCount` diagnostic drifted increasingly negative on every batched sender.

Git archaeology: the original TPL Dataflow implementation incremented `_queued` as batches formed and derived `QueuedCount` as `_queued + _batching.ItemCount + _serializing.InputCount`. The switch-to-Channels rewrite kept only the decrement.

## The fix

`SendAsync` now does an `Interlocked.Increment` per accepted envelope, pairing with the existing per-batch `Interlocked.Add(-batch.Messages.Count)`. `QueuedCount` is now a true posted-minus-flushed gauge covering the serializing, batching, and in-flight-send stages — no block internals consulted, no allocation on the hot path.

There are no in-repo readers of `BatchedSender.QueuedCount` today (the `{QueuedCount}` log in `RecoverIncomingMessagesCommand` reads the *listener* circuit's `QueueCount`, which is unrelated and healthy), so this is a fix to the public diagnostic surface only.

## Test

`queued_count_tracks_posted_minus_flushed_envelopes` gates the `ISenderProtocol` on a `TaskCompletionSource`, posts five envelopes, asserts the count sits at exactly 5 (deterministic: the increment is synchronous and the gated protocol blocks the only decrement), then releases the gate and drains to zero, asserting the count never goes negative along the way.

Known edges left as-is: `PingAsync` bypasses the pipeline entirely (touches the counter on neither side), and `SendBatchAsync`'s early return under a cancelled token skips the decrement — the count can stay elevated during shutdown teardown of a sender that is being disposed anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)