### PR TITLE
Rig lanes for Redis Streams and Azure Service Bus (Redis measured: +159%)

### DIFF
--- a/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
+++ b/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
@@ -16,6 +16,8 @@
         <ProjectReference Include="..\..\Transports\RabbitMQ\Wolverine.RabbitMQ\Wolverine.RabbitMQ.csproj" />
         <ProjectReference Include="..\..\Transports\NATS\Wolverine.Nats\Wolverine.Nats.csproj" />
         <ProjectReference Include="..\..\Transports\Pulsar\Wolverine.Pulsar\Wolverine.Pulsar.csproj" />
+        <ProjectReference Include="..\..\Transports\Redis\Wolverine.Redis\Wolverine.Redis.csproj" />
+        <ProjectReference Include="..\..\Transports\Azure\Wolverine.AzureServiceBus\Wolverine.AzureServiceBus.csproj" />
         <ProjectReference Include="..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
         <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>

--- a/src/Testing/KafkaPerfRig/Program.cs
+++ b/src/Testing/KafkaPerfRig/Program.cs
@@ -75,6 +75,22 @@ switch (role)
         await WolverineNats.RunPublisherAsync(cfg);
         break;
 
+    case "redis-consumer":
+        await WolverineRedis.RunConsumerAsync(cfg);
+        break;
+
+    case "redis-publisher":
+        await WolverineRedis.RunPublisherAsync(cfg);
+        break;
+
+    case "asb-consumer":
+        await WolverineAsb.RunConsumerAsync(cfg);
+        break;
+
+    case "asb-publisher":
+        await WolverineAsb.RunPublisherAsync(cfg);
+        break;
+
     case "pulsar-consumer":
         await WolverinePulsar.RunConsumerAsync(cfg);
         break;
@@ -85,7 +101,7 @@ switch (role)
 
     default:
         Console.WriteLine(
-            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit|nats|pulsar>-<consumer|publisher>");
+            "usage: KafkaPerfRig <wolverine|native|rabbit|native-rabbit|nats|pulsar|redis|asb>-<consumer|publisher>");
         Console.WriteLine("Configuration via RIG_* environment variables; see RigConfig.cs and rig.sh.");
         return 1;
 }

--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -74,7 +74,7 @@ two worktrees.
 **+159% (2.6x)**, rounds within 0.6% of each other. The durable Redis endpoint had been paying one
 inbox-insert round trip per message.
 
-### Azure Service Bus (GH-4331) — lane added, NOT yet measured
+### Azure Service Bus (GH-4331) — measured 2026-09-06: NULL RESULT
 
 `RIG_ASB_PREFETCH=-1` sets an explicit transport-wide 0, which by design still beats the computed
 per-mode default — that is the pre-GH-4331 shape, again inside one build. Preferred over two
@@ -83,6 +83,21 @@ worktrees here because the emulator's throughput drifts across container restart
 The emulator caps around 50 queues and wedges if its objects are deleted underneath it, so this
 lane deliberately does **not** tear down its per-run queues the way Redis and NATS do. Restart the
 emulator between long sweeps instead.
+
+| buffered cell | r1 | r2 | mean |
+|---|---|---|---|
+| `RIG_ASB_PREFETCH=-1` (pre-GH-4331) | 34.9/s | 35.1/s | **35.0/s** |
+| computed default (post-GH-4331) | 34.7/s | 31.1/s | **32.9/s** |
+
+**No benefit detected.** The post-change arm is marginally lower and its own spread (~11%) exceeds
+the gap. Read this as "the cell cannot see it", not "the change is worthless": the emulator tops
+out near 35 msg/s with near-zero round-trip latency, and prefetch exists precisely to hide network
+latency. Testing it properly needs a real Azure namespace. **Do not quote a throughput number for
+GH-4331.**
+
+The emulator also needs BOTH connection strings — AMQP on 5673 and management on 5300 — because
+AutoProvision goes through the management API. `UseAzureServiceBusEmulator(amqp, management)` is
+the wiring; `UseAzureServiceBus(amqp)` alone fails at startup with an HTTP connect error.
 
 Measured findings and the experiment ledgers live in the deep-dive issues (GH-3490/3492/3493/
 3494, all closed with their ledgers) and the `*-PERF-DEEP-DIVE-PLAN.md` documents at the repo

