### PR TITLE
Revert GH-4331: Azure Service Bus prefetch default goes back to zero

### DIFF
--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -74,10 +74,10 @@ two worktrees.
 **+159% (2.6x)**, rounds within 0.6% of each other. The durable Redis endpoint had been paying one
 inbox-insert round trip per message.
 
-### Azure Service Bus (GH-4331) — measured 2026-09-06: NULL RESULT
+### Azure Service Bus (GH-4331) — measured 2026-09-06: NULL RESULT → **change reverted**
 
-`RIG_ASB_PREFETCH=-1` sets an explicit transport-wide 0, which by design still beats the computed
-per-mode default — that is the pre-GH-4331 shape, again inside one build. Preferred over two
+`RIG_ASB_PREFETCH=-1` sets an explicit transport-wide 0, which by design still beat the computed
+per-mode default — that was the pre-GH-4331 shape, again inside one build. Preferred over two
 worktrees here because the emulator's throughput drifts across container restarts.
 
 The emulator caps around 50 queues and wedges if its objects are deleted underneath it, so this
@@ -94,6 +94,19 @@ the gap. Read this as "the cell cannot see it", not "the change is worthless": t
 out near 35 msg/s with near-zero round-trip latency, and prefetch exists precisely to hide network
 latency. Testing it properly needs a real Azure namespace. **Do not quote a throughput number for
 GH-4331.**
+
+**Outcome: the change was reverted.** No measured benefit, and prefetch is not free — a buffered
+message ages against its Azure Service Bus lock from the moment the *client* holds it, with no
+Envelope yet and therefore no `LeaseRenewalTracker` renewal. A default that trades real lock
+exposure for an unmeasured gain does not earn its place. The lane and the knob stay; the knob's
+polarity flipped. `RIG_ASB_PREFETCH=0` (the default) is now the shipping shape, and a **positive**
+value reproduces what GH-4331 proposed — `RIG_ASB_PREFETCH=20` is one receive batch. Re-run this
+against a real namespace to settle the issue.
+
+GH-4331 also shipped with a red unit test: `native_ack_prefetch_defaults_4051.every_other_mode_
+keeps_the_shipping_default_of_zero` asserts 0 for Buffered/Durable/Inline and was never updated,
+so `main` carried a failing Azure Service Bus unit test from #4351 until the revert. The lesson is
+in the ledger's own ground rules — run the covering lane, not just the one you were thinking about.
 
 The emulator also needs BOTH connection strings — AMQP on 5673 and management on 5300 — because
 AutoProvision goes through the management API. `UseAzureServiceBusEmulator(amqp, management)` is

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -90,8 +90,9 @@ public class RigConfig
         env("RIG_ASB_MANAGEMENT", Servers.AzureServiceBusManagementConnectionString);
     public string AsbSmallQueue => $"rig-{RunId}-small";
     public string AsbLargeQueue => $"rig-{RunId}-large";
-    // 0 leaves the endpoint's computed default (GH-4331 gives Buffered/Durable one receive batch);
-    // set explicitly to A/B the prefetch value inside one build.
+    // 0 is the shipping shape: no prefetch on anything but NativeAck, after GH-4331's computed
+    // Buffered/Durable default measured as a null result here and was reverted. Set a positive value
+    // to A/B the GH-4331 proposal inside one build (20 == one receive batch).
     public int AsbPrefetch { get; } = envInt("RIG_ASB_PREFETCH", 0);
 
     public string NatsUrl { get; } = env("RIG_NATS_URL", "nats://localhost:4222");

--- a/src/Testing/KafkaPerfRig/WolverineAsb.cs
+++ b/src/Testing/KafkaPerfRig/WolverineAsb.cs
@@ -9,18 +9,25 @@ namespace KafkaPerfRig;
 
 /// <summary>
 /// Azure Service Bus twin of <see cref="WolverineNats" />, sharing the corpus, rate loops, stage clock
-/// and recorder. Added for GH-4331, which gave <c>BufferedInMemory</c> and <c>Durable</c> endpoints a
-/// computed <c>PrefetchCount</c> default of one receive batch; before that only NativeAck had one and
-/// the other two sat at Azure's shipping default of 0 — no client-side buffering at all, so the batched
-/// listener paid a full AMQP round trip per batch.
+/// and recorder. Added for GH-4331, which briefly gave <c>BufferedInMemory</c> and <c>Durable</c>
+/// endpoints a computed <c>PrefetchCount</c> default of one receive batch. This lane measured that
+/// change as a NULL RESULT against the emulator and it was reverted, so every mode but NativeAck is
+/// back at Azure's shipping default of 0. The lane is what will settle GH-4331 for real.
 ///
 /// <para>
