### PR TITLE
GH-4316: recovery poll and handled-cleanup get indexes they can actually use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,22 @@
 
 ### WolverineFx.RDBMS (all relational providers)
 
+- **The durability recovery poll and expired-handled cleanup finally have indexes they can use.**
+  (closes [#4316](https://github.com/JasperFx/wolverine/issues/4316)) The GH-3971 owner index is
+  partial on `owner_id <> 0` -- and `owner_id = 0` is exactly what the 5-second recovery poll, the
+  per-listener recovery page load, and the outgoing recovery poll all ask for, so every polling
+  cycle was a full scan of an inbox dominated by retained Handled rows, per database, per node. The
+  60-second expired-handled cleanup (`status = 'Handled' and keep_until <= now`) had no supporting
+  index at all. PostgreSQL and SQL Server now provision partial/filtered indexes for the recoverable
+  slices (`received_at where status = 'Incoming' and owner_id = 0`, `keep_until where
+  status = 'Handled'`, and `destination where owner_id = 0` on the outbox); on a 2-million-row test
+  inbox the recovery poll went from a 37ms parallel seq scan touching ~25k buffers to a 0.04ms
+  index-only scan touching 2, and both degrade to an empty index read when there is nothing to
+  recover. MySQL and Oracle already carried a plain owner index the `owner_id = 0` equality can use.
+  The database queue transports' anti-duplicate delete also now scopes its inbox probe to the rows
+  this queue's own pop could have stranded (`received_at = <queue address>`) instead of correlating
+  against the entire inbox.
+
 - **The advisory lock no longer shares one connection with nothing guarding it.** (closes
   [#4261](https://github.com/JasperFx/wolverine/issues/4261)) Every `AdvisoryLock` implementation --
   Postgres, SQL Server, MySQL, Oracle and SQLite -- kept one long-lived connection and synchronised

--- a/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueueListener.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/Transport/MySqlQueueListener.cs
@@ -268,8 +268,12 @@ WHERE id IN (SELECT id FROM temp_move_{_queueName})");
                 return cmd;
             }
 
-            // First, delete any messages that are already in the incoming table (deduplication)
-            await using var dedupCmd = CreateCmd($"DELETE FROM {_queueTableName} WHERE id IN (SELECT id FROM {_schemaName}.{DatabaseConstants.IncomingTable})");
+            // First, delete any messages that are already in the incoming table (deduplication).
+            // GH-4316: rows this can legitimately hit were put in the inbox by this queue's own
+            // earlier pop, which always stamps received_at with this listener's address — scope
+            // the probe instead of correlating against the entire inbox.
+            await using var dedupCmd = CreateCmd($"DELETE FROM {_queueTableName} WHERE id IN (SELECT id FROM {_schemaName}.{DatabaseConstants.IncomingTable} WHERE {DatabaseConstants.ReceivedAt} = @receivedAt)");
+            dedupCmd.Parameters.AddWithValue("@receivedAt", Address.ToString());
             await dedupCmd.ExecuteNonQueryAsync(cancellationToken);
 
             // Create temp table for this operation

--- a/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueueListener.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/Transport/OracleQueueListener.cs
@@ -267,8 +267,12 @@ internal class OracleQueueListener : IListener
                 return cmd;
             }
 
-            // First, delete any messages that are already in the incoming table (deduplication)
-            await using var dedupCmd = CreateCmd($"DELETE FROM {_queueTableName} WHERE id IN (SELECT id FROM {_schemaName}.{DatabaseConstants.IncomingTable})");
+            // First, delete any messages that are already in the incoming table (deduplication).
+            // GH-4316: rows this can legitimately hit were put in the inbox by this queue's own
+            // earlier pop, which always stamps received_at with this listener's address — scope
+            // the probe instead of correlating against the entire inbox.
+            await using var dedupCmd = CreateCmd($"DELETE FROM {_queueTableName} WHERE id IN (SELECT id FROM {_schemaName}.{DatabaseConstants.IncomingTable} WHERE {DatabaseConstants.ReceivedAt} = :receivedAt)");
+            dedupCmd.With("receivedAt", Address.ToString());
             await dedupCmd.ExecuteNonQueryAsync(cancellationToken);
 
             // Select messages to process with lock

--- a/src/Persistence/PostgresqlTests/EnvelopeTables_recovery_index_creation.cs
+++ b/src/Persistence/PostgresqlTests/EnvelopeTables_recovery_index_creation.cs
@@ -1,0 +1,81 @@
+using IntegrationTests;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Wolverine;
+using Wolverine.Postgresql.Schema;
+using Wolverine.RDBMS;
+
+namespace PostgresqlTests;
+
+// GH-4316: the 5-second recovery poll and the per-listener recovery load ask for
+// `owner_id = 0` — exactly the value the GH-3971 owner index excludes — and the expired-handled
+// cleanup filters on `status = 'Handled' and keep_until <= now` with no index at all, so all of
+// them were full scans of an inbox dominated by retained Handled rows. The envelope tables now
+// provision partial indexes for the recoverable and expired-handled slices. These tests prove the
+// indexes are created AND that their compound predicates round-trip through pg_get_indexdef so a
+// subsequent migration reports no drift (a mismatched predicate would make Weasel drop+recreate
+// the index on every startup).
+public class EnvelopeTables_recovery_index_creation : IAsyncLifetime
+{
+    private NpgsqlConnection theConnection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theConnection = new NpgsqlConnection(Servers.PostgresConnectionString);
+        await theConnection.OpenAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theConnection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task incoming_recovery_indexes_are_created_and_stable()
+    {
+        await theConnection.ResetSchemaAsync("env_idx_incoming", ct: TestContext.Current.CancellationToken);
+
+        var table = new IncomingEnvelopeTable(new DurabilitySettings(), "env_idx_incoming");
+
+        table.Indexes.ShouldContain(x => x.Name.Contains("recover"));
+        table.Indexes.ShouldContain(x => x.Name.Contains("keep_until"));
+
+        await table.ApplyChangesAsync(theConnection, ct: TestContext.Current.CancellationToken);
+
+        // Re-reading the just-created schema must report NO difference. If a partial-index
+        // predicate did not round-trip, this would come back as Update and thrash on every startup.
+        var delta = await table.FindDeltaAsync(theConnection, TestContext.Current.CancellationToken);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task incoming_recovery_indexes_are_stable_with_inbox_partitioning()
+    {
+        await theConnection.ResetSchemaAsync("env_idx_part", ct: TestContext.Current.CancellationToken);
+
+        var durability = new DurabilitySettings { EnableInboxPartitioning = true };
+        var table = new IncomingEnvelopeTable(durability, "env_idx_part");
+
+        await table.ApplyChangesAsync(theConnection, ct: TestContext.Current.CancellationToken);
+
+        var delta = await table.FindDeltaAsync(theConnection, TestContext.Current.CancellationToken);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task outgoing_recovery_index_is_created_and_stable()
+    {
+        await theConnection.ResetSchemaAsync("env_idx_outgoing", ct: TestContext.Current.CancellationToken);
+
+        var table = new OutgoingEnvelopeTable(new DurabilitySettings(), "env_idx_outgoing");
+
+        table.Indexes.ShouldContain(x => x.Name.Contains("recover"));
+
+        await table.ApplyChangesAsync(theConnection, ct: TestContext.Current.CancellationToken);
+
+        var delta = await table.FindDeltaAsync(theConnection, TestContext.Current.CancellationToken);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Persistence/SqlServerTests/EnvelopeTables_recovery_index_creation.cs
+++ b/src/Persistence/SqlServerTests/EnvelopeTables_recovery_index_creation.cs
@@ -1,0 +1,68 @@
+using IntegrationTests;
+using Microsoft.Data.SqlClient;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer;
+using Wolverine;
+using Wolverine.RDBMS;
+using Wolverine.SqlServer.Schema;
+
+namespace SqlServerTests;
+
+// GH-4316: the 5-second recovery poll and the per-listener recovery load ask for
+// `owner_id = 0` — exactly the value the GH-3971 owner index excludes — and the expired-handled
+// cleanup filters on `status = 'Handled' and keep_until <= now` with no index at all, so all of
+// them were full scans of an inbox dominated by retained Handled rows. The envelope tables now
+// provision filtered indexes for the recoverable and expired-handled slices. These tests prove the
+// indexes are created AND that their compound filter predicates round-trip through sys.indexes
+// (SqlServer stores e.g. `([status]='Incoming' AND [owner_id]=(0))`, which must canonicalize back
+// to the configured predicate or Weasel drops+recreates the index on every startup).
+[Collection("sqlserver")]
+public class EnvelopeTables_recovery_index_creation : IAsyncLifetime
+{
+    private SqlConnection theConnection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theConnection = new SqlConnection(Servers.SqlServerConnectionString);
+        await theConnection.OpenAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theConnection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task incoming_recovery_indexes_are_created_and_stable()
+    {
+        await theConnection.ResetSchemaAsync("env_idx_incoming", ct: TestContext.Current.CancellationToken);
+
+        var table = new IncomingEnvelopeTable(new DurabilitySettings(), "env_idx_incoming");
+
+        table.Indexes.ShouldContain(x => x.Name.Contains("recover"));
+        table.Indexes.ShouldContain(x => x.Name.Contains("keep_until"));
+
+        await table.ApplyChangesAsync(theConnection, ct: TestContext.Current.CancellationToken);
+
+        // Re-reading the just-created schema must report NO difference. If a filtered-index
+        // predicate did not round-trip, this would come back as Update and thrash on every startup.
+        var delta = await table.FindDeltaAsync(theConnection, TestContext.Current.CancellationToken);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task outgoing_recovery_index_is_created_and_stable()
+    {
+        await theConnection.ResetSchemaAsync("env_idx_outgoing", ct: TestContext.Current.CancellationToken);
+
+        var table = new OutgoingEnvelopeTable(new DurabilitySettings(), "env_idx_outgoing");
+
+        table.Indexes.ShouldContain(x => x.Name.Contains("recover"));
+
+        await table.ApplyChangesAsync(theConnection, ct: TestContext.Current.CancellationToken);
+
+        var delta = await table.FindDeltaAsync(theConnection, TestContext.Current.CancellationToken);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/Schema/IncomingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Schema/IncomingEnvelopeTable.cs
@@ -59,5 +59,26 @@ internal class IncomingEnvelopeTable : Table
             Predicate = $"{DatabaseConstants.OwnerId} <> 0"
         });
 
+        // GH-4316: the owner index above deliberately excludes owner_id = 0, but that is exactly
+        // what the 5-second recovery poll asks for (`status = 'Incoming' and owner_id = 0 group by
+        // received_at`) and what the per-listener recovery page load filters on — so recovery was
+        // a full scan of an inbox dominated by retained Handled rows, every cycle, per database,
+        // per node. Partial on the recoverable predicate so the index holds only unowned incoming
+        // rows and the poll degrades to an empty index-only scan when there is nothing to recover.
+        Indexes.Add(new IndexDefinition(PostgresqlIdentifier.Shorten($"idx_{DatabaseConstants.IncomingTable}_recover"))
+        {
+            Columns = [DatabaseConstants.ReceivedAt],
+            Predicate = $"{DatabaseConstants.Status} = 'Incoming' AND {DatabaseConstants.OwnerId} = 0"
+        });
+
+        // GH-4316: the 60-second expired-handled cleanup probes `status = 'Handled' and
+        // keep_until <= now`, which had no supporting index — a full scan of the largest slice of
+        // the inbox on every cycle. Partial on the Handled slice so the probe only ever touches
+        // rows the sweep could delete.
+        Indexes.Add(new IndexDefinition(PostgresqlIdentifier.Shorten($"idx_{DatabaseConstants.IncomingTable}_keep_until"))
+        {
+            Columns = [DatabaseConstants.KeepUntil],
+            Predicate = $"{DatabaseConstants.Status} = 'Handled'"
+        });
     }
 }

--- a/src/Persistence/Wolverine.Postgresql/Schema/OutgoingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.Postgresql/Schema/OutgoingEnvelopeTable.cs
@@ -37,5 +37,14 @@ internal class OutgoingEnvelopeTable : Table
             Predicate = $"{DatabaseConstants.OwnerId} <> 0"
         });
 
+        // GH-4316: the outgoing recovery poll (`select distinct destination where owner_id = 0`)
+        // and the per-destination recovery load ask for exactly the value the owner index above
+        // excludes, so both were full scans every 5-second cycle. Partial on unowned rows so the
+        // poll reads only what is actually recoverable.
+        Indexes.Add(new IndexDefinition(PostgresqlIdentifier.Shorten($"idx_{DatabaseConstants.OutgoingTable}_recover"))
+        {
+            Columns = [DatabaseConstants.Destination],
+            Predicate = $"{DatabaseConstants.OwnerId} = 0"
+        });
     }
 }

--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
@@ -203,7 +203,11 @@ SELECT message.{DatabaseConstants.Body} from message;
     {
         var builder = new BatchBuilder();
 
-        builder.Append($"delete FROM {_queueTableName} where id in (select id from {_quotedSchemaName}.{DatabaseConstants.IncomingTable})");
+        // GH-4316: rows this anti-duplicate delete can legitimately hit were put in the inbox by
+        // this queue's own earlier pop (a crash between the inbox INSERT below and the queue
+        // DELETE), and that INSERT always stamps received_at with this listener's address — so
+        // scope the probe instead of correlating against the entire inbox.
+        builder.Append($"delete FROM {_queueTableName} where id in (select id from {_quotedSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.ReceivedAt} = '{Address}')");
         builder.StartNewCommand();
         builder.Append($"create temporary table temp_pop_{_queueName} ON COMMIT DROP as select id, body, message_type, keep_until from {_queueTableName} ORDER BY {_queueTableName}.timestamp limit ");
         builder.AppendParameter(count);

--- a/src/Persistence/Wolverine.SqlServer/Schema/IncomingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Schema/IncomingEnvelopeTable.cs
@@ -46,5 +46,26 @@ internal class IncomingEnvelopeTable : Table
             Predicate = $"[{DatabaseConstants.OwnerId}]<>0"
         });
 
