### PR TITLE
GH-3987: let the leader wait for the node set to settle before assigning agents

### DIFF
--- a/docs/guide/durability/marten/distribution.md
+++ b/docs/guide/durability/marten/distribution.md
@@ -221,6 +221,37 @@ Only `Other` is treated as potentially self-healing, so it is the only category 
 will auto-restart. The rest are left alone until you resolve the underlying problem, at which point
 restarting or rewinding the agent picks it back up.
 
+## Waiting for the Node Set to Settle <Badge type="tip" text="6.x" />
+
+A rolling deploy brings pods up one at a time. The leader assigns agents against whatever nodes exist at
+that instant, so every pod that joins afterwards triggers another rebalance that moves agents again. On a
+large agent universe — database-per-tenant Marten with one subscription agent per tenant per projection —
+each of those waves is thousands of agent starts and stops, and the fleet is below full throughput until
+the last one lands.
+
+`AssignmentSettlePeriod` makes the leader wait for the node set to go quiet before it assigns:
+
+```csharp
+opts.Durability.AssignmentSettlePeriod = TimeSpan.FromSeconds(30);  // default: TimeSpan.Zero, off
+opts.Durability.MaxAssignmentSettleTime = TimeSpan.FromMinutes(1);  // default
+opts.Durability.AssignmentSettleNodeCount = 0;                      // default, off
+```
+
+Only nodes *joining* are waited out. A node that leaves has taken its agents with it, so that work is
+running nowhere — a departure is assigned immediately and cancels any wait in progress, which is what keeps
+a real node loss (or a leader takeover) as responsive as it was before. `MaxAssignmentSettleTime` bounds the
+wait from the first join, so a cluster that keeps gaining nodes — an autoscaler ramping up, or a node
+flapping — is still served.
+
+`AssignmentSettleNodeCount` ends the wait early: once that many nodes are live the leader assigns without
+waiting the period out. Use it on a cold start of a deployment whose replica count you know, where the timer
+is then only the fallback for a pod that never arrives. Leave it off for a rolling deploy — the outgoing
+pods are still live and counted, so the target is met on the first tick and nothing is ever waited out.
+
+The cost of a non-zero settle period is that a cold start runs no agents at all until it elapses, which is
+why the default is off. Size it against the rollout it is meant to absorb: tens of seconds for a deploy whose pods
+come up within a minute of each other.
+
 ## Agent Start Retries <Badge type="tip" text="6.x" />
 
 An agent's very first assignment can race the subsystems it depends on coming up — an event-subscription