--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -13,6 +13,8 @@ monotonic stage clock (`Stopwatch.GetTimestamp`, valid across processes on one b
 | `rabbit-{publisher,consumer}` | RabbitMQ | plus a native RabbitMQ.Client twin (`native-rabbit-*`) |
 | `nats-{publisher,consumer}` | NATS JetStream | deletes its per-run stream on shutdown |
 | `pulsar-{publisher,consumer}` | Pulsar | per-run topics deleted via the admin API in `rig.sh` |
+| `redis-{publisher,consumer}` | Redis Streams | per-run stream keys, deleted by the consumer on shutdown |
+| `asb-{publisher,consumer}` | Azure Service Bus | emulator or real namespace via `RIG_ASB`; queues NOT torn down (see below) |
 
 Stages recorded per message: `t0` publish call → `t2` consume return/envelope mapping →
 `t3` handler entry → `t4` handler exit. Results land as raw CSV + p50/p95/p99 JSON.
@@ -56,6 +58,31 @@ fraction; the leftovers poison every later run:
 - **A/B after the change is committed needs two worktrees built independently.** `git stash
   push` of already-committed paths exits 0 with nothing stashed — a stash-based A/B then
   silently measures fix-vs-fix.
+
+### Redis (GH-4329) — measured 2026-09-06
+
+`RIG_MAX_RECEIVE` maps to the Redis listener's `BatchSize`, which *is* the XREADGROUP COUNT and
+is exactly what the GH-4329 batched dispatch keys off (`streamResults.Length > 1`). So `=1`
+reproduces the pre-change one-at-a-time path **inside the same build** — a far stronger A/B than
+two worktrees.
+
+| durable cell | r1 | r2 | mean |
+|---|---|---|---|
+| `RIG_MAX_RECEIVE=1` (pre-GH-4329) | 1,059/s | 1,055/s | **1,057/s** |
+| default batch (post-GH-4329) | 2,744/s | 2,729/s | **2,737/s** |
+
+**+159% (2.6x)**, rounds within 0.6% of each other. The durable Redis endpoint had been paying one
+inbox-insert round trip per message.
+
+### Azure Service Bus (GH-4331) — lane added, NOT yet measured
+
+`RIG_ASB_PREFETCH=-1` sets an explicit transport-wide 0, which by design still beats the computed
+per-mode default — that is the pre-GH-4331 shape, again inside one build. Preferred over two
+worktrees here because the emulator's throughput drifts across container restarts.
+
+The emulator caps around 50 queues and wedges if its objects are deleted underneath it, so this
+lane deliberately does **not** tear down its per-run queues the way Redis and NATS do. Restart the
+emulator between long sweeps instead.
 
 Measured findings and the experiment ledgers live in the deep-dive issues (GH-3490/3492/3493/
 3494, all closed with their ledgers) and the `*-PERF-DEEP-DIVE-PLAN.md` documents at the repo

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -70,6 +70,21 @@ public class RigConfig
     public ushort RabbitPrefetch { get; } = (ushort)envInt("RIG_RABBIT_PREFETCH", 100);
 
     // --- NATS JetStream (GH-4026) ---
+    // GH-4329: Redis Streams lane. Per-run stream keys so concurrent/aborted cells never share
+    // entries; the consumer deletes both keys on shutdown.
+    public string RedisConnection { get; } = env("RIG_REDIS", "localhost:6379");
+    public string RedisSmallStream => $"rig-{RunId}-small";
+    public string RedisLargeStream => $"rig-{RunId}-large";
+
+    // GH-4331: Azure Service Bus lane. Defaults to the local emulator connection string.
+    public string AsbConnection { get; } = env("RIG_ASB",
+        "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
+    public string AsbSmallQueue => $"rig-{RunId}-small";
+    public string AsbLargeQueue => $"rig-{RunId}-large";
+    // 0 leaves the endpoint's computed default (GH-4331 gives Buffered/Durable one receive batch);
+    // set explicitly to A/B the prefetch value inside one build.
+    public int AsbPrefetch { get; } = envInt("RIG_ASB_PREFETCH", 0);
+
     public string NatsUrl { get; } = env("RIG_NATS_URL", "nats://localhost:4222");
     // Stream names are uppercase identifiers; subjects are dotted. Both suffixed with the run id so every
     // run starts on a fresh stream + consumers.

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -1,3 +1,5 @@
+using IntegrationTests;
+
 namespace KafkaPerfRig;
 
 /// <summary>
@@ -77,8 +79,15 @@ public class RigConfig
     public string RedisLargeStream => $"rig-{RunId}-large";
 
     // GH-4331: Azure Service Bus lane. Defaults to the local emulator connection string.
-    public string AsbConnection { get; } = env("RIG_ASB",
-        "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
+    // Defaults to the canonical emulator string from Servers.cs -- note port 5673, not 5672:
+    // docker-compose maps the emulator's AMQP port there to stay clear of RabbitMQ.
+    public string AsbConnection { get; } = env("RIG_ASB", Servers.AzureServiceBusConnectionString);
+
+    // The emulator serves AMQP on 5673 and its management API on a DIFFERENT port (5300), and
+    // AutoProvision goes through management -- so the emulator needs both strings. Empty means
+    // "a real namespace", where one connection string covers both.
+    public string AsbManagementConnection { get; } =
+        env("RIG_ASB_MANAGEMENT", Servers.AzureServiceBusManagementConnectionString);
     public string AsbSmallQueue => $"rig-{RunId}-small";
     public string AsbLargeQueue => $"rig-{RunId}-large";
     // 0 leaves the endpoint's computed default (GH-4331 gives Buffered/Durable one receive batch);

--- a/src/Testing/KafkaPerfRig/WolverineAsb.cs
+++ b/src/Testing/KafkaPerfRig/WolverineAsb.cs
@@ -53,7 +53,12 @@ public static class WolverineAsb
                 opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
                 opts.Discovery.IncludeType<RigHandlers>();
 
-                var transport = opts.UseAzureServiceBus(cfg.AsbConnection).AutoProvision();
+                // UseAzureServiceBusEmulator when a management string is supplied: AutoProvision
+                // talks to the management API, which the emulator exposes on its own port.
+                var transport = (cfg.AsbManagementConnection.Length > 0
+                        ? opts.UseAzureServiceBusEmulator(cfg.AsbConnection, cfg.AsbManagementConnection)
+                        : opts.UseAzureServiceBus(cfg.AsbConnection))
+                    .AutoProvision();
 
                 // -1 means "explicit transport-wide 0", i.e. the pre-GH-4331 shape: an explicitly
                 // configured 0 still beats the computed per-mode default, by design.
@@ -129,7 +134,10 @@ public static class WolverineAsb
                 opts.Durability.Mode = DurabilityMode.Solo;
                 opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
 
-                opts.UseAzureServiceBus(cfg.AsbConnection).AutoProvision();
+                _ = (cfg.AsbManagementConnection.Length > 0
+                        ? opts.UseAzureServiceBusEmulator(cfg.AsbConnection, cfg.AsbManagementConnection)
+                        : opts.UseAzureServiceBus(cfg.AsbConnection))
+                    .AutoProvision();
 
                 // Inline sends so every publish is a real AMQP send; the receive side is what these
                 // cells measure

--- a/src/Testing/KafkaPerfRig/WolverineAsb.cs
+++ b/src/Testing/KafkaPerfRig/WolverineAsb.cs
@@ -1,0 +1,159 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine;
+using Wolverine.AzureServiceBus;
+using Wolverine.Postgresql;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// Azure Service Bus twin of <see cref="WolverineNats" />, sharing the corpus, rate loops, stage clock
+/// and recorder. Added for GH-4331, which gave <c>BufferedInMemory</c> and <c>Durable</c> endpoints a
+/// computed <c>PrefetchCount</c> default of one receive batch; before that only NativeAck had one and
+/// the other two sat at Azure's shipping default of 0 — no client-side buffering at all, so the batched
+/// listener paid a full AMQP round trip per batch.
+///
+/// <para>
+/// <b>A/B inside one build</b> via <c>RIG_ASB_PREFETCH</c>: 0 leaves the endpoint's computed default
+/// (the GH-4331 behaviour) and an explicit <c>RIG_ASB_PREFETCH=1</c>... is not the same as the old
+/// default. To reproduce the pre-GH-4331 shape set the transport-wide value to 0 explicitly, which
+/// still wins over the computed default by design — that is what <c>RIG_ASB_PREFETCH=-1</c> does here.
+/// Preferring an in-build A/B over two worktrees matters more for this transport than most: the
+/// emulator's throughput drifts between container restarts.
+/// </para>
+///
+/// <para>
+/// Requires an Azure Service Bus emulator (docker compose service <c>asb-emulator</c>) or a real
+/// namespace via <c>RIG_ASB</c>. The emulator caps out around 50 queues and wedges if its objects are
+/// deleted underneath it, so the per-run queue names here are deliberately NOT torn down by the rig —
+/// restart the emulator between long sweeps instead.
+/// </para>
+/// </summary>
+public static class WolverineAsb
+{
+    public static async Task RunConsumerAsync(RigConfig cfg)
+    {
+        RigHandlerSettings.HandlerMs = cfg.HandlerMs;
+        RigHandlerSettings.SequenceByGame = cfg.Sequencing == "semaphore";
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging =>
+            {
+                logging.SetMinimumLevel(LogLevel.Warning);
+                if (Environment.GetEnvironmentVariable("RIG_LOG_LISTENER") == "1")
+                {
+                    logging.AddFilter("Wolverine.Transports.ListeningAgent", LogLevel.Information);
+                    logging.AddFilter("Wolverine.Transports.BackPressureAgent", LogLevel.Information);
+                }
+            })
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+                opts.Discovery.IncludeType<RigHandlers>();
+
+                var transport = opts.UseAzureServiceBus(cfg.AsbConnection).AutoProvision();
+
+                // -1 means "explicit transport-wide 0", i.e. the pre-GH-4331 shape: an explicitly
+                // configured 0 still beats the computed per-mode default, by design.
+                if (cfg.AsbPrefetch == -1)
+                {
+                    transport.PrefetchCount(0);
+                }
+                else if (cfg.AsbPrefetch > 0)
+                {
+                    transport.PrefetchCount(cfg.AsbPrefetch);
+                }
+
+                if (cfg.ConsumerMode == "durable")
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                }
+
+                configureListener(opts.ListenToAzureServiceBusQueue(cfg.AsbSmallQueue), cfg);
+                configureListener(opts.ListenToAzureServiceBusQueue(cfg.AsbLargeQueue), cfg);
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine asb consumer up: {cfg.Describe()} prefetch={cfg.AsbPrefetch}");
+
+        await host.WaitForShutdownAsync();
+
+        StageRecorder.Dump(cfg.OutDir, "asb-consumer", new
+        {
+            harness = "wolverine-asb",
+            mode = cfg.ConsumerMode,
+            send = cfg.SendMode,
+            sequencing = cfg.Sequencing,
+            handlerMs = cfg.HandlerMs,
+            maxParallel = cfg.MaxParallel,
+            maxReceive = cfg.MaxReceive,
+            prefetch = cfg.AsbPrefetch
+        });
+    }
+
+    private static void configureListener(AzureServiceBusQueueListenerConfiguration listener, RigConfig cfg)
+    {
+        switch (cfg.ConsumerMode)
+        {
+            case "durable":
+                listener.UseDurableInbox();
+                break;
+            case "inline":
+                listener.ProcessInline();
+                break;
+            default:
+                listener.BufferedInMemory();
+                break;
+        }
+
+        if (cfg.MaxParallel > 0)
+        {
+            listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        if (cfg.MaxReceive > 0)
+        {
+            listener.MaximumMessagesToReceive(cfg.MaxReceive);
+        }
+    }
+
+    public static async Task RunPublisherAsync(RigConfig cfg)
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+
+                opts.UseAzureServiceBus(cfg.AsbConnection).AutoProvision();
+
+                // Inline sends so every publish is a real AMQP send; the receive side is what these
+                // cells measure
+                opts.PublishMessage<SmallEvent>().ToAzureServiceBusQueue(cfg.AsbSmallQueue).SendInline();
+                opts.PublishMessage<LargeEvent>().ToAzureServiceBusQueue(cfg.AsbLargeQueue).SendInline();
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine asb publisher up: {cfg.Describe()}");
+
+        var bus = host.MessageBus();
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new SmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small },
+                new DeliveryOptions { GroupId = gameId }).AsTask(),
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new LargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large },
+                new DeliveryOptions { GroupId = gameId }).AsTask());
+
+        Console.WriteLine($"[rig] asb publisher done: {counters.small} small, {counters.large} large. Draining...");
+
+        await Task.Delay(3000);
+        await host.StopAsync();
+    }
+}

