### PR TITLE
Revert GH-4332's coalescer Queue: it measured slower at real backlog depths

### DIFF
--- a/src/Testing/Benchmarks/PerfWaveBenchmarks.cs
+++ b/src/Testing/Benchmarks/PerfWaveBenchmarks.cs
@@ -230,22 +230,28 @@ public class PerfWaveBenchmarks
     // ─────────────────────────────────────────────────────────────────────────
     // GH-4332 — InboxCompletionCoalescer drain under backlog.
     //
-    // MEASURED, and the answer has a crossover worth knowing (net9.0, --job short):
+    // MEASURED across depths, three arms, net9.0 --job short --inProcess:
     //
-    //   depth      List (before)     Queue (after)    ratio
-    //     100          586 ns            677 ns       1.15x SLOWER
-    //   1,000        5,922 ns          7,315 ns       1.24x SLOWER
-    //  10,000      103,131 ns         69,552 ns       0.67x faster
-    //  50,000    1,954,797 ns        400,482 ns       0.20x faster (4.9x)
+    //   depth   List GetRange (orig)   Queue (GH-4332)      List CopyTo (shipping)
+    //     100     540.8 ns / 4.82 KB    692.1 ns  1.28x      483.6 ns  0.89x / 0.83x alloc
+    //   1,000   5,932.1 ns / 47.7 KB  7,674.1 ns  1.29x    5,538.5 ns  0.93x / 0.82x alloc
+    //  10,000    94,612 ns             74,014 ns  0.78x       88,920 ns  0.94x / 0.82x alloc
+    //  50,000 1,812,535 ns            370,377 ns  0.20x    1,780,025 ns  0.98x / 0.82x alloc
     //
-    // The quadratic claim holds: the List goes superlinear (5x more depth costs 19x more time
-    // between 10k and 50k) while the Queue stays linear (5.8x). But below ~5k the memmove is
-    // cheaper than Queue.Dequeue's per-item overhead, so the Queue is marginally SLOWER in the
-    // common shallow case -- by ~90ns at depth 100, which is noise next to the database round
-    // trip the flush is about to make. Allocation is 18% lower at every depth.
+    // GH-4332's quadratic claim holds: between 10k and 50k the List costs 19x more time for 5x
+    // more depth while the Queue stays linear (5.8x), and at 50k the Queue is 4.9x faster. But the
+    // crossover sits near 5,000 pending completions, and 100-1,000 is the depth a healthy node
+    // actually runs at -- so in the common case the Queue is the SLOWER of the three, by ~29%.
     //
-    // Net: the right trade, because it bounds the pathological case (a node far behind, which is
-    // exactly when completions must not get slower) at a negligible cost when things are healthy.
+    // Hence the revert. What shipped is NOT the original "before": that drained with
+    // GetRange(0, n).ToArray(), which allocates a List of n, copies n, allocates an array of n and
+    // copies n again. CopyTo straight into the pre-sized array the flush already needs does it in
+    // one allocation and one copy. That third arm is the best of both -- fastest of the three at
+    // every depth below the crossover, and it keeps the Queue's ~18% allocation reduction at every
+    // depth, which was the one thing GH-4332 won outright.
+    //
+    // Keep this benchmark. If a deployment is ever found sitting 10,000+ completions behind, the
+    // table says exactly what to switch to and what it buys.
     // ─────────────────────────────────────────────────────────────────────────
 
     [BenchmarkCategory("GH-4332 Drain"), Benchmark(Baseline = true, Description = "Drain 1000 via List GetRange+RemoveRange (before)")]
@@ -266,7 +272,7 @@ public class PerfWaveBenchmarks
         return drained;
     }
 
