### PR TITLE
GH-4324: metric accumulator lookups stop scanning; destination classification is cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### WolverineFx (core)
 
+- **Metric accumulator lookups stop scanning; destination classification is cached.** (closes
+  [#4324](https://github.com/JasperFx/wolverine/issues/4324)) `MetricsAccumulator.FindAccumulator`
+  ran 2-4x per message on the CritterWatch/Hybrid metrics modes and scanned the whole
+  (message type x destination) accumulator array with an ordinal string compare plus a full
+  component-wise `Uri.Equals` per entry; lookups now go through a copy-on-write `ImHashMap` trie
+  keyed message-type-then-Uri, with the immutable array kept solely for the export loop's
+  iteration. On the same paths, `IsSystemEndpoint` re-ran a `ToString()` substring scan and the
+  external-destination gate re-ran two case-insensitive scheme compares per message — both are pure
+  functions of a destination Uri drawn from a small bounded set and are now answered by one cached
+  classification probe.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,6 @@
 
 ### WolverineFx (core)
 
-- **Metric accumulator lookups stop scanning; destination classification is cached.** (closes
-  [#4324](https://github.com/JasperFx/wolverine/issues/4324)) `MetricsAccumulator.FindAccumulator`
-  ran 2-4x per message on the CritterWatch/Hybrid metrics modes and scanned the whole
-  (message type x destination) accumulator array with an ordinal string compare plus a full
-  component-wise `Uri.Equals` per entry; lookups now go through a copy-on-write `ImHashMap` trie
-  keyed message-type-then-Uri, with the immutable array kept solely for the export loop's
-  iteration. On the same paths, `IsSystemEndpoint` re-ran a `ToString()` substring scan and the
-  external-destination gate re-ran two case-insensitive scheme compares per message — both are pure
-  functions of a destination Uri drawn from a small bounded set and are now answered by one cached
-  classification probe.
 - **The execution pipeline sheds four per-message costs.** (closes
   [#4322](https://github.com/JasperFx/wolverine/issues/4322)) `Executor.ExecuteAsync` (and its
   tracing twin) allocated a timeout `CancellationTokenSource` — timer registration included — plus a

--- a/src/Testing/CoreTests/Runtime/Metrics/MetricsAccumulatorLookupTests.cs
+++ b/src/Testing/CoreTests/Runtime/Metrics/MetricsAccumulatorLookupTests.cs
@@ -1,0 +1,81 @@
+using CoreTests.Runtime;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Metrics;
+using Xunit;
+
+namespace CoreTests.Runtime.Metrics;
+
+// GH-4324: FindAccumulator moved from a linear scan (string compare + full Uri.Equals per entry,
+// per message) to an ImHashMap lookup, and the per-destination system/external classification is
+// now cached per Uri. These tests pin the identity semantics the swap must preserve.
+public class MetricsAccumulatorLookupTests
+{
+    private readonly MetricsAccumulator theAccumulator = new(new MockWolverineRuntime());
+
+    [Fact]
+    public void same_message_type_and_destination_return_the_same_accumulator()
+    {
+        var one = theAccumulator.FindAccumulator("MyApp.MyMessage", new Uri("tcp://localhost:5000"));
+        var two = theAccumulator.FindAccumulator("MyApp.MyMessage", new Uri("tcp://localhost:5000"));
+
+        // Distinct-but-equal Uri instances must land on the same accumulator (value equality)
+        two.ShouldBeSameAs(one);
+    }
+
+    [Fact]
+    public void different_destination_returns_a_different_accumulator()
+    {
+        var one = theAccumulator.FindAccumulator("MyApp.MyMessage", new Uri("tcp://localhost:5000"));
+        var two = theAccumulator.FindAccumulator("MyApp.MyMessage", new Uri("tcp://localhost:5001"));
+
+        two.ShouldNotBeSameAs(one);
+        one.Destination.ShouldBe(new Uri("tcp://localhost:5000"));
+        two.Destination.ShouldBe(new Uri("tcp://localhost:5001"));
+    }
+
+    [Fact]
+    public void different_message_type_returns_a_different_accumulator()
+    {
+        var one = theAccumulator.FindAccumulator("MyApp.MyMessage", new Uri("tcp://localhost:5000"));
+        var two = theAccumulator.FindAccumulator("MyApp.OtherMessage", new Uri("tcp://localhost:5000"));
+
+        two.ShouldNotBeSameAs(one);
+        one.MessageType.ShouldBe("MyApp.MyMessage");
+        two.MessageType.ShouldBe("MyApp.OtherMessage");
+    }
+
+    [Theory]
+    [InlineData("local://durable", true)]
+    [InlineData("rabbitmq://queue/wolverine.response.node1", true)]
+    [InlineData("rabbitmq://queue/incoming", false)]
+    [InlineData("stub://one", false)]
+    public void is_system_endpoint(string uri, bool expected)
+    {
+        // twice, so both the computing and the cached path are exercised
+        WolverineRuntime.IsSystemEndpoint(new Uri(uri)).ShouldBe(expected);
+        WolverineRuntime.IsSystemEndpoint(new Uri(uri)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void is_system_endpoint_is_false_for_null()
+    {
+        WolverineRuntime.IsSystemEndpoint(null).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("local://durable", false)]
+    [InlineData("stub://one", false)]
+    [InlineData("rabbitmq://queue/incoming", true)]
+    [InlineData("tcp://localhost:5000", true)]
+    public void is_external_destination(string uri, bool expected)
+    {
+        WolverineRuntime.IsExternalDestination(new Uri(uri)).ShouldBe(expected);
+        WolverineRuntime.IsExternalDestination(new Uri(uri)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void is_external_destination_is_false_for_null()
+    {
+        WolverineRuntime.IsExternalDestination(null).ShouldBeFalse();
+    }
+}

--- a/src/Wolverine/Runtime/Metrics/MetricsAccumulator.cs
+++ b/src/Wolverine/Runtime/Metrics/MetricsAccumulator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ImTools;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
@@ -23,6 +24,14 @@ public class MetricsAccumulator : IAsyncDisposable
     private readonly object _syncLock = new();
 
     private ImmutableArray<MessageTypeMetricsAccumulator> _accumulators = ImmutableArray<MessageTypeMetricsAccumulator>.Empty;
+
+    // GH-4324: FindAccumulator runs 2-4x per message, and the array above is only the right shape
+    // for the export loop's iteration. Lookups go through this copy-on-write trie instead — the
+    // previous linear scan paid an ordinal string compare plus a full component-wise Uri.Equals
+    // per entry over the whole (message type x destination) cross-product, per message.
+    private ImHashMap<string, ImHashMap<Uri, MessageTypeMetricsAccumulator>> _byMessageType =
+        ImHashMap<string, ImHashMap<Uri, MessageTypeMetricsAccumulator>>.Empty;
+
     private Task _runner = null!;
 
     /// <summary>
@@ -56,30 +65,26 @@ public class MetricsAccumulator : IAsyncDisposable
     /// <returns>The accumulator for the given message type and destination.</returns>
     public MessageTypeMetricsAccumulator FindAccumulator(string messageTypeName, Uri endpointUri)
     {
-        var snapshot = _accumulators;
-        for (var i = 0; i < snapshot.Length; i++)
+        if (_byMessageType.TryFind(messageTypeName, out var byUri) &&
+            byUri.TryFind(endpointUri, out var accumulator))
         {
-            var acc = snapshot[i];
-            if (acc.MessageType == messageTypeName && acc.Destination == endpointUri)
-            {
-                return acc;
-            }
+            return accumulator;
         }
 
         lock (_syncLock)
         {
-            snapshot = _accumulators;
-            for (var i = 0; i < snapshot.Length; i++)
+            if (_byMessageType.TryFind(messageTypeName, out byUri) &&
+                byUri.TryFind(endpointUri, out accumulator))
             {
-                var acc = snapshot[i];
-                if (acc.MessageType == messageTypeName && acc.Destination == endpointUri)
-                {
-                    return acc;
-                }
+                return accumulator;
             }
 
-            var accumulator = new MessageTypeMetricsAccumulator(messageTypeName, endpointUri);
+            accumulator = new MessageTypeMetricsAccumulator(messageTypeName, endpointUri);
             _accumulators = _accumulators.Add(accumulator);
+
+            byUri ??= ImHashMap<Uri, MessageTypeMetricsAccumulator>.Empty;
+            _byMessageType = _byMessageType.AddOrUpdate(messageTypeName, byUri.AddOrUpdate(endpointUri, accumulator));
+
             return accumulator;
         }
     }

--- a/src/Wolverine/Runtime/WolverineRuntime.DirectMetrics.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.DirectMetrics.cs
@@ -54,9 +54,7 @@ public partial class WolverineRuntime
 
         public void Received(Envelope envelope)
         {
-            var isExternal = envelope.Destination != null
-                             && !envelope.Destination.Scheme.EqualsIgnoreCase("local")
-                             && !envelope.Destination.Scheme.EqualsIgnoreCase("stub");
+            var isExternal = IsExternalDestination(envelope.Destination);
 
             if (isExternal && envelope.MessageType.IsNotEmpty() && !IsSystemEndpoint(envelope.Destination))
             {

--- a/src/Wolverine/Runtime/WolverineRuntime.Tracking.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.Tracking.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
@@ -95,9 +96,7 @@ public sealed partial class WolverineRuntime : IMessageTracker
 
     public void Received(Envelope envelope)
     {
-        var isExternal = envelope.Destination != null
-                         && !envelope.Destination.Scheme.EqualsIgnoreCase("local")
-                         && !envelope.Destination.Scheme.EqualsIgnoreCase("stub");
+        var isExternal = IsExternalDestination(envelope.Destination);
 
         if (isExternal)
         {
@@ -309,6 +308,45 @@ public sealed partial class WolverineRuntime : IMessageTracker
         }
     }
 
+    // GH-4324: both classifications below are pure functions of a destination Uri drawn from a
+    // small bounded set (endpoints plus per-node reply queues), yet ran per message — the system
+    // check with a full ToString() substring scan, the external check with two case-insensitive
+    // scheme compares, 2-4x per message between them. One lock-free trie probe answers both; a
+    // lost racing update just recomputes the same value next time.
+    private static ImHashMap<Uri, DestinationClassification> _destinationClassifications =
+        ImHashMap<Uri, DestinationClassification>.Empty;
+
+    [Flags]
+    private enum DestinationClassification
+    {
+        None = 0,
+        System = 1,
+        External = 2
+    }
+
+    private static DestinationClassification classifyDestination(Uri destination)
+    {
+        if (_destinationClassifications.TryFind(destination, out var classification))
+        {
+            return classification;
+        }
+
+        var isLocal = destination.Scheme.EqualsIgnoreCase("local");
+
+        if (isLocal || destination.ToString().Contains("wolverine.response", StringComparison.OrdinalIgnoreCase))
+        {
+            classification |= DestinationClassification.System;
+        }
+
+        if (!isLocal && !destination.Scheme.EqualsIgnoreCase("stub"))
+        {
+            classification |= DestinationClassification.External;
+        }
+
+        _destinationClassifications = _destinationClassifications.AddOrUpdate(destination, classification);
+        return classification;
+    }
+
     /// <summary>
     /// Returns true if the destination URI belongs to a Wolverine system endpoint
     /// (e.g. wolverine.response reply queues or local:// queues) that should not
@@ -316,8 +354,18 @@ public sealed partial class WolverineRuntime : IMessageTracker
     /// </summary>
     internal static bool IsSystemEndpoint(Uri? destination)
     {
-        if (destination == null) return false;
-        return destination.ToString().Contains("wolverine.response", StringComparison.OrdinalIgnoreCase)
-               || destination.Scheme.EqualsIgnoreCase("local");
+        return destination != null &&
+               (classifyDestination(destination) & DestinationClassification.System) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if the destination URI points at an external transport endpoint —
+    /// i.e. anything other than a local queue or a stub — the gate for the external
+    /// send/receive counters.
+    /// </summary>
+    internal static bool IsExternalDestination(Uri? destination)
+    {
+        return destination != null &&
+               (classifyDestination(destination) & DestinationClassification.External) != 0;
     }
 }


### PR DESCRIPTION
Closes #4324. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

`MetricsAccumulator.FindAccumulator` runs 2–4× per message under the CritterWatch/Hybrid metrics modes — i.e. exactly the deployments whose numbers are being watched — and scanned the whole (message type × destination) accumulator array with an ordinal string compare plus a full component-wise `Uri.Equals` per entry. Lookups now go through a nested copy-on-write `ImHashMap` (message type → Uri → accumulator) per the house hot-path convention; the `ImmutableArray` stays as the export loop's iteration shape, and the locked creation path double-checks the map before inserting, exactly as the scan did.

On the same tracking paths, `IsSystemEndpoint` re-ran a full `ToString().Contains` substring scan per call and the external-destination gate re-ran two case-insensitive scheme compares per received envelope. Both are pure functions of a destination Uri drawn from a small bounded set (endpoints plus per-node reply queues), so a single cached classification probe now answers both; a lost racing cache update just recomputes the same deterministic value next time. The `isExternal` inline computations in `Received` (both the meter path and the direct-metrics path) route through the new `IsExternalDestination`.

New `MetricsAccumulatorLookupTests` pin the identity semantics (same accumulator instance for equal-but-distinct Uri instances; distinct per message type/destination) and the classification truth table on both the computing and cached paths.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2831 passed / 2 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)