--- a/src/Testing/CoreTests/Runtime/Agents/waiting_for_the_node_set_to_settle.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/waiting_for_the_node_set_to_settle.cs
@@ -1,0 +1,228 @@
+using CoreTests.Transports;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// A rolling deploy brings pods up one at a time, and the leader assigns agents against whatever nodes
+/// exist at that instant, so every pod that joins afterwards triggers another rebalance. On a large agent
+/// universe each of those waves is thousands of agent starts and stops.
+/// <see cref="DurabilitySettings.AssignmentSettlePeriod" /> lets the leader wait for the node set to go
+/// quiet first, <see cref="DurabilitySettings.AssignmentSettleNodeCount" /> ends that wait as soon as the
+/// deployment is fully up, and <see cref="DurabilitySettings.MaxAssignmentSettleTime" /> bounds it. A node
+/// that LEAVES is never waited out — its agents are running nowhere.
+/// </summary>
+public class waiting_for_the_node_set_to_settle
+{
+    private readonly WolverineOptions _options;
+    private readonly INodeAgentPersistence _persistence;
+    private readonly NodeAgentController _controller;
+    private readonly FrozenClock _clock = new(new DateTimeOffset(2026, 9, 6, 12, 0, 0, TimeSpan.Zero));
+
+    public waiting_for_the_node_set_to_settle()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false;
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(_options);
+        runtime.DurabilitySettings.Returns(_options.Durability);
+        runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        _persistence = Substitute.For<INodeAgentPersistence>();
+        _persistence.HasLeadershipLock().Returns(false);
+        _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>()).Returns(true);
+
+        _controller = new NodeAgentController(
+            runtime,
+            _persistence,
+            Array.Empty<IAgentFamily>(),
+            NullLogger<NodeAgentController>.Instance,
+            CancellationToken.None) { TimeProvider = _clock };
+    }
+
+    private WolverineNode Row(Guid nodeId, int number) => new()
+    {
+        NodeId = nodeId,
+        AssignedNodeNumber = number,
+        ControlUri = new Uri("fake://node" + number),
+        LastHealthCheck = DateTimeOffset.UtcNow
+    };
+
+    private WolverineNode Self() => Row(_options.UniqueNodeId, _options.Durability.AssignedNodeNumber);
+
+    private void ClusterIs(params WolverineNode[] nodes)
+    {
+        foreach (var node in nodes)
+        {
+            node.LastHealthCheck = DateTimeOffset.UtcNow;
+        }
+
+        _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new NodeAgentState(nodes, new AgentRestrictions()));
+    }
+
+    [Fact]
+    public async Task assigns_on_the_first_tick_when_the_settle_period_is_off()
+    {
+        // The shipped default. Anything else would change the startup behavior of every existing app.
+        _options.Durability.AssignmentSettlePeriod.ShouldBe(TimeSpan.Zero);
+
+        ClusterIs(Self());
+
+        await _controller.DoHealthChecksAsync();
+
+        _controller.IsLeader.ShouldBeTrue();
+        _controller.LastAssignments.ShouldNotBeNull(
+            "the leader must assign immediately when no settle period is configured");
+    }
+
+    [Fact]
+    public async Task holds_the_first_assignment_back_while_the_node_set_is_still_new()
+    {
+        _options.Durability.AssignmentSettlePeriod = 30.Seconds();
+
+        ClusterIs(Self());
+
+        await _controller.DoHealthChecksAsync();
+
+        _controller.IsLeader.ShouldBeTrue("leadership is still taken — only the assignment pass waits");
+        _controller.LastAssignments.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task assigns_once_the_node_set_has_been_quiet_for_the_settle_period()
+    {
+        _options.Durability.AssignmentSettlePeriod = 30.Seconds();
+
+        var second = Row(Guid.NewGuid(), 2);
+
+        ClusterIs(Self());
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldBeNull();
+
+        // The second pod of the rollout arrives 10 seconds in, which restarts the wait rather than
+        // triggering the rebalance it would have triggered before.
+        _clock.Advance(10.Seconds());
+        ClusterIs(Self(), second);
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldBeNull();
+
+        _clock.Advance(20.Seconds());
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldBeNull("the wait restarted when the second node joined");
+
+        _clock.Advance(10.Seconds());
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldNotBeNull();
+        _controller.LastAssignments!.Nodes.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task assigns_immediately_when_a_node_leaves()
+    {
+        _options.Durability.AssignmentSettlePeriod = 30.Seconds();
+
+        var second = Row(Guid.NewGuid(), 2);
+
+        ClusterIs(Self(), second);
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldBeNull();
+
+        // A node whose agents are running nowhere is the one case that must never wait.
+        _clock.Advance(5.Seconds());
+        ClusterIs(Self());
+        await _controller.DoHealthChecksAsync();
+
+        _controller.LastAssignments.ShouldNotBeNull(
+            "a departure must be acted on without waiting out the settle period");
+    }
+
+    [Fact]
+    public async Task gives_up_waiting_after_the_maximum_settle_time()
+    {
+        _options.Durability.AssignmentSettlePeriod = 30.Seconds();
+        _options.Durability.MaxAssignmentSettleTime = 45.Seconds();
+
+        var nodes = new List<WolverineNode> { Self() };
+        ClusterIs(nodes.ToArray());
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldBeNull();
+
+        // A cluster that gains a node on every tick never goes quiet on its own.
+        for (var i = 2; i <= 4; i++)
+        {
+            _clock.Advance(20.Seconds());
+            nodes.Add(Row(Guid.NewGuid(), i));
+            ClusterIs(nodes.ToArray());
+            await _controller.DoHealthChecksAsync();
+        }
+
+        _controller.LastAssignments.ShouldNotBeNull(
+            "MaxAssignmentSettleTime must serve a cluster that never settles");
+    }
+
+    [Fact]
+    public async Task assigns_as_soon_as_the_expected_node_count_is_live()
+    {
+        _options.Durability.AssignmentSettlePeriod = 30.Seconds();
+        _options.Durability.AssignmentSettleNodeCount = 3;
+
+        var second = Row(Guid.NewGuid(), 2);
+        var third = Row(Guid.NewGuid(), 3);
+
+        ClusterIs(Self(), second);
+        await _controller.DoHealthChecksAsync();
+        _controller.LastAssignments.ShouldBeNull("the deployment is not fully up yet");
+
+        // The last replica lands well inside the settle period. There is nothing left to wait for.
+        _clock.Advance(2.Seconds());
+        ClusterIs(Self(), second, third);
+        await _controller.DoHealthChecksAsync();
+
+        _controller.LastAssignments.ShouldNotBeNull();
+        _controller.LastAssignments!.Nodes.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_leader_taking_over_from_a_departed_leader_assigns_immediately()
+    {
+        _options.Durability.AssignmentSettlePeriod = 30.Seconds();
+
+        var oldLeader = Row(Guid.NewGuid(), 2);
+
+        // This node runs as a follower first. Membership is tracked whatever the role, which is what lets
+        // it recognise the takeover below as a node LEAVING rather than as a cluster that is still coming up.
+        _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>()).Returns(false);
+        ClusterIs(Self(), oldLeader);
+        await _controller.DoHealthChecksAsync();
+        _controller.IsLeader.ShouldBeFalse();
+
+        // The leader dies and this node wins the election. Its agents are running nowhere.
+        _clock.Advance(5.Seconds());
+        _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>()).Returns(true);
+        ClusterIs(Self());
+        await _controller.DoHealthChecksAsync();
+
+        _controller.IsLeader.ShouldBeTrue();
+        _controller.LastAssignments.ShouldNotBeNull(
+            "a leader inheriting a dead leader's agents must not wait for the node set to settle");
+    }
+
+    private sealed class FrozenClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -1,4 +1,4 @@
-using JasperFx.Core;
+﻿using JasperFx.Core;
 using JasperFx.Descriptors;
 using JasperFx.MultiTenancy;
 using Wolverine.Persistence;
@@ -496,6 +496,46 @@ public class DurabilitySettings : IDescribeMyself
     public TimeSpan CheckAssignmentPeriod { get; set; } = 30.Seconds();
 
     /// <summary>
+    ///     How long the cluster's node set must be unchanged before the leader runs its first agent
+    ///     assignment pass. A rolling deploy brings pods up one at a time, and the leader assigns against
+    ///     whatever nodes exist at that moment, so every pod that joins afterwards triggers another
+    ///     rebalance. On a large agent universe -- database-per-tenant Marten with one subscription agent
+    ///     per tenant per projection -- each wave is thousands of agent starts and stops, and the fleet is
+    ///     below full throughput until the last one lands. Waiting for the node set to go quiet collapses
+    ///     those waves into a single pass.
+    ///
+    ///     Only nodes <i>joining</i> are waited out. A node that leaves has taken its agents with it, so
+    ///     that work is running nowhere and waiting would be exactly wrong -- a departure assigns
+    ///     immediately and cancels any wait in progress. <see cref="MaxAssignmentSettleTime" /> bounds the
+    ///     wait so a cluster that keeps gaining nodes is still served.
+    ///
+    ///     Zero (the default) keeps the previous behavior: assign on the first tick after leadership,
+    ///     however new the node set is. The cost of a non-zero value is that a cold start runs no agents at
+    ///     all until it elapses, so size it against the rollout it is meant to absorb -- tens of seconds for
+    ///     a rolling deploy whose pods come up within a minute of each other.
+    /// </summary>
+    public TimeSpan AssignmentSettlePeriod { get; set; } = 0.Seconds();
+
+    /// <summary>
+    ///     The longest the leader will hold agent assignment back waiting for
+    ///     <see cref="AssignmentSettlePeriod" /> of quiet. A cluster that gains a node every few seconds --
+    ///     an autoscaler ramping up, or a node flapping in and out -- would otherwise never settle and never
+    ///     be assigned. Measured from the first join of the current wait, not from process start. Ignored
+    ///     when <see cref="AssignmentSettlePeriod" /> is zero. Default 1 minute.
+    /// </summary>
+    public TimeSpan MaxAssignmentSettleTime { get; set; } = 1.Minutes();
+
+    /// <summary>
+    ///     The node count that ends a <see cref="AssignmentSettlePeriod" /> wait early: once at least this
+    ///     many nodes are live, the leader assigns without waiting the period out. This is the fast path for
+    ///     a cold start of a deployment whose replica count you know — the timer is then only the fallback
+    ///     for a pod that never arrives. Leave it at zero (the default, off) for a rolling deploy where the
+    ///     outgoing pods are still live and counted, since the target would already be met on the first tick
+    ///     and nothing would ever be waited out. Ignored when <see cref="AssignmentSettlePeriod" /> is zero.
+    /// </summary>
+    public int AssignmentSettleNodeCount { get; set; }
+
+    /// <summary>
     ///     GH-3604 / D3: the maximum number of agent assignments the leader packs into a single
     ///     <c>StartAgents</c> control message to a node. A node running a very large agent universe
     ///     (e.g. database-per-tenant Marten with thousands of subscription shards) cannot start
@@ -768,6 +808,9 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(HealthCheckPollingTime), HealthCheckPollingTime);
         desc.AddValue(nameof(StaleNodeTimeout), StaleNodeTimeout);
         desc.AddValue(nameof(CheckAssignmentPeriod), CheckAssignmentPeriod);
