### PR TITLE
GH-4328: stop decoding every reserved header twice on four transports

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
@@ -51,6 +51,12 @@ public class AzureServiceBusEnvelopeMapper : EnvelopeMapper<ServiceBusReceivedMe
 
     }
 
+    // GH-4328: writeIncomingHeaders copies every wire header into Envelope.Headers with the same
+    // keys and stringification the per-property reader would produce, so let the ~20 reserved
+    // property reads answer from the copied dictionary instead of re-probing (and re-stringifying
+    // from) the transport message on every one. Same opt-in RabbitMQ and Kafka took in GH-3490/92.
+    protected override bool preferCopiedIncomingHeaders => true;
+
     protected override void writeOutgoingHeader(ServiceBusMessage outgoing, string key, string value)
     {
         outgoing.ApplicationProperties[key] = value;

--- a/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubEnvelopeMapper.cs
+++ b/src/Transports/GCP/Wolverine.Pubsub/Internal/PubsubEnvelopeMapper.cs
@@ -49,6 +49,12 @@ public class PubsubEnvelopeMapper : EnvelopeMapper<PubsubMessage, PubsubMessage>
         outgoing.Attributes[key] = value;
     }
 
+    // GH-4328: writeIncomingHeaders copies every wire header into Envelope.Headers with the same
+    // keys and stringification the per-property reader would produce, so let the ~20 reserved
+    // property reads answer from the copied dictionary instead of re-probing (and re-stringifying
+    // from) the transport message on every one. Same opt-in RabbitMQ and Kafka took in GH-3490/92.
+    protected override bool preferCopiedIncomingHeaders => true;
+
     protected override void writeIncomingHeaders(PubsubMessage incoming, Envelope envelope)
     {
         if (incoming.Attributes is null)

--- a/src/Transports/NATS/Wolverine.Nats/Internal/NatsEnvelopeMapper.cs
+++ b/src/Transports/NATS/Wolverine.Nats/Internal/NatsEnvelopeMapper.cs
@@ -1,3 +1,4 @@
+using ImTools;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
 using Wolverine.Runtime.Serialization;
@@ -7,6 +8,24 @@ namespace Wolverine.Nats.Internal;
 
 public class NatsEnvelopeMapper : EnvelopeMapper<NatsMsg<byte[]>, NatsHeaders>
 {
+    // GH-4328: one Uri per received message was being parsed from an interpolated string, but the
+    // subject on an incoming message is the listener's own subscribed subject — a small bounded
+    // set. Reply subjects are deliberately NOT cached: request/reply uses ephemeral per-request
+    // _INBOX.* subjects and caching those would grow without bound.
+    private static ImHashMap<string, Uri> _subjectUris = ImHashMap<string, Uri>.Empty;
+
+    internal static Uri UriForIncomingSubject(string subject)
+    {
+        if (_subjectUris.TryFind(subject, out var uri))
+        {
+            return uri;
+        }
+
+        uri = new Uri($"nats://subject/{subject}");
+        _subjectUris = _subjectUris.AddOrUpdate(subject, uri);
+        return uri;
+    }
+
     private readonly ITenantSubjectMapper? _tenantMapper;
     
     public NatsEnvelopeMapper(NatsEndpoint endpoint, ITenantSubjectMapper? tenantMapper = null)
@@ -19,6 +38,12 @@ public class NatsEnvelopeMapper : EnvelopeMapper<NatsMsg<byte[]>, NatsHeaders>
     {
         headers[key] = value;
     }
+
+    // GH-4328: writeIncomingHeaders copies every wire header into Envelope.Headers with the same
+    // keys and stringification the per-property reader would produce, so let the ~20 reserved
+    // property reads answer from the copied dictionary instead of re-probing (and re-stringifying
+    // from) the transport message on every one. Same opt-in RabbitMQ and Kafka took in GH-3490/92.
+    protected override bool preferCopiedIncomingHeaders => true;
 
     protected override bool tryReadIncomingHeader(
         NatsMsg<byte[]> incoming,
@@ -45,7 +70,7 @@ public class NatsEnvelopeMapper : EnvelopeMapper<NatsMsg<byte[]>, NatsHeaders>
     protected override void writeIncomingHeaders(NatsMsg<byte[]> incoming, Envelope envelope)
     {
         envelope.Data = incoming.Data;
-        envelope.Destination = new Uri($"nats://subject/{incoming.Subject}");
+        envelope.Destination = UriForIncomingSubject(incoming.Subject);
 
         if (_tenantMapper != null)
         {
@@ -90,6 +115,12 @@ public class JetStreamEnvelopeMapper : EnvelopeMapper<INatsJSMsg<byte[]>, NatsHe
         headers[key] = value;
     }
 
+    // GH-4328: writeIncomingHeaders copies every wire header into Envelope.Headers with the same
+    // keys and stringification the per-property reader would produce, so let the ~20 reserved
+    // property reads answer from the copied dictionary instead of re-probing (and re-stringifying
+    // from) the transport message on every one. Same opt-in RabbitMQ and Kafka took in GH-3490/92.
+    protected override bool preferCopiedIncomingHeaders => true;
+
     protected override bool tryReadIncomingHeader(
         INatsJSMsg<byte[]> incoming,
         string key,
@@ -115,7 +146,7 @@ public class JetStreamEnvelopeMapper : EnvelopeMapper<INatsJSMsg<byte[]>, NatsHe
     protected override void writeIncomingHeaders(INatsJSMsg<byte[]> incoming, Envelope envelope)
     {
         envelope.Data = incoming.Data;
-        envelope.Destination = new Uri($"nats://subject/{incoming.Subject}");
+        envelope.Destination = NatsEnvelopeMapper.UriForIncomingSubject(incoming.Subject);
 
         if (_tenantMapper != null)
         {

--- a/src/Transports/Redis/Wolverine.Redis/RedisEnvelopeMapper.cs
+++ b/src/Transports/Redis/Wolverine.Redis/RedisEnvelopeMapper.cs
@@ -15,8 +15,20 @@ public class RedisEnvelopeMapper : EnvelopeMapper<StreamEntry, List<NameValueEnt
 
     public RedisEnvelopeMapper(Endpoint endpoint) : base(endpoint)
     {
-        MapProperty(x => x.Data!, 
-            (e, m) => e.Data = m.Values.FirstOrDefault(x => x.Name == "payload").Value,
+        MapProperty(x => x.Data!,
+            // GH-4328: plain loop — FirstOrDefault allocated an enumerator + predicate delegate
+            // per received message for a single-field probe
+            (e, m) =>
+            {
+                foreach (var entry in m.Values)
+                {
+                    if (entry.Name == "payload")
+                    {
+                        e.Data = entry.Value;
+                        return;
+                    }
+                }
+            },
             (e, m) => m.Add(new NameValueEntry("payload", e.Data)));
     }
 
@@ -28,6 +40,12 @@ public class RedisEnvelopeMapper : EnvelopeMapper<StreamEntry, List<NameValueEnt
 
         outgoing.Add(new NameValueEntry($"{HeaderPrefix}{key}", value));
     }
+
+    // GH-4328: writeIncomingHeaders copies every wire header into Envelope.Headers with the same
+    // keys and stringification the per-property reader would produce, so let the ~20 reserved
+    // property reads answer from the copied dictionary instead of re-probing (and re-stringifying
+    // from) the transport message on every one. Same opt-in RabbitMQ and Kafka took in GH-3490/92.
+    protected override bool preferCopiedIncomingHeaders => true;
 
     protected override bool tryReadIncomingHeader(StreamEntry incoming, string key, out string? value)
     {


### PR DESCRIPTION
Closes #4328. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

RabbitMQ and Kafka set `preferCopiedIncomingHeaders => true` back in the GH-3490/3492 waves so the ~20 reserved-property readers pull from the already-copied `Envelope.Headers` instead of re-probing the transport message. **Azure Service Bus, GCP Pub/Sub, NATS (core + JetStream) and Redis all satisfy the same precondition** — their `writeIncomingHeaders` copies every wire header verbatim, same keys, same stringification — and simply never took the flag. Each was re-probing *and re-stringifying* ~20 times per received envelope:

- **ASB**: `pair.Value?.ToString()` on the copy, then `header.ToString()` again per reserved read — ~21 redundant boxed `ToString()`s per message.
- **Redis** (worst): every probe interpolated a `wolverine-`-prefixed key string *and* linearly scanned the entry's fields — O(21 × fieldCount) plus 21 interpolations per message.
- **NATS / JetStream, Pub/Sub**: same double-probe shape.

**NATS Uri interning.** The destination was parsed from an interpolated string per received message. The incoming subject is the listener's own subscribed subject — a small bounded set — so it's now interned in an `ImHashMap`. Reply subjects are deliberately *not* interned: request/reply uses ephemeral per-request `_INBOX.*` subjects, and caching those would grow without bound. That distinction is the reason this is a targeted cache rather than a blanket one.

**Redis payload lookup** drops a LINQ `FirstOrDefault` (enumerator + predicate delegate per message) for a plain loop over the same fields.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate — and worth noting it caught two real compile errors in the NATS change that an earlier truncated per-project build had hidden from me)
- NATS mapper/envelope tests: 15/15
- Redis mapper/envelope tests: 15/15
- The ASB and Pub/Sub emulator lanes in CI are the integration gate for those two

🤖 Generated with [Claude Code](https://claude.com/claude-code)