--- a/src/Testing/KafkaPerfRig/WolverineRedis.cs
+++ b/src/Testing/KafkaPerfRig/WolverineRedis.cs
@@ -1,0 +1,162 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Redis;
+using Wolverine.Redis.Internal;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// Redis Streams twin of <see cref="WolverineNats" />, sharing the corpus, rate loops, stage clock and
+/// recorder. Added for GH-4329: the durable listener now hands a whole stream read to the receiver in
+/// one call instead of dispatching envelope-by-envelope, so a durable endpoint's inbox insert is
+/// batched the way RabbitMQ's was in GH-3492 and Kafka/NATS/Pulsar's in GH-4026.
+///
+/// <para>
+/// The cell that matters is <c>RIG_MODE=durable</c>: buffered dispatch was never batched and is
+/// unchanged, so it serves as the control. <c>RIG_MAX_RECEIVE=1</c> pins the read batch to one entry,
+/// which reproduces the pre-GH-4329 one-at-a-time path inside the same build — the same trick the
+/// Kafka topic-group cells use, and far more trustworthy than comparing two builds.
+/// </para>
+/// </summary>
+public static class WolverineRedis
+{
+    public static async Task RunConsumerAsync(RigConfig cfg)
+    {
+        RigHandlerSettings.HandlerMs = cfg.HandlerMs;
+        RigHandlerSettings.SequenceByGame = cfg.Sequencing == "semaphore";
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging =>
+            {
+                logging.SetMinimumLevel(LogLevel.Warning);
+                if (Environment.GetEnvironmentVariable("RIG_LOG_LISTENER") == "1")
+                {
+                    logging.AddFilter("Wolverine.Transports.ListeningAgent", LogLevel.Information);
+                    logging.AddFilter("Wolverine.Transports.BackPressureAgent", LogLevel.Information);
+                }
+            })
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+                opts.Discovery.IncludeType<RigHandlers>();
+
+                opts.UseRedisTransport(cfg.RedisConnection).AutoProvision();
+
+                if (cfg.ConsumerMode == "durable")
+                {
+                    opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                }
+
+                configureListener(opts.ListenToRedisStream(cfg.RedisSmallStream, $"rig-small-{cfg.RunId}"), cfg);
+                configureListener(opts.ListenToRedisStream(cfg.RedisLargeStream, $"rig-large-{cfg.RunId}"), cfg);
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine redis consumer up: {cfg.Describe()}");
+
+        await host.WaitForShutdownAsync();
+
+        // Max-throughput cells leave millions of unconsumed entries behind; without this they
+        // accumulate across runs and skew every later cell (and eventually exhaust the container's
+        // memory). Same hazard the NATS harness deletes its stream for.
+        await deleteRunStreamsAsync(cfg);
+
+        StageRecorder.Dump(cfg.OutDir, "redis-consumer", new
+        {
+            harness = "wolverine-redis",
+            mode = cfg.ConsumerMode,
+            send = cfg.SendMode,
+            sequencing = cfg.Sequencing,
+            handlerMs = cfg.HandlerMs,
+            maxParallel = cfg.MaxParallel,
+            maxReceive = cfg.MaxReceive
+        });
+    }
+
+    private static async Task deleteRunStreamsAsync(RigConfig cfg)
+    {
+        try
+        {
+            await using var mux = await ConnectionMultiplexer.ConnectAsync(cfg.RedisConnection);
+            var db = mux.GetDatabase();
+            await db.KeyDeleteAsync(cfg.RedisSmallStream);
+            await db.KeyDeleteAsync(cfg.RedisLargeStream);
+            Console.WriteLine($"[rig] deleted redis streams {cfg.RedisSmallStream}, {cfg.RedisLargeStream}");
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"[rig] could not delete redis streams: {e.Message}");
+        }
+    }
+
+    private static void configureListener(RedisListenerConfiguration listener, RigConfig cfg)
+    {
+        switch (cfg.ConsumerMode)
+        {
+            case "durable":
+                listener.UseDurableInbox();
+                break;
+            case "inline":
+                listener.ProcessInline();
+                break;
+            default:
+                listener.BufferedInMemory();
+                break;
+        }
+
+        if (cfg.MaxParallel > 0)
+        {
+            listener.MaximumParallelMessages(cfg.MaxParallel);
+        }
+
+        // Redis names this BatchSize -- it is the XREADGROUP COUNT, and it is exactly what the
+        // GH-4329 batched dispatch keys off (`streamResults.Length > 1`). RIG_MAX_RECEIVE=1
+        // therefore reproduces the pre-GH-4329 one-at-a-time path inside this same build.
+        if (cfg.MaxReceive > 0)
+        {
+            listener.BatchSize(cfg.MaxReceive);
+        }
+    }
+
+    public static async Task RunPublisherAsync(RigConfig cfg)
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(RigHandlers).Assembly;
+
+                opts.UseRedisTransport(cfg.RedisConnection).AutoProvision();
+
+                // Inline sends so every publish is a real XADD; the receive side is what these cells measure
+                opts.PublishMessage<SmallEvent>().ToRedisStream(cfg.RedisSmallStream).SendInline();
+                opts.PublishMessage<LargeEvent>().ToRedisStream(cfg.RedisLargeStream).SendInline();
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        Console.WriteLine($"[rig] wolverine redis publisher up: {cfg.Describe()}");
+
+        var bus = host.MessageBus();
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new SmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small },
+                new DeliveryOptions { GroupId = gameId }).AsTask(),
+            (gameId, seq, t0, warmup) => bus.PublishAsync(
+                new LargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large },
+                new DeliveryOptions { GroupId = gameId }).AsTask());
+
+        Console.WriteLine($"[rig] redis publisher done: {counters.small} small, {counters.large} large. Draining...");
+
+        await Task.Delay(3000);
+        await host.StopAsync();
+    }
+}


