### PR TITLE
GH-4322: the execution pipeline sheds four per-message costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### WolverineFx (core)
 
+- **The execution pipeline sheds four per-message costs.** (closes
+  [#4322](https://github.com/JasperFx/wolverine/issues/4322)) `Executor.ExecuteAsync` (and its
+  tracing twin) allocated a timeout `CancellationTokenSource` — timer registration included — plus a
+  second linked source with two callback registrations, per message, every message; one linked source
+  with `CancelAfter` now carries the identical either-cancels semantics at half the cost.
+  `FlushOutgoingMessagesAsync` awaited `AssertAnyRequiredResponseWasGenerated` unconditionally — an
+  async state machine per message whose body no-ops unless a reply was requested — and the
+  scheduled-message flush ran its own state machine over a nearly-always-empty list; both are now
+  guarded. `HandlerPipeline.executeAsync` returns `ValueTask<IContinuation>` so a synchronously
+  completing handler no longer boxes a `Task` for a singleton continuation. And `RequiresEncryption`
+  answers from two count reads instead of probing the message-type map per envelope when no
+  encryption policy is configured — which is nearly every application.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -328,6 +328,15 @@ public class HandlerPipeline : IHandlerPipeline
     {
         var options = _runtime.Options;
 
+        // GH-4322: for the overwhelmingly common no-encryption configuration, answer from two
+        // count reads instead of paying the message-type map probe below on every envelope. Read
+        // per call rather than cached at construction because policies may register encrypted
+        // types lazily after this pipeline is built.
+        if (options.RequiredEncryptedListenerUris.Count == 0 && options.RequiredEncryptedTypes.Count == 0)
+        {
+            return false;
+        }
+
         // Use the listener's own URI, not envelope.Destination: the latter is sender-
         // controlled and not populated on broker transports (Rabbit/Kafka/SB).
         // For per-type enforcement, defer to IsEncryptionRequired so the check
@@ -340,7 +349,10 @@ public class HandlerPipeline : IHandlerPipeline
                     && options.IsEncryptionRequired(type));
     }
 
-    private async Task<IContinuation> executeAsync(MessageContext context, Envelope envelope, Activity? activity)
+    // GH-4322: ValueTask because the deserialization pre-checks complete synchronously for the
+    // common already-deserialized case and the success result is a singleton — Task<IContinuation>
+    // was one box per message.
+    private async ValueTask<IContinuation> executeAsync(MessageContext context, Envelope envelope, Activity? activity)
     {
         if (envelope.IsExpired())
         {

--- a/src/Wolverine/Runtime/Handlers/Executor.cs
+++ b/src/Wolverine/Runtime/Handlers/Executor.cs
@@ -234,12 +234,17 @@ internal class Executor : IExecutor
 
         envelope.Attempts++;
 
-        using var timeout = new CancellationTokenSource(_timeout);
-        using var combined = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellation);
+        // GH-4322: one linked source with CancelAfter replaces the previous timeout-CTS +
+        // linked-CTS pair — the token still cancels on whichever of the execution timeout or the
+        // caller's token fires first, at half the per-message allocations and registrations.
+        using var cts = cancellation.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellation)
+            : new CancellationTokenSource();
+        cts.CancelAfter(_timeout);
 
         try
         {
-            await Handler.HandleAsync(context, combined.Token).ConfigureAwait(false);
+            await Handler.HandleAsync(context, cts.Token).ConfigureAwait(false);
 
             if (context.Envelope!.ReplyRequested.IsNotEmpty())
             {

--- a/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
+++ b/src/Wolverine/Runtime/Handlers/TracingExecutor.cs
@@ -162,12 +162,15 @@ internal class TracingExecutor : IExecutor
 
         envelope.Attempts++;
 
-        using var timeout = new CancellationTokenSource(_timeout);
-        using var combined = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellation);
+        // GH-4322: same single-CTS shape as Executor.ExecuteAsync — see the comment there.
+        using var cts = cancellation.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellation)
+            : new CancellationTokenSource();
+        cts.CancelAfter(_timeout);
 
         try
         {
-            await Handler.HandleAsync(context, combined.Token);
+            await Handler.HandleAsync(context, cts.Token);
             if (context.Envelope!.ReplyRequested.IsNotEmpty())
             {
                 await context.AssertAnyRequiredResponseWasGenerated();

--- a/src/Wolverine/Runtime/MessageContext.cs
+++ b/src/Wolverine/Runtime/MessageContext.cs
@@ -185,7 +185,13 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
             }
         }
 
-        await AssertAnyRequiredResponseWasGenerated().ConfigureAwait(false);
+        // GH-4322: the assertion no-ops unless a reply was requested, but awaiting the async
+        // method still built a state machine per message — the overwhelmingly common
+        // fire-and-forget case now skips it outright.
+        if (hasRequestedReply())
+        {
+            await AssertAnyRequiredResponseWasGenerated().ConfigureAwait(false);
+        }
 
         // Snapshot under lock so concurrent publishes from a Marten projection
         // (Block parallelism = 10 in AggregationRunner) cannot corrupt the list
@@ -250,7 +256,7 @@ public class MessageContext : MessageBus, IMessageContext, IHasTenantId, IEnvelo
             }
         }
 
-        if (ReferenceEquals(Transaction, this))
+        if (Scheduled.Count > 0 && ReferenceEquals(Transaction, this))
         {
             await flushScheduledMessagesAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
Closes #4322. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**One CTS instead of two, per message.** `Executor.ExecuteAsync` (and `TracingExecutor`) built a timeout `CancellationTokenSource` — `TimerQueueTimer` allocation and TimerQueue lock traffic included — plus a second linked source with two callback registrations, on every message. A single linked source with `CancelAfter` has the identical either-cancels semantics (handler token fires on whichever of the execution timeout or the caller's token cancels first) at half the allocations and registrations. Pooling via `TryReset()` was considered and deferred — it needs rig numbers to justify its lifecycle complexity; this halving is free.

**Guarded no-op state machines.** `FlushOutgoingMessagesAsync` awaited `AssertAnyRequiredResponseWasGenerated` unconditionally — a per-message `async Task` box whose body no-ops unless `ReplyRequested` is set (the `Executor` call site already guards exactly this way; the flush site didn't) — and the scheduled-message flush ran its own state machine over a nearly-always-empty `Scheduled` list. Both now short-circuit.

**`ValueTask<IContinuation>`** for `HandlerPipeline.executeAsync`: a synchronously completing handler chain no longer allocates a `Task` box for what is almost always the singleton `MessageSucceededContinuation`.

**Encryption pre-check**: `RequiresEncryption` ran a string-keyed message-type map probe per envelope even with no encryption configured — which is nearly every application. Two `Count` reads now answer first; deliberately read per call rather than cached at construction because policies can register encrypted types lazily after the pipeline exists.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2818 passed / 2 skipped / 0 failed (includes the execution-timeout and request/reply assertion suites that pin the CTS and guard semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)