### PR TITLE
GH-4335: hot-path cruft sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### WolverineFx (core)
 
+- **Hot-path cruft sweep.** (closes [#4335](https://github.com/JasperFx/wolverine/issues/4335)) The
+  `Envelope` default constructor carried a leftover `Debug.WriteLine("Being created")` that fired on
+  every envelope in every Debug build — i.e. most local benchmarking and test runs — and
+  `EmptyMessageRouter` a sibling `Debug.WriteLine("Here")`; both are gone. The request/reply response
+  log dropped from Information to Debug to match every other per-message log in `MessageContext`.
+  `tryReadTimestamp` now tries the transport-header exact format before `XmlConvert`, so timestamps
+  written by an `EnvelopeMapper` no longer pay a full exception throw/catch on every read (the
+  XmlConvert-before-TryParse ordering is preserved because the two disagree on offset-less values).
+  The unused `RabbitMqSender._routingType` field is deleted. `ReservedHeaderKeys` deliberately stays
+  a `FrozenSet`: consumers enumerate it, which `ImHashMap` does not model well.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,6 @@
 
 ### WolverineFx (core)
 
-- **Hot-path cruft sweep.** (closes [#4335](https://github.com/JasperFx/wolverine/issues/4335)) The
-  `Envelope` default constructor carried a leftover `Debug.WriteLine("Being created")` that fired on
-  every envelope in every Debug build — i.e. most local benchmarking and test runs — and
-  `EmptyMessageRouter` a sibling `Debug.WriteLine("Here")`; both are gone. The request/reply response
-  log dropped from Information to Debug to match every other per-message log in `MessageContext`.
-  `tryReadTimestamp` now tries the transport-header exact format before `XmlConvert`, so timestamps
-  written by an `EnvelopeMapper` no longer pay a full exception throw/catch on every read (the
-  XmlConvert-before-TryParse ordering is preserved because the two disagree on offset-less values).
-  The unused `RabbitMqSender._routingType` field is deleted. `ReservedHeaderKeys` deliberately stays
-  a `FrozenSet`: consumers enumerate it, which `ImHashMap` does not model well.
 - **The execution pipeline sheds four per-message costs.** (closes
   [#4322](https://github.com/JasperFx/wolverine/issues/4322)) `Executor.ExecuteAsync` (and its
   tracing twin) allocated a timeout `CancellationTokenSource` — timer registration included — plus a

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqSender.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqSender.cs
@@ -11,7 +11,6 @@ namespace Wolverine.RabbitMQ.Internal;
 internal class RabbitMqSender : RabbitMqChannelAgent, ISender
 {
     private readonly RabbitMqEndpoint _endpoint;
-    private readonly RoutingMode _routingType;
     private readonly IWolverineRuntime _runtime;
     private readonly CachedString _exchangeName;
     private readonly bool _isDurable;
@@ -35,7 +34,6 @@ internal class RabbitMqSender : RabbitMqChannelAgent, ISender
 
         _mapper = endpoint.BuildMapper(runtime);
         _endpoint = endpoint;
-        _routingType = routingType;
         _runtime = runtime;
     }
 

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -43,7 +43,6 @@ public partial class Envelope : IHasTenantId
     
     public Envelope()
     {
-        Debug.WriteLine("Being created");
     }
 
     public Envelope(object message)

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -314,7 +314,9 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
             else
             {
                 Activity.Current?.SetTag("reply-uri", Envelope!.ReplyUri!.ToString());
-                Runtime.Logger.LogInformation("Sending requested reply of type {MessageType} to reply-uri {ReplyUri}", Envelope!.ReplyRequested, Envelope.ReplyUri);
+                // Debug, not Information: this fires on every request/reply response, and every
+                // sibling per-message log in this class is Debug-level.
+                Runtime.Logger.LogDebug("Sending requested reply of type {MessageType} to reply-uri {ReplyUri}", Envelope!.ReplyRequested, Envelope.ReplyUri);
             }
         }
     }

--- a/src/Wolverine/Runtime/Routing/EmptyMessageRouter.cs
+++ b/src/Wolverine/Runtime/Routing/EmptyMessageRouter.cs
@@ -1,12 +1,9 @@
-using System.Diagnostics;
-
 namespace Wolverine.Runtime.Routing;
 
 public class EmptyMessageRouter<T> : MessageRouterBase<T>
 {
     public EmptyMessageRouter(WolverineRuntime runtime) : base(runtime)
     {
-        Debug.WriteLine("Here");
     }
 
     public override IMessageRoute[] Routes => Array.Empty<MessageRoute>();

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -205,6 +205,17 @@ public static class EnvelopeSerializer
     /// </summary>
     private static bool tryReadTimestamp(string value, out DateTimeOffset parsed)
     {
+        // The transport-header format goes first because it is the one common input XmlConvert
+        // rejects: with the old order, every timestamp written by an EnvelopeMapper paid a full
+        // exception throw/catch per read (GH-4335). An exact-format parse can never claim a value
+        // meant for the parses below, so the reorder changes cost, not semantics.
+        if (DateTimeOffset.TryParseExact(value, EnvelopeConstants.TransportHeaderDateTimeFormat,
+                CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out parsed))
+        {
+            return true;
+        }
+
         try
         {
             parsed = XmlConvert.ToDateTime(value, XmlDateTimeSerializationMode.Utc);
@@ -212,18 +223,11 @@ public static class EnvelopeSerializer
         }
         catch (Exception)
         {
-            // Not an xsd/round-trip value; fall through to the looser attempts below.
+            // Not an xsd/round-trip value; fall through to the loosest attempt below. XmlConvert
+            // stays ahead of TryParse because the two disagree on offset-less values (Utc vs local).
         }
 
-        if (DateTimeOffset.TryParse(value, out parsed))
-        {
-            return true;
-        }
-
-        // EnvelopeMapper's transport-header format, which neither of the parses above accepts.
-        return DateTimeOffset.TryParseExact(value, EnvelopeConstants.TransportHeaderDateTimeFormat,
-            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out parsed);
+        return DateTimeOffset.TryParse(value, out parsed);
     }
 
     public static Envelope[] ReadMany(byte[] buffer)


### PR DESCRIPTION
Closes #4335. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

- **`Debug.WriteLine` leftovers deleted**: `Envelope()`'s "Being created" fired on every envelope construction in every Debug build — i.e. most local benchmarking and test runs — and `EmptyMessageRouter`'s ctor had a sibling "Here".
- **Request/reply response log** drops from Information to Debug, matching every other per-message log in `MessageContext`.
- **`tryReadTimestamp` no longer throws on the common mapper path**: the transport-header exact format (`TransportHeaderDateTimeFormat`) now parses first, so timestamps written by an `EnvelopeMapper` stop paying a full exception throw/catch per read. Ordering note: `XmlConvert` deliberately stays ahead of the loose `TryParse` because the two disagree on offset-less values (Utc vs local) — only the exception-free exact parse moved.
- **`RabbitMqSender._routingType`**: assigned, never read; deleted.
- **Scope trim**: `ReservedHeaderKeys` stays a `FrozenSet` despite the house ImHashMap convention — the Kafka mapper and two test suites *enumerate* it, which a map models poorly, and a 24-string frozen set lookup is not a measurable cost.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- CoreTests Serialization + reserved-header filtering: 193/193
- Kafka mapper timestamp tests (the direct coverage of the parse reorder): 34/34 solo (one flake under suite contention on the first pass, clean on the authoritative solo run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)