### PR TITLE
GH-4329: batched durable arrival and guarded debug logs for Redis streams

### DIFF
--- a/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
+++ b/src/Transports/Redis/Wolverine.Redis/Internal/RedisStreamListener.cs
@@ -291,12 +291,20 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
         {
             if (!envelope.Headers.TryGetValue(RedisEnvelopeMapper.RedisEntryIdHeader, out var idString) || string.IsNullOrEmpty(idString))
             {
-                _logger.LogDebug("No Redis stream id header present for envelope {EnvelopeId}; skipping ACK", envelope.Id);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("No Redis stream id header present for envelope {EnvelopeId}; skipping ACK", envelope.Id);
+                }
+
                 return;
             }
 
             await acknowledgeAsync(getDatabase(), idString!);
-            _logger.LogDebug("Acknowledged Redis stream message {StreamId} on {StreamKey}", idString, _endpoint.StreamKey);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Acknowledged Redis stream message {StreamId} on {StreamKey}", idString, _endpoint.StreamKey);
+            }
         }
         catch (Exception ex)
         {
@@ -452,15 +460,27 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
                 return false;
             }
 
-            // Process each message
-            foreach (var message in streamResults)
+            // GH-4329: a Durable listener hands the whole read to the receiver at once so the
+            // inbox persists it with ONE batched insert instead of a round trip per message --
+            // the same batched-arrival shape RabbitMQ got in GH-3492 and Kafka/NATS/Pulsar in
+            // GH-4026. (The branch for that wave was even named for Redis, but never touched it.)
+            // Every other mode keeps strict one-at-a-time dispatch: their settlement is
+            // per-message and there is no shared round trip to amortize.
+            if (_endpoint.Mode == EndpointMode.Durable && streamResults.Length > 1)
             {
-                if (token.IsCancellationRequested)
+                await processBatchAsync(streamResults, token);
+            }
+            else
+            {
+                foreach (var message in streamResults)
                 {
-                    break;
-                }
+                    if (token.IsCancellationRequested)
+                    {
+                        break;
+                    }
 
-                await ProcessMessage(message);
+                    await ProcessMessage(message);
+                }
             }
 
             return true;
@@ -485,6 +505,44 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
         }
     }
 
+    /// <summary>
+    /// GH-4329. One receiver call for the whole read, so a durable endpoint's inbox insert is
+    /// batched. An entry that cannot be mapped is skipped rather than failing its neighbours --
+    /// unacknowledged, so the consumer group redelivers it, exactly as the per-message path does.
+    /// </summary>
+    private async Task processBatchAsync(StreamEntry[] streamResults, CancellationToken token)
+    {
+        _endpoint.EnvelopeMapper ??= _endpoint.BuildMapper(_runtime);
+
+        var envelopes = new List<Envelope>(streamResults.Length);
+        foreach (var streamEntry in streamResults)
+        {
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                var envelope = new Envelope { TopicName = _endpoint.StreamKey };
+                _endpoint.EnvelopeMapper.MapIncomingToEnvelope(envelope, streamEntry);
+                envelopes.Add(envelope);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to read message {MessageId} from Redis stream {StreamKey}",
+                    streamEntry.Id, _endpoint.StreamKey);
+            }
+        }
+
+        if (envelopes.Count == 0)
+        {
+            return;
+        }
+
+        await _receiver.ReceivedAsync(this, envelopes.ToArray());
+    }
+
     private async Task ProcessMessage(StreamEntry streamEntry)
     {
         try
@@ -495,14 +553,22 @@ public class RedisStreamListener : IListener, ISupportDeadLetterQueue, IReportCo
             var envelope = new Envelope { TopicName = _endpoint.StreamKey };
             _endpoint.EnvelopeMapper.MapIncomingToEnvelope(envelope, streamEntry);
 
-            _logger.LogDebug("Received message {EnvelopeId} from Redis stream {StreamKey} (stream message ID: {StreamMessageId})",
-                envelope.Id, _endpoint.StreamKey, streamEntry.Id);
+            // GH-4329: guarded — these run per message, and the params object[] plus the boxed
+            // Guid are allocated at the call site before ILogger ever checks IsEnabled
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Received message {EnvelopeId} from Redis stream {StreamKey} (stream message ID: {StreamMessageId})",
+                    envelope.Id, _endpoint.StreamKey, streamEntry.Id);
+            }
 
             // Send to Wolverine for processing (this will invoke continuations that may call Complete/Defer)
             await _receiver.ReceivedAsync(this, envelope);
 
             // Do not ACK here; CompleteAsync/DeferAsync will handle ACK or requeue as appropriate
-            _logger.LogDebug("Processed message {EnvelopeId} from Redis stream {StreamKey}", envelope.Id, _endpoint.StreamKey);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Processed message {EnvelopeId} from Redis stream {StreamKey}", envelope.Id, _endpoint.StreamKey);
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Closes #4329. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

**Batched durable arrival.** The read loop already pulls a `BatchSize` batch from the stream — and then dispatched it one envelope at a time. So a durable Redis endpoint paid an inbox-insert round trip *per message* and never received the batched-arrival treatment RabbitMQ got in GH-3492 and Kafka / NATS JetStream / Pulsar got in GH-4026. (Amusingly, the branch for that wave was named `gh-4026/redis-batched-arrival` but touched no Redis file.)

A `Durable` listener now hands the whole read to the receiver in one call. **Every other mode keeps strict one-at-a-time dispatch** — their settlement is per-message and there's no shared round trip to amortize, so batching would be churn without a win. An entry that fails to map is skipped and left unacknowledged for the consumer group to redeliver, matching the per-message path's behavior exactly rather than failing its neighbours.

**Guarded debug logs.** Four `LogDebug` calls on the per-message path allocated a `params object[]` and boxed a `Guid` at the call site, before `ILogger` ever checked `IsEnabled`.

## What I deliberately did not do

**Batching the `XACK`.** Redis's `StreamAcknowledgeAsync(key, group, RedisValue[])` genuinely accepts multiple ids — unlike RabbitMQ's per-delivery ack — so the API does support it. But coalescing acks means `CompleteAsync` returns *before* the message is actually acknowledged, which changes the settlement contract. And the one time this project measured ack coalescing (RabbitMQ, GH-3492) it came out at **−10%** and became a standing "do not revisit".

That is exactly the shape of change that needs a rig number before it earns a semantic concession, so I've left it on the issue rather than shipping it on reasoning.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- The supervised `CIRedis` lane (Testcontainers-provisioned) is the real gate for the dispatch change and is queued in tonight's local run

🤖 Generated with [Claude Code](https://claude.com/claude-code)