+        desc.AddValue(nameof(AssignmentSettlePeriod), AssignmentSettlePeriod);
+        desc.AddValue(nameof(MaxAssignmentSettleTime), MaxAssignmentSettleTime);
+        desc.AddValue(nameof(AssignmentSettleNodeCount), AssignmentSettleNodeCount);
         desc.AddValue(nameof(TenantCheckPeriod), TenantCheckPeriod);
         desc.AddValue(nameof(UpdateMetricsPeriod), UpdateMetricsPeriod);
         desc.AddValue(nameof(DurabilityMetricsEnabled), DurabilityMetricsEnabled);

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace Wolverine.Runtime.Agents;
 
@@ -195,6 +195,12 @@ public partial class NodeAgentController
             nodes = nodes.Concat(new[] { WolverineNode.For(_runtime.Options) }).ToList();
         }
 
+        // The node list is final for this tick, so record the membership now -- on every node, whatever its
+        // role. A follower that keeps this warm knows the cluster it inherits the moment it wins an
+        // election, which is what lets a new leader tell "the old leader died" from "the cluster is still
+        // coming up". Only the leader branches below act on the answer.
+        var waitForNodeSetToSettle = trackMembershipAndDecideWait(nodes);
+
         // Do it no matter what
         await ejectStaleNodes(staleNodes);
 