+        // GH-4316: the owner index above deliberately excludes owner_id = 0, but that is exactly
+        // what the 5-second recovery poll asks for (`status = 'Incoming' and owner_id = 0 group by
+        // received_at`) and what the per-listener recovery page load filters on — so recovery was
+        // a full scan of an inbox dominated by retained Handled rows, every cycle, per database,
+        // per node. Filtered on the recoverable predicate so the index holds only unowned incoming
+        // rows and the poll degrades to an empty index seek when there is nothing to recover.
+        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.IncomingTable}_recover")
+        {
+            Columns = [DatabaseConstants.ReceivedAt],
+            Predicate = $"[{DatabaseConstants.Status}]='Incoming' AND [{DatabaseConstants.OwnerId}]=0"
+        });
+
+        // GH-4316: the 60-second expired-handled cleanup probes `status = 'Handled' and
+        // keep_until <= now`, which had no supporting index — a full scan of the largest slice of
+        // the inbox on every cycle. Filtered on the Handled slice so the probe only ever touches
+        // rows the sweep could delete.
+        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.IncomingTable}_keep_until")
+        {
+            Columns = [DatabaseConstants.KeepUntil],
+            Predicate = $"[{DatabaseConstants.Status}]='Handled'"
+        });
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Schema/OutgoingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Schema/OutgoingEnvelopeTable.cs
@@ -35,5 +35,14 @@ internal class OutgoingEnvelopeTable : Table
             Predicate = $"[{DatabaseConstants.OwnerId}]<>0"
         });
 
