### PR TITLE
GH-4321: idle polling stops hammering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### WolverineFx (core)
 
+- **Idle polling stops hammering.** (closes [#4321](https://github.com/JasperFx/wolverine/issues/4321))
+  Three sources of steady-state chatter learned to be quiet. The database control queue polled at a
+  hard 1 Hz — a connection, a transaction, a DELETE and a SELECT per tick per node, ~86k
+  transactions/day against an almost-always-empty queue; it now stays at 1s while control traffic is
+  flowing and relaxes to 5s after ten quiet seconds. The orphaned-message sweep opened two
+  connections and read the identical live-node list twice per cycle; one connection and one node
+  read now serve both tables, with the GH-3850 owners-before-nodes ordering preserved (both owner
+  reads still precede the single node read). And every back-pressure-enforcing listener owned its
+  own 2-second `System.Timers.Timer` — an `ElapsedEventArgs`, a state machine, and a fire-and-forget
+  `Task` per endpoint per tick forever; one shared `PeriodicTimer` sweep now walks all of them.
+  `LeaseRenewalTracker.Untrack` also stops probing the lease-lost dictionary per message when it is
+  empty, which is any time there is no active lease-loss incident. Deliberately NOT touched: the
+  twice-per-interval node heartbeat — the second write also carries the GH-3604/D2 row-restoration
+  duty, not just the GH-2682 invariant, so deduplicating it is cluster-liveness surgery that needs
+  its own design pass.
+
 - **JasperFx dependencies bumped to 2.63.1, with the event-store family in lockstep.** Carries the
   [jasperfx#742](https://github.com/JasperFx/jasperfx/issues/742) guard — `AddJasperFx` no longer calls
   `GetReferencedAssemblies()` into a `PlatformNotSupportedException` under Native AOT, which was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,6 @@
 
 ### WolverineFx (core)
 
-- **Idle polling stops hammering.** (closes [#4321](https://github.com/JasperFx/wolverine/issues/4321))
-  Three sources of steady-state chatter learned to be quiet. The database control queue polled at a
-  hard 1 Hz — a connection, a transaction, a DELETE and a SELECT per tick per node, ~86k
-  transactions/day against an almost-always-empty queue; it now stays at 1s while control traffic is
-  flowing and relaxes to 5s after ten quiet seconds. The orphaned-message sweep opened two
-  connections and read the identical live-node list twice per cycle; one connection and one node
-  read now serve both tables, with the GH-3850 owners-before-nodes ordering preserved (both owner
-  reads still precede the single node read). And every back-pressure-enforcing listener owned its
-  own 2-second `System.Timers.Timer` — an `ElapsedEventArgs`, a state machine, and a fire-and-forget
-  `Task` per endpoint per tick forever; one shared `PeriodicTimer` sweep now walks all of them.
-  `LeaseRenewalTracker.Untrack` also stops probing the lease-lost dictionary per message when it is
-  empty, which is any time there is no active lease-loss incident. Deliberately NOT touched: the
-  twice-per-interval node heartbeat — the second write also carries the GH-3604/D2 row-restoration
-  duty, not just the GH-2682 invariant, so deduplicating it is cluster-liveness surgery that needs
-  its own design pass.
-
 - **The execution pipeline sheds four per-message costs.** (closes
   [#4322](https://github.com/JasperFx/wolverine/issues/4322)) `Executor.ExecuteAsync` (and its
   tracing twin) allocated a timeout `CancellationTokenSource` — timer registration included — plus a

--- a/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesCommand.cs
+++ b/src/Persistence/Wolverine.RDBMS/Durability/ReleaseOrphanedMessagesCommand.cs
@@ -66,27 +66,55 @@ internal class ReleaseOrphanedMessagesCommand : IAgentCommand
         var incoming = _database.DbObjectNameFor(DatabaseConstants.IncomingTable);
         var outgoing = _database.DbObjectNameFor(DatabaseConstants.OutgoingTable);
 
-        await sweepAsync(incoming, cancellationToken);
-        await sweepAsync(outgoing, cancellationToken);
-
-        return AgentCommands.Empty;
-    }
-
-    private async Task sweepAsync(DbObjectName table, CancellationToken cancellationToken)
-    {
-        int[] dead;
+        // GH-4321: the inbox and outbox sweeps used to each open their own connection and each
+        // re-read the identical live-node list — 2 connection acquisitions and 4 queries per
+        // polling cycle in a healthy fleet where the sweep finds nothing. One connection and one
+        // node read now serve both. The GH-3850 owners-then-nodes ordering survives intact:
+        // BOTH owner reads happen before the single live-node read, so a node registering in the
+        // gap is in the node list and cannot own anything either owner read saw.
+        int[] deadIncoming;
+        int[] deadOutgoing;
 
         try
         {
-            dead = await findDeadOwnersAsync(table, cancellationToken);
+            await using var conn = await _database.DataSource.OpenConnectionAsync(cancellationToken);
+
+            try
+            {
+                var incomingOwners = await fetchNodeNumbersAsync(
+                    conn.CreateCommand(_database.DistinctOwnerIdsSql(incoming)), cancellationToken);
+                var outgoingOwners = await fetchNodeNumbersAsync(
+                    conn.CreateCommand(_database.DistinctOwnerIdsSql(outgoing)), cancellationToken);
+
+                var live = await liveOwnersAsync(conn, cancellationToken);
+                if (live == null)
+                {
+                    return AgentCommands.Empty;
+                }
+
+                deadIncoming = DetermineDeadOwners(incomingOwners, live, _highWaterMark);
+                deadOutgoing = DetermineDeadOwners(outgoingOwners, live, _highWaterMark);
+            }
+            finally
+            {
+                await conn.CloseAsync();
+            }
         }
         catch (Exception e)
         {
             _logger.LogError(e,
-                "Error determining orphaned message owners in {Table} of database {Database}", table, _database.Name);
-            return;
+                "Error determining orphaned message owners in database {Database}", _database.Name);
+            return AgentCommands.Empty;
         }
 
+        await sweepAsync(incoming, deadIncoming, cancellationToken);
+        await sweepAsync(outgoing, deadOutgoing, cancellationToken);
+
+        return AgentCommands.Empty;
+    }
+
+    private async Task sweepAsync(DbObjectName table, int[] dead, CancellationToken cancellationToken)
+    {
         // The steady state, and the whole point of the change: nothing owned by a departed node, so
         // nothing is read and nothing is written.
         if (dead.Length == 0) return;
@@ -113,37 +141,15 @@ internal class ReleaseOrphanedMessagesCommand : IAgentCommand
         }
     }
 
-    /// <summary>
-    /// The owners present in the table that no live node accounts for.
-    /// </summary>
-    private async Task<int[]> findDeadOwnersAsync(DbObjectName table, CancellationToken cancellationToken)
-    {
-        await using var conn = await _database.DataSource.OpenConnectionAsync(cancellationToken);
-
-        try
-        {
-            // ORDER MATTERS: the owners present in the table are read BEFORE the live node list, and the
-            // two reads are not atomic with respect to a node registering in between.
-            //
-            //   owners-then-nodes: a node that registers in the gap cannot have written any envelope the
-            //   first read saw, and IS in the second read, so it is never judged dead.
-            //
-            //   nodes-then-owners: that same node is absent from the node list and its brand-new envelopes
-            //   ARE in the owner list -- so its live, in-flight work gets reset to owner_id = 0 and handed
-            //   to somebody else. That is precisely the failure GH-3850 exists to prevent.
-            var owners = await fetchNodeNumbersAsync(
-                conn.CreateCommand(_database.DistinctOwnerIdsSql(table)), cancellationToken);
-
-            var live = await liveOwnersAsync(conn, cancellationToken);
-            if (live == null) return [];
-
-            return DetermineDeadOwners(owners, live, _highWaterMark);
-        }
-        finally
-        {
-            await conn.CloseAsync();
-        }
-    }
+    // ORDER MATTERS in ExecuteAsync above: the owners present in the tables are read BEFORE the live
+    // node list, and the reads are not atomic with respect to a node registering in between.
+    //
+    //   owners-then-nodes: a node that registers in the gap cannot have written any envelope the
+    //   owner reads saw, and IS in the node read, so it is never judged dead.
+    //
+    //   nodes-then-owners: that same node is absent from the node list and its brand-new envelopes
+    //   ARE in the owner list -- so its live, in-flight work gets reset to owner_id = 0 and handed
+    //   to somebody else. That is precisely the failure GH-3850 exists to prevent.
 
     /// <summary>
     /// Which of the owners actually present in the table have departed. Pure, and deliberately separated

--- a/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlListener.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/DatabaseControlListener.cs
@@ -16,6 +16,21 @@ internal class DatabaseControlListener : IListener
     private readonly RetryBlock<Envelope> _retryBlock;
     private readonly DatabaseControlTransport _transport;
 
+    // GH-4321: the control queue is empty almost all of the time, but this listener polled it at
+    // a hard 1 Hz — a connection, a transaction, a DELETE and a SELECT per tick per node,
+    // ~86k transactions/day/node against the main store. The loop stays at 1s while there has
+    // been recent traffic and relaxes to 5s once the queue has been quiet, so a burst of agent
+    // commands is still consumed promptly while a quiet cluster stops hammering the database.
+    private static readonly TimeSpan ActivePollInterval = 1.Seconds();
+    private static readonly TimeSpan IdlePollInterval = 5.Seconds();
+    private const long IdleAfterMilliseconds = 10_000;
+    private long _lastActivityTicks = Environment.TickCount64;
+
+    internal void MarkActivity()
+    {
+        Interlocked.Exchange(ref _lastActivityTicks, Environment.TickCount64);
+    }
+
     public DatabaseControlListener(DatabaseControlTransport transport, DatabaseControlEndpoint endpoint,
         IReceiver receiver, ILogger<DatabaseControlListener> logger, CancellationToken cancellationToken)
     {
@@ -44,7 +59,8 @@ internal class DatabaseControlListener : IListener
                     logger.LogError(e, "Error trying to poll for messages from the database control queue");
                 }
 
-                await Task.Delay(1.Seconds());
+                var idleFor = Environment.TickCount64 - Interlocked.Read(ref _lastActivityTicks);
+                await Task.Delay(idleFor < IdleAfterMilliseconds ? ActivePollInterval : IdlePollInterval);
             }
         }, _cancellation.Token);
 

