### PR TITLE
GH-4318: SQL Server metrics counts come from index metadata, not three full scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,22 +190,6 @@
   shard tears down, because the row cannot be dropped before the agent has actually stopped without
   lying about ownership. Acting on the window was the defect, not the window.
 
-### WolverineFx.SqlServer
-
-- **The metrics sampler stops scanning; per-status counts come from index metadata.** (closes
-  [#4318](https://github.com/JasperFx/wolverine/issues/4318)) `FetchCountsAsync` ran a
-  `group by status` scan of the inbox plus two bare `count(*)` scans (outbox, dead letters) on
-  every 5-second `UpdateMetricsPeriod` tick — on a multi-million-row inbox with handled-message
-  retention, likely the most expensive recurring query in a SQL Server deployment. One
-  `sys.dm_db_partition_stats` metadata query now answers everything with zero scans at any size:
-  unlike PostgreSQL's sampled `reltuples`, `row_count` is transactionally-maintained and exact, the
-  GH-4316 `keep_until` filtered index supplies the Handled slice, and a new
-  `idx_wolverine_incoming_scheduled` filtered index supplies the Scheduled slice — an index that
-  also gives the scheduled-message promotion poll (`status = 'Scheduled' and execution_time <= now`)
-  an index seek instead of its own full scan every recovery cycle. Principals without
-  VIEW DATABASE STATE and schemas that predate the filtered indexes fall back to the old scanning
-  form automatically.
-
 ### WolverineFx.RDBMS (all relational providers)
 
 - **The durability recovery poll and expired-handled cleanup finally have indexes they can use.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,22 @@
   shard tears down, because the row cannot be dropped before the agent has actually stopped without
   lying about ownership. Acting on the window was the defect, not the window.
 
+### WolverineFx.SqlServer
+
+- **The metrics sampler stops scanning; per-status counts come from index metadata.** (closes
+  [#4318](https://github.com/JasperFx/wolverine/issues/4318)) `FetchCountsAsync` ran a
+  `group by status` scan of the inbox plus two bare `count(*)` scans (outbox, dead letters) on
+  every 5-second `UpdateMetricsPeriod` tick — on a multi-million-row inbox with handled-message
+  retention, likely the most expensive recurring query in a SQL Server deployment. One
+  `sys.dm_db_partition_stats` metadata query now answers everything with zero scans at any size:
+  unlike PostgreSQL's sampled `reltuples`, `row_count` is transactionally-maintained and exact, the
+  GH-4316 `keep_until` filtered index supplies the Handled slice, and a new
+  `idx_wolverine_incoming_scheduled` filtered index supplies the Scheduled slice — an index that
+  also gives the scheduled-message promotion poll (`status = 'Scheduled' and execution_time <= now`)
+  an index seek instead of its own full scan every recovery cycle. Principals without
+  VIEW DATABASE STATE and schemas that predate the filtered indexes fall back to the old scanning
+  form automatically.
+
 ### WolverineFx.RDBMS (all relational providers)
 
 - **The durability recovery poll and expired-handled cleanup finally have indexes they can use.**

--- a/src/Persistence/SqlServerTests/EnvelopeTables_recovery_index_creation.cs
+++ b/src/Persistence/SqlServerTests/EnvelopeTables_recovery_index_creation.cs
@@ -42,6 +42,7 @@ public class EnvelopeTables_recovery_index_creation : IAsyncLifetime
 
         table.Indexes.ShouldContain(x => x.Name.Contains("recover"));
         table.Indexes.ShouldContain(x => x.Name.Contains("keep_until"));
+        table.Indexes.ShouldContain(x => x.Name.Contains("scheduled"));
 
         await table.ApplyChangesAsync(theConnection, ct: TestContext.Current.CancellationToken);
 

--- a/src/Persistence/SqlServerTests/Persistence/fetch_counts_via_partition_stats.cs
+++ b/src/Persistence/SqlServerTests/Persistence/fetch_counts_via_partition_stats.cs
@@ -1,0 +1,95 @@
+using IntegrationTests;
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Weasel.SqlServer;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.SqlServer;
+
+namespace SqlServerTests.Persistence;
+
+// GH-4318: FetchCountsAsync answers from sys.dm_db_partition_stats plus the filtered-index row
+// counts instead of three full scans. dm_db_partition_stats.row_count is transactionally
+// maintained metadata, so the numbers must EXACTLY match what the old group-by scan reported —
+// this seeds every status the split has to reconstruct (Incoming, Handled, Scheduled) plus the
+// outbox and asserts the arithmetic.
+[Collection("sqlserver")]
+public class fetch_counts_via_partition_stats : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IMessageStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using (var conn = new SqlConnection(Servers.SqlServerConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.DropSchemaAsync("counts_stats");
+            await conn.CloseAsync();
+        }
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, "counts_stats");
+            })
+            .StartAsync();
+
+        _store = _host.Services.GetRequiredService<IMessageStore>();
+        await _store.Admin.ClearAllAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task counts_match_seeded_rows_across_every_status()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            var incoming = ObjectMother.Envelope();
+            incoming.Status = EnvelopeStatus.Incoming;
+            await _store.Inbox.StoreIncomingAsync(incoming);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            var handled = ObjectMother.Envelope();
+            handled.Status = EnvelopeStatus.Incoming;
+            await _store.Inbox.StoreIncomingAsync(handled);
+            await _store.Inbox.MarkIncomingEnvelopeAsHandledAsync(handled);
+        }
+
+        for (var i = 0; i < 2; i++)
+        {
+            // StoreIncomingAsync persists whatever status the envelope carries; the dedicated
+            // ScheduleExecutionAsync path is an update against an already-stored row
+            var scheduled = ObjectMother.Envelope();
+            scheduled.Status = EnvelopeStatus.Scheduled;
+            scheduled.OwnerId = 0;
+            scheduled.ScheduledTime = DateTimeOffset.UtcNow.AddHours(1);
+            await _store.Inbox.StoreIncomingAsync(scheduled);
+        }
+
+        for (var i = 0; i < 4; i++)
+        {
+            var outgoing = ObjectMother.Envelope();
+            await _store.Outbox.StoreOutgoingAsync(outgoing, 0);
+        }
+
+        var counts = await _store.Admin.FetchCountsAsync();
+
+        counts.Incoming.ShouldBe(5);
+        counts.Handled.ShouldBe(3);
+        counts.Scheduled.ShouldBe(2);
+        counts.Outgoing.ShouldBe(4);
+        counts.DeadLetter.ShouldBe(0);
+    }
+}

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -222,6 +222,97 @@ public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnection
 
     public override async Task<PersistedCounts> FetchCountsAsync()
     {
+        // GH-4318: this runs on every UpdateMetricsPeriod tick (5s default), and the scanning
+        // form below pays three full scans of tables that can hold millions of retained rows.
+        // sys.dm_db_partition_stats.row_count is transactionally-maintained metadata — exact,
+        // unlike PostgreSQL's sampled reltuples — and the GH-4316/GH-4318 filtered indexes carry
+        // the per-status split (Handled and Scheduled slices) as their own row counts, so one
+        // metadata query answers everything with zero scans at any table size. Reading the DMV
+        // needs VIEW DATABASE STATE, and an old schema may lack the filtered indexes; both cases
+        // fall back to the scanning form.
+        try
+        {
+            var counts = await tryFetchCountsFromPartitionStatsAsync();
+            if (counts != null)
+            {
+                return counts;
+            }
+        }
+        catch (SqlException)
+        {
+            // Most likely a principal without VIEW DATABASE STATE — pay for the scans instead
+        }
+
+        return await fetchCountsWithScansAsync();
+    }
+
+    private async Task<PersistedCounts?> tryFetchCountsFromPartitionStatsAsync()
+    {
+        var sql = $@"
+select o.name, ps.index_id, isnull(i.name, ''), sum(ps.row_count)
+from sys.dm_db_partition_stats ps
+join sys.objects o on ps.object_id = o.object_id
+join sys.schemas s on o.schema_id = s.schema_id
+join sys.indexes i on ps.object_id = i.object_id and ps.index_id = i.index_id
+where s.name = @schema
+  and o.name in ('{DatabaseConstants.IncomingTable}', '{DatabaseConstants.OutgoingTable}', '{DatabaseConstants.DeadLetterTable}')
+group by o.name, ps.index_id, i.name";
+
+        long incomingTotal = 0;
+        long? handled = null;
+        long? scheduled = null;
+        var counts = new PersistedCounts();
+
+        await using (var reader = await CreateCommand(sql).With("schema", SchemaName).ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                var tableName = await reader.GetFieldValueAsync<string>(0);
+                var indexId = await reader.GetFieldValueAsync<int>(1);
+                var indexName = await reader.GetFieldValueAsync<string>(2);
+                var rows = await reader.GetFieldValueAsync<long>(3);
+
+                if (tableName == DatabaseConstants.OutgoingTable)
+                {
+                    if (indexId <= 1) counts.Outgoing = (int)rows;
+                }
+                else if (tableName == DatabaseConstants.DeadLetterTable)
+                {
+                    if (indexId <= 1) counts.DeadLetter = (int)rows;
+                }
+                else if (indexId <= 1)
+                {
+                    incomingTotal = rows;
+                }
+                else if (indexName == $"idx_{DatabaseConstants.IncomingTable}_keep_until")
+                {
+                    handled = rows;
+                }
+                else if (indexName == $"idx_{DatabaseConstants.IncomingTable}_scheduled")
+                {
+                    scheduled = rows;
+                }
+            }
+
+            await reader.CloseAsync();
+        }
+
+        // Without both filtered indexes there is no per-status split — an older schema that was
+        // never migrated. Let the caller take the scanning path.
+        if (handled == null || scheduled == null)
+        {
+            return null;
+        }
+
+        counts.Handled = (int)handled.Value;
+        counts.Scheduled = (int)scheduled.Value;
+        counts.Incoming = (int)Math.Max(0, incomingTotal - handled.Value - scheduled.Value);
+
+        return counts;
+    }
+
+    private async Task<PersistedCounts> fetchCountsWithScansAsync()
+    {
         var counts = new PersistedCounts();
 
         await using (var reader = await CreateCommand($"select status, count(*) from {SchemaName}.{DatabaseConstants.IncomingTable} group by status")

--- a/src/Persistence/Wolverine.SqlServer/Schema/IncomingEnvelopeTable.cs
+++ b/src/Persistence/Wolverine.SqlServer/Schema/IncomingEnvelopeTable.cs
@@ -67,5 +67,16 @@ internal class IncomingEnvelopeTable : Table
             Columns = [DatabaseConstants.KeepUntil],
             Predicate = $"[{DatabaseConstants.Status}]='Handled'"
         });
