### PR TITLE
Restore the outstanding-envelope dedup that GH-4325 removed

### DIFF
--- a/src/Wolverine/Runtime/MessageBus.cs
+++ b/src/Wolverine/Runtime/MessageBus.cs
@@ -356,8 +356,8 @@ public partial class MessageBus : IMessageBus, IMessageContext
         {
             lock (_outstandingLock)
             {
-                // GH-4325: Add, not Fill — see the comment in PersistOrSendAsync(Envelope[])
-                _outstanding.Add(envelope);
+                // Fill, NOT Add. The dedup is load-bearing -- see PersistOrSendAsync(Envelope[]).
+                _outstanding.Fill(envelope);
             }
 
             await envelope.PersistAsync(Transaction).ConfigureAwait(false);
@@ -473,13 +473,19 @@ public partial class MessageBus : IMessageBus, IMessageContext
 
             lock (_outstandingLock)
             {
-                // GH-4325: AddRange, not Fill. Fill is Contains-then-Add — a closure, a Where
-                // iterator, and an O(list) scan per envelope, quadratic when a batch handler or
-                // projection cascades hundreds. Every envelope here is freshly minted by the
-                // router with its own Id, so the dedup could never hit. The IEnvelopeTransaction
-                // entry points below deliberately keep Fill: they are integration surface where
-                // a caller could legitimately persist the same envelope twice.
-                _outstanding.AddRange(outgoing);
+                // Fill, NOT AddRange. GH-4325 replaced this with AddRange on the reasoning that
+                // every envelope here is freshly minted by the router and so the Contains check
+                // could never hit. That reasoning was WRONG and it broke request/reply over the
+                // database transports: an envelope can reach this list twice in one context, and
+                // the second entry makes FlushOutgoingMessagesAsync store-and-forward the same
+                // envelope Id a second time. The duplicate insert throws, the catch in the flush
+                // loop logs "Unable to send an outgoing message" and swallows it, and the reply is
+                // silently never sent -- a green-looking system that drops responses.
+                //
+                // Caught by PostgresqlTests.Transport.end_to_end_from_scratch. If the O(n^2) cost
+                // of Fill is ever worth removing, it needs a dedup that is still a dedup (a HashSet
+                // of ids alongside the list), not the removal of one.
+                _outstanding.Fill(outgoing);
             }
         }
         else


### PR DESCRIPTION
**Fixes a regression I introduced in #4342 (GH-4325) earlier today.**

## What broke

#4342 replaced `_outstanding.Fill(...)` with `Add`/`AddRange` in `MessageBus.PersistOrSendAsync`, on the stated reasoning that *"every envelope here is freshly minted by the router with its own Id, so the dedup could never hit."*

That reasoning was wrong. An envelope can reach `_outstanding` twice within a single `MessageContext`. The second entry makes `FlushOutgoingMessagesAsync` store-and-forward the same envelope Id a second time; the duplicate insert throws; the `catch` inside the flush loop logs `"Unable to send an outgoing message"` and swallows it — and **the reply is never sent**.

The failure mode is the worst kind: no crash, no red test in the unit suites, a system that looks healthy while silently dropping responses.

## How it was caught

`PostgresqlTests.Transport.end_to_end_from_scratch.can_send_messages_end_to_end` — the request arrives at the API host, the response never comes back to the UI host. It passed at the pre-wave commit (`4bdf4b07b`) and failed on merged main, and a commit-by-commit bisect landed on #4342. Reverting only the `Fill` change turns it green; reverting only the `IsLocal` change does not.

## What this PR does

Restores `Fill` at both sites, with a comment that records *why* the dedup is load-bearing so the next person tempted by the same optimization has the failure mode in front of them.

**The rest of GH-4325 stays** — the indexed rule loops and the single `sender.Destination` read are unaffected and independently sound.

If `Fill`'s O(n²) Contains scan is ever worth removing, the replacement has to still *be* a dedup (a `HashSet<Guid>` of ids maintained alongside the list), not the removal of one.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean
- PostgresqlTests Transport: 133 passed / 1 skipped / **0 failed** (was 1 failed)
- Full CoreTests: 2841 passed / 2 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)