### PR TITLE
GH-4331: Azure Service Bus prefetches one batch on the settle-early modes

### DIFF
--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_prefetch_count.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_prefetch_count.cs
@@ -7,12 +7,47 @@ namespace Wolverine.AzureServiceBus.Tests;
 public class configuring_prefetch_count
 {
     [Fact]
-    public void prefetch_is_disabled_by_default()
+    public void the_transport_wide_default_is_still_zero()
+    {
+        // The transport-level value is the explicit opt-in knob and is unchanged; what varies is
+        // what an endpoint computes when nothing was configured (see the per-mode tests below)
+        new AzureServiceBusTransport().PrefetchCount.ShouldBe(0);
+    }
+
+    // GH-4331: Buffered and Durable settle at receipt / right after the inbox insert, so a modest
+    // prefetch buffer does not age against a lock across handler execution. Inline does run the
+    // handler before settling, so it keeps zero.
+    [Theory]
+    [InlineData(EndpointMode.BufferedInMemory)]
+    [InlineData(EndpointMode.Durable)]
+    public void settle_early_modes_prefetch_one_receive_batch_by_default(EndpointMode mode)
+    {
+        var queue = new AzureServiceBusTransport().Queues["incoming"];
+        queue.Mode = mode;
+
+        queue.PrefetchCount.ShouldBe(queue.MaximumMessagesToReceive);
+    }
+
+    [Fact]
+    public void inline_still_disables_prefetch_by_default()
+    {
+        var queue = new AzureServiceBusTransport().Queues["incoming"];
+        queue.Mode = EndpointMode.Inline;
+
+        queue.PrefetchCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void an_explicit_transport_wide_zero_still_wins_over_the_computed_default()
     {
         var transport = new AzureServiceBusTransport();
+        transport.PrefetchCount = 0;
 
-        transport.PrefetchCount.ShouldBe(0);
-        transport.Queues["incoming"].PrefetchCount.ShouldBe(0);
+        var queue = transport.Queues["incoming"];
+        queue.Mode = EndpointMode.Durable;
+
+        // Setting it explicitly to 0 is a deliberate "no prefetch", not an absence of configuration
+        queue.PrefetchCount.ShouldBe(0);
     }
 
     [Fact]

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -109,6 +109,25 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
                 return lanes * 2;
             }
 
+            // GH-4331. Buffered and Durable were the two modes left at Azure Service Bus's shipping
+            // default of 0 -- no prefetch at all -- so the batched listener paid a full AMQP round
+            // trip per batch with nothing buffered client-side. They are also the two modes where
+            // prefetch is SAFEST: buffered settles at receipt and durable settles right after the
+            // inbox insert, so neither holds a lock across handler execution the way NativeAck does.
+            //
+            // Not risk-free, and that is why this is one batch rather than a throughput-only number:
+            // a prefetched message ages against its lock from the moment the CLIENT buffers it, with
+            // no Envelope yet and so no lease renewal. The exposure is (buffer depth / consumption
+            // rate), so sizing the buffer to exactly one receive batch bounds it at roughly the time
+            // to drain one batch.
+            //
+            // Inline deliberately keeps 0: it runs the handler before settling, so a prefetch buffer
+            // there ages against a lock behind arbitrarily slow user code.
+            if (Mode is EndpointMode.BufferedInMemory or EndpointMode.Durable)
+            {
+                return MaximumMessagesToReceive;
+            }
+
             return Parent.PrefetchCount;
         }
         set


### PR DESCRIPTION
Closes #4331. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

Only NativeAck got a computed `PrefetchCount` default (GH-4051). `BufferedInMemory` and `Durable` fell through to Azure Service Bus's shipping default of **0** — no prefetch at all — so `BatchedAzureServiceBusListener` paid a full AMQP round trip per batch with nothing buffered client-side.

**Why these two modes are the safe ones.** The hazard prefetch guards against is a message aging against its lock while buffered with no `Envelope` and therefore no `LeaseRenewalTracker` coverage. Buffered settles at receipt; durable settles right after the inbox insert. Neither holds a lock across handler execution the way NativeAck does — so the modes carrying the real risk had the tuning and the safe ones had zero.

**Why one batch and not a throughput number.** It is not risk-free: a prefetched message ages from the moment the *client* buffers it, and the exposure is (buffer depth ÷ consumption rate). Sizing the buffer to exactly one receive batch bounds that at roughly the time to drain one batch, which is the same order as the receive loop's own cadence.

**Inline deliberately keeps 0** — it runs the handler before settling, so a prefetch buffer there ages against a lock behind arbitrarily slow user code.

The transport-wide knob is untouched, and an explicit `PrefetchCount = 0` still wins over the computed default: `ExplicitPrefetchCount` is nullable, so a configured zero reads as a deliberate "no prefetch" rather than as absent configuration. There's a test for exactly that.

## An honest caveat

**This is not rig-measured.** The audit reasoned it is the largest single-transport lever available, and the mechanism is clear, but that stays a hypothesis until an ASB lane actually runs it. I'd rather land the reasoning and the tests and let the number arrive than claim a win I haven't seen — this repo has a standing "ack coalescing measured −10%, do not revisit" entry for precisely this reason.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- `configuring_prefetch_count`: 15/15. The pre-existing `prefetch_is_disabled_by_default` test genuinely changed meaning, so rather than edit it to pass I replaced it with per-mode assertions that state the new intent explicitly (settle-early modes prefetch a batch; Inline stays 0; explicit 0 still wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)