### PR TITLE
/claim #4360: Use ephemeral ports in HTTP tests to avoid macOS AirPlay port 5000 collision

### DIFF
--- a/src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs
+++ b/src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs
@@ -1,12 +1,14 @@
-﻿using Alba;
+using Alba;
 using JasperFx.Core.Reflection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Wolverine.Runtime;
 using Wolverine.Tracking;
+using System;
 
 namespace Wolverine.Http.Tests.Bugs;
 
@@ -77,8 +79,20 @@ public class Bug_using_host_stop
 
     private static async Task<IHost> CreateAlbaHostWithWithFactory()
     {
-        return await AlbaHost.For<WolverineWebApi.Program>(x =>
-            x.ConfigureServices(ConfigureWolverine));
+        // Some macOS systems have the AirPlay Receiver bound to port 5000 by default.
+        // Force the ASP.NET Core host to bind to an ephemeral port (0) to avoid collisions.
+        var previous = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+        Environment.SetEnvironmentVariable("ASPNETCORE_URLS", "http://127.0.0.1:0");
+        try
+        {
+            return await AlbaHost.For<WolverineWebApi.Program>(x =>
+                x.ConfigureServices(ConfigureWolverine));
+        }
+        finally
+        {
+            // Restore previous value to avoid surprising other tests
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", previous);
+        }
     }
 
     private static async Task<IHost> CreateHostWithWebApplicationBuilder()
@@ -94,6 +108,11 @@ public class Bug_using_host_stop
         var builder = WebApplication.CreateBuilder([]);
         ConfigureWolverine(builder.Services);
         builder.Services.AddWolverine(_ => { });
+
+        // Bind to an ephemeral port to avoid binding to the platform default (5000)
+        // which on macOS can be occupied by the AirPlay Receiver.
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+
         return builder;
     }
 


### PR DESCRIPTION
Summary:
- Force test hosts to bind to an ephemeral port (port 0) instead of the platform default (5000).
- Applied for WebApplicationBuilder-created hosts and AlbaHost factory hosts; environment variable changes are temporary and restored.

Why:
- On macOS the AirPlay Receiver (ControlCenter) commonly listens on port 5000, causing test failures with "address already in use". These tests only need a runnable host and do not depend on a specific port.

Files changed:
- src/Http/Wolverine.Http.Tests/Bugs/Bug_using_host_stop.cs

How to verify:
- On a macOS machine with AirPlay Receiver enabled (or any machine where port 5000 is in use), run the affected tests:
  - dotnet test src/Http/Wolverine.Http.Tests -f net7.0 --filter "Bug_using_host_stop"
- Expect the two tests in Bug_using_host_stop to pass instead of failing with an "address already in use" IOException.

Closes #4360

Closes #4360