### PR TITLE
GH-4332: receive-loop and completion-path allocation trims

### DIFF
--- a/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
+++ b/src/Transports/AWS/Wolverine.AmazonSqs/Internal/SqsListener.cs
@@ -169,7 +169,8 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
 
         var results = await _transport.Client!.ReceiveMessageAsync(request, token);
 
-        if (results.Messages == null || !results.Messages.Any())
+        // GH-4332: .Count, not .Any() -- the latter boxes an enumerator on a List
+        if (results.Messages == null || results.Messages.Count == 0)
         {
             // No work — the loop applies its idle delay before polling again.
             return false;
@@ -219,11 +220,15 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
         }
 
         // ReSharper disable once CoVariantArrayConversion
-        if (envelopes.Any())
+        if (envelopes.Count > 0)
         {
+            // GH-4332: materialize the array once and reuse it on both branches; the heartbeat
+            // branch used to build it twice for the same list
+            var batch = envelopes.ToArray();
+
             if (_heartbeat == null)
             {
-                await _receiver.ReceivedAsync(this, envelopes.ToArray());
+                await _receiver.ReceivedAsync(this, batch);
             }
             else
             {
@@ -233,7 +238,7 @@ internal class SqsListener : IListener, ISupportDeadLetterQueue, IReportReceiveL
                 _heartbeat.Track(inFlight);
                 try
                 {
-                    await _receiver.ReceivedAsync(this, envelopes.ToArray());
+                    await _receiver.ReceivedAsync(this, batch);
                 }
                 finally
                 {

--- a/src/Wolverine/Runtime/Handlers/FanoutMessageHandler.cs
+++ b/src/Wolverine/Runtime/Handlers/FanoutMessageHandler.cs
@@ -6,7 +6,11 @@ internal class FanoutMessageHandler<T> : MessageHandler<T>
 
     public FanoutMessageHandler(Uri[] localQueueUris, HandlerChain chain)
     {
-        _localQueueUris = localQueueUris;
+        // GH-4332 / GH-2303: deduplicate ONCE here. The safety net against a sticky handler
+        // queue reachable by multiple paths is a property of this fixed array, so recomputing it
+        // per message (a HashSet<Uri> allocation plus a full-string Uri.GetHashCode per entry)
+        // only ever produced the same answer.
+        _localQueueUris = localQueueUris.Distinct().ToArray();
         Chain = chain;
     }
 
@@ -23,16 +27,10 @@ internal class FanoutMessageHandler<T> : MessageHandler<T>
             }
         }
 
-        // Safety net: deduplicate target URIs to prevent double delivery
-        // when the same sticky handler queue is reachable via multiple paths.
-        // See https://github.com/JasperFx/wolverine/issues/2303
-        var sent = new HashSet<Uri>();
+        // _localQueueUris is already distinct -- see the constructor
         foreach (var uri in _localQueueUris)
         {
-            if (sent.Add(uri))
-            {
-                await context.EndpointFor(uri).SendAsync(message, options);
-            }
+            await context.EndpointFor(uri).SendAsync(message, options);
         }
     }
 }

--- a/src/Wolverine/Runtime/WorkerQueues/InboxCompletionCoalescer.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InboxCompletionCoalescer.cs
@@ -25,7 +25,11 @@ internal class InboxCompletionCoalescer
     private readonly ILogger _logger;
     private readonly Uri _uri;
     private readonly object _lock = new();
-    private readonly List<Pending> _pending = new();
+
+    // GH-4332: a Queue, not a List. Draining a List with RemoveRange(0, n) memmoves everything
+    // behind the batch on every flush, so a deep backlog costs O(N) per flush of _maximumBatchSize
+    // -- quadratic overall exactly when the system is most behind.
+    private readonly Queue<Pending> _pending = new();
     private bool _flushing;
     private Task? _flushLoop;
 
@@ -69,7 +73,7 @@ internal class InboxCompletionCoalescer
         var startLoop = false;
         lock (_lock)
         {
-            _pending.Add(pending);
+            _pending.Enqueue(pending);
             if (!_flushing)
             {
                 _flushing = true;
@@ -121,8 +125,11 @@ internal class InboxCompletionCoalescer
                 }
 
                 var take = Math.Min(_maximumBatchSize, _pending.Count);
-                batch = _pending.GetRange(0, take).ToArray();
-                _pending.RemoveRange(0, take);
+                batch = new Pending[take];
+                for (var i = 0; i < take; i++)
+                {
+                    batch[i] = _pending.Dequeue();
+                }
             }
 
             await flushAsync(batch).ConfigureAwait(false);
