### PR TITLE
GH-4327: stop double-copying the payload on every persisted envelope

### DIFF
--- a/src/Testing/CoreTests/Serialization/serialize_to_base64_4327.cs
+++ b/src/Testing/CoreTests/Serialization/serialize_to_base64_4327.cs
@@ -1,0 +1,64 @@
+using JasperFx.Core;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Serialization;
+
+// GH-4327: SerializeToBase64 writes straight from the stream buffer to the base64 string instead
+// of Serialize()'s byte[] then Convert.ToBase64String -- one payload-sized allocation instead of
+// three. Because it uses GetBuffer() rather than ToArray(), the length bound is the whole
+// correctness question: an off-by-one there silently ships the MemoryStream's uninitialized slack
+// as trailing garbage. These tests pin the byte-for-byte equivalence with the old two-step form.
+public class serialize_to_base64_4327
+{
+    private static Envelope envelopeWithPayload(int payloadSize)
+    {
+        var envelope = new Envelope
+        {
+            SentAt = DateTime.Today.ToUniversalTime(),
+            Data = payloadSize == 0 ? [] : Enumerable.Range(0, payloadSize).Select(x => (byte)(x % 251)).ToArray(),
+            Destination = "sqs://queue/incoming".ToUri(),
+            ReplyUri = "sqs://queue/replies".ToUri(),
+            MessageType = "some-message",
+            ContentType = "application/json"
+        };
+
+        envelope.Headers.Add("name", "Jeremy");
+        return envelope;
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(6)]
+    [InlineData(1024)]
+    [InlineData(100_000)]
+    public void matches_the_serialize_then_base64_encode_form(int payloadSize)
+    {
+        var envelope = envelopeWithPayload(payloadSize);
+
+        var expected = Convert.ToBase64String(EnvelopeSerializer.Serialize(envelope));
+
+        EnvelopeSerializer.SerializeToBase64(envelope).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(6)]
+    [InlineData(100_000)]
+    public void round_trips_through_the_reader(int payloadSize)
+    {
+        var envelope = envelopeWithPayload(payloadSize);
+
+        var incoming = EnvelopeSerializer.Deserialize(
+            Convert.FromBase64String(EnvelopeSerializer.SerializeToBase64(envelope)));
+
+        incoming.Data.ShouldBe(envelope.Data);
+        incoming.Destination.ShouldBe(envelope.Destination);
+        incoming.ReplyUri.ShouldBe(envelope.ReplyUri);
+        incoming.MessageType.ShouldBe(envelope.MessageType);
+        incoming.Headers["name"].ShouldBe("Jeremy");
+    }
+}

--- a/src/Transports/AWS/Wolverine.AmazonSqs/ISqsEnvelopeMapper.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/ISqsEnvelopeMapper.cs
@@ -28,14 +28,22 @@ public class DefaultSqsEnvelopeMapper : ISqsEnvelopeMapper
 {
     public string BuildMessageBody(Envelope envelope)
     {
-        var data = EnvelopeSerializer.Serialize(envelope);
-        return Convert.ToBase64String(data);
+        // GH-4327: straight to base64 — the old shape paid stream-growth copies, a ToArray, and
+        // then the base64 string, three payload-sized allocations per outgoing message
+        return EnvelopeSerializer.SerializeToBase64(envelope);
     }
+
+    // GH-4327: the attribute set is constant, so don't run a yield-iterator state machine per
+    // outgoing message. Consumers only read the shared value into the outgoing request.
+    private static readonly KeyValuePair<string, MessageAttributeValue>[] _protocolAttributes =
+    [
+        new(TransportConstants.ProtocolVersion,
+            new MessageAttributeValue { StringValue = "1.0", DataType = "String" })
+    ];
 
     public IEnumerable<KeyValuePair<string, MessageAttributeValue>> ToAttributes(Envelope envelope)
     {
-        yield return new KeyValuePair<string, MessageAttributeValue>(TransportConstants.ProtocolVersion,
-            new MessageAttributeValue { StringValue = "1.0", DataType = "String" });
+        return _protocolAttributes;
     }
 
     public void ReadEnvelopeData(Envelope envelope, string messageBody,

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubEnvelopeMapper.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubEnvelopeMapper.cs
@@ -28,7 +28,10 @@ public class PubsubEnvelopeMapper : EnvelopeMapper<PubsubMessage, PubsubMessage>
                     return;
                 }
 
-                m.Data = ByteString.CopyFrom(e.Data);
+                // GH-4327: UnsafeWrap shares the buffer instead of copying it — Wolverine never
+                // mutates Envelope.Data after handing it to the sender, so the wrap is safe and
+                // removes a payload-sized allocation per outgoing message
+                m.Data = UnsafeByteOperations.UnsafeWrap(e.Data);
             }
         );
 
