### PR TITLE
GH-4334: drop the per-poll temp tables in the database queue transports

### DIFF
--- a/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
+++ b/src/Persistence/Wolverine.Postgresql/Transport/PostgresqlQueueListener.cs
@@ -151,14 +151,29 @@ SELECT message.{DatabaseConstants.Body} from message;
 
         try
         {
+            // GH-4334: same temp-table removal as the durable pop, plus a bound. The move was
+            // unbounded -- every due scheduled message promoted in one statement, which on a large
+            // backlog is one enormous transaction holding locks the receive path needs. Capped at
+            // RecoveryBatchSize per cycle; the poller runs again immediately after a full batch.
             var builder = new BatchBuilder();
-            builder.Append($"create temporary table temp_move_{_queueName} on commit drop as select id, body, message_type, keep_until from {_scheduledTableName} WHERE {DatabaseConstants.ExecutionTime} <= (now() at time zone 'utc') AND ID NOT IN (select id from {_queueTableName}) for update skip locked");
-            builder.StartNewCommand();
-            builder.Append($"INSERT INTO {_queueTableName} (id, body, message_type, keep_until) SELECT id, body, message_type, keep_until FROM temp_move_{_queueName}");
-            builder.StartNewCommand();
-            builder.Append($"DELETE from {_scheduledTableName} where id in (select id from temp_move_{_queueName})");
-            builder.StartNewCommand();
-            builder.Append($"select count(*) from temp_move_{_queueName}");
+            var parameters = builder.AppendWithParameters($@"
+WITH moved AS (
+    DELETE FROM {_scheduledTableName} WHERE CTID IN (
+        SELECT ctid FROM {_scheduledTableName}
+        WHERE {DatabaseConstants.ExecutionTime} <= (now() at time zone 'utc')
+          AND id NOT IN (SELECT id FROM {_queueTableName})
+        ORDER BY {DatabaseConstants.ExecutionTime}
+        LIMIT ? FOR UPDATE SKIP LOCKED
+    )
+    RETURNING id, body, message_type, keep_until
+), promoted AS (
+    INSERT INTO {_queueTableName} (id, body, message_type, keep_until)
+    SELECT id, body, message_type, keep_until FROM moved
+)
+SELECT count(*) FROM moved");
+
+            parameters[0].Value = _settings.RecoveryBatchSize;
+            parameters[0].NpgsqlDbType = NpgsqlDbType.Integer;
 
             await using var batch = builder.Compile();
             batch.Connection = conn;
@@ -209,19 +224,30 @@ SELECT message.{DatabaseConstants.Body} from message;
         // scope the probe instead of correlating against the entire inbox.
         builder.Append($"delete FROM {_queueTableName} where id in (select id from {_quotedSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.ReceivedAt} = '{Address}')");
         builder.StartNewCommand();
-        builder.Append($"create temporary table temp_pop_{_queueName} ON COMMIT DROP as select id, body, message_type, keep_until from {_queueTableName} ORDER BY {_queueTableName}.timestamp limit ");
-        builder.AppendParameter(count);
-        builder.Append(" for update skip locked");
 
-        builder.StartNewCommand();
-        builder.Append($"delete from {_queueTableName} where id in (select id from temp_pop_{_queueName})");
-        builder.StartNewCommand();
-        var parameters = builder.AppendWithParameters($"INSERT INTO {_quotedSchemaName}.{DatabaseConstants.IncomingTable} (id, status, owner_id, body, message_type, received_at, keep_until) SELECT id, 'Incoming', ?, body, message_type, '{Address}', keep_until FROM temp_pop_{_queueName}");
-        parameters[0].Value = settings.AssignedNodeNumber;
+        // GH-4334: one CTE instead of create-temp-table / delete / insert / select. The old shape
+        // created and dropped `temp_pop_{queue}` on EVERY poll of every queue -- a pg_class and
+        // pg_attribute insert-and-delete per poll (catalog churn), and a fresh relation each time
+        // means the plan is never reused. This is the same DELETE ... RETURNING shape the
+        // non-durable pop above already uses, extended with the inbox insert as a second CTE.
+        var parameters = builder.AppendWithParameters($@"
+WITH popped AS (
+    DELETE FROM {_queueTableName} WHERE CTID IN (
+        SELECT ctid FROM {_queueTableName} ORDER BY {_queueTableName}.timestamp LIMIT ? FOR UPDATE SKIP LOCKED
+    )
+    RETURNING {DatabaseConstants.Id}, {DatabaseConstants.Body}, {DatabaseConstants.MessageType}, {DatabaseConstants.KeepUntil}
+), inserted AS (
+    INSERT INTO {_quotedSchemaName}.{DatabaseConstants.IncomingTable}
+        (id, status, owner_id, body, message_type, received_at, keep_until)
+    SELECT id, 'Incoming', ?, body, message_type, '{Address}', keep_until FROM popped
+)
+SELECT {DatabaseConstants.Body} FROM popped");
+
+        parameters[0].Value = count;
         parameters[0].NpgsqlDbType = NpgsqlDbType.Integer;
+        parameters[1].Value = settings.AssignedNodeNumber;
+        parameters[1].NpgsqlDbType = NpgsqlDbType.Integer;
 
-        builder.StartNewCommand();
-        builder.Append($"select body from temp_pop_{_queueName}");
         await using var batch = builder.Compile();
 
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueue.cs
@@ -17,6 +17,11 @@ namespace Wolverine.SqlServer.Transport;
 
 public class SqlServerQueue : Endpoint, IBrokerQueue, IDatabaseBackedEndpoint, IStorageBackedQueue
 {
+    // GH-4334: mirrors DurabilitySettings.RecoveryBatchSize's default. These statements are built
+    // in the constructor, before any DurabilitySettings is in hand, so the bound is a constant here;
+    // the listener's own copy of this SQL uses the configured value.
+    private const int ScheduledPromotionBatchSize = 100;
+
     internal static Uri ToUri(string name, string? databaseName)
     {
         return databaseName.IsEmpty()
@@ -376,16 +381,24 @@ WHERE {DatabaseConstants.Id} = @id;
 DELETE FROM {Parent.MessageStorageSchemaName}.{DatabaseConstants.OutgoingTable} WHERE {DatabaseConstants.Id} = @id;
 ";
 
+        // GH-4334: table variable instead of a per-call #temp_move (tempdb churn + a statement
+        // recompile each time), and a TOP bound so a large due backlog is promoted in bounded
+        // batches rather than one enormous lock-holding transaction.
         _moveScheduledToReadyQueueSql = $@"
-select id, body, message_type, keep_until into #temp_move_{Name}
-FROM {ScheduledTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK)
-WHERE {DatabaseConstants.ExecutionTime} <= SYSDATETIMEOFFSET() AND ID NOT IN (select id from {QueueTable.Identifier})
-ORDER BY {ScheduledTable.Identifier}.{orderBy};
-delete from {ScheduledTable.Identifier} where id in (select id from #temp_move_{Name});
+DECLARE @moved TABLE (id uniqueidentifier, body varbinary(max), message_type varchar(250), keep_until datetimeoffset);
+
+WITH due AS (
+    SELECT TOP({ScheduledPromotionBatchSize}) id, body, message_type, keep_until
+    FROM {ScheduledTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK)
+    WHERE {DatabaseConstants.ExecutionTime} <= SYSDATETIMEOFFSET() AND ID NOT IN (select id from {QueueTable.Identifier})
+    ORDER BY {ScheduledTable.Identifier}.{orderBy})
+DELETE FROM due
+OUTPUT deleted.id, deleted.body, deleted.message_type, deleted.keep_until INTO @moved;
+
 INSERT INTO {QueueTable.Identifier}
 (id, body, message_type, keep_until)
- SELECT id, body, message_type, keep_until FROM #temp_move_{Name};
-select count(*) from #temp_move_{Name}
+ SELECT id, body, message_type, keep_until FROM @moved;
+select count(*) from @moved
 ";
 
         _deleteExpiredSql =
@@ -413,14 +426,20 @@ IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
 SET NOCOUNT ON;
 
 delete FROM {QueueTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK) where id in (select id from {Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.ReceivedAt} = '{Uri}');
-select top(@count) id, body, message_type, keep_until into #temp_pop_{Name}
-FROM {QueueTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK)
-ORDER BY {QueueTable.Identifier}.{orderBy};
-delete from {QueueTable.Identifier} where id in (select id from #temp_pop_{Name});
+-- GH-4334: table variable + DELETE ... OUTPUT instead of SELECT ... INTO #temp_pop
+DECLARE @popped TABLE (id uniqueidentifier, body varbinary(max), message_type varchar(250), keep_until datetimeoffset);
+
+WITH message AS (
+    SELECT TOP(@count) id, body, message_type, keep_until
+    FROM {QueueTable.Identifier} WITH (UPDLOCK, READPAST, ROWLOCK)
+    ORDER BY {QueueTable.Identifier}.{orderBy})
+DELETE FROM message
+OUTPUT deleted.id, deleted.body, deleted.message_type, deleted.keep_until INTO @popped;
+
 INSERT INTO {Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable}
 (id, status, owner_id, body, message_type, received_at, keep_until)
- SELECT id, 'Incoming', @node, body, message_type, '{Uri}', keep_until FROM #temp_pop_{Name};
-select body from #temp_pop_{Name};
+ SELECT id, 'Incoming', @node, body, message_type, '{Uri}', keep_until FROM @popped;
+select body from @popped;
 
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";

--- a/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
+++ b/src/Persistence/Wolverine.SqlServer/Transport/SqlServerQueueListener.cs
@@ -78,28 +78,45 @@ IF ( (512 & @@OPTIONS) = 512 ) SET @NOCOUNT = 'ON';
 SET NOCOUNT ON;
 
 delete FROM {queueTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK) where id in (select id from {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable} where {DatabaseConstants.ReceivedAt} = '{Address}');
-select top(@count) id, body, message_type, keep_until into #temp_pop_{queue.Name}
-FROM {queueTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK)
-ORDER BY {queueTableIdentifier}.{orderBy};
-delete from {queueTableIdentifier} where id in (select id from #temp_pop_{queue.Name});
+-- GH-4334: a declared table variable instead of SELECT ... INTO #temp_pop. The temp table was
+-- created and dropped on every poll of every queue: tempdb allocation churn plus a statement
+-- recompile each time, because a SELECT INTO builds a fresh schema the optimizer has never seen.
+-- The CTE + DELETE ... OUTPUT shape is the one _tryPopMessagesDirectlySql already uses.
+DECLARE @popped TABLE (id uniqueidentifier, body varbinary(max), message_type varchar(250), keep_until datetimeoffset);
+
+WITH message AS (
+    SELECT TOP(@count) id, body, message_type, keep_until
+    FROM {queueTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK)
+    ORDER BY {queueTableIdentifier}.{orderBy})
+DELETE FROM message
+OUTPUT deleted.id, deleted.body, deleted.message_type, deleted.keep_until INTO @popped;
+
 INSERT INTO {queue.Parent.MessageStorageSchemaName}.{DatabaseConstants.IncomingTable}
 (id, status, owner_id, body, message_type, received_at, keep_until)
- SELECT id, 'Incoming', @node, body, message_type, '{Address}', keep_until FROM #temp_pop_{queue.Name};
-select body from #temp_pop_{queue.Name};
+ SELECT id, 'Incoming', @node, body, message_type, '{Address}', keep_until FROM @popped;
+select body from @popped;
 
 IF (@NOCOUNT = 'ON') SET NOCOUNT ON;
 IF (@NOCOUNT = 'OFF') SET NOCOUNT OFF;";
 
+        // GH-4334: same temp-table removal as the pop above, plus a TOP bound. This move was
+        // unbounded -- every due scheduled message promoted in a single statement, which on a
+        // large backlog is one enormous transaction holding locks the receive path needs.
         _moveScheduledToReadyQueueSql = $@"
-select id, body, message_type, keep_until into #temp_move_{queue.Name}
-FROM {scheduledTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK)
-WHERE {DatabaseConstants.ExecutionTime} <= SYSDATETIMEOFFSET() AND ID NOT IN (select id from {queueTableIdentifier})
-ORDER BY {scheduledTableIdentifier}.{orderBy};
-delete from {scheduledTableIdentifier} where id in (select id from #temp_move_{queue.Name});
+DECLARE @moved TABLE (id uniqueidentifier, body varbinary(max), message_type varchar(250), keep_until datetimeoffset);
+
+WITH due AS (
+    SELECT TOP({_settings.RecoveryBatchSize}) id, body, message_type, keep_until
+    FROM {scheduledTableIdentifier} WITH (UPDLOCK, READPAST, ROWLOCK)
+    WHERE {DatabaseConstants.ExecutionTime} <= SYSDATETIMEOFFSET() AND ID NOT IN (select id from {queueTableIdentifier})
+    ORDER BY {scheduledTableIdentifier}.{orderBy})
+DELETE FROM due
+OUTPUT deleted.id, deleted.body, deleted.message_type, deleted.keep_until INTO @moved;
+
 INSERT INTO {queueTableIdentifier}
 (id, body, message_type, keep_until)
- SELECT id, body, message_type, keep_until FROM #temp_move_{queue.Name};
-select count(*) from #temp_move_{queue.Name}
+ SELECT id, body, message_type, keep_until FROM @moved;
+select count(*) from @moved
 ";
 
         _deleteExpiredSql =


### PR DESCRIPTION
Closes #4334. From the 2026-09-05 hot-path performance audit (GH-4316 wave).

## What was happening

Every durable pop and every scheduled-message promotion created **and dropped a temp table on every poll of every queue**:

- **PostgreSQL** — `temp_pop_{queue}` / `temp_move_{queue}` `ON COMMIT DROP`: a `pg_class` and `pg_attribute` insert-and-delete per poll (catalog churn), and a brand-new relation each time means the planner never reuses a plan.
- **SQL Server** — `SELECT ... INTO #temp_pop_{queue}`: tempdb allocation plus a statement recompile every call, because `SELECT INTO` builds a fresh schema the optimizer has not seen.

At the default 5-second polling interval that is 12 times a minute, per queue, per node, forever.

## What replaces them

**PostgreSQL**: one data-modifying CTE — `DELETE ... RETURNING` feeding the inbox `INSERT`, then selecting the bodies. This is the *same shape the non-durable pop in this very file already used*, extended with the insert as a second CTE.

**SQL Server**: a declared table variable with the `WITH ... DELETE ... OUTPUT ... INTO @table` pattern that `_tryPopMessagesDirectlySql` had already proved out. A table variable also avoids the recompile a `SELECT INTO` forces.

## Bounded scheduled promotion

Both movers were **unbounded** — every due scheduled message promoted in a single statement, which on a large backlog is one enormous transaction holding the very locks the receive path needs. Now bounded: `RecoveryBatchSize` where `DurabilitySettings` is in hand, and a matching named constant in `SqlServerQueue` where the SQL is built in the constructor before any settings exist. The poller re-runs immediately after a full batch, so throughput is unchanged and only the lock/transaction scope is capped.

## Verification

Both rewrites were **run statement-by-statement against live PostgreSQL and SQL Server containers** before any suite: each pops the right rows, inserts them into the inbox with the right owner and address, returns the bodies, and empties the queue.

Suite status: PostgreSQL transport tests pass. The SQL Server transport suite showed timeout failures on a first run, but that run happened on a box carrying load average 16+ with four emulated amd64-on-arm64 SQL Server containers from stale sessions; those have been cleaned up and this is being re-verified on a quiet box via the supervised `CISqlServer` lane before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)