+
+        // GH-4318: earns its keep twice. The scheduled-message promotion poll
+        // (`status = 'Scheduled' and execution_time <= now order by execution_time`) gets an
+        // index seek instead of a full scan every recovery cycle, and the filtered index's own
+        // sys.dm_db_partition_stats row count gives FetchCountsAsync the Scheduled slice for
+        // free — the per-status metrics split no longer needs a `group by status` scan.
+        Indexes.Add(new IndexDefinition($"idx_{DatabaseConstants.IncomingTable}_scheduled")
+        {
+            Columns = [DatabaseConstants.ExecutionTime],
+            Predicate = $"[{DatabaseConstants.Status}]='Scheduled'"
+        });
     }
 }


### PR DESCRIPTION
Closes #4318. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

`FetchCountsAsync` ran a `group by status` scan of the inbox plus bare `count(*)` scans of the outbox and dead-letter tables on **every** `UpdateMetricsPeriod` tick (5s default). On a multi-million-row inbox with handled-message retention that is likely the most expensive recurring query in a SQL Server deployment. PostgreSQL got the `pg_class.reltuples` estimate treatment for exactly this reason; SQL Server never got its equivalent.

**Why `sys.dm_db_partition_stats` rather than an estimate**: `row_count` is transactionally maintained, so unlike PostgreSQL's *sampled* `reltuples` it is exact — none of the GH-3885 small-table staleness gating is needed here, and the numbers reported to CritterWatch don't change at all, only their cost.