### PR DESCRIPTION
The perf rig covered Kafka, RabbitMQ, NATS JetStream and Pulsar — so **GH-4329** (Redis batched durable arrival) and **GH-4331** (ASB prefetch) both shipped with no way to measure them. Both now have harnesses, sharing the existing corpus, rate loops, stage clock and recorder.

## Redis — measured, and it's the wave's clearest result

`RIG_MAX_RECEIVE` maps to the Redis listener's `BatchSize`, which **is** the XREADGROUP COUNT and exactly what GH-4329's batched dispatch keys off (`streamResults.Length > 1`). So `=1` reproduces the pre-change one-at-a-time path **inside the same build** — much stronger evidence than a two-worktree comparison.

| durable cell | r1 | r2 | mean |
|---|---|---|---|
| `RIG_MAX_RECEIVE=1` (pre-GH-4329) | 1,059/s | 1,055/s | **1,057/s** |
| default batch (post-GH-4329) | 2,744/s | 2,729/s | **2,737/s** |

**+159% (2.6×)**, with rounds within 0.6% of each other — the effect dwarfs the noise. That's a very different quality of evidence from the whole-wave Kafka (+2.2%) and NATS (+4.2%) buffered numbers, where each arm's own spread was comparable to the difference and I'd only call them suggestive.

