### PR TITLE
GH-4325: routing and send-path per-message trims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### WolverineFx (core)
 
+- **Routing and send-path trims.** (closes [#4325](https://github.com/JasperFx/wolverine/issues/4325))
+  The outstanding-envelope bookkeeping used JasperFx `Fill` — Contains-then-Add, i.e. a closure, a
+  `Where` iterator, and an O(list) scan per envelope, quadratic when a batch handler or Marten
+  projection cascades hundreds of messages — on lists that only ever receive freshly-minted router
+  output; the two router-fed sites now use plain `Add`/`AddRange`, while the `IEnvelopeTransaction`
+  entry points deliberately keep `Fill` as defensive integration surface. Envelope-rule application
+  loops (`MessageRoute.CreateForSending`, the remote-invoke path, and `DestinationEndpoint`) switch
+  from `foreach` over an `IList`-typed property — which boxes a `List` enumerator per send, even
+  with zero rules — to indexed loops. `CreateForSending` also reads `sender.Destination` once
+  instead of three times and reuses the ctor-computed `IsLocal` instead of re-running a type test
+  per send. Evaluated and deferred: a single-route fast path to avoid the `Envelope[]` per publish —
+  it forks the persist-or-send semantics for one small array and needs its own careful pass.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,6 @@
 
 ### WolverineFx (core)
 
-- **Routing and send-path trims.** (closes [#4325](https://github.com/JasperFx/wolverine/issues/4325))
-  The outstanding-envelope bookkeeping used JasperFx `Fill` — Contains-then-Add, i.e. a closure, a
-  `Where` iterator, and an O(list) scan per envelope, quadratic when a batch handler or Marten
-  projection cascades hundreds of messages — on lists that only ever receive freshly-minted router
-  output; the two router-fed sites now use plain `Add`/`AddRange`, while the `IEnvelopeTransaction`
-  entry points deliberately keep `Fill` as defensive integration surface. Envelope-rule application
-  loops (`MessageRoute.CreateForSending`, the remote-invoke path, and `DestinationEndpoint`) switch
-  from `foreach` over an `IList`-typed property — which boxes a `List` enumerator per send, even
-  with zero rules — to indexed loops. `CreateForSending` also reads `sender.Destination` once
-  instead of three times and reuses the ctor-computed `IsLocal` instead of re-running a type test
-  per send. Evaluated and deferred: a single-route fast path to avoid the `Envelope[]` per publish —
-  it forks the persist-or-send semantics for one small array and needs its own careful pass.
 - **The execution pipeline sheds four per-message costs.** (closes
   [#4322](https://github.com/JasperFx/wolverine/issues/4322)) `Executor.ExecuteAsync` (and its
   tracing twin) allocated a timeout `CancellationTokenSource` — timer registration included — plus a

--- a/src/Wolverine/Runtime/DestinationEndpoint.cs
+++ b/src/Wolverine/Runtime/DestinationEndpoint.cs
@@ -42,7 +42,10 @@ internal class DestinationEndpoint : IDestinationEndpoint
             envelope.Serializer = _parent.Runtime.Options.FindSerializer(options.ContentType);
         }
 
-        foreach (var rule in route.Rules) rule.Modify(envelope);
+        for (var i = 0; i < route.Rules.Count; i++)
+        {
+            route.Rules[i].Modify(envelope);
+        }
 
         // Delivery options win
         options?.Override(envelope);
@@ -85,7 +88,10 @@ internal class DestinationEndpoint : IDestinationEndpoint
             envelope.SetMessageType(messageType);
             
             var route = _endpoint.RouteFor(messageType, _parent.Runtime);
-            foreach (var rule in route.Rules) rule.Modify(envelope);
+            for (var i = 0; i < route.Rules.Count; i++)
+        {
+            route.Rules[i].Modify(envelope);
+        }
         }
         
         configure?.Invoke(envelope);

--- a/src/Wolverine/Runtime/MessageBus.cs
+++ b/src/Wolverine/Runtime/MessageBus.cs
@@ -356,7 +356,8 @@ public partial class MessageBus : IMessageBus, IMessageContext
         {
             lock (_outstandingLock)
             {
-                _outstanding.Fill(envelope);
+                // GH-4325: Add, not Fill — see the comment in PersistOrSendAsync(Envelope[])
+                _outstanding.Add(envelope);
             }
 
             await envelope.PersistAsync(Transaction).ConfigureAwait(false);
@@ -472,7 +473,13 @@ public partial class MessageBus : IMessageBus, IMessageContext
 
             lock (_outstandingLock)
             {
-                _outstanding.Fill(outgoing);
+                // GH-4325: AddRange, not Fill. Fill is Contains-then-Add — a closure, a Where
+                // iterator, and an O(list) scan per envelope, quadratic when a batch handler or
+                // projection cascades hundreds. Every envelope here is freshly minted by the
+                // router with its own Id, so the dedup could never hit. The IEnvelopeTransaction
+                // entry points below deliberately keep Fill: they are integration surface where
+                // a caller could legitimately persist the same envelope twice.
+                _outstanding.AddRange(outgoing);
             }
         }
         else

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -142,19 +142,21 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         // is a no-op (returns `new Envelope()`) for any other agent shape, so the
         // semantics here are unchanged for buffered / durable / local-queue routes.
         var envelope = runtime.AcquireOutgoingEnvelope(sender);
+        var destination = sender.Destination;
         envelope.Message = message;
         envelope.Sender = sender;
         envelope.Serializer = Serializer
             ?? (message is ISerializable ? IntrinsicSerializer.Instance : sender.Endpoint.DefaultSerializer);
         envelope.ContentType = envelope.Serializer?.ContentType;
-        envelope.Destination = sender.Destination;
-        envelope.ReplyUri = sender.ReplyUri?.MaybeCorrectScheme(sender.Destination.Scheme);
+        envelope.Destination = destination;
+        envelope.ReplyUri = sender.ReplyUri?.MaybeCorrectScheme(destination.Scheme);
         envelope.TopicName = topicName;
         envelope.WireTap = _endpoint.WireTap;
         envelope.TenantId = options?.TenantId;
         envelope.GroupId = options?.GroupId;
 
-        if (sender.Endpoint is LocalQueue)
+        // GH-4325: IsLocal is the ctor-computed answer to exactly this type test
+        if (IsLocal)
         {
             envelope.Status = EnvelopeStatus.Incoming;
         }
@@ -170,7 +172,12 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         // make decisions on the final outgoing envelope metadata.
         envelope.GroupId = _partitioning.DetermineGroupId(envelope);
 
-        foreach (var rule in Rules) rule.Modify(envelope);
+        // GH-4325: indexed loop — foreach over the IList-typed property boxes a List enumerator
+        // per send, even when there are no rules at all (the common case)
+        for (var i = 0; i < Rules.Count; i++)
+        {
+            Rules[i].Modify(envelope);
+        }
 
         // Delivery options win
         options?.Override(envelope);
@@ -256,7 +263,11 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
         
         options?.Override(envelope);
 
-        foreach (var rule in Rules) rule.Modify(envelope);
+        for (var i = 0; i < Rules.Count; i++)
+        {
+            Rules[i].Modify(envelope);
+        }
+
         if (typeof(T) == typeof(Acknowledgement))
         {
             envelope.AckRequested = true;


### PR DESCRIPTION
Closes #4325. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**`Fill` → `Add`/`AddRange` on the router-fed outstanding lists.** JasperFx `Fill` is Contains-then-Add: a display class, a delegate, a `Where` iterator, and an O(list) scan with `Envelope.Equals` (Guid) per added envelope — quadratic when a batch handler or Marten projection cascades hundreds of messages. Every envelope reaching the two converted sites is freshly minted by the router with its own Id (`DeliveryOptions` cannot inject an Id), so the dedup could never hit. The `IEnvelopeTransaction.PersistOutgoingAsync` entry points **deliberately keep `Fill`**: they are integration surface where a caller could legitimately persist the same envelope twice (e.g. transaction copy flows).

**Rule loops stop boxing.** `foreach` over the `IList`-typed `Rules` property boxes a `List<>.Enumerator` per send even when there are no rules at all — the common case. `MessageRoute.CreateForSending`, the remote-invoke path, and both `DestinationEndpoint` sites now use indexed loops.

**`CreateForSending` trims**: `sender.Destination` read once instead of three times; the `sender.Endpoint is LocalQueue` type test replaced by the ctor-computed `IsLocal` (same endpoint by construction, including the GH-2897 fallback which resolves by the same Uri).

**Evaluated and deferred** (noted on the issue): the single-route fast path to avoid the `Envelope[]` allocation per publish — it forks the `PersistOrSendAsync` persist-or-send semantics for one 32-byte array and deserves its own careful pass; and the `applyTenantContext` caller-options mutation, which is a behavioral question rather than a mechanical trim.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2818 passed / 2 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)