+        // GH-4316: the outgoing recovery poll (`select distinct destination where owner_id = 0`)
+        // and the per-destination recovery load ask for exactly the value the owner index above
+        // excludes, so both were full scans every 5-second cycle. Filtered on unowned rows so the
+        // poll reads only what is actually recoverable.
+        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.OutgoingTable}_recover")
+        {
+            Columns = [DatabaseConstants.Destination],
+            Predicate = $"[{DatabaseConstants.OwnerId}]=0"
+        });
     }
 }

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
@@ -412,7 +412,7 @@ DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
 IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
 SET NOCOUNT ON;
 
-delete FROM {QueueTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK) where id in (select id from {Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable});
+delete FROM {QueueTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK) where id in (select id from {Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.ReceivedAt} = '{Uri}');
 select top(@count) id, body, message_type, keep_until into #temp_pop_{Name}
 FROM {QueueTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK)
 ORDER BY {QueueTable.Identifier}.{orderBy};

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
@@ -77,7 +77,7 @@ DECLARE @NOCOUNT VARCHAR(3) = 'OFF';
 IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
 SET NOCOUNT ON;
 
-delete FROM {queueTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK) where id in (select id from {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable});
+delete FROM {queueTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK) where id in (select id from {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.ReceivedAt} = '{Address}');
 select top(@count) id, body, message_type, keep_until into #temp_pop_{queue.Name}
 FROM {queueTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK)
 ORDER BY {queueTableIdentifier}.{orderBy};