--- a/src/Persistence/Wolverine.RDBMS/Transport/PollDatabaseControlQueue.cs
+++ b/src/Persistence/Wolverine.RDBMS/Transport/PollDatabaseControlQueue.cs
@@ -26,6 +26,10 @@ internal class PollDatabaseControlQueue : IDatabaseOperation, IAgentCommand
     public async Task<AgentCommands> ExecuteAsync(IWolverineRuntime runtime,
         CancellationToken cancellationToken)
     {
+        // GH-4321: only runs when the poll actually found envelopes — keep the listener at its
+        // active polling cadence while traffic is flowing
+        _listener.MarkActivity();
+
         await _receiver.ReceivedAsync(_listener, _envelopes.ToArray());
 
         await _transport.DeleteEnvelopesAsync(_envelopes, cancellationToken);

--- a/src/Wolverine/Runtime/WolverineRuntime.cs
+++ b/src/Wolverine/Runtime/WolverineRuntime.cs
@@ -20,6 +20,7 @@ using Wolverine.Runtime.RemoteInvocation;
 using Wolverine.Runtime.Routing;
 using Wolverine.Runtime.Scheduled;
 using Wolverine.Runtime.Stubs;
+using Wolverine.Transports;
 using Wolverine.Transports.Stub;
 
 namespace Wolverine.Runtime;
@@ -113,6 +114,10 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
         Cancellation = DurabilitySettings.Cancellation;
         _agentCancellation = CancellationTokenSource.CreateLinkedTokenSource(Cancellation);
 
+        // GH-4321: one shared 2s sweep serves every back-pressure-enforcing listener; its loop
+        // only starts when the first agent registers and dies with Cancellation
+        BackPressureSweeper = new BackPressureSweeper(Logger, Cancellation);
+
         Tracker = new WolverineTracker(Logger);
 
         _endpoints = new EndpointCollection(this);
@@ -189,6 +194,8 @@ public sealed partial class WolverineRuntime : IWolverineRuntime, IWolverineRunt
     /// See wolverine#2726.
     /// </summary>
     internal ObjectPool<Envelope> EnvelopePool { get; }
+
+    internal BackPressureSweeper BackPressureSweeper { get; }
 
     public HandlerGraph Handlers { get; }
 

--- a/src/Wolverine/Runtime/WorkerQueues/LeaseRenewalTracker.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/LeaseRenewalTracker.cs
@@ -151,7 +151,13 @@ internal class LeaseRenewalTracker : IAsyncDisposable
     public void Untrack(Envelope envelope)
     {
         _inFlight.TryRemove(envelope.Id, out _);
-        _lost.TryRemove(envelope.Id, out _);
+
+        // GH-4321: runs per message in native-ack mode, and _lost is empty except during an
+        // actual lease-loss incident — skip the bucket probe rather than paying it every time
+        if (!_lost.IsEmpty)
+        {
+            _lost.TryRemove(envelope.Id, out _);
+        }
     }
 
     private async Task runAsync()

--- a/src/Wolverine/Transports/BackPressureAgent.cs
+++ b/src/Wolverine/Transports/BackPressureAgent.cs
@@ -1,52 +1,44 @@
-using System.Timers;
 using Microsoft.Extensions.Logging;
 using Wolverine.Configuration;
 using Wolverine.Runtime.Agents;
-using Timer = System.Timers.Timer;
 
 namespace Wolverine.Transports;
 
 internal class BackPressureAgent : IDisposable
 {
-    // At the 2 second polling interval, this logs roughly once a minute while latched
+    // At the 2 second sweep interval, this logs roughly once a minute while latched
     internal const int LatchedChecksPerReminder = 30;
 
     private readonly IListeningAgent _agent;
     private readonly Endpoint _endpoint;
     private readonly IWolverineObserver _observer;
     private readonly ILogger _logger;
-    private Timer? _timer;
+    // GH-4321: the shared runtime sweeper replaced the per-endpoint System.Timers.Timer; null in
+    // unit tests that drive CheckNowAsync directly
+    private readonly BackPressureSweeper? _sweeper;
     private int _latchedChecks;
 
-    public BackPressureAgent(IListeningAgent agent, Endpoint endpoint, IWolverineObserver observer, ILogger logger)
+    public BackPressureAgent(IListeningAgent agent, Endpoint endpoint, IWolverineObserver observer, ILogger logger,
+        BackPressureSweeper? sweeper = null)
     {
         _agent = agent;
         _endpoint = endpoint;
         _observer = observer;
         _logger = logger;
+        _sweeper = sweeper;
     }
 
     public void Dispose()
     {
-        _timer?.Dispose();
+        _sweeper?.Unregister(this);
     }
 
     public void Start()
     {
-        _timer = new Timer
-        {
-            AutoReset = true, Enabled = true, Interval = 2000
-        };
-
-        _timer.Elapsed += TimerOnElapsed;
+        _sweeper?.Register(this);
     }
 
-    private void TimerOnElapsed(object? sender, ElapsedEventArgs e)
-    {
-        _ = checkSafelyAsync();
-    }
-
-    private async Task checkSafelyAsync()
+    internal async Task CheckSafelyAsync()
     {
         // An exception escaping CheckNowAsync from the timer used to be an unobserved ValueTask
         // fault — a listener whose restart kept throwing simply never resumed, with nothing in the

--- a/src/Wolverine/Transports/BackPressureSweeper.cs
+++ b/src/Wolverine/Transports/BackPressureSweeper.cs
@@ -1,0 +1,81 @@
+using System.Collections.Immutable;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Transports;
+
+/// <summary>
+/// GH-4321: one shared 2-second sweep over every back-pressure-enforcing listener. Each
+/// <see cref="BackPressureAgent"/> used to own a <c>System.Timers.Timer</c> — one timer-queue
+/// entry, an <c>ElapsedEventArgs</c>, an async state machine, and a fire-and-forget Task per
+/// endpoint per tick, forever, even on an idle process. One <see cref="PeriodicTimer"/> walking
+/// a copy-on-write list does the same work with a single timer wheel entry.
+/// </summary>
+internal class BackPressureSweeper
+{
+    internal static readonly TimeSpan Interval = 2.Seconds();
+
+    private readonly CancellationToken _cancellation;
+    private readonly ILogger _logger;
+    private readonly object _lock = new();
+    private ImmutableArray<BackPressureAgent> _agents = ImmutableArray<BackPressureAgent>.Empty;
+    private Task? _loop;
+
+    public BackPressureSweeper(ILogger logger, CancellationToken cancellation)
+    {
+        _logger = logger;
+        _cancellation = cancellation;
+    }
+
+    public void Register(BackPressureAgent agent)
+    {
+        lock (_lock)
+        {
+            if (!_agents.Contains(agent))
+            {
+                _agents = _agents.Add(agent);
+            }
+
+            // The loop only exists once something is actually listening with back pressure enabled
+            _loop ??= Task.Run(runAsync, _cancellation);
+        }
+    }
+
+    public void Unregister(BackPressureAgent agent)
+    {
+        lock (_lock)
+        {
+            _agents = _agents.Remove(agent);
+        }
+    }
+
+    private async Task runAsync()
+    {
+        using var timer = new PeriodicTimer(Interval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(_cancellation))
+            {
+                var snapshot = _agents;
+                foreach (var agent in snapshot)
+                {
+                    // CheckSafelyAsync contains its own per-agent try/catch (GH CritterWatch#922);
+                    // this outer guard only protects the loop itself
+                    try
+                    {
+                        await agent.CheckSafelyAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Unexpected error in the back pressure sweep");
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down
+        }
+    }
+}

--- a/src/Wolverine/Transports/ListeningAgent.cs
+++ b/src/Wolverine/Transports/ListeningAgent.cs
@@ -116,7 +116,8 @@ public class ListeningAgent : IAsyncDisposable, IDisposable, IListeningAgent
 
         if (endpoint.ShouldEnforceBackPressure())
         {
-            _backPressureAgent = new BackPressureAgent(this, endpoint, runtime.Observer, _logger);
+            _backPressureAgent = new BackPressureAgent(this, endpoint, runtime.Observer, _logger,
+                runtime.BackPressureSweeper);
             _backPressureAgent.Start();
         }
     }


### PR DESCRIPTION
Closes #4321. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**Control-queue idle backoff.** `DatabaseControlListener` polled at a hard 1 Hz — connection + transaction + DELETE + SELECT per tick per node, ~86k transactions/day/node against an almost-always-empty queue. The loop stays at 1s while control traffic flows (`PollDatabaseControlQueue` marks activity whenever it actually finds envelopes — it only executes then, by its own `PostProcessingCommands` gate) and relaxes to 5s after ten quiet seconds. Worst-case added latency for the first control message after a quiet spell is one 5s tick; the burst that follows runs at 1s again.

**Orphan sweep consolidation.** The inbox and outbox sweeps each opened their own connection and re-read the identical live-node list — 2 connections, 4 queries per 5s cycle in a healthy fleet where the sweep finds nothing. One connection and one node read now serve both. The GH-3850 owners-then-nodes race invariant is preserved *by construction*: both owner reads still precede the single live-node read, so a node registering in the gap appears in the node list and cannot own anything either owner read saw. (The invariant comment moved with the code.)

**One back-pressure sweep instead of N timers.** Each back-pressure-enforcing listener owned a 2-second `System.Timers.Timer` — an `ElapsedEventArgs`, an async state machine, and a fire-and-forget `Task` per endpoint per tick, forever, idle or not. A runtime-owned `BackPressureSweeper` (one `PeriodicTimer`, copy-on-write agent list, loop starts on first registration, dies with the runtime cancellation) walks them all. `BackPressureAgent`'s check logic is byte-for-byte unchanged; the existing unit tests drive `CheckNowAsync` directly and still pass; the CircuitBreaking CI lane exercises the swept path end-to-end.

**`LeaseRenewalTracker.Untrack`** skips the `_lost` dictionary probe per message when it's empty — i.e. whenever there is no active lease-loss incident.

**Deliberately deferred** (noted here rather than silently dropped): the twice-per-10s heartbeat write. The audit read it as redundant with the GH-2682 invariant, but the in-health-check write also carries the GH-3604/D2 "row deleted out from under us → re-register with real identity" duty. Deduplicating it is cluster-liveness surgery deserving its own design pass, not a rider on a polling PR.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2818 passed / 2 skipped / 0 failed (BackPressureAgent + lease-renewal suites included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)