### PR TITLE
OTel: the executing span covers a handler's full async execution, not just its synchronous prefix

### DIFF
--- a/src/Testing/CoreTests/Runtime/executing_activity_spans_async_handler.cs
+++ b/src/Testing/CoreTests/Runtime/executing_activity_spans_async_handler.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Tracking;
+using Wolverine.Util;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+// The 2-arg HandlerPipeline.InvokeAsync is synchronous and starts the executing activity
+// before handing off to the async 3-arg overload. When the activity was held in a `using`
+// declaration there, it was disposed -- and therefore stopped -- at the inner overload's
+// first suspension point, so the execution span only ever covered the synchronous prefix
+// of message processing and none of a handler's actual async work. These tests pin the
+// span to the handler's full execution.
+public class executing_activity_spans_async_handler : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private readonly List<Activity> _capturedActivities = new();
+    private ActivityListener _listener = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Wolverine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                lock (_capturedActivities)
+                {
+                    _capturedActivities.Add(activity);
+                }
+            }
+        };
+        ActivitySource.AddActivityListener(_listener);
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _listener.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task execution_span_duration_covers_the_await_in_an_async_handler()
+    {
+        // Send (not invoke) so the message travels through the local queue's receiver and
+        // the synchronous 2-arg HandlerPipeline.InvokeAsync -- the path where the premature
+        // disposal lived. Executor.InvokeInlineAsync never had the defect.
+        //
+        // The first message pays for building and compiling the executor *inside* the
+        // executing span's synchronous prefix, which is easily hundreds of milliseconds and
+        // would let a truncated span still look "long enough". Warm up first, then measure
+        // the second message, whose synchronous prefix is trivial.
+        await _host.SendMessageAndWaitAsync(new SlowTracedMessage());
+
+        lock (_capturedActivities)
+        {
+            _capturedActivities.Clear();
+        }
+
+        await _host.SendMessageAndWaitAsync(new SlowTracedMessage());
+
+        // Give a moment for activities to be captured
+        await Task.Delay(100.Milliseconds(), TestContext.Current.CancellationToken);
+
+        List<Activity> executing;
+        lock (_capturedActivities)
+        {
+            executing = _capturedActivities
+                .Where(a => a.OperationName == typeof(SlowTracedMessage).ToMessageTypeName())
+                .ToList();
+        }
+
+        var activity = executing.Single();
+
+        // A little slack under the handler's 250ms delay to keep timer resolution out of the
+        // assertion. The truncated shape stopped the span at the first suspension point, which
+        // on a warmed-up executor is effectively immediate.
+        activity.Duration.ShouldBeGreaterThan(200.Milliseconds());
+
+        // And the span must not have ended before the handler finished.
+        (activity.StartTimeUtc + activity.Duration).ShouldBeGreaterThanOrEqualTo(
+            SlowTracedMessageHandler.LastCompletedUtc.UtcDateTime);
+    }
+}
+
+public record SlowTracedMessage;
+
+public static class SlowTracedMessageHandler
+{
+    public static DateTimeOffset LastCompletedUtc;
+
+    public static async Task Handle(SlowTracedMessage message)
+    {
+        await Task.Delay(250.Milliseconds());
+        LastCompletedUtc = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -64,7 +64,11 @@ public class HandlerPipeline : IHandlerPipeline
             return Task.CompletedTask;
         }
 
-        using var activity = TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
+        // NOT a `using` declaration: this method is synchronous, so a `using` would dispose --
+        // and therefore Stop() -- the activity as soon as the async overload below hits its
+        // first suspension point, truncating the execution span to the synchronous prefix of
+        // message processing. The 3-arg overload's finally owns the Stop.
+        var activity = TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
 
         // No runtime check for HandlerExecutionDiagnosticsEnabled — diagnostic tag
         // stamping is baked into the generated handler chain via
@@ -75,13 +79,15 @@ public class HandlerPipeline : IHandlerPipeline
 
     public async Task InvokeAsync(Envelope envelope, IChannelCallback channel, Activity? activity)
     {
-        if (_cancellation.IsCancellationRequested)
-        {
-            return;
-        }
-
         try
         {
+            // Inside the try so the early return still stops the activity in the finally;
+            // the 2-arg overload above relies on this method to stop what it started.
+            if (_cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+
             var context = _contextPool.Get();
             context.ReadEnvelope(envelope, channel);
 


### PR DESCRIPTION
## The defect

The 2-arg `HandlerPipeline.InvokeAsync(Envelope, IChannelCallback)` is **synchronous** but declared the executing activity with `using var`:

```csharp
using var activity = TelemetryEnabled ? WolverineTracing.StartExecuting(envelope) : null;
return InvokeAsync(envelope, channel, activity);
```

Because the method is synchronous, the `using` disposed the `Activity` as soon as the async 3-arg overload returned its `Task` — i.e. at its **first suspension point**. `Activity.Dispose()` calls `Stop()`, so the handler-execution span's duration was truncated to the synchronous prefix of message execution, and the `finally { activity?.Stop(); }` at the end of the 3-arg overload was a no-op. On a warmed-up pipeline that prefix is effectively zero; on a cold one it is mostly executor build + codegen — so the span that claimed to measure handler execution was really measuring everything *except* the handler's async work.

Every receive path that goes through the 2-arg overload was affected: the buffered, durable, and native-ack receivers, `StubEndpoint`, and the Kafka/Pulsar replay loops.

## The fix

- Dropped the `using`; the 3-arg overload's `finally` owns the `Stop()`, which it already did on paper.
- Moved the 3-arg overload's cancellation early-return inside its `try/finally`, so a shutdown race between the two overloads' cancellation checks cannot leave a started activity unstopped (an unstopped activity also pollutes `Activity.Current` on that async context).

## Audit of the other span-start sites

Checked every `StartExecuting`/`StartReceiving`/`StartSending` call site in `src/Wolverine` and `src/Transports`: `DurableReceiver`, `InlineReceiver`, `Executor.InvokeInlineAsync`, `TracingExecutor`, the sending agents, and `Envelope.Internals` all start their activities inside genuinely `async` methods (disposal runs after the awaits), and `BufferedReceiver.Enqueue`/`NativeAckReceiver` use intentional short enqueue spans with explicit `Stop()`. This was the only site with the sync-method-returning-a-Task shape.

## The test

`CoreTests/Runtime/executing_activity_spans_async_handler.cs` captures Wolverine activities with an `ActivityListener`, sends a message whose handler awaits `Task.Delay(250ms)` through the local-queue receiver (the defective path — `InvokeAsync` on the bus never had the defect), and asserts the executing span outlasts the handler's await and does not end before the handler's recorded completion timestamp.

One trap worth calling out: a naive version of this test **passes against the broken code**, because the first message's executor build + codegen (~450ms measured) lands inside the span's synchronous prefix and makes even the truncated span look long. The test therefore sends a warm-up message first and measures the second. Verified red with the `using` reintroduced, green with the fix.

## Verification

- New test red-on-bug / green-on-fix, plus all 53 tracing-related CoreTests green
- Full CoreTests suite: 2,819 passed, 0 failed
- `dotnet build wolverine.slnx -c Release -f net9.0` clean, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)