@@ -221,10 +227,12 @@ public partial class NodeAgentController
             {
                 if (IsLeader)
                 {
-                    return await EvaluateAssignmentsAsync(nodes, restrictions);
+                    return waitForNodeSetToSettle
+                        ? AgentCommands.Empty
+                        : await EvaluateAssignmentsAsync(nodes, restrictions);
                 }
 
-                return await tryStartLeadershipAsync(nodes, restrictions);
+                return await tryStartLeadershipAsync(nodes, restrictions, waitForNodeSetToSettle);
             }
 
             if (IsLeader)
@@ -294,7 +302,7 @@ public partial class NodeAgentController
     }
 
     private async Task<AgentCommands> tryStartLeadershipAsync(IReadOnlyList<WolverineNode> nodes,
-        AgentRestrictions restrictions)
+        AgentRestrictions restrictions, bool waitForNodeSetToSettle = false)
     {
         try
         {
@@ -319,8 +327,99 @@ public partial class NodeAgentController
         // This is important, some of the assignment logic depends on knowing what the leader is
         var self = nodes.FirstOrDefault(x => x.NodeId == _runtime.Options.UniqueNodeId);
         self!.AssignAgents([LeaderUri]);
-        
-        return await EvaluateAssignmentsAsync(nodes, restrictions);
+
+        // The pass a brand new leader would run right here is the one AssignmentSettlePeriod exists to
+        // hold back: it sees the pods that happen to be up at this instant, and every later arrival costs
+        // another rebalance. Leadership itself is already taken, so nothing is lost by letting the next
+        // health-check tick place the agents.
+        return waitForNodeSetToSettle
+            ? AgentCommands.Empty
+            : await EvaluateAssignmentsAsync(nodes, restrictions);
+    }
+
+    // The node ids seen on the previous health-check tick, and the timestamps that bound the current wait.
+    // Only ever touched from the serialized health-check path.
+    private HashSet<Guid> _knownNodes = [];
+    private DateTimeOffset? _lastNodeJoin;
+    private DateTimeOffset? _waitingSince;
+
+    /// <summary>
+    ///     Record this tick's cluster membership and answer whether the leader should hold its assignment
+    ///     pass back until the node set stops changing. See
+    ///     <see cref="DurabilitySettings.AssignmentSettlePeriod" /> for why, and
+    ///     <see cref="DurabilitySettings.MaxAssignmentSettleTime" /> for the cap that keeps a cluster which
+    ///     never goes quiet from never being assigned. The wait also ends the moment
+    ///     <see cref="DurabilitySettings.AssignmentSettleNodeCount" /> nodes are live. A node leaving is
+    ///     never waited out -- its agents are running nowhere.
+    /// </summary>
+    private bool trackMembershipAndDecideWait(IReadOnlyList<WolverineNode> nodes)
+    {
+        var current = nodes.Select(x => x.NodeId).ToHashSet();
+        var joined = current.Count(x => !_knownNodes.Contains(x));
+        var departed = _knownNodes.Count(x => !current.Contains(x));
+        _knownNodes = current;
+
+        var settlePeriod = _runtime.Options.Durability.AssignmentSettlePeriod;
+        if (settlePeriod <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        if (departed > 0)
+        {
+            endWait();
+            return false;
+        }
+
+        var expectedNodes = _runtime.Options.Durability.AssignmentSettleNodeCount;
+        if (expectedNodes > 0 && current.Count >= expectedNodes)
+        {
+            endWait();
+            return false;
+        }
+
+        var now = TimeProvider.GetUtcNow();
+
+        if (joined > 0)
+        {
+            _lastNodeJoin = now;
+            _waitingSince ??= now;
+        }
+
+        if (_lastNodeJoin is null || _waitingSince is null)
+        {
+            return false;
+        }
+
+        if (now - _lastNodeJoin.Value >= settlePeriod)
+        {
+            endWait();
+            return false;
+        }
+
+        var cap = _runtime.Options.Durability.MaxAssignmentSettleTime;
+        var waited = now - _waitingSince.Value;
+        if (cap > TimeSpan.Zero && waited >= cap)
+        {
+            _logger.LogInformation(
+                "Node {NodeNumber} is assigning agents without waiting for the node set to settle; the cluster has kept changing for {Waited} (MaxAssignmentSettleTime)",
+                _runtime.Options.Durability.AssignedNodeNumber, waited);
+
+            endWait();
+            return false;
+        }
+
+        _logger.LogDebug(
+            "Node {NodeNumber} is holding agent assignment back for {Waited} while the node set settles; {Joined} node(s) joined on this tick",
+            _runtime.Options.Durability.AssignedNodeNumber, waited, joined);
+
+        return true;
+    }
+
+    private void endWait()
+    {
+        _lastNodeJoin = null;
+        _waitingSince = null;
     }
 
     // GH-3604 / D1: consecutive stale-observation counts per node id, used to add hysteresis to the


### PR DESCRIPTION
Toward #3987. This is the "much simpler amelioration" you described on #4297:

> Just simply saying "don't bother assigning anything until at least this much time has passed or this many nodes exist" would help a ton.

It is deliberately just that, and nothing else — no capacity model, no reconciliation, no new test tooling. It does not close #3987 on its own and it does not overlap with #4297's capacity work.

## The problem

A rolling deploy replaces pods one at a time. On our last rollout the three new pods came up at 19:02:31, 19:03:12 and 19:03:52 while the two old ones were still serving. The leader assigns agents against whatever nodes exist at that instant, so every pod that joins afterwards triggers another rebalance that moves agents again.

At 512 shards, ~2 500 tenants and one agent per tenant per projection, each of those waves is thousands of `AssignmentChanged` rows and thousands of agent starts and stops. After that rollout the new projection's agents arrived gradually — 735 tenants had one at 19:12, 2 310 at 19:49, and the full 2 556 only at 19:56. Roughly fifty minutes from rollout to complete coverage, with `AgentStartBatchSize` and `MaxAgentStartParallelism` already at 400 and `CheckAssignmentPeriodSeconds` at 15.

Nothing today waits: `FirstNodeReassignmentExecution` governs reassigning persisted *messages* from offline nodes, and `AgentStartBatchSize` / `MaxAgentStartParallelism` / `CheckAssignmentPeriod` / `FirstHealthCheckExecution` change how fast and how often assignment runs, never how long the leader waits before the first pass.

## The change

Three settings on `DurabilitySettings`, all off or inert by default:

```csharp
opts.Durability.AssignmentSettlePeriod = TimeSpan.FromSeconds(30);  // default TimeSpan.Zero — off
opts.Durability.AssignmentSettleNodeCount = 0;                      // default — off
opts.Durability.MaxAssignmentSettleTime = TimeSpan.FromMinutes(1);  // default
```

With `AssignmentSettlePeriod` at zero — the default — `trackMembershipAndDecideWait` returns `false` on every tick and the behaviour is bit-for-bit what it is today.

Set it, and the leader holds its assignment pass back until the node set has been unchanged for that long. The wait ends early once `AssignmentSettleNodeCount` nodes are live (the "or this many nodes exist" half — the fast path for a cold start of a deployment whose replica count you know), and `MaxAssignmentSettleTime` caps it so a cluster that keeps gaining nodes is still served.

Two properties that seemed worth getting right:

**A node leaving is never waited out.** Its agents are running nowhere, so a departure assigns immediately and cancels any wait in progress. That is what keeps a real node loss — and a leader takeover — exactly as responsive as it is today; only joins are debounced.

**Membership is tracked on every node, whatever its role.** A follower that keeps this warm already knows the cluster it inherits the moment it wins an election, so a new leader can tell "the old leader died" (a departure — act now) from "the cluster is still coming up" (a join — wait). Without that, every new leader would see a brand-new roster and wait out the full period at the worst possible moment.

The gate sits on both leader-side calls into `EvaluateAssignmentsAsync` — the `IsLeader` branch and the first pass inside `tryStartLeadershipAsync`. It never touches leadership attainment or lease renewal, so a waiting leader still holds its lock normally.

## Trade-off

During the wait no agents are assigned at all, so a cold start runs nothing until it elapses. That is the honest cost and it is why the default is off, why the departure case is exempt, and why both the node-count and the hard cap are there. Sizing guidance is in the docs page.

## Testing

Six tests in `CoreTests.Runtime.Agents.waiting_for_the_node_set_to_settle`, on the existing `NodeAgentController` unit harness with a frozen `TimeProvider`: default-off assigns on the first tick, the first pass is held back, a join restarts the wait, quiet ends it, the expected node count ends it early, a departure assigns immediately, and the cap serves a cluster that never settles. Full `CoreTests.Runtime.Agents` namespace is green (375 tests).

Happy to change any of the three names, or to drop `AssignmentSettleNodeCount` or the cap if you would rather ship the timer alone.
