### PR TITLE
GH-4320: stop rebuilding the parameter placeholder list per envelope

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
@@ -37,21 +37,23 @@ public static class DatabasePersistence
     private static void ConfigureOutgoingCommand(IMessageDatabase settings, DbCommandBuilder builder, Envelope envelope,
         DbParameter owner)
     {
-        var list = new List<DbParameter>
-        {
-            builder.AddParameter(EnvelopeSerializer.Serialize(envelope)),
-            builder.AddParameter(envelope.Id),
-            owner,
-            builder.AddParameter(envelope.Destination!.ToString()),
-            builder.AddParameter(envelope.DeliverBy),
-            builder.AddParameter(envelope.Attempts),
-            builder.AddParameter(envelope.MessageType)
-        };
-
-        var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
-
+        // GH-4320: AppendParameter registers the parameter AND writes its placeholder, so the
+        // per-envelope List<DbParameter> plus the LINQ projection and string join that only
+        // existed to rebuild "@p0, @p1, ..." are gone. Emitted SQL is byte-for-byte identical.
         builder.Append(
-            $"insert into {settings.TableNameFor(DatabaseConstants.OutgoingTable)} ({DatabaseConstants.OutgoingFields}) values ({parameterList});");
+            $"insert into {settings.TableNameFor(DatabaseConstants.OutgoingTable)} ({DatabaseConstants.OutgoingFields}) values (");
+        builder.AppendParameter(EnvelopeSerializer.Serialize(envelope));
+        builder.Append(", ");
+        builder.AppendParameter(envelope.Id);
+        builder.Append($", @{owner.ParameterName}, ");
+        builder.AppendParameter(envelope.Destination!.ToString());
+        builder.Append(", ");
+        builder.AppendParameter(envelope.DeliverBy);
+        builder.Append(", ");
+        builder.AppendParameter(envelope.Attempts);
+        builder.Append(", ");
+        builder.AppendParameter((object?)envelope.MessageType);
+        builder.Append(");");
     }
 
     public static DbCommand BuildIncomingStorageCommand(IEnumerable<Envelope> envelopes,
@@ -70,23 +72,28 @@ public static class DatabasePersistence
         // Don't store any data if the envelope is already marked as handled
         var data = envelope.Status == EnvelopeStatus.Handled ? [] : EnvelopeSerializer.Serialize(envelope);
         
-        var list = new List<DbParameter>
-        {
-            builder.AddParameter(data),
-            builder.AddParameter(envelope.Id),
-            builder.AddParameter(envelope.Status.ToString()),
-            builder.AddParameter(envelope.OwnerId),
-            builder.AddParameter(envelope.ScheduledTime),
-            builder.AddParameter(envelope.Attempts),
-            builder.AddParameter(envelope.MessageType),
-            builder.AddParameter(envelope.Destination?.ToString()),
-            builder.AddParameter(envelope.KeepUntil)
-        };
-
-        var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
-
+        // GH-4320: see ConfigureOutgoingCommand -- same removal of the per-envelope
+        // List<DbParameter> + LINQ + string.Join that only rebuilt the placeholder list.
         builder.Append(
-            $@"insert into {settings.TableNameFor(DatabaseConstants.IncomingTable)}({DatabaseConstants.IncomingFields}) values ({parameterList});");
+            $@"insert into {settings.TableNameFor(DatabaseConstants.IncomingTable)}({DatabaseConstants.IncomingFields}) values (");
+        builder.AppendParameter(data);
+        builder.Append(", ");
+        builder.AppendParameter(envelope.Id);
+        builder.Append(", ");
+        builder.AppendParameter(envelope.Status.ToString());
+        builder.Append(", ");
+        builder.AppendParameter(envelope.OwnerId);
+        builder.Append(", ");
+        builder.AppendParameter(envelope.ScheduledTime);
+        builder.Append(", ");
+        builder.AppendParameter(envelope.Attempts);
+        builder.Append(", ");
+        builder.AppendParameter((object?)envelope.MessageType);
+        builder.Append(", ");
+        builder.AppendParameter((object?)envelope.Destination?.ToString());
+        builder.Append(", ");
+        builder.AppendParameter(envelope.KeepUntil);
+        builder.Append(");");
     }
 
     public static async Task<Envelope> ReadIncomingAsync(DbDataReader reader, CancellationToken cancellation = default)


### PR DESCRIPTION
Closes #4320. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

Both batched-insert builders (`ConfigureOutgoingCommand`, `BuildIncomingStorageCommand`) allocated a `List<DbParameter>` **per envelope**, then ran a LINQ projection and a `string.Join` over it — for no purpose other than reconstructing the `@p0, @p1, ...` placeholders the builder had just handed back. At the 100-envelope batches these run at, that's 100 lists, 100 LINQ pipelines and ~900 interpolated strings per flush.

Weasel's `AppendParameter` registers the parameter *and* writes its placeholder in one step, so the list, the projection and the join all disappear.

**The emitted SQL is byte-for-byte identical** — this changes only how the string is assembled. The nullable columns (`MessageType`, `Destination`) keep the `AddParameter(object?)` overload the original bound to, so parameter typing is unchanged as well; the compiler initially picked the `string` overload for those and I cast rather than let it.

## What I deliberately did not do

**The `unnest`/TVP rewrite.** That's the larger half of this issue and the one with the real ceiling — fixed-arity statements would give these inserts a reusable server-side plan instead of unique command text per batch size, which is what currently defeats Npgsql's `MaxAutoPrepare` and SQL Server's plan cache.

But it changes the *shape* of the SQL on the most critical write path in the system, its benefit here is unmeasured, and it needs per-provider verification (PostgreSQL `unnest`, SQL Server TVP, and sensible fallbacks for MySQL/Oracle/SQLite). That deserves its own PR with numbers, not a rider on an allocation cleanup.

## Testing
- `dotnet build wolverine.slnx -c Release -f net9.0` clean (the pinned CI gate)
- Full CoreTests: 2841 passed / 2 skipped / 0 failed
- PostgresqlTests persistence + inbox/outbox slice: 16/16
- The supervised `CIPersistence`, `CISqlServer`, `CIMySql` and `CIOracle` lanes all exercise these builders and are queued in tonight's local run

🤖 Generated with [Claude Code](https://claude.com/claude-code)