**How the per-status split works without scanning**: the heap/clustered entry (`index_id <= 1`) gives each table's total; the GH-4316 `keep_until` filtered index (`where status = 'Handled'`) has exactly the Handled rows in its own row count; a new `idx_wolverine_incoming_scheduled` filtered index (`where status = 'Scheduled'`) supplies Scheduled; Incoming is the remainder. That new index earns its keep twice — the scheduled-message promotion poll (`status = 'Scheduled' and execution_time <= now order by execution_time`) gets an index seek instead of its own full scan on every recovery cycle.

**Fallbacks, so nobody gets wrong numbers instead of slow ones**: a `SqlException` (a principal lacking VIEW DATABASE STATE) or a missing filtered index (a schema predating GH-4316/GH-4318) drops straight back to the original scanning implementation, which is retained intact.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- New `fetch_counts_via_partition_stats`: seeds Incoming/Handled/Scheduled/Outgoing rows and asserts each count exactly — this is the test that proves the metadata split reconstructs what the group-by scan reported (it caught one wrong seeding assumption during development)
- `EnvelopeTables_recovery_index_creation` extended for the new filtered index, including the `FindDeltaAsync == None` migration-thrash guard
- SqlServerTests index + transport data-operations slice green alongside

🤖 Generated with [Claude Code](https://claude.com/claude-code)