-/// <b>A/B inside one build</b> via <c>RIG_ASB_PREFETCH</c>: 0 leaves the endpoint's computed default
-/// (the GH-4331 behaviour) and an explicit <c>RIG_ASB_PREFETCH=1</c>... is not the same as the old
-/// default. To reproduce the pre-GH-4331 shape set the transport-wide value to 0 explicitly, which
-/// still wins over the computed default by design — that is what <c>RIG_ASB_PREFETCH=-1</c> does here.
-/// Preferring an in-build A/B over two worktrees matters more for this transport than most: the
-/// emulator's throughput drifts between container restarts.
+/// <b>A/B inside one build</b> via <c>RIG_ASB_PREFETCH</c>: 0 (the default) is now the shipping shape
+/// — no client-side buffering on Buffered/Durable — and a positive value reproduces what GH-4331
+/// proposed, e.g. <c>RIG_ASB_PREFETCH=20</c> for one receive batch. <c>-1</c> sets an explicit
+/// transport-wide 0, which is indistinguishable from the default now that the computed default is
+/// gone; it is kept so the ledger's original cells stay reproducible. Preferring an in-build A/B over
+/// two worktrees matters more for this transport than most: the emulator's throughput drifts between
+/// container restarts.
+/// </para>
+///
+/// <para>
+/// <b>The emulator cannot see this knob.</b> It tops out near 35 msg/s with near-zero round-trip
+/// latency, and prefetch exists to hide latency. Run this lane against a real namespace
+/// (<c>RIG_ASB</c>) before quoting any prefetch number.
 /// </para>
 ///
 /// <para>

--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_prefetch_count.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/configuring_prefetch_count.cs
@@ -7,46 +7,28 @@ namespace Wolverine.AzureServiceBus.Tests;
 public class configuring_prefetch_count
 {
     [Fact]
-    public void the_transport_wide_default_is_still_zero()
+    public void prefetch_is_disabled_by_default()
     {
-        // The transport-level value is the explicit opt-in knob and is unchanged; what varies is
-        // what an endpoint computes when nothing was configured (see the per-mode tests below)
-        new AzureServiceBusTransport().PrefetchCount.ShouldBe(0);
+        var transport = new AzureServiceBusTransport();
+
+        transport.PrefetchCount.ShouldBe(0);
+        transport.Queues["incoming"].PrefetchCount.ShouldBe(0);
     }
 
-    // GH-4331: Buffered and Durable settle at receipt / right after the inbox insert, so a modest
-    // prefetch buffer does not age against a lock across handler execution. Inline does run the
-    // handler before settling, so it keeps zero.
+    // GH-4331 gave these two modes a computed default of one receive batch on the reasoning that
+    // they settle early and so do not hold a lock across handler execution. The rig lane measured
+    // no benefit, and prefetch is not free -- a buffered message ages against its lock with no
+    // Envelope and therefore no lease renewal -- so the default went back to zero. This test is the
+    // guard on that reversal, not a claim that prefetch is useless.
     [Theory]
     [InlineData(EndpointMode.BufferedInMemory)]
     [InlineData(EndpointMode.Durable)]
-    public void settle_early_modes_prefetch_one_receive_batch_by_default(EndpointMode mode)
+    [InlineData(EndpointMode.Inline)]
+    public void no_mode_other_than_native_ack_computes_a_prefetch_default(EndpointMode mode)
     {
         var queue = new AzureServiceBusTransport().Queues["incoming"];
         queue.Mode = mode;
 
-        queue.PrefetchCount.ShouldBe(queue.MaximumMessagesToReceive);
-    }
-
-    [Fact]
-    public void inline_still_disables_prefetch_by_default()
-    {
-        var queue = new AzureServiceBusTransport().Queues["incoming"];
-        queue.Mode = EndpointMode.Inline;
-
-        queue.PrefetchCount.ShouldBe(0);
-    }
-
-    [Fact]
-    public void an_explicit_transport_wide_zero_still_wins_over_the_computed_default()
-    {
-        var transport = new AzureServiceBusTransport();
-        transport.PrefetchCount = 0;
-
-        var queue = transport.Queues["incoming"];
-        queue.Mode = EndpointMode.Durable;
-
-        // Setting it explicitly to 0 is a deliberate "no prefetch", not an absence of configuration
         queue.PrefetchCount.ShouldBe(0);
     }
 

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEndpoint.cs
@@ -109,25 +109,15 @@ public abstract class AzureServiceBusEndpoint : Endpoint<IAzureServiceBusEnvelop
                 return lanes * 2;
             }
 