### PR DESCRIPTION
Closes #4316. From the 2026-09-05 hot-path performance audit.

## What

**Indexes (PostgreSQL + SQL Server).** The GH-3971 owner index is partial on `owner_id <> 0` — and `owner_id = 0` is exactly what the 5-second recovery poll, the per-listener recovery page load, and the outgoing recovery poll ask for, so every polling cycle was a full scan of an inbox dominated by retained Handled rows, per database, per node. The 60-second expired-handled cleanup (`status = 'Handled' and keep_until <= now`) had no supporting index at all. Both providers now provision:

- incoming: partial on `received_at where status = 'Incoming' and owner_id = 0` (recovery poll + page load)
- incoming: partial on `keep_until where status = 'Handled'` (expired-handled cleanup)
- outgoing: partial on `destination where owner_id = 0` (outgoing recovery)

MySQL and Oracle already carry a plain (unfiltered) owner index the `owner_id = 0` equality can use, so they only get the query change below.

**Query scoping (all four DB-queue providers).** The durable pop's anti-duplicate delete correlated the queue table against the *entire* inbox (`id in (select id from wolverine_incoming)`). The only rows it can legitimately hit are ones this queue's own crashed pop stranded, and the pop always stamps `received_at` with the listener address — so the probe is now scoped to `received_at = <queue address>`, matching each path's own INSERT stamp exactly (interpolated `Address`/`Uri` on PG/SQL Server, parameterized `Address.ToString()` on MySQL/Oracle).

