### PR TITLE
GH-4323: keep the lazy header dictionary lazy; stop manufacturing header strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### WolverineFx (core)
 
+- **The lazy header dictionary stays lazy, and the mapper stops manufacturing strings.** (closes
+  [#4323](https://github.com/JasperFx/wolverine/issues/4323)) `Envelope.Headers` allocates on first
+  touch, and the hottest call sites were the ones touching it: the first action of every outgoing
+  broker dispatch forced the dictionary into existence just to see it was empty, the reserved-header
+  reader probed it ~20x per incoming message, the binary serializer walked it per persisted envelope,
+  and the tracing tags probed it per span. A new `Envelope.HasHeaders` answers without allocating and
+  every one of those sites now uses it (or `TryGetHeader`). The accepted-content-types header — the
+  literal `application/json` on virtually every message — no longer round-trips through a `Join` per
+  send and a `Split` plus fresh array per receive on every transport; both sides short-circuit to the
+  shared canonical value. And the mapper's `writeInt` now skips zero the way `writeGuid` skips
+  `Guid.Empty`, so `attempts` stops stringifying `0` on every first-send — the binary writer already
+  guarded this way, and an absent header reads back as 0, so the wire round-trip is unchanged. The
+  O(reserved)→O(present) incoming-loop inversion stays on the issue pending mapper benchmarks.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,6 @@
 
 ### WolverineFx (core)
 
-- **The lazy header dictionary stays lazy, and the mapper stops manufacturing strings.** (closes
-  [#4323](https://github.com/JasperFx/wolverine/issues/4323)) `Envelope.Headers` allocates on first
-  touch, and the hottest call sites were the ones touching it: the first action of every outgoing
-  broker dispatch forced the dictionary into existence just to see it was empty, the reserved-header
-  reader probed it ~20x per incoming message, the binary serializer walked it per persisted envelope,
-  and the tracing tags probed it per span. A new `Envelope.HasHeaders` answers without allocating and
-  every one of those sites now uses it (or `TryGetHeader`). The accepted-content-types header — the
-  literal `application/json` on virtually every message — no longer round-trips through a `Join` per
-  send and a `Split` plus fresh array per receive on every transport; both sides short-circuit to the
-  shared canonical value. And the mapper's `writeInt` now skips zero the way `writeGuid` skips
-  `Guid.Empty`, so `attempts` stops stringifying `0` on every first-send — the binary writer already
-  guarded this way, and an absent header reads back as 0, so the wire round-trip is unchanged. The
-  O(reserved)→O(present) incoming-loop inversion stays on the issue pending mapper benchmarks.
 - **The execution pipeline sheds four per-message costs.** (closes
   [#4322](https://github.com/JasperFx/wolverine/issues/4322)) `Executor.ExecuteAsync` (and its
   tracing twin) allocated a timeout `CancellationTokenSource` — timer registration included — plus a

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -464,7 +464,7 @@ public partial class Envelope
         // An occurrence published by opts.Schedules carries its schedule's name in a header;
         // surfacing it as a tag is what lets trace consumers (CritterWatch among them) attribute
         // the handler span to the cron job that caused it.
-        if (Headers.TryGetValue(RecurringMessage.HeaderKey, out var scheduleName))
+        if (TryGetHeader(RecurringMessage.HeaderKey, out var scheduleName))
         {
             activity.MaybeSetTag(WolverineTracing.ScheduleName, scheduleName);
         }

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -64,6 +64,12 @@ public partial class Envelope : IHasTenantId
     }
 
     /// <summary>
+    /// True if any headers have been recorded on this envelope. Unlike touching
+    /// <see cref="Headers"/>, this never forces the lazy dictionary to allocate.
+    /// </summary>
+    public bool HasHeaders => _headers is { Count: > 0 };
+
+    /// <summary>
     /// Try to read a header value by key without forcing dictionary allocation.
     /// Returns true if the header exists and has a non-null value.
     /// </summary>

--- a/src/Wolverine/Runtime/Handlers/FanoutMessageHandler.cs
+++ b/src/Wolverine/Runtime/Handlers/FanoutMessageHandler.cs
@@ -14,7 +14,7 @@ internal class FanoutMessageHandler<T> : MessageHandler<T>
     {
         var incoming = context.Envelope!;
         DeliveryOptions? options = null;
-        if (incoming.Headers.Count > 0)
+        if (incoming.HasHeaders)
         {
             options = new DeliveryOptions();
             foreach (var header in incoming.Headers)

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -98,7 +98,10 @@ public static class EnvelopeSerializer
                     break;
 
                 case EnvelopeConstants.AcceptedContentTypesKey:
-                    env.AcceptedContentTypes = value.Split(',');
+                    // GH-4323: virtually always the default — reuse the shared array
+                    env.AcceptedContentTypes = value == EnvelopeConstants.JsonContentType
+                        ? Envelope.DefaultAcceptedContentTypes
+                        : value.Split(',');
                     break;
 
                 case EnvelopeConstants.IdKey:
@@ -371,8 +374,11 @@ public static class EnvelopeSerializer
 
         if (env.AcceptedContentTypes.Length != 0)
         {
+            // GH-4323: the shared default joins to the constant — skip the per-envelope Join
             writer.WriteProp(ref count, EnvelopeConstants.AcceptedContentTypesKey,
-                string.Join(",", env.AcceptedContentTypes));
+                ReferenceEquals(env.AcceptedContentTypes, Envelope.DefaultAcceptedContentTypes)
+                    ? EnvelopeConstants.JsonContentType
+                    : string.Join(",", env.AcceptedContentTypes));
         }
 
         writer.WriteProp(ref count, EnvelopeConstants.IdKey, env.Id);
@@ -403,6 +409,11 @@ public static class EnvelopeSerializer
 
         writer.WriteProp(ref count, EnvelopeConstants.AttemptsKey, env.Attempts);
         writer.WriteProp(ref count, EnvelopeConstants.DeliverByKey, env.DeliverBy);
+
+        if (!env.HasHeaders)
+        {
+            return count;
+        }
 
         foreach (var pair in env.Headers)
         {

--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -307,11 +307,17 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
     /// </summary>
     protected virtual bool preferCopiedIncomingHeaders => false;
 
+    // GH-4323: the one canonical accepted-content-types array, shared with Envelope's own default
+    // so the write-side reference check below also hits for round-tripped envelopes
+    private static readonly string[] DefaultAcceptedContentTypeArray = (string[])Envelope.DefaultAcceptedContentTypes!;
+
     private delegate bool ReadHeader(Envelope env, TIncoming incoming, string key, out string? value);
 
     private bool tryReadCopiedOrIncomingHeader(Envelope env, TIncoming incoming, string key, out string? value)
     {
-        if (env.Headers.TryGetValue(key, out value) && value != null)
+        // HasHeaders first: this probe runs once per reserved property (~20x) per incoming
+        // message, and must not be the thing that forces the lazy dictionary into existence
+        if (env.HasHeaders && env.Headers.TryGetValue(key, out value) && value != null)
         {
             return true;
         }
@@ -390,7 +396,13 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         if (propType == typeof(string[]))
         {
             var typed = (Action<Envelope, string[]>)setter.CreateDelegate(typeof(Action<Envelope, string[]>));
-            return (env, inc) => typed(env, read(env, inc, headerKey, out var raw) ? raw!.Split(',') : []);
+            // GH-4323: the value is virtually always the default accepted-content-types header
+            // that every Wolverine sender writes — hand back the canonical shared array instead
+            // of allocating a fresh one-element array plus a copied string per message. Nothing
+            // in the framework mutates the array's elements.
+            return (env, inc) => typed(env, read(env, inc, headerKey, out var raw)
+                ? raw == EnvelopeConstants.JsonContentType ? DefaultAcceptedContentTypeArray : raw!.Split(',')
+                : []);
         }
 
         // Fallback: treat as string — matches the original expression-tree code
@@ -464,7 +476,9 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
 
     protected void writeOutgoingOtherHeaders(TOutgoing outgoing, Envelope envelope)
     {
-        if (envelope.Headers.Count == 0)
+        // GH-4323: this runs first in the outgoing dispatch on every broker send — touching
+        // envelope.Headers here allocated the lazy dictionary just to observe it is empty
+        if (!envelope.HasHeaders)
         {
             return;
         }
@@ -532,7 +546,12 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
     {
         if (value != null)
         {
-            writeOutgoingHeader(outgoing, key, value.Join(","));
+            // GH-4323: virtually every envelope carries the shared default accepted-content-types
+            // array — write the constant instead of re-joining it per message
+            writeOutgoingHeader(outgoing, key,
+                ReferenceEquals(value, Envelope.DefaultAcceptedContentTypes)
+                    ? EnvelopeConstants.JsonContentType
+                    : value.Join(","));
         }
     }
 
@@ -554,7 +573,13 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
 
     protected void writeInt(TOutgoing outgoing, string key, int value)
     {
-        writeOutgoingHeader(outgoing, key, value.ToString());
+        // GH-4323: skip the default just like writeGuid skips Guid.Empty — an absent header reads
+        // back as 0, and `attempts` is 0 on every first send, so this was a per-message string.
+        // The binary EnvelopeSerializer already guards the same way; the two writers now agree.
+        if (value != 0)
+        {
+            writeOutgoingHeader(outgoing, key, value.ToString());
+        }
     }
 
     protected void writeGuid(TOutgoing outgoing, string key, Guid value)


### PR DESCRIPTION
Closes #4323. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**`Envelope.HasHeaders`.** The lazy `Headers` getter (`_headers ??= new()`) was defeated by its own hottest consumers: `writeOutgoingOtherHeaders` (first action in every broker transport's outgoing dispatch) allocated the dictionary per send just to see `Count == 0`; `tryReadCopiedOrIncomingHeader` probed it ~20×/incoming message; `EnvelopeSerializer.writeHeaders`, `Envelope.WriteTags` (per traced span), and `FanoutMessageHandler` all forced it too. The new non-allocating `HasHeaders` guards every one of those sites.

**Accepted-content-types fast paths.** The header is the literal `application/json` on virtually every message (the shared `Envelope.DefaultAcceptedContentTypes`). Mapper + binary serializer writes now emit the constant on a reference check instead of `Join(",")` per send; reads hand back the canonical shared array instead of `Split(',')` allocating a one-element array plus a copied string per receive. Nothing in the framework mutates the array's elements, and sharing one canonical instance means round-tripped envelopes hit the write-side reference check too.

**`writeInt` zero-guard.** `attempts = 0` was stringified on every first send. An absent header reads back as `default` (0) through the same reader, and the binary `EnvelopeSerializer` already guards `> 0` — the two writers disagreed; now they agree. Wire round-trip unchanged in both directions and both version-mix directions (old↔new).

**Deferred to the issue**: the O(reserved)→O(headers-present) incoming-loop inversion — the GH-3490 ledger's 5–12ns lookup measurement is a caution that the win must come from skipping absent-key delegate invocations, which needs the #3501 mapper benchmarks re-run before claiming.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2818 passed / 2 skipped / 0 failed (includes the serialization round-trip and reserved-header filtering suites)
- RabbitMQ envelope/mapper tests: 18/18 (a `preferCopiedIncomingHeaders` transport, so the copied-headers probe guard is exercised on the wire path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)