@@ -39,7 +42,7 @@ public class PubsubEnvelopeMapper : EnvelopeMapper<PubsubMessage, PubsubMessage>
 
     public void MapOutgoingToMessage(OutgoingMessageBatch outgoing, PubsubMessage message)
     {
-        message.Data = ByteString.CopyFrom(outgoing.Data);
+        message.Data = UnsafeByteOperations.UnsafeWrap(outgoing.Data);
         message.Attributes["destination"] = outgoing.Destination.ToString();
         message.Attributes["batched"] = "1";
     }

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -313,9 +313,21 @@ public static class EnvelopeSerializer
         envelope.Data = br.ReadBytes(byteCount);
     }
 
+    // GH-4327: generous fixed allowance for the header/metadata portion of a serialized envelope.
+    // Undershooting only costs one growth doubling; the old unsized stream started at 0 and
+    // doubled its way past the whole body, copying the payload multiple times per persisted
+    // envelope on the way.
+    private const int HeaderSizeEstimate = 512;
+
     public static byte[] Serialize(IList<Envelope> messages)
     {
-        using var stream = new MemoryStream();
+        var size = HeaderSizeEstimate * messages.Count + sizeof(int);
+        for (var i = 0; i < messages.Count; i++)
+        {
+            size += messages[i].Data?.Length ?? 0;
+        }
+
+        using var stream = new MemoryStream(size);
         using var writer = new BinaryWriter(stream);
         writer.Write(messages.Count);
         foreach (var message in messages) writeSingle(writer, message);
@@ -325,11 +337,26 @@ public static class EnvelopeSerializer
 
     public static byte[] Serialize(Envelope env)
     {
-        using var stream = new MemoryStream();
+        using var stream = new MemoryStream((env.Data?.Length ?? 0) + HeaderSizeEstimate);
         using var writer = new BinaryWriter(stream);
         writeSingle(writer, env);
         writer.Flush();
         return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Serialize an envelope straight to a base64 string (the SQS body encoding) without
+    /// materializing the intermediate byte[] that <see cref="Serialize(Envelope)"/> returns.
+    /// </summary>
+    public static string SerializeToBase64(Envelope env)
+    {
+        using var stream = new MemoryStream((env.Data?.Length ?? 0) + HeaderSizeEstimate);
+        using var writer = new BinaryWriter(stream);
+        writeSingle(writer, env);
+        writer.Flush();
+
+        // GetBuffer avoids the ToArray copy; the base64 string is the one unavoidable allocation
+        return Convert.ToBase64String(stream.GetBuffer(), 0, (int)stream.Length);
     }
 
     private static void writeSingle(BinaryWriter writer, Envelope env)


### PR DESCRIPTION
Closes #4327. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

`EnvelopeSerializer.Serialize` wrote through an **unsized** `MemoryStream` — which doubled its way past the body, copying the payload repeatedly on the way — and then paid a full `ToArray()`. Two payload-sized copies per envelope on every durable inbox insert, outbox insert, DLQ move, scheduled-send wrap, and TCP/SQS body. The stream is now sized from the body length plus a header allowance, so the common case is one buffer and one copy.

The SQS body path stacked a **third** copy on top (base64 of the returned array). A new `SerializeToBase64` goes straight from the stream buffer to the base64 string via `GetBuffer()` with an explicit length bound.

**That length bound is the whole correctness question** — `GetBuffer()` returns the backing array including uninitialized slack, so an off-by-one silently ships trailing garbage on the wire. It's pinned by tests asserting byte-for-byte equality with the old serialize-then-encode form across empty / 1-byte / 6-byte / 1KB / 100KB payloads, plus reader round-trips.

Also: the default SQS mapper's constant attribute set no longer runs a `yield return` iterator state machine per outgoing message, and GCP Pub/Sub outgoing payloads use `UnsafeByteOperations.UnsafeWrap` instead of `ByteString.CopyFrom` — Wolverine never mutates `Envelope.Data` after handing it to a sender, so that copy bought nothing.

The read-side copies (`ReadBytes`, the broker-buffer `ToArray()`s) need `Envelope.Data` to stop being a `byte[]`; that's the #4333 design item, deliberately not attempted here.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- New `serialize_to_base64_4327`: 8/8 — the equivalence and round-trip guards described above
- CoreTests Serialization suite: 193/193
- The SQS integration lanes (CIAWSSqs, CIAWSSqsCompliance) are the wire-level gate and run here in CI; I did not commandeer the LocalStack container another session on this machine is using

🤖 Generated with [Claude Code](https://claude.com/claude-code)