## Measured (docker PostgreSQL, 2M-row inbox, `EXPLAIN (ANALYZE, BUFFERS)`)

| query | before | after |
|---|---|---|
| recovery poll | parallel seq scan, **37.3 ms**, 24,835 buffers | index-only scan, **0.04 ms**, 2 buffers |
| handled-cleanup probe | parallel seq scan, **44.4 ms**, 24,749 buffers | index scan, **0.04 ms**, 3 buffers |

Both degrade to an empty index read when there is nothing to recover — the common case, 12×/minute.

Honest note on the delete scoping: EXPLAIN showed the unscoped anti-dup delete was already a per-queue-row PK probe (0.4 ms), *not* the full-inbox semi-join it reads as — so that part is a strictly-tighter-and-plan-proof hardening, not a headline win. The remaining per-poll costs there (temp table per pop, unbounded scheduled move) are tracked in #4334.

## Migration-thrash safety

New `EnvelopeTables_recovery_index_creation` tests on both providers mirror the GH-3279 `DeadLetterTable_index_creation` pattern: apply the table, assert the indexes exist, and assert `FindDeltaAsync` reports `None` — a compound partial/filtered predicate that failed to round-trip through `pg_get_indexdef` / `sys.indexes` would fail the build instead of drop+recreating the index on every application start. Includes the partitioned-inbox variant on PostgreSQL. SQL Server's normalized `filter_definition` (`([status]='Incoming' AND [owner_id]=(0))`) was verified to canonicalize back to the configured predicate.

## Testing

- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- PostgresqlTests (index creation + Transport basic_functionality + PostgresqlQueueTests): 28/28
- SqlServerTests (index creation + Transport data_operations + SqlServerQueueTests): 18/18
- MySqlTests (Transport basic_functionality): 15/15
- Oracle: compile-verified only — no local Oracle container; the change is the same self-consistent one-line predicate scoping as MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)