@@ -139,7 +146,15 @@ internal class InboxCompletionCoalescer
             }
             else
             {
-                await _markBatch(batch.Select(x => x.Envelope).ToList()).ConfigureAwait(false);
+                // Pre-sized array rather than a LINQ projection into a List: this runs once per
+                // flush on every durable endpoint
+                var envelopes = new Envelope[batch.Length];
+                for (var i = 0; i < batch.Length; i++)
+                {
+                    envelopes[i] = batch[i].Envelope;
+                }
+
+                await _markBatch(envelopes).ConfigureAwait(false);
             }
         }
         catch (Exception e)

--- a/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/NativeAckReceiver.cs
@@ -215,7 +215,10 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
 
         if (await admitAsync(listener, envelope, now).ConfigureAwait(false) is { } entry)
         {
-            await postAllAsync([entry]).ConfigureAwait(false);
+            // GH-4332: RabbitMQ and Pub/Sub deliver one at a time, so this is the dominant
+            // native-ack path -- postAllAsync([entry]) allocated a single-element tuple array and
+            // boxed it behind IReadOnlyList per message
+            await postOneAsync(entry.Envelope, entry.Activity).ConfigureAwait(false);
         }
 
         _logger.IncomingReceived(envelope, Uri);
@@ -270,6 +273,28 @@ internal class NativeAckReceiver : IReceiver, IFaultTrackingReceiver, ILatchedRe
     /// what separates this mode from BufferedInMemory: the delivery stays unacknowledged until the pipeline
     /// settles it.
     /// </summary>
+    /// <summary>
+    /// The single-delivery twin of <see cref="postAllAsync" />, with identical failure semantics:
+    /// a failed post releases what tracking admitAsync registered, leaves the delivery unsettled
+    /// for the broker to redeliver, and rethrows. See GH-4091.
+    /// </summary>
+    private async ValueTask postOneAsync(Envelope envelope, Activity? activity)
+    {
+        try
+        {
+            await _receivingBlock.PostAsync(envelope).ConfigureAwait(false);
+        }
+        catch
+        {
+            _leases?.Untrack(envelope);
+            _idempotency?.Release(envelope);
+            activity?.Stop();
+            throw;
+        }
+
+        activity?.Stop();
+    }
+
     private async ValueTask postAllAsync(IReadOnlyList<(Envelope Envelope, Activity? Activity)> admitted)
     {
         for (var i = 0; i < admitted.Count; i++)


### PR DESCRIPTION
Closes #4332. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**`InboxCompletionCoalescer` was quadratic under backlog.** It drained with `GetRange(0, n).ToArray()` (a double copy) followed by `RemoveRange(0, n)`, which memmoves everything behind the batch — so a deep backlog pays O(N) per flush of 100, i.e. O(N²/100) overall, precisely when the system is furthest behind. Now a `Queue<Pending>` with a pre-sized drain array: one allocation, no shifting. The batch projection into `_markBatch` drops its LINQ `Select().ToList()` for the same pre-sized shape. This is on every durable message's completion.

**`NativeAckReceiver` single-delivery path** called `postAllAsync([entry])` — a single-element tuple array plus interface boxing per message. RabbitMQ and Pub/Sub deliver one at a time, so this is the *dominant* native-ack path. The new `postOneAsync` carries identical GH-4091 failure semantics: a failed post releases what `admitAsync` registered (lease untrack, idempotency release, activity stop), leaves the delivery unsettled so the broker redelivers, and rethrows.

**`SqsListener`**: `.Any()` on a `List` boxes an enumerator (twice per poll), and the heartbeat branch built the same envelope array twice.

**`FanoutMessageHandler`**: rebuilt a `HashSet<Uri>` per message — with a full-string `Uri.GetHashCode` per entry — to deduplicate a constructor-fixed array. The GH-2303 double-delivery safety net now runs once at construction, where the answer is actually decided; the per-message loop just sends.

**Not included** (needs its own measured pass, noted on the issue): the `BatchedSender` three-channel-hop consolidation and the SQS concurrent-receive ceiling — both change concurrency behavior rather than just allocation, and sit adjacent to the RabbitMQ ack-coalescing result that measured −10%.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2820 passed / 2 skipped / 0 failed — includes the coalescer's own tests (`PendingCount`, drain ordering, batch-failure fallback) and the native-ack lease/idempotency suites that pin the failure semantics above

🤖 Generated with [Claude Code](https://claude.com/claude-code)