-    [BenchmarkCategory("GH-4332 Drain"), Benchmark(Description = "Drain 1000 via Queue.Dequeue (after)")]
+    [BenchmarkCategory("GH-4332 Drain"), Benchmark(Description = "Drain 1000 via Queue.Dequeue (GH-4332, reverted)")]
     public int DrainAfter()
     {
         var pending = new Queue<object>(BacklogDepth);
@@ -278,6 +284,27 @@ public class PerfWaveBenchmarks
             var take = Math.Min(FlushBatch, pending.Count);
             var batch = new object[take];
             for (var i = 0; i < take; i++) batch[i] = pending.Dequeue();
+            drained += batch.Length;
+        }
+
+        return drained;
+    }
+
+    // What actually shipped after the revert: the List the shallow numbers favour, minus the
+    // intermediate List that GetRange().ToArray() allocated on every flush.
+    [BenchmarkCategory("GH-4332 Drain"), Benchmark(Description = "Drain 1000 via List CopyTo+RemoveRange (reverted-to)")]
+    public int DrainReverted()
+    {
+        var pending = new List<object>(BacklogDepth);
+        for (var i = 0; i < BacklogDepth; i++) pending.Add(i);
+
+        var drained = 0;
+        while (pending.Count > 0)
+        {
+            var take = Math.Min(FlushBatch, pending.Count);
+            var batch = new object[take];
+            pending.CopyTo(0, batch, 0, take);
+            pending.RemoveRange(0, take);
             drained += batch.Length;
         }
 

--- a/src/Wolverine/Runtime/WorkerQueues/InboxCompletionCoalescer.cs
+++ b/src/Wolverine/Runtime/WorkerQueues/InboxCompletionCoalescer.cs
@@ -26,10 +26,22 @@ internal class InboxCompletionCoalescer
     private readonly Uri _uri;
     private readonly object _lock = new();
 
-    // GH-4332: a Queue, not a List. Draining a List with RemoveRange(0, n) memmoves everything
-    // behind the batch on every flush, so a deep backlog costs O(N) per flush of _maximumBatchSize
-    // -- quadratic overall exactly when the system is most behind.
-    private readonly Queue<Pending> _pending = new();
+    // GH-4332 swapped this for a Queue on the theory that List.RemoveRange(0, n) memmoves the
+    // remainder and so goes quadratic under a deep backlog. The theory is right -- and irrelevant
+    // at the depths this actually runs at. PerfWaveBenchmarks ("GH-4332 Drain", swept across
+    // depths) puts the crossover near 5,000 pending completions: below it the memmove is CHEAPER
+    // than Queue.Dequeue's per-item overhead, and the Queue measured 1.28x SLOWER at depth 100 and
+    // 1.29x at 1,000 -- which is the shape a healthy node runs at. So the Queue was reverted.
+    //
+    // The drain below is not what preceded GH-4332 either. That was GetRange(0, n).ToArray():
+    // a List of n allocated and copied, then an array of n allocated and copied again. CopyTo
+    // straight into the array the flush already needs is one allocation and one copy, and measures
+    // fastest of the three at every depth below the crossover while keeping the ~18% allocation
+    // reduction the Queue won at all of them.
+    //
+    // If a deployment is ever found sitting 10,000+ completions behind, the Queue is the right
+    // answer there -- 4.9x faster at 50,000 -- and the benchmark table says so.
+    private readonly List<Pending> _pending = new();
     private bool _flushing;
     private Task? _flushLoop;
 
@@ -73,7 +85,7 @@ internal class InboxCompletionCoalescer
         var startLoop = false;
         lock (_lock)
         {
-            _pending.Enqueue(pending);
+            _pending.Add(pending);
             if (!_flushing)
             {
                 _flushing = true;
@@ -126,10 +138,8 @@ internal class InboxCompletionCoalescer
 
                 var take = Math.Min(_maximumBatchSize, _pending.Count);
                 batch = new Pending[take];
-                for (var i = 0; i < take; i++)
-                {
-                    batch[i] = _pending.Dequeue();
-                }
+                _pending.CopyTo(0, batch, 0, take);
+                _pending.RemoveRange(0, take);
             }
 
             await flushAsync(batch).ConfigureAwait(false);


### PR DESCRIPTION
GH-4332 swapped `InboxCompletionCoalescer`'s pending `List` for a `Queue`, on the theory that `RemoveRange(0, n)` memmoves the remainder and so goes quadratic under a deep backlog. **The theory is right. It just does not pay off at the depths this code actually runs at.**

Swept across depths, three arms (net9.0, `--job short`):

| depth | `GetRange+RemoveRange` (pre-4332) | `Queue.Dequeue` (GH-4332) | `CopyTo+RemoveRange` (this PR) |
|---|---|---|---|
| 100 | 540.8 ns / 4.82 KB | 692.1 ns — **1.28x slower** | **483.6 ns — 0.89x**, 0.83x alloc |
| 1,000 | 5,932.1 ns / 47.7 KB | 7,674.1 ns — **1.29x slower** | **5,538.5 ns — 0.93x**, 0.82x alloc |
| 10,000 | 94,612 ns | 74,014 ns — 0.78x | 88,920 ns — 0.94x, 0.82x alloc |
| 50,000 | 1,812,535 ns | 370,377 ns — 0.20x | 1,780,025 ns — 0.98x, 0.82x alloc |

The crossover sits near **5,000 pending completions**. Below it the memmove is cheaper than `Queue.Dequeue`'s per-item overhead, and 100–1,000 deep is the shape a healthy node runs at — so in the common case GH-4332 made completions ~28% slower. That is the wrong direction for a path every durable endpoint takes on every message.

### What ships is not the pre-GH-4332 code either

That drained with `GetRange(0, n).ToArray()`: a `List` of n allocated and copied, then an array of n allocated and copied again. `CopyTo` straight into the array the flush already needs is one allocation and one copy.

The result is the best of the three: **fastest at every depth below the crossover**, and it keeps the ~18% allocation reduction the `Queue` won outright at all four depths — the one thing GH-4332 got unambiguously right.

### Scope

GH-4332's other three changes are **untouched** — `NativeAckReceiver.postOneAsync`, the `SqsListener` `.Any()` boxing, and `FanoutMessageHandler`'s per-message `HashSet`. None of them measured negative; only the drain did.

The benchmark keeps all three arms and the depth table. If a deployment is ever found sitting 10,000+ completions behind, the `Queue` is the right answer there — 4.9x faster at 50,000 — and the comment says exactly that.

### Verification

Per the wave's own ground rule that unit suites do not catch this class of bug, this ran the covering integration lane, not just the unit tests:

- `./build.sh PersistenceTests` — **110 passed, 0 retries**, 2m32s under the supervised runner
- `batched_mark_as_handled_3711` — 8/8, including the chunked-flush ordering test
- Full `wolverine.slnx` compile — **0 warnings, 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)