### PR TITLE
Revert GH-4320: AppendParameter changes SQL Server parameter typing

### DIFF
--- a/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabasePersistence.cs
@@ -37,23 +37,21 @@ public static class DatabasePersistence
     private static void ConfigureOutgoingCommand(IMessageDatabase settings, DbCommandBuilder builder, Envelope envelope,
         DbParameter owner)
     {
-        // GH-4320: AppendParameter registers the parameter AND writes its placeholder, so the
-        // per-envelope List<DbParameter> plus the LINQ projection and string join that only
-        // existed to rebuild "@p0, @p1, ..." are gone. Emitted SQL is byte-for-byte identical.
+        var list = new List<DbParameter>
+        {
+            builder.AddParameter(EnvelopeSerializer.Serialize(envelope)),
+            builder.AddParameter(envelope.Id),
+            owner,
+            builder.AddParameter(envelope.Destination!.ToString()),
+            builder.AddParameter(envelope.DeliverBy),
+            builder.AddParameter(envelope.Attempts),
+            builder.AddParameter(envelope.MessageType)
+        };
+
+        var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
+
         builder.Append(
-            $"insert into {settings.TableNameFor(DatabaseConstants.OutgoingTable)} ({DatabaseConstants.OutgoingFields}) values (");
-        builder.AppendParameter(EnvelopeSerializer.Serialize(envelope));
-        builder.Append(", ");
-        builder.AppendParameter(envelope.Id);
-        builder.Append($", @{owner.ParameterName}, ");
-        builder.AppendParameter(envelope.Destination!.ToString());
-        builder.Append(", ");
-        builder.AppendParameter(envelope.DeliverBy);
-        builder.Append(", ");
-        builder.AppendParameter(envelope.Attempts);
-        builder.Append(", ");
-        builder.AppendParameter((object?)envelope.MessageType);
-        builder.Append(");");
+            $"insert into {settings.TableNameFor(DatabaseConstants.OutgoingTable)} ({DatabaseConstants.OutgoingFields}) values ({parameterList});");
     }
 
     public static DbCommand BuildIncomingStorageCommand(IEnumerable<Envelope> envelopes,
@@ -72,28 +70,23 @@ public static class DatabasePersistence
         // Don't store any data if the envelope is already marked as handled
         var data = envelope.Status == EnvelopeStatus.Handled ? [] : EnvelopeSerializer.Serialize(envelope);
         
-        // GH-4320: see ConfigureOutgoingCommand -- same removal of the per-envelope
-        // List<DbParameter> + LINQ + string.Join that only rebuilt the placeholder list.
+        var list = new List<DbParameter>
+        {
+            builder.AddParameter(data),
+            builder.AddParameter(envelope.Id),
+            builder.AddParameter(envelope.Status.ToString()),
+            builder.AddParameter(envelope.OwnerId),
+            builder.AddParameter(envelope.ScheduledTime),
+            builder.AddParameter(envelope.Attempts),
+            builder.AddParameter(envelope.MessageType),
+            builder.AddParameter(envelope.Destination?.ToString()),
+            builder.AddParameter(envelope.KeepUntil)
+        };
+
+        var parameterList = list.Select(x => $"@{x.ParameterName}").Join(", ");
+
         builder.Append(
-            $@"insert into {settings.TableNameFor(DatabaseConstants.IncomingTable)}({DatabaseConstants.IncomingFields}) values (");
-        builder.AppendParameter(data);
-        builder.Append(", ");
-        builder.AppendParameter(envelope.Id);
-        builder.Append(", ");
-        builder.AppendParameter(envelope.Status.ToString());
-        builder.Append(", ");
-        builder.AppendParameter(envelope.OwnerId);
-        builder.Append(", ");
-        builder.AppendParameter(envelope.ScheduledTime);
-        builder.Append(", ");
-        builder.AppendParameter(envelope.Attempts);
-        builder.Append(", ");
-        builder.AppendParameter((object?)envelope.MessageType);
-        builder.Append(", ");
-        builder.AppendParameter((object?)envelope.Destination?.ToString());
-        builder.Append(", ");
-        builder.AppendParameter(envelope.KeepUntil);
-        builder.Append(");");
+            $@"insert into {settings.TableNameFor(DatabaseConstants.IncomingTable)}({DatabaseConstants.IncomingFields}) values ({parameterList});");
     }
 
     public static async Task<Envelope> ReadIncomingAsync(DbDataReader reader, CancellationToken cancellation = default)


### PR DESCRIPTION
**Reverts #4356, which broke main.** Caught by the supervised `CIPersistence` lane:

```
PersistenceTests.Postgresql.Transport.data_operations.move_from_outgoing_to_queue_async
PersistenceTests.Postgresql.Transport.data_operations.move_from_outgoing_to_scheduled_async
  SqlException : Implicit conversion from data type sql_variant to uniqueidentifier
                 is not allowed. Use the CONVERT function to run this query.
```

## Why it broke

The two APIs are **not** equivalent, which I assumed they were:

- `AddParameter(value, dbType: null)` — the original — never calls `SetParameterType`, so ADO.NET infers the parameter type from the value.
- `AppendParameter(x)` — what I swapped in — resolves to a typed overload (`AppendParameter(Guid)`, `AppendParameter(string)`, …) that passes an explicit `_provider.XParameterType` and therefore *does* call `SetParameterType`.

Through the generic `DbCommandBuilder` those explicit types don't land as the provider-native types the columns expect, and the `id` parameter reaches SQL Server as `sql_variant` against a `uniqueidentifier` column.

My PR claimed "the emitted SQL is byte-for-byte identical" — that was true of the *text* and irrelevant, because the bug is in the parameter metadata, which I never checked.

## Verification

The revert turns both failing tests green (`Passed! 2/2`). Reverting rather than patching because #4356 was a pure allocation optimization with no behavioural benefit to preserve — main should be correct now and the optimization can come back properly typed.

## Re-doing it correctly

GH-4320 stays open. A future attempt has to keep `AddParameter(object?, null)`'s type inference — build the placeholder text without the intermediate `List` + LINQ, but leave parameter typing exactly as it is — and must be validated by `CIPersistence` and `CISqlServer` **before** merge, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)