### PR TITLE
GH-4330: keep the blocking Kafka consume loop off the thread pool

### DIFF
--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaListener.cs
@@ -61,7 +61,14 @@ public class KafkaListener : IListener, IDisposable, ISupportDeadLetterQueue, IR
             topic.CommitBatchInterval, logger);
 
         _consumer.Subscribe(topic.TopicName);
-        _loop = new BackgroundReceiveLoop(Address, logger, consumeOnceAsync, _cancellation.Token);
+        // GH-4330: IConsumer.Consume(CancellationToken) blocks synchronously, so this loop holds
+        // its thread for the listener's whole lifetime. On the pool that is one worker gone per
+        // Kafka listener -- multiply by topics and ListenerCount and it eats into the same pool
+        // the handler pipeline and every other transport's continuations run on.
+        _loop = new BackgroundReceiveLoop(Address, logger, consumeOnceAsync, _cancellation.Token)
+        {
+            UsesBlockingIteration = true
+        };
         _loop.Start();
     }
 

--- a/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaOffsetCommitter.cs
+++ b/src/Transports/Kafka/Wolverine.Kafka/Internals/KafkaOffsetCommitter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
@@ -45,6 +46,18 @@ internal sealed class KafkaOffsetCommitter
 
     private readonly object _lock = new();
     private readonly Dictionary<TopicPartition, OffsetWatermark> _watermarks = new();
+
+    // GH-4330: Track runs per consumed record and Complete per handled record, and both were
+    // allocating a TopicPartition (a class) just to key the watermark lookup. The set of
+    // (topic, partition) pairs a listener sees is small and fixed by the assignment, so intern them.
+    private readonly ConcurrentDictionary<(string Topic, int Partition), TopicPartition> _topicPartitions = new();
+
+    private TopicPartition topicPartitionFor(string topic, int partition)
+    {
+        return _topicPartitions.TryGetValue((topic, partition), out var existing)
+            ? existing
+            : _topicPartitions.GetOrAdd((topic, partition), key => new TopicPartition(key.Topic, new Partition(key.Partition)));
+    }
     private int _sinceLastCommit;
     private long _lastCommitTimestamp;
 
@@ -127,7 +140,7 @@ internal sealed class KafkaOffsetCommitter
             return;
         }
 
-        var tp = new TopicPartition(topic, new Partition(partition));
+        var tp = topicPartitionFor(topic, partition);
         lock (_lock)
         {
             WatermarkFor(tp).Track(offset);
@@ -147,7 +160,7 @@ internal sealed class KafkaOffsetCommitter
             return;
         }
 
-        var tp = new TopicPartition(topic, new Partition(partition));
+        var tp = topicPartitionFor(topic, partition);
 
         List<TopicPartitionOffset>? toCommit = null;
         List<TopicPartitionOffset>? toStore = null;

--- a/src/Wolverine/Transports/BackgroundReceiveLoop.cs
+++ b/src/Wolverine/Transports/BackgroundReceiveLoop.cs
@@ -74,6 +74,20 @@ public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoop
         }
     }
 
+    /// <summary>
+    /// GH-4330. Set when the iteration blocks a thread synchronously rather than awaiting — the
+    /// Kafka consumer's <c>Consume(CancellationToken)</c> being the case this exists for. Such a
+    /// loop occupies its thread for the listener's entire lifetime, and on the default
+    /// <see cref="Task.Run(Func{Task})" /> path that thread is a pool worker, permanently removed
+    /// from the pool the handler pipeline and every other transport's continuations share.
+    ///
+    /// <para>
+    /// Leave false for genuinely async iterations (SQS, Redis, the database queues): they release
+    /// their thread at every await, so a dedicated thread would waste one.
+    /// </para>
+    /// </summary>
+    public bool UsesBlockingIteration { get; init; }
+
     /// <summary>Start iterating on a background task. Idempotent — a second call is a no-op.</summary>
     public void Start()
     {
@@ -83,7 +97,11 @@ public sealed class BackgroundReceiveLoop : IAsyncDisposable, IReportReceiveLoop
         }
 
         _status = ReceiveLoopStatus.Running;
-        _task = Task.Run(runAsync, _cancellation.Token);
+
+        _task = UsesBlockingIteration
+            ? Task.Factory.StartNew(runAsync, _cancellation.Token, TaskCreationOptions.LongRunning,
+                TaskScheduler.Default).Unwrap()
+            : Task.Run(runAsync, _cancellation.Token);
     }
 
     private async Task runAsync()


### PR DESCRIPTION
Closes #4330. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**A blocking loop on a pool thread.** `IConsumer.Consume(CancellationToken)` blocks synchronously, and `BackgroundReceiveLoop` starts its iteration with `Task.Run` — so every Kafka listener permanently occupies a thread-pool worker for its entire lifetime. With several topics, or `ListenerCount > 1`, that is several workers removed from the same pool the handler pipeline and every other transport's continuations run on: classic starvation exactly under the load Kafka is chosen for.

`BackgroundReceiveLoop` gains an opt-in `UsesBlockingIteration` that starts the loop with `TaskCreationOptions.LongRunning` (a dedicated thread), and Kafka sets it. **Deliberately opt-in rather than the default**: the SQS, Redis, Pulsar and database-queue loops are genuinely async and release their thread at every await, so a dedicated thread there would waste one.

**`KafkaOffsetCommitter` allocations.** `Track` runs per consumed record and `Complete` per handled record, and both allocated a `TopicPartition` (a class, with its own hash/equals) purely to key the watermark lookup. The `(topic, partition)` set a listener sees is small and fixed by its partition assignment, so they're interned in a `ConcurrentDictionary` now.

## What I deliberately did not do

Two items from the issue are **not** in this PR, and I want to be explicit rather than quietly drop them:

1. **Sharding the committer's `_lock` per partition.** That lock also guards the flush loop's iteration over every watermark, so per-partition locking is a real concurrency refactor, not a mechanical change.
2. **Widening the batched-drain gate beyond `Durable`.** The zero-timeout drain is indeed free, but the *benefit* outside Durable is amortized receiver bookkeeping — not the durable-inbox-insert win GH-3490 actually measured. The upside is speculative and the settlement interaction with NativeAck's lease tracking is subtle.

Both are legitimate candidates. Neither should land on reasoning alone — and today's #4353 regression, where exactly that kind of reasoning removed a load-bearing guard, is why.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2841 passed / 2 skipped / 0 failed (covers `BackgroundReceiveLoop`'s own lifecycle tests on the unchanged default path)
- The supervised `CIKafka` lane is the real gate for the listener change and is queued for tonight's local run

🤖 Generated with [Claude Code](https://claude.com/claude-code)