-            // GH-4331. Buffered and Durable were the two modes left at Azure Service Bus's shipping
-            // default of 0 -- no prefetch at all -- so the batched listener paid a full AMQP round
-            // trip per batch with nothing buffered client-side. They are also the two modes where
-            // prefetch is SAFEST: buffered settles at receipt and durable settles right after the
-            // inbox insert, so neither holds a lock across handler execution the way NativeAck does.
-            //
-            // Not risk-free, and that is why this is one batch rather than a throughput-only number:
-            // a prefetched message ages against its lock from the moment the CLIENT buffers it, with
-            // no Envelope yet and so no lease renewal. The exposure is (buffer depth / consumption
-            // rate), so sizing the buffer to exactly one receive batch bounds it at roughly the time
-            // to drain one batch.
-            //
-            // Inline deliberately keeps 0: it runs the handler before settling, so a prefetch buffer
-            // there ages against a lock behind arbitrarily slow user code.
-            if (Mode is EndpointMode.BufferedInMemory or EndpointMode.Durable)
-            {
-                return MaximumMessagesToReceive;
-            }
-
+            // GH-4331 briefly gave BufferedInMemory and Durable a computed default of one receive
+            // batch. Reverted: the rig lane in src/Testing/KafkaPerfRig measured a NULL RESULT
+            // (35.0/s before, 32.9/s after, the post-change arm's own spread wider than the gap),
+            // and the change is not free -- a prefetched message ages against its Azure Service Bus
+            // lock from the moment the CLIENT buffers it, with no Envelope yet and therefore no
+            // LeaseRenewalTracker renewal. Unmeasured benefit is not worth that exposure by default.
+            // The emulator cannot see prefetch (near-zero round-trip latency is exactly what
+            // prefetch exists to hide), so this stays at 0 until a real Azure namespace says
+            // otherwise. See GH-4331.
             return Parent.PrefetchCount;
         }
         set


### PR DESCRIPTION
The GH-4331 change gave `BufferedInMemory` and `Durable` Azure Service Bus endpoints a computed `PrefetchCount` default of one receive batch. It was merged unmeasured, on reasoning alone. The rig lane built for it (#4363) has now measured it:

| buffered cell | r1 | r2 | mean |
|---|---|---|---|
| explicit transport-wide 0 (pre-GH-4331) | 34.9/s | 35.1/s | **35.0/s** |
| computed default (post-GH-4331) | 34.7/s | 31.1/s | **32.9/s** |

**Null result.** The post-change arm is marginally lower and its own spread (~11%) exceeds the gap.

That is not evidence the idea is wrong — the emulator tops out near 35 msg/s with near-zero round-trip latency, and prefetch exists precisely to hide latency, so the cell cannot see the effect. But it is also not evidence the change earns its keep, and the change is not free: a prefetched message ages against its Azure Service Bus lock from the moment the *client* buffers it, with no `Envelope` yet and therefore nothing for `LeaseRenewalTracker` to renew. Prefetch is the one part of an endpoint's backlog that renewal does not protect. An unmeasured benefit does not justify a default that trades real lock exposure for it.

### #4351 also landed red

`native_ack_prefetch_defaults_4051.every_other_mode_keeps_the_shipping_default_of_zero` asserts 0 for `BufferedInMemory`, `Inline` and `Durable`. It was never updated, so `main` has been carrying a failing Azure Service Bus unit test:

```
Shouldly.ShouldAssertException : queueWith(EndpointMode.BufferedInMemory).PrefetchCount
    should be 0 but was 20
```

That test is green again here.

### What is unchanged

- **NativeAck's computed default (GH-4051) stays.** It is the one mode that holds a lock across handler execution, and it is sized to the lane count for exactly that reason.
- The transport-wide `PrefetchCount` knob and every explicit setting path are untouched.
- `configuring_prefetch_count` now guards the reversal from the other side: no mode but NativeAck computes a default.

### The rig lane stays, with its polarity flipped

`RIG_ASB_PREFETCH=0` (the default) is now the shipping shape; a **positive** value reproduces what GH-4331 proposed — `RIG_ASB_PREFETCH=20` is one receive batch. `-1` is kept so the ledger's original cells stay reproducible. The README ledger records the reversal and the reason.

**GH-4331 stays open.** Settling it needs a real Azure namespace, not the emulator.

### Verification

`Wolverine.AzureServiceBus.Tests` — **46/46 passing** on `net9.0`, including the emulator-backed native-ack lane. The same filter on `main` fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)