### PR TITLE
GH-4326: DateTimeOffset.Now is gone from the per-message paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### WolverineFx (core)
 
+- **`DateTimeOffset.Now` is gone from the per-message paths.** (closes
+  [#4326](https://github.com/JasperFx/wolverine/issues/4326)) `BufferedReceiver`, `NativeAckReceiver`,
+  and `BufferedLocalQueue.EnqueueDirectly` — the last of these the highest-frequency call site in the
+  process — stamped receipt and evaluated scheduled-for-later with `DateTimeOffset.Now`, which pays a
+  `TimeZoneInfo.Local` offset resolution on every read, while `DurableReceiver`, `InlineReceiver`, and
+  the neighbouring line in the same file used `UtcNow`. Every comparison downstream is offset-aware, so
+  the swap is behaviorally free. The sweep also covers `Envelope.IsExpired()`, the `ScheduleDelay`
+  setter, the RabbitMQ TTL computation, `WolverineNode.LastHealthCheck`, and the in-memory scheduled
+  job processor — shipped Wolverine code no longer calls `DateTimeOffset.Now` anywhere.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqEnvelopeMapper.cs
@@ -56,7 +56,7 @@ public class RabbitMqEnvelopeMapper : EnvelopeMapper<IReadOnlyBasicProperties, I
         {
             if (e.DeliverBy.HasValue)
             {
-                var ttl = Convert.ToInt32(e.DeliverBy.Value.Subtract(DateTimeOffset.Now).TotalMilliseconds);
+                var ttl = Convert.ToInt32(e.DeliverBy.Value.Subtract(DateTimeOffset.UtcNow).TotalMilliseconds);
                 props.Expiration = ttl.ToString();
             }
         });

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -421,7 +421,7 @@ public partial class Envelope : IHasTenantId
     /// <returns></returns>
     public Envelope ScheduleDelayed(TimeSpan delay)
     {
-        ScheduledTime = DateTimeOffset.Now.Add(delay);
+        ScheduledTime = DateTimeOffset.UtcNow.Add(delay);
         return this;
     }
     
@@ -532,7 +532,7 @@ public partial class Envelope : IHasTenantId
     /// <returns></returns>
     public bool IsExpired()
     {
-        return DeliverBy.HasValue && DeliverBy <= DateTimeOffset.Now;
+        return DeliverBy.HasValue && DeliverBy <= DateTimeOffset.UtcNow;
     }
 
     internal string GetMessageTypeName()

--- a/src/Wolverine/Runtime/Agents/WolverineNode.cs
+++ b/src/Wolverine/Runtime/Agents/WolverineNode.cs
@@ -19,7 +19,7 @@ public class WolverineNode
     
     public List<Uri> ActiveAgents { get; set; } = new();
     public DateTimeOffset Started { get; set; }
-    public DateTimeOffset LastHealthCheck { get; set; } = DateTimeOffset.Now;
+    public DateTimeOffset LastHealthCheck { get; set; } = DateTimeOffset.UtcNow;
     
     public bool IsLeader()
     {

--- a/src/Wolverine/Runtime/Scheduled/InMemoryScheduledJobProcessor.cs
+++ b/src/Wolverine/Runtime/Scheduled/InMemoryScheduledJobProcessor.cs
@@ -104,7 +104,7 @@ public class InMemoryScheduledJobProcessor : IScheduledJobProcessor
                 _task = Task.Delay(delayTime, _cancellation.Token).ContinueWith(_ => publish(), TaskScheduler.Default);
             }
 
-            ReceivedAt = DateTimeOffset.Now;
+            ReceivedAt = DateTimeOffset.UtcNow;
         }
 
         public DateTimeOffset ExecutionTime { get; }

--- a/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/BufferedReceiver.cs
@@ -321,7 +321,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
 
     async ValueTask IReceiver.ReceivedAsync(IListener listener, Envelope[] messages)
     {
-        var now = DateTimeOffset.Now;
+        var now = DateTimeOffset.UtcNow;
 
         if (_settings.Cancellation.IsCancellationRequested)
         {
@@ -344,7 +344,7 @@ internal class BufferedReceiver : ILocalQueue, IChannelCallback, ISupportNativeS
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
-        var now = DateTimeOffset.Now;
+        var now = DateTimeOffset.UtcNow;
         envelope.MarkReceived(listener, now, _settings, _endpoint.WireTap);
 
         if (envelope.IsExpired())

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -185,7 +185,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
             throw new OperationCanceledException();
         }
 
-        var now = DateTimeOffset.Now;
+        var now = DateTimeOffset.UtcNow;
         stampReceipt(now);
 
         // GH-4091. TWO passes, deliberately. Posting blocks once the execution block is at capacity, so a
@@ -210,7 +210,7 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
 
     public async ValueTask ReceivedAsync(IListener listener, Envelope envelope)
     {
-        var now = DateTimeOffset.Now;
+        var now = DateTimeOffset.UtcNow;
         stampReceipt(now);
 
         if (await admitAsync(listener, envelope, now).ConfigureAwait(false) is { } entry)

--- a/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/BufferedLocalQueue.cs
@@ -115,7 +115,7 @@ internal class BufferedLocalQueue : BufferedReceiver, ISendingAgent, IListenerCi
         _messageTracker.Sent(envelope);
         envelope.ReplyUri = envelope.ReplyUri ?? ReplyUri;
 
-        if (envelope.IsScheduledForLater(DateTimeOffset.Now))
+        if (envelope.IsScheduledForLater(DateTimeOffset.UtcNow))
         {
             ScheduleExecution(envelope);
         }


### PR DESCRIPTION
Closes #4326. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

`DateTimeOffset.Now` pays a `TimeZoneInfo.Local` offset resolution on every read — several times the cost of `UtcNow` — and the per-message receive paths were split down the middle: `BufferedReceiver`, `NativeAckReceiver`, and `BufferedLocalQueue.EnqueueDirectly` (the highest-frequency call site in the process — every local/cascading message) used `.Now`, while `DurableReceiver`, `InlineReceiver`, and even the neighbouring line 30 lines up in the same `BufferedLocalQueue` used `.UtcNow`. Clear drift, not intent.

Every downstream consumer (`MarkReceived`, `IsScheduledForLater`, TTL subtraction, staleness comparisons) compares `DateTimeOffset` values, which is offset-aware — same instant, same behavior. The only observable difference is the offset representation carried by stored values (+00:00 instead of local), which every comparison and the wire format (`ToUniversalTime` on serialization) already normalize.

Swept all ten remaining sites so shipped Wolverine code no longer calls `DateTimeOffset.Now` at all: the three receivers, `Envelope.IsExpired()`, the `ScheduleDelay` setter, the RabbitMQ `DeliverBy` TTL computation, `WolverineNode.LastHealthCheck`'s default, and `InMemoryScheduledJobProcessor`.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- CoreTests scheduled/expiry/DeliverBy slice: 48/48

🤖 Generated with [Claude Code](https://claude.com/claude-code)