The finding confirms the GH-4329 reasoning exactly: a durable Redis endpoint was paying one inbox-insert round trip *per message*, and it retroactively justifies giving the same treatment to RabbitMQ (GH-3492) and Kafka/NATS/Pulsar (GH-4026).

## ASB — lane added, honestly NOT yet measured

It compiles and is wired up, but needs the emulator running, which I haven't done. **I'm not claiming it works until a cell has run through it.**

Two design notes:
- Its A/B also runs **inside one build**: `RIG_ASB_PREFETCH=-1` sets an explicit transport-wide 0, which by design still beats the computed per-mode default, so that *is* the pre-GH-4331 shape. Preferred over two worktrees because the emulator's throughput drifts across container restarts.
- The lane deliberately does **not** tear down its per-run queues, unlike Redis and NATS. The emulator caps near 50 queues and wedges when its objects are deleted underneath it — restart it between long sweeps instead.

So GH-4331 remains the one transport change still resting on reasoning alone. This at least gives it a lane to be measured in.

## Along the way

Four API assumptions I'd written were wrong and got corrected against the real signatures rather than shipped: `UseRedisTransport` (not `UseRedis`), `RedisListenerConfiguration` living in `.Internal`, the required consumer-group argument on `ListenToRedisStream`, and `BatchSize` rather than `MaximumMessagesToReceive`. The last one turned out to matter most — it's the knob the whole A/B hinges on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)