### PR TITLE
GH-4319: coalesce the last un-batched per-message durability round trips

### DIFF
--- a/src/Persistence/PersistenceTests/Durability/coalesced_local_queue_storage_4319.cs
+++ b/src/Persistence/PersistenceTests/Durability/coalesced_local_queue_storage_4319.cs
@@ -1,0 +1,127 @@
+using System.Collections.Concurrent;
+using Wolverine.ComplianceTests;
+using IntegrationTests;
+using JasperFx.Core;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace PersistenceTests.Durability;
+
+/// <summary>
+/// GH-4319. The durable local queue used to pay one connection and one INSERT per published message.
+/// It now coalesces concurrent publishes into one batched insert. These tests exist to prove that
+/// batching changed the number of round trips and nothing else: the same messages land, exactly once,
+/// and a duplicate in the middle of a burst still fails only itself.
+/// </summary>
+[Collection("marten")]
+public class coalesced_local_queue_storage_4319 : PostgresqlContext, IAsyncLifetime
+{
+    private const string TheSchema = "coalesced_4319";
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static Task<IHost> hostAsync(int batchSize)
+    {
+        return Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "Coalesced4319";
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, TheSchema);
+                opts.Policies.UseDurableLocalQueues();
+                opts.Durability.StoreIncomingBatchSize = batchSize;
+
+                opts.Services.AddResourceSetupOnStartup(StartupAction.ResetState);
+            }).StartAsync();
+    }
+
+    /// <summary>
+    /// The batch size is the ONLY difference between these two runs. Coalesced or not, every message
+    /// published in the burst has to be handled exactly once -- that is the whole safety claim.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]     // coalescing off: one round trip per publish, the pre-GH-4319 shape
+    [InlineData(100)]   // the shipping default
+    public async Task a_concurrent_burst_is_persisted_and_handled_exactly_once(int batchSize)
+    {
+        CoalesceTarget.Received.Clear();
+
+        using var host = await hostAsync(batchSize);
+
+        var messages = Enumerable.Range(0, 200).Select(i => new CoalesceMessage(i)).ToArray();
+
+        await host.TrackActivity()
+            .Timeout(60.Seconds())
+            .ExecuteAndWaitAsync(publishAll);
+
+        // Publish them all at once from many threads. Concurrency is the only thing that forms a
+        // batch -- there is deliberately no timer to wait on.
+        Task publishAll(IMessageContext context) =>
+            Parallel.ForEachAsync(messages, TestContext.Current.CancellationToken,
+                async (message, _) => await context.PublishAsync(message));
+
+        CoalesceTarget.Received.Count.ShouldBe(messages.Length);
+        CoalesceTarget.Received.OrderBy(x => x).ShouldBe(messages.Select(x => x.Number).OrderBy(x => x));
+    }
+
+    /// <summary>
+    /// The contract the coalescer's fallback rests on. A batched insert that hits a duplicate key
+    /// rolls the whole batch back and reports which identities were already present -- so the
+    /// coalescer can safely retry each envelope on its own and let only the duplicate fail. If this
+    /// ever became a partial write, the coalesced local queue would double-insert on retry.
+    /// </summary>
+    [Fact]
+    public async Task a_failed_batch_insert_rolls_back_whole_and_names_the_duplicates()
+    {
+        using var host = await hostAsync(100);
+        var inbox = host.GetRuntime().Storage.Inbox;
+
+        var alreadyThere = ObjectMother.Envelope();
+        alreadyThere.Status = EnvelopeStatus.Incoming;
+        await inbox.StoreIncomingAsync(alreadyThere);
+
+        var fresh = Enumerable.Range(0, 5).Select(_ =>
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.Status = EnvelopeStatus.Incoming;
+            return envelope;
+        }).ToArray();
+
+        var batch = fresh.Append(alreadyThere).ToArray();
+
+        var ex = await Should.ThrowAsync<DuplicateIncomingEnvelopeException>(
+            () => inbox.StoreIncomingAsync(batch));
+
+        // Pinpointed, not "the whole batch might be duplicates": the coalescer's fallback is only
+        // safe because the store can tell exactly which identity collided
+        ex.Duplicates.ShouldHaveSingleItem().Id.ShouldBe(alreadyThere.Id);
+
+        // Rolled back whole: not one of the fresh envelopes was left behind, which is what makes the
+        // per-envelope retry safe rather than a source of duplicates
+        foreach (var envelope in fresh)
+        {
+            (await inbox.ExistsAsync(envelope, TestContext.Current.CancellationToken))
+                .ShouldBeFalse($"Envelope {envelope.Id} survived a rolled-back batch");
+        }
+    }
+}
+
+public record CoalesceMessage(int Number);
+
+public static class CoalesceTarget
+{
+    public static readonly ConcurrentBag<int> Received = new();
+}
+
+public static class CoalesceMessageHandler
+{
+    public static void Handle(CoalesceMessage message) => CoalesceTarget.Received.Add(message.Number);
+}

--- a/src/Persistence/SqlServerTests/Transport/external_message_tables.cs
+++ b/src/Persistence/SqlServerTests/Transport/external_message_tables.cs
@@ -27,6 +27,13 @@ public class external_message_tables : IAsyncLifetime
         await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
         await conn.OpenAsync();
         await conn.DropSchemaAsync("outside");
+
+        // end_to_end_default_variable_message_types listens on outgoing.incoming1, and only "outside"
+        // was ever dropped -- so any row that run did not consume stayed there forever and the NEXT
+        // run's SingleEnvelope<Message2>() saw it too. Observed as "Received 4 messages of type
+        // Message2" from a test that published exactly one, then passing again once the backlog had
+        // been drained, which is the signature that makes this kind of flake read as someone's diff.
+        await conn.DropSchemaAsync("outgoing");
     }
     
     public ValueTask DisposeAsync()

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
@@ -60,6 +60,37 @@ public abstract partial class MessageDatabase<T>
         envelope.WasPersistedInOutbox = true;
     }
 
+    /// <summary>
+    /// GH-4319. The batched twin of the single-envelope overload above: one pooled connection and one
+    /// multi-statement command for the whole batch instead of one of each per envelope. The batch
+    /// command builder was already here -- <c>DurableSendingAgent</c> simply had no way to reach it
+    /// outside an ambient transaction.
+    /// </summary>
+    public async Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        if (HasDisposed || envelopes.Count == 0) return;
+
+        var array = envelopes as Envelope[] ?? envelopes.ToArray();
+        var command = DatabasePersistence.BuildOutgoingStorageCommand(array, ownerId, this);
+
+        await using var conn = await DataSource.OpenConnectionAsync(_cancellation);
+
+        try
+        {
+            command.Connection = conn;
+            await command.ExecuteNonQueryAsync(_cancellation);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+
+        foreach (var envelope in array)
+        {
+            envelope.WasPersistedInOutbox = true;
+        }
+    }
+
     protected abstract string
         determineOutgoingEnvelopeSql(DurabilitySettings settings);
 }

--- a/src/Testing/CoreTests/Persistence/Durability/coalesced_envelope_storage_4319.cs
+++ b/src/Testing/CoreTests/Persistence/Durability/coalesced_envelope_storage_4319.cs
@@ -1,0 +1,236 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Xunit;
+
+namespace CoreTests.Persistence.Durability;
+
+/// <summary>
+/// GH-4319. The insert-side twin of GH-3711's completion coalescing. Concurrent single-envelope
+/// durability writes share one batched round trip, a lone write still goes immediately, and a batch
+/// that fails is retried one envelope at a time so each caller sees its own outcome.
+/// </summary>
+public class coalesced_envelope_storage_4319
+{
+    private readonly List<IReadOnlyList<Envelope>> theBatches = new();
+    private readonly List<Envelope> theSingles = new();
+    private readonly object theLock = new();
+
+    private static readonly Uri theUri = new("local://durable");
+
+    private Func<IReadOnlyList<Envelope>, Task> _batch;
+    private Func<Envelope, Task> _one;
+
+    public coalesced_envelope_storage_4319()
+    {
+        _batch = envelopes =>
+        {
+            lock (theLock) theBatches.Add(envelopes);
+            return Task.CompletedTask;
+        };
+
+        _one = envelope =>
+        {
+            lock (theLock) theSingles.Add(envelope);
+            return Task.CompletedTask;
+        };
+    }
+
+    private EnvelopeStoreCoalescer coalescer(int batchSize = 100)
+    {
+        return new EnvelopeStoreCoalescer(e => _batch(e), e => _one(e), batchSize, theUri,
+            NullLogger.Instance);
+    }
+
+    private static Envelope envelope() => ObjectMother.Envelope();
+
+    /// <summary>
+    /// Hold the first write open so everything posted meanwhile piles up behind it. That is the only
+    /// way to make "batches form from concurrency alone" deterministic.
+    /// </summary>
+    private (TaskCompletionSource gate, TaskCompletionSource started) gateTheFirstWrite()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = true;
+
+        var innerOne = _one;
+        _one = async envelope =>
+        {
+            await innerOne(envelope);
+            if (first)
+            {
+                first = false;
+                started.TrySetResult();
+                await gate.Task;
+            }
+        };
+
+        return (gate, started);
+    }
+
+    [Fact]
+    public async Task a_lone_write_goes_immediately_on_the_per_envelope_path()
+    {
+        var lone = envelope();
+
+        await coalescer().StoreAsync(lone);
+
+        theSingles.ShouldHaveSingleItem().ShouldBeSameAs(lone);
+        theBatches.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task writes_that_arrive_during_a_flush_share_the_next_flush()
+    {
+        var theCoalescer = coalescer();
+        var (gate, started) = gateTheFirstWrite();
+
+        var first = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        var others = Enumerable.Range(0, 5).Select(_ => envelope()).ToArray();
+        var pending = others.Select(e => theCoalescer.StoreAsync(e)).ToArray();
+
+        // Nothing released yet, so nothing is stored
+        first.IsCompleted.ShouldBeFalse();
+        pending.Any(x => x.IsCompleted).ShouldBeFalse();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // The lone first write took the per-envelope path; the five that piled up went as ONE batch
+        theSingles.ShouldHaveSingleItem();
+        var batch = theBatches.ShouldHaveSingleItem();
+        batch.Count.ShouldBe(5);
+        others.ShouldAllBe(e => batch.Contains(e));
+    }
+
+    [Fact]
+    public async Task store_async_does_not_return_until_the_write_has_landed()
+    {
+        var theCoalescer = coalescer();
+        var (gate, started) = gateTheFirstWrite();
+
+        var pending = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+        pending.IsCompleted.ShouldBeFalse("StoreAsync returned before the write finished");
+
+        gate.SetResult();
+        await pending.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_pile_up_larger_than_the_batch_size_is_flushed_in_chunks()
+    {
+        var theCoalescer = coalescer(batchSize: 3);
+        var (gate, started) = gateTheFirstWrite();
+
+        var first = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        var pending = Enumerable.Range(0, 6).Select(_ => theCoalescer.StoreAsync(envelope())).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        theBatches.Count.ShouldBe(2);
+        theBatches.ShouldAllBe(x => x.Count == 3);
+    }
+
+    [Fact]
+    public async Task a_maximum_batch_size_of_one_never_batches()
+    {
+        var theCoalescer = coalescer(batchSize: 1);
+        var (gate, started) = gateTheFirstWrite();
+
+        var first = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        var pending = Enumerable.Range(0, 4).Select(_ => theCoalescer.StoreAsync(envelope())).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        theBatches.ShouldBeEmpty();
+        theSingles.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task a_failed_batch_falls_back_to_storing_one_at_a_time()
+    {
+        var theCoalescer = coalescer();
+        var (gate, started) = gateTheFirstWrite();
+        _batch = _ => throw new InvalidOperationException("nope");
+
+        var first = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        var others = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+        var pending = others.Select(e => theCoalescer.StoreAsync(e)).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Every envelope still landed, one round trip each: the lone first, then the four fallbacks
+        theSingles.Count.ShouldBe(5);
+        others.ShouldAllBe(e => theSingles.Contains(e));
+    }
+
+    /// <summary>
+    /// The behaviour that separates this from InboxCompletionCoalescer: a caller that knows how to
+    /// handle its own envelope's failure -- DurableLocalQueue catching DuplicateIncomingEnvelopeException,
+    /// for instance -- must keep seeing exactly that exception for exactly that envelope, and one
+    /// poisoned envelope must not fail its neighbours.
+    /// </summary>
+    [Fact]
+    public async Task a_failure_reaches_only_its_own_caller()
+    {
+        var theCoalescer = coalescer();
+        var (gate, started) = gateTheFirstWrite();
+        _batch = _ => throw new InvalidOperationException("batch always fails here");
+
+        var first = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        var poison = envelope();
+        var healthy = Enumerable.Range(0, 3).Select(_ => envelope()).ToArray();
+
+        var innerOne = _one;
+        _one = e => e == poison
+            ? throw new DuplicateIncomingEnvelopeException(e)
+            : innerOne(e);
+
+        var poisonTask = theCoalescer.StoreAsync(poison);
+        var healthyTasks = healthy.Select(e => theCoalescer.StoreAsync(e)).ToArray();
+
+        gate.SetResult();
+
+        await Should.ThrowAsync<DuplicateIncomingEnvelopeException>(
+            () => poisonTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+
+        await Task.WhenAll(healthyTasks).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        healthyTasks.ShouldAllBe(x => x.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task drain_waits_for_the_flush_in_flight()
+    {
+        var theCoalescer = coalescer();
+        var (gate, started) = gateTheFirstWrite();
+
+        var pending = theCoalescer.StoreAsync(envelope());
+        await started.Task;
+
+        var drain = theCoalescer.DrainAsync();
+        drain.IsCompleted.ShouldBeFalse();
+
+        gate.SetResult();
+        await drain.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        pending.IsCompleted.ShouldBeTrue();
+    }
+}

--- a/src/Testing/CoreTests/Persistence/Durability/coalesced_outbox_storage_4319.cs
+++ b/src/Testing/CoreTests/Persistence/Durability/coalesced_outbox_storage_4319.cs
@@ -1,0 +1,228 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.Logging;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Transports;
+using Wolverine.Transports.Sending;
+using Xunit;
+
+namespace CoreTests.Persistence.Durability;
+
+/// <summary>
+/// GH-4319. The non-transactional outbox paid one connection and one INSERT per envelope on the way
+/// out, and a second single-row DELETE per envelope on the way back -- while the many-envelope forms
+/// of both already existed. These now coalesce.
+///
+/// <para>
+/// The load-bearing assertion in here is <see cref="a_lone_send_is_stored_immediately" />. The outbox
+/// store gates the send, so any batching WINDOW in front of it would delay delivery rather than
+/// bookkeeping; GH-3490 measured that shape at a 5,767ms transit p50. A lone envelope going straight
+/// through is the property that makes this design safe, not an optimization detail.
+/// </para>
+/// </summary>
+public class coalesced_outbox_storage_4319 : IAsyncDisposable
+{
+    private readonly IMessageOutbox _outbox = Substitute.For<IMessageOutbox>();
+    private readonly Uri _destination = new("stub://one");
+    private readonly ISender _sender = Substitute.For<ISender>();
+    private DurableSendingAgent? _agent;
+
+    public coalesced_outbox_storage_4319()
+    {
+        _sender.Destination.Returns(_destination);
+        _sender.SupportsNativeScheduledSend.Returns(true);
+    }
+
+    private DurableSendingAgent agent(int batchSize = 100)
+    {
+        var settings = new DurabilitySettings { StoreOutgoingBatchSize = batchSize };
+        _agent = new DurableSendingAgent(_sender, settings, NullLogger.Instance,
+            Substitute.For<IMessageTracker>(), _outbox, new CoalesceEndpoint(_destination));
+        return _agent;
+    }
+
+    private class CoalesceEndpoint : Endpoint
+    {
+        public CoalesceEndpoint(Uri uri) : base(uri, EndpointRole.Application)
+        {
+        }
+
+        public override ValueTask<IListener> BuildListenerAsync(IWolverineRuntime runtime, IReceiver receiver)
+            => throw new NotSupportedException();
+
+        protected override ISender CreateSender(IWolverineRuntime runtime) => throw new NotSupportedException();
+
+        protected override bool supportsMode(EndpointMode mode) => true;
+    }
+
+    private static Envelope envelope() => new()
+    {
+        Id = Guid.NewGuid(), Data = [1, 2, 3], MessageType = "some.message", Destination = new Uri("stub://one")
+    };
+
+    /// <summary>
+    /// Hold the first store open so everything sent meanwhile piles up behind it. Concurrency is the
+    /// only thing that forms a batch here -- there is deliberately no timer to wait on.
+    /// </summary>
+    private (TaskCompletionSource gate, TaskCompletionSource started) gateTheFirstStore()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = true;
+
+        _outbox.StoreOutgoingAsync(Arg.Any<Envelope>(), Arg.Any<int>()).Returns(_ =>
+        {
+            if (first)
+            {
+                first = false;
+                started.TrySetResult();
+                return gate.Task;
+            }
+
+            return Task.CompletedTask;
+        });
+
+        return (gate, started);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_agent != null) await _agent.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task a_lone_send_is_stored_immediately()
+    {
+        var theAgent = agent();
+        var lone = envelope();
+
+        await theAgent.StoreAndForwardAsync(lone);
+
+        await _outbox.Received(1).StoreOutgoingAsync(lone, Arg.Any<int>());
+        await _outbox.DidNotReceive().StoreOutgoingAsync(Arg.Any<IReadOnlyList<Envelope>>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task sends_that_arrive_during_a_store_share_the_next_batch()
+    {
+        var theAgent = agent();
+        var (gate, started) = gateTheFirstStore();
+
+        var first = theAgent.StoreAndForwardAsync(envelope()).AsTask();
+        await started.Task;
+
+        var others = Enumerable.Range(0, 5).Select(_ => envelope()).ToArray();
+        var pending = others.Select(e => theAgent.StoreAndForwardAsync(e).AsTask()).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await _outbox.Received(1).StoreOutgoingAsync(
+            Arg.Is<IReadOnlyList<Envelope>>(list => list.Count == 5 && others.All(list.Contains)),
+            Arg.Any<int>());
+    }
+
+    /// <summary>
+    /// The store gates the send, so an envelope must never reach the sender before its row exists --
+    /// coalescing changes how many round trips there are, not that ordering.
+    /// </summary>
+    [Fact]
+    public async Task nothing_reaches_the_sender_before_its_row_is_stored()
+    {
+        var theAgent = agent();
+        var (gate, started) = gateTheFirstStore();
+
+        var first = theAgent.StoreAndForwardAsync(envelope()).AsTask();
+        await started.Task;
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+        await _sender.DidNotReceive().SendAsync(Arg.Any<Envelope>());
+
+        gate.SetResult();
+        await first.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_batch_size_of_one_stores_every_envelope_on_its_own()
+    {
+        var theAgent = agent(batchSize: 1);
+        var (gate, started) = gateTheFirstStore();
+
+        var first = theAgent.StoreAndForwardAsync(envelope()).AsTask();
+        await started.Task;
+
+        var pending = Enumerable.Range(0, 4).Select(_ => theAgent.StoreAndForwardAsync(envelope()).AsTask()).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await _outbox.Received(5).StoreOutgoingAsync(Arg.Any<Envelope>(), Arg.Any<int>());
+        await _outbox.DidNotReceive().StoreOutgoingAsync(Arg.Any<IReadOnlyList<Envelope>>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task a_failed_batch_store_falls_back_to_one_at_a_time()
+    {
+        var theAgent = agent();
+        var (gate, started) = gateTheFirstStore();
+        _outbox.StoreOutgoingAsync(Arg.Any<IReadOnlyList<Envelope>>(), Arg.Any<int>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("nope")));
+
+        var first = theAgent.StoreAndForwardAsync(envelope()).AsTask();
+        await started.Task;
+
+        var others = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+        var pending = others.Select(e => theAgent.StoreAndForwardAsync(e).AsTask()).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(first)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Every envelope still stored, and still forwarded
+        foreach (var e in others)
+        {
+            await _outbox.Received(1).StoreOutgoingAsync(e, Arg.Any<int>());
+        }
+    }
+
+    /// <summary>
+    /// The other half of GH-4319: MarkSuccessfulAsync(Envelope) used to pay a single-row DELETE per
+    /// envelope even though DeleteOutgoingAsync(Envelope[]) already existed for the batched sends.
+    /// </summary>
+    [Fact]
+    public async Task successful_single_sends_delete_their_rows_in_one_batch()
+    {
+        var theAgent = agent();
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = true;
+
+        _outbox.DeleteOutgoingAsync(Arg.Any<Envelope>()).Returns(_ =>
+        {
+            if (first)
+            {
+                first = false;
+                started.TrySetResult();
+                return gate.Task;
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var lone = theAgent.MarkSuccessfulAsync(envelope());
+        await started.Task;
+
+        var others = Enumerable.Range(0, 4).Select(_ => envelope()).ToArray();
+        var pending = others.Select(e => theAgent.MarkSuccessfulAsync(e)).ToArray();
+
+        gate.SetResult();
+        await Task.WhenAll(pending.Append(lone)).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await _outbox.Received(1).DeleteOutgoingAsync(
+            Arg.Is<Envelope[]>(list => list.Length == 4 && others.All(list.Contains)));
+    }
+}

--- a/src/Testing/KafkaPerfRig/Program.cs
+++ b/src/Testing/KafkaPerfRig/Program.cs
@@ -83,6 +83,10 @@ switch (role)
         await WolverineRedis.RunPublisherAsync(cfg);
         break;
 
+    case "local-queue":
+        await WolverineLocalQueue.RunAsync(cfg);
+        break;
+
     case "asb-consumer":
         await WolverineAsb.RunConsumerAsync(cfg);
         break;

--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -74,6 +74,52 @@ two worktrees.
 **+159% (2.6x)**, rounds within 0.6% of each other. The durable Redis endpoint had been paying one
 inbox-insert round trip per message.
 
+### Durable local queue (GH-4319) — measured 2026-09-06
+
+The only lane with no broker in it: one process publishes into a durable local queue backed by
+PostgreSQL and handles the messages itself. That isolates exactly what GH-4319 changes —
+`DurableLocalQueue.StoreAndForwardAsync`'s inbox `INSERT`, which used to open its own pooled
+connection for one row on every publish.
+
+`RIG_STORE_BATCH=1` sets `StoreIncomingBatchSize` to 1, which is the pre-GH-4319 one-INSERT-per-publish
+path **inside the same build**. Run it as `dotnet run -c Release -- local-queue`.
+
+**Coalescing only happens where the application publishes concurrently.** There is no timer, so a
+single awaited publish loop never has two writes in flight and forms no batches at all — it pays
+nothing and gains nothing. The saturated cell therefore runs `RIG_PUBLISHERS=16`, which is the shape
+a server handling concurrent requests actually has. A rig cell at `RIG_PUBLISHERS=1` would measure
+this change as a null result, correctly and uselessly.
+
+Two cells, two rounds each, interleaved, `RIG_HANDLER_MS=0 RIG_SEQ=none`:
+
+**Saturated** (`RIG_SMALL_RATE=-1 RIG_PUBLISHERS=16`, 15s warmup + 45s):
+
+| cell | r1 | r2 | mean | publish p50 | publish p99 |
+|---|---|---|---|---|---|
+| `RIG_STORE_BATCH=1` (pre-GH-4319) | 7,297/s | 7,413/s | **7,355/s** | 2.29ms | 3.69ms |
+| default batch 100 (post-GH-4319) | 9,156/s | 9,164/s | **9,160/s** | **1.70ms** | **2.71ms** |
+
+**+24.5% throughput, and latency went DOWN 26% at p50 / 27% at p99.** Round spread inside each arm
+is 1.6% and 0.1%, well under the 24% gap. The latency direction is the point, not a bonus: a
+time-windowed coalescer here would have moved p50 the other way, which is precisely the shape
+GH-3490 measured at a 5,767ms transit p50. Batching that forms only from concurrency takes pressure
+off the connection pool instead of adding delay.
+
+**Trickle** (`RIG_SMALL_RATE=8 RIG_LARGE_RATE=0.6`, 20s warmup + 60s) — the safety cell:
+
+| cell | r1 publish p50 | r2 publish p50 | mean |
+|---|---|---|---|
+| `RIG_STORE_BATCH=1` (pre-GH-4319) | 2.091ms | 2.057ms | **2.07ms** |
+| default batch 100 (post-GH-4319) | 2.094ms | 2.130ms | **2.11ms** |
+
+**No measurable change**, and that is the result being looked for: at 8/s the publishes are ~125ms
+apart, nothing is ever concurrent, every write goes straight down the per-envelope path. The 0.04ms
+gap is inside the round-to-round spread of the *before* arm alone (0.034ms). Throughput is identical
+by construction — both arms are rate-controlled and handled all 640 messages.
+
+Measure both cells for any future change here. Throughput alone cannot tell a coalescer that helps
+under load from one that quietly taxes a lone publish.
+
 ### Azure Service Bus (GH-4331) — measured 2026-09-06: NULL RESULT → **change reverted**
 
 `RIG_ASB_PREFETCH=-1` sets an explicit transport-wide 0, which by design still beat the computed

--- a/src/Testing/KafkaPerfRig/RigConfig.cs
+++ b/src/Testing/KafkaPerfRig/RigConfig.cs
@@ -48,6 +48,11 @@ public class RigConfig
 
     public string PostgresSchema { get; } = env("RIG_PG_SCHEMA", "kafka_rig");
 
+    // GH-4319. Durable local queue publishes now coalesce into one batched inbox INSERT.
+    // 0 leaves Wolverine's default (100); 1 gives every publish its own round trip, which is the
+    // pre-GH-4319 shape reproduced INSIDE the same build -- the A/B this lane exists for.
+    public int StoreIncomingBatchSize { get; } = envInt("RIG_STORE_BATCH", 0);
+
     // 0 = leave the endpoint's default listener count
     public int ListenerCount { get; } = envInt("RIG_LISTENER_COUNT", 0);
 

--- a/src/Testing/KafkaPerfRig/WolverineLocalQueue.cs
+++ b/src/Testing/KafkaPerfRig/WolverineLocalQueue.cs
@@ -1,0 +1,212 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Wolverine;
+using Wolverine.Postgresql;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// GH-4319. The only single-process lane in the rig: no broker at all, just publish into a durable
+/// local queue backed by PostgreSQL and handle it in the same host. That isolates precisely what
+/// GH-4319 changes — <c>DurableLocalQueue.StoreAndForwardAsync</c>'s inbox <c>INSERT</c>, which used
+/// to open its own pooled connection for one row on every single publish.
+///
+/// <para>
+/// <b>A/B inside one build</b> via <c>RIG_STORE_BATCH</c>: 0 (default) leaves the coalesced default,
+/// and <c>RIG_STORE_BATCH=1</c> sets <c>StoreIncomingBatchSize</c> to 1, which is exactly the
+/// pre-GH-4319 one-INSERT-per-publish path in the same binary. No worktrees, no stash, no chance of
+/// measuring fix-versus-fix.
+/// </para>
+///
+/// <para>
+/// <b>Two numbers, and the second one is the point.</b> Throughput alone cannot catch the failure
+/// mode this design was constrained by: the store gates the send, so any batching window in front of
+/// it delays delivery, and GH-3490 measured that shape at a 5,767ms transit p50. So this lane also
+/// records the <i>publish call latency</i> — the wall time of the awaited <c>PublishAsync</c>, which
+/// on a durable local queue IS the store round trip. It is measured in the publisher, with no
+/// cross-thread handoff and therefore no race to misread. Run the trickle cell as well as the
+/// saturated one: coalescing that helps at saturation and hurts a lone publish is a regression.
+/// </para>
+/// </summary>
+public static class WolverineLocalQueue
+{
+    public static async Task RunAsync(RigConfig cfg)
+    {
+        LocalRigHandlers.HandlerMs = cfg.HandlerMs;
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(LocalRigHandlers).Assembly;
+                opts.Discovery.IncludeType<LocalRigHandlers>();
+
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                opts.Policies.UseDurableLocalQueues();
+
+                if (cfg.StoreIncomingBatchSize > 0)
+                {
+                    opts.Durability.StoreIncomingBatchSize = cfg.StoreIncomingBatchSize;
+                }
+
+                if (cfg.MaxParallel > 0)
+                {
+                    opts.LocalQueueFor<LocalSmallEvent>().MaximumParallelMessages(cfg.MaxParallel);
+                    opts.LocalQueueFor<LocalLargeEvent>().MaximumParallelMessages(cfg.MaxParallel);
+                }
+            });
+
+        using var host = builder.Build();
+        await host.StartAsync();
+
+        var effectiveBatch = cfg.StoreIncomingBatchSize > 0 ? cfg.StoreIncomingBatchSize.ToString() : "default(100)";
+        Console.WriteLine($"[rig] wolverine local-queue up: {cfg.Describe()} storeBatch={effectiveBatch}");
+
+        var bus = host.MessageBus();
+
+        var counters = await PublishLoops.RunAsync(cfg,
+            (gameId, seq, t0, warmup) => publishAsync(bus,
+                new LocalSmallEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Small },
+                warmup),
+            (gameId, seq, t0, warmup) => publishAsync(bus,
+                new LocalLargeEvent { GameId = gameId, Seq = seq, T0 = t0, Warmup = warmup, Payload = Payloads.Large },
+                warmup));
+
+        Console.WriteLine($"[rig] local-queue published: {counters.small} small, {counters.large} large. Draining...");
+
+        // The queue is in-process, so a short drain is enough for the tail to be handled
+        await Task.Delay(3000);
+        await host.StopAsync();
+
+        PublishLatencyRecorder.Dump(cfg.OutDir, "local-queue");
+
+        StageRecorder.Dump(cfg.OutDir, "local-queue", new
+        {
+            harness = "wolverine-local-queue",
+            mode = "durable-local",
+            sequencing = cfg.Sequencing,
+            handlerMs = cfg.HandlerMs,
+            maxParallel = cfg.MaxParallel,
+            storeIncomingBatchSize = effectiveBatch
+        });
+    }
+
+    /// <summary>
+    /// The awaited publish IS the measurement. On a durable local queue PublishAsync does not return
+    /// until StoreAndForwardAsync has the row in the inbox, so this wall time is the store round trip
+    /// plus nothing else -- and it is where a time-windowed coalescer would show up as added delay.
+    /// </summary>
+    private static async Task publishAsync(IMessageBus bus, object message, bool warmup)
+    {
+        var kind = message is LocalLargeEvent ? "large" : "small";
+        var start = Stopwatch.GetTimestamp();
+        await bus.PublishAsync(message);
+        PublishLatencyRecorder.Record(kind, warmup, Stopwatch.GetTimestamp() - start);
+    }
+}
+
+public class LocalSmallEvent
+{
+    public string GameId { get; set; } = string.Empty;
+    public int Seq { get; set; }
+    public long T0 { get; set; }
+    public bool Warmup { get; set; }
+    public string Payload { get; set; } = string.Empty;
+}
+
+public class LocalLargeEvent
+{
+    public string GameId { get; set; } = string.Empty;
+    public int Seq { get; set; }
+    public long T0 { get; set; }
+    public bool Warmup { get; set; }
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Separate from <see cref="RigHandlers" /> so the local lane's message types never collide with the
+/// broker lanes' -- two handlers for one message type is a bootstrap error, not a rig option.
+/// </summary>
+public class LocalRigHandlers
+{
+    public static int HandlerMs;
+
+    public static Task Handle(LocalSmallEvent message) => processAsync("small", message.T0, message.Warmup);
+
+    public static Task Handle(LocalLargeEvent message) => processAsync("large", message.T0, message.Warmup);
+
+    private static async Task processAsync(string kind, long t0, bool warmup)
+    {
+        var t3 = Stopwatch.GetTimestamp();
+
+        if (HandlerMs > 0)
+        {
+            await Task.Delay(HandlerMs);
+        }
+
+        // No transport hop, so there is no separate consume timestamp to stamp: T2 == T3 and dwell is
+        // zero by construction. transit_ms is therefore not the interesting column in this lane --
+        // publish latency (above) and total_ms are.
+        StageRecorder.Record(new StageSample(kind, warmup, t0, t3, t3, Stopwatch.GetTimestamp()));
+    }
+}
+
+/// <summary>
+/// Publisher-side latency capture. Deliberately not routed through <see cref="StageRecorder" />: that
+/// one is stamped in the handler, and getting a publish-return timestamp across to it would need a
+/// cross-thread handoff that the handler can win, silently reporting a zero transit.
+/// </summary>
+public static class PublishLatencyRecorder
+{
+    private static readonly ConcurrentQueue<(string Kind, bool Warmup, long Ticks)> _samples = new();
+
+    public static void Record(string kind, bool warmup, long elapsedTicks)
+    {
+        _samples.Enqueue((kind, warmup, elapsedTicks));
+    }
+
+    public static void Dump(string outDir, string label)
+    {
+        Directory.CreateDirectory(outDir);
+        var samples = _samples.ToArray();
+
+        var summary = new Dictionary<string, object> { ["samples"] = samples.Length };
+
+        foreach (var kind in new[] { "small", "large" })
+        {
+            // Post-warmup only, same rule StageRecorder uses for its latency percentiles
+            var measured = samples.Where(s => s.Kind == kind && !s.Warmup)
+                .Select(s => s.Ticks * 1000.0 / Stopwatch.Frequency)
+                .OrderBy(x => x)
+                .ToArray();
+
+            if (measured.Length == 0) continue;
+
+            double at(double p)
+            {
+                var index = (int)Math.Ceiling(p / 100.0 * measured.Length) - 1;
+                return Math.Round(measured[Math.Clamp(index, 0, measured.Length - 1)], 3);
+            }
+
+            summary[kind] = new Dictionary<string, double>
+            {
+                ["count"] = measured.Length,
+                ["p50"] = at(50),
+                ["p95"] = at(95),
+                ["p99"] = at(99),
+                ["max"] = Math.Round(measured[^1], 3),
+                ["mean"] = Math.Round(measured.Average(), 3)
+            };
+        }
+
+        var json = JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(Path.Combine(outDir, $"{label}-publish-latency.json"), json);
+        Console.WriteLine($"[rig] {label} publish latency (ms):");
+        Console.WriteLine(json);
+    }
+}

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -197,6 +197,30 @@ public class DurabilitySettings : IDescribeMyself
     public int MarkAsHandledBatchSize { get; set; } = 100;
 
     /// <summary>
+    /// GH-4319. The most concurrent durable local queue publishes Wolverine coalesces into one batched
+    /// inbox <c>INSERT</c>. Same shape as <see cref="MarkAsHandledBatchSize" /> and deliberately timer-free:
+    /// one flush is in flight at a time, every publish that arrives while it runs joins the next flush, and
+    /// a lone publish is written immediately -- so trickle traffic pays exactly the one round trip it paid
+    /// before and batches can only form where there was already a flush to hide behind. Every publisher
+    /// still waits for its own row to land before <c>StoreAndForwardAsync</c> returns. A batch that fails
+    /// rolls back whole and falls back to storing each envelope individually, so a duplicate envelope
+    /// still raises <c>DuplicateIncomingEnvelopeException</c> for itself alone. Set to 1 to give every
+    /// publish its own round trip as before. Default 100.
+    /// </summary>
+    public int StoreIncomingBatchSize { get; set; } = 100;
+
+    /// <summary>
+    /// GH-4319. The most concurrent non-transactional outbox stores Wolverine coalesces into one batched
+    /// outgoing <c>INSERT</c>, and the most successful single-envelope sends it coalesces into one batched
+    /// <c>DELETE</c>. Timer-free for a reason that matters more here than anywhere else in Wolverine: the
+    /// outbox store <i>gates the send</i>, so a max-age window in front of it would delay delivery rather
+    /// than bookkeeping -- GH-3490 measured that shape at a 5,767ms transit p50. A lone send is therefore
+    /// stored and forwarded immediately and batches form only from concurrency. Set to 1 to give every
+    /// send its own round trip as before. Default 100.
+    /// </summary>
+    public int StoreOutgoingBatchSize { get; set; } = 100;
+
+    /// <summary>
     /// If non-null, this directs Wolverine to "push" any message in the durable outbox that is older
     /// than the configured time even if the message is marked as owned by an active node
     /// </summary>

--- a/src/Wolverine/Persistence/Durability/DelegatingMessageInbox.cs
+++ b/src/Wolverine/Persistence/Durability/DelegatingMessageInbox.cs
@@ -40,8 +40,8 @@ internal class DelegatingMessageInbox : IMessageInbox
         return (envelope.Store?.Inbox ?? _inner).StoreIncomingAsync(envelope);
     }
 
-    // This would only be coming from a batch receipt and not from any kind of
-    // local queueing
+    // Reached from a batch receipt and, since GH-4319, from the durable local queue's coalesced
+    // publish as well -- which is why the grouping below is load-bearing rather than defensive.
     public async Task StoreIncomingAsync(IReadOnlyList<Envelope> envelopes)
     {
         // Route by ancillary store exactly like the single-envelope overload above —

--- a/src/Wolverine/Persistence/Durability/DelegatingMessageOutbox.cs
+++ b/src/Wolverine/Persistence/Durability/DelegatingMessageOutbox.cs
@@ -21,6 +21,24 @@ internal class DelegatingMessageOutbox : IMessageOutbox
         return (envelope.Store?.Outbox ?? _inner).StoreOutgoingAsync(envelope, ownerId);
     }
 
+    // GH-4319. Same grouping rule as DeleteOutgoingAsync below: a coalesced batch can carry envelopes
+    // bound for different ancillary stores, and handing the whole thing to one of them would write
+    // rows into the wrong database.
+    public async Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        var groups = envelopes.GroupBy(x => x.Store).ToList();
+        if (groups.Count == 1)
+        {
+            await (groups[0].Key?.Outbox ?? _inner).StoreOutgoingAsync(envelopes, ownerId);
+            return;
+        }
+
+        foreach (var group in groups)
+        {
+            await (group.Key?.Outbox ?? _inner).StoreOutgoingAsync(group.ToArray(), ownerId);
+        }
+    }
+
     public async Task DeleteOutgoingAsync(Envelope[] envelopes)
     {
         // Going to purposely leave this naive and let the whole thing be retried

--- a/src/Wolverine/Persistence/Durability/DurableSendingAgent.cs
+++ b/src/Wolverine/Persistence/Durability/DurableSendingAgent.cs
@@ -19,6 +19,12 @@ internal class DurableSendingAgent : SendingAgent
     private readonly SemaphoreSlim _queueLock = new(1, 1);
     private readonly RetryBlock<Envelope> _storeAndForward;
 
+    // GH-4319. Null when the batch sizes are 1. The store gates the send, so these coalescers are
+    // strictly timer-free: a lone envelope is written immediately and batches only ever form behind a
+    // flush that was already in flight.
+    private readonly EnvelopeStoreCoalescer? _storeCoalescer;
+    private readonly EnvelopeStoreCoalescer? _deleteCoalescer;
+
     private IList<Envelope> _queued = new List<Envelope>();
 
     public DurableSendingAgent(ISender sender, DurabilitySettings settings, ILogger logger,
@@ -45,9 +51,33 @@ internal class DurableSendingAgent : SendingAgent
         _enqueueForRetry = new RetryBlock<OutgoingMessageBatch>((batch, _) => enqueueForRetryAsync(batch), _logger,
             _settings.Cancellation);
 
+        if (settings.StoreOutgoingBatchSize > 1)
+        {
+            _storeCoalescer = new EnvelopeStoreCoalescer(
+                envelopes => _outbox.StoreOutgoingAsync(envelopes, settings.AssignedNodeNumber),
+                envelope => _outbox.StoreOutgoingAsync(envelope, settings.AssignedNodeNumber),
+                settings.StoreOutgoingBatchSize, endpoint.Uri, logger);
+
+            // GH-4319. The success path already had a many-envelope DELETE -- OutgoingMessageBatch has
+            // used it since it existed -- but a single-envelope send paid its own round trip to remove
+            // one row. Same coalescer, same guarantee: MarkSuccessfulAsync does not return until this
+            // envelope's row is gone, which is what makes releasing a pooled envelope afterwards safe.
+            _deleteCoalescer = new EnvelopeStoreCoalescer(
+                envelopes => _outbox.DeleteOutgoingAsync(envelopes as Envelope[] ?? envelopes.ToArray()),
+                envelope => _deleteOutgoingOne.PostAsync(envelope),
+                settings.StoreOutgoingBatchSize, endpoint.Uri, logger);
+        }
+
         _storeAndForward = new RetryBlock<Envelope>(async (e, _) =>
         {
-            await _outbox.StoreOutgoingAsync(e, _settings.AssignedNodeNumber);
+            if (_storeCoalescer != null)
+            {
+                await _storeCoalescer.StoreAsync(e);
+            }
+            else
+            {
+                await _outbox.StoreOutgoingAsync(e, _settings.AssignedNodeNumber);
+            }
 
             await _sending.PostAsync(e);
         }, _logger, settings.Cancellation);
@@ -59,6 +89,16 @@ internal class DurableSendingAgent : SendingAgent
 
     protected override async Task drainOtherAsync()
     {
+        if (_storeCoalescer != null)
+        {
+            await _storeCoalescer.DrainAsync();
+        }
+
+        if (_deleteCoalescer != null)
+        {
+            await _deleteCoalescer.DrainAsync();
+        }
+
         await _deleteOutgoingMany.DrainAsync();
         await _deleteOutgoingOne.DrainAsync();
         await _enqueueForRetry.DrainAsync();
@@ -201,6 +241,11 @@ internal class DurableSendingAgent : SendingAgent
 
     public override Task MarkSuccessfulAsync(Envelope outgoing)
     {
+        if (_deleteCoalescer != null)
+        {
+            return _deleteCoalescer.StoreAsync(outgoing);
+        }
+
         return _deleteOutgoingOne.PostAsync(outgoing);
     }
 

--- a/src/Wolverine/Persistence/Durability/EnvelopeStoreCoalescer.cs
+++ b/src/Wolverine/Persistence/Durability/EnvelopeStoreCoalescer.cs
@@ -1,0 +1,204 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Persistence.Durability;
+
+/// <summary>
+///     GH-4319. Coalesces concurrent single-envelope durability writes into one batched round trip,
+///     without ever making a caller wait for other work to show up. This is the insert-side twin of
+///     <see cref="Wolverine.Runtime.WorkerQueues.InboxCompletionCoalescer" /> and shares its shape: one
+///     flush is in flight at a time, every write that arrives while it runs is taken by the next flush
+///     as a single batch, and the task handed back to a caller completes only once that caller's own
+///     envelope is really in the database.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <b>There is deliberately no timer, and adding one would be a bug.</b> On the outbox path the store
+///     gates the send -- <c>DurableSendingAgent</c> stores the envelope and only then posts it to the
+///     sender -- so any max-age window in front of the store delays <i>delivery</i>, not just bookkeeping.
+///     GH-3490 measured that exact shape at a 5,767ms transit p50. Here a lone write flushes immediately,
+///     so trickle traffic pays precisely what it paid before (one round trip) and batches form from
+///     concurrency alone: they can only appear when there was already a flush in flight to hide behind.
+///     </para>
+///     <para>
+///     <b>Failures fall back to one envelope at a time, and the exception reaches its own caller.</b> That
+///     matters more here than on the completion side. The batched
+///     <c>StoreIncomingAsync(IReadOnlyList&lt;Envelope&gt;)</c> runs inside an explicit transaction and
+///     rolls the whole batch back on a duplicate key, so a batch failure means nothing was written; the
+///     per-envelope retry then produces the real per-envelope outcome. A caller that knows how to handle
+///     <see cref="DuplicateIncomingEnvelopeException" /> for its own envelope keeps seeing exactly that
+///     exception for exactly that envelope, and one poisoned envelope cannot fail its neighbours.
+///     </para>
+/// </remarks>
+internal class EnvelopeStoreCoalescer
+{
+    private readonly Func<IReadOnlyList<Envelope>, Task> _storeBatch;
+    private readonly Func<Envelope, Task> _storeOne;
+    private readonly int _maximumBatchSize;
+    private readonly ILogger _logger;
+    private readonly Uri _uri;
+    private readonly object _lock = new();
+    private readonly List<Pending> _pending = new();
+    private bool _flushing;
+    private Task? _flushLoop;
+
+    /// <param name="storeBatch">The batched write. May throw; a failure falls back to <paramref name="storeOne" /> per envelope</param>
+    /// <param name="storeOne">The single-envelope write. Its exception is delivered to that envelope's caller</param>
+    /// <param name="maximumBatchSize">Most envelopes in one flush</param>
+    /// <param name="uri">Endpoint, for logging</param>
+    /// <param name="logger"></param>
+    public EnvelopeStoreCoalescer(Func<IReadOnlyList<Envelope>, Task> storeBatch, Func<Envelope, Task> storeOne,
+        int maximumBatchSize, Uri uri, ILogger logger)
+    {
+        _storeBatch = storeBatch;
+        _storeOne = storeOne;
+        _maximumBatchSize = Math.Max(1, maximumBatchSize);
+        _uri = uri;
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Number of envelopes waiting for the next flush. Exposed for tests.
+    /// </summary>
+    public int PendingCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _pending.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Write this envelope. The returned task completes only after the database has it -- whether by
+    ///     the shared batch or by the per-envelope fallback -- and faults with whatever the per-envelope
+    ///     write threw for this envelope.
+    /// </summary>
+    public Task StoreAsync(Envelope envelope)
+    {
+        var pending = new Pending(envelope,
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+
+        var startLoop = false;
+        lock (_lock)
+        {
+            _pending.Add(pending);
+            if (!_flushing)
+            {
+                _flushing = true;
+                startLoop = true;
+            }
+        }
+
+        if (startLoop)
+        {
+            // Off the caller's thread: under sustained load the loop keeps finding work, and whichever
+            // caller happened to arrive first must not be conscripted into flushing everyone else's
+            // writes forever.
+            var loop = Task.Run(flushLoopAsync);
+            lock (_lock)
+            {
+                _flushLoop = loop;
+            }
+        }
+
+        return pending.Completion.Task;
+    }
+
+    /// <summary>
+    ///     Wait for any flush in flight (and whatever it sweeps up) to finish. Bounded by the caller.
+    /// </summary>
+    public Task DrainAsync()
+    {
+        Task? loop;
+        lock (_lock)
+        {
+            loop = _flushLoop;
+        }
+
+        return loop ?? Task.CompletedTask;
+    }
+
+    private async Task flushLoopAsync()
+    {
+        while (true)
+        {
+            Pending[] batch;
+            lock (_lock)
+            {
+                if (_pending.Count == 0)
+                {
+                    _flushing = false;
+                    _flushLoop = null;
+                    return;
+                }
+
+                var take = Math.Min(_maximumBatchSize, _pending.Count);
+                batch = new Pending[take];
+                _pending.CopyTo(0, batch, 0, take);
+                _pending.RemoveRange(0, take);
+            }
+
+            await flushAsync(batch).ConfigureAwait(false);
+        }
+    }
+
+    private async Task flushAsync(Pending[] batch)
+    {
+        if (batch.Length == 1)
+        {
+            await storeOneAsync(batch[0]).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            var envelopes = new Envelope[batch.Length];
+            for (var i = 0; i < batch.Length; i++)
+            {
+                envelopes[i] = batch[i].Envelope;
+            }
+
+            await _storeBatch(envelopes).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            // Debug, not Warning: the overwhelmingly common cause is one duplicate envelope in the
+            // batch, which is ordinary traffic and whose real handling belongs to the caller that owns
+            // that envelope. The per-envelope pass below is what decides each outcome.
+            _logger.LogDebug(e,
+                "Failed to store a batch of {Count} envelopes at {Uri}; falling back to storing them one at a time",
+                batch.Length, _uri);
+
+            foreach (var pending in batch)
+            {
+                await storeOneAsync(pending).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        foreach (var pending in batch)
+        {
+            pending.Completion.TrySetResult();
+        }
+    }
+
+    private async Task storeOneAsync(Pending pending)
+    {
+        try
+        {
+            await _storeOne(pending.Envelope).ConfigureAwait(false);
+            pending.Completion.TrySetResult();
+        }
+        catch (Exception e)
+        {
+            // The caller owns this envelope and its failure handling -- a DuplicateIncomingEnvelopeException
+            // has to reach the same catch block it reached before this coalescer existed.
+            pending.Completion.TrySetException(e);
+        }
+    }
+
+    private sealed record Pending(Envelope Envelope, TaskCompletionSource Completion);
+}

--- a/src/Wolverine/Persistence/Durability/IMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/IMessageStore.cs
@@ -56,6 +56,22 @@ public interface IMessageOutbox
     Task<IReadOnlyList<Envelope>> LoadOutgoingAsync(Uri destination);
 
     Task StoreOutgoingAsync(Envelope envelope, int ownerId);
+
+    /// <summary>
+    ///     GH-4319. Store a batch of outgoing envelopes in one round trip. The default implementation
+    ///     stores them one at a time, which is correct for every store and is exactly what the outbox
+    ///     did before this overload existed -- so an implementation that does not override it loses the
+    ///     batching and nothing else. Wrapping stores (ancillary, multi-tenanted) DO override it, because
+    ///     a batch that spans two databases has to be split before it reaches either of them.
+    /// </summary>
+    async Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        foreach (var envelope in envelopes)
+        {
+            await StoreOutgoingAsync(envelope, ownerId);
+        }
+    }
+
     Task DeleteOutgoingAsync(Envelope[] envelopes);
     Task DeleteOutgoingAsync(Envelope envelope);
 

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -211,6 +211,34 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         await database.Outbox.StoreOutgoingAsync(envelope, ownerId);
     }
 
+    // GH-4319. A coalesced outbox batch can span tenants, so it is split by tenant before it reaches
+    // any one database -- the same rule StoreIncomingAsync and DeleteOutgoingAsync already follow.
+    async Task IMessageOutbox.StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        var groups = envelopes.GroupBy(x => x.TenantId).ToArray();
+
+        if (groups.Length == 1)
+        {
+            var database = await GetDatabaseAsync(groups[0].Key);
+            await database.Outbox.StoreOutgoingAsync(envelopes, ownerId);
+            return;
+        }
+
+        foreach (var group in groups)
+        {
+            try
+            {
+                var database = await GetDatabaseAsync(group.Key);
+                await database.Outbox.StoreOutgoingAsync(group.ToArray(), ownerId);
+            }
+            catch (UnknownTenantIdException e)
+            {
+                _logger.LogError(e, "Encountered unknown tenant {TenantId} while trying to store outgoing envelopes",
+                    group.Key);
+            }
+        }
+    }
+
     async Task IMessageOutbox.DeleteOutgoingAsync(Envelope[] envelopes)
     {
         var groups = envelopes.GroupBy(x => x.TenantId).ToArray();

--- a/src/Wolverine/Persistence/Durability/NullMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/NullMessageStore.cs
@@ -117,6 +117,11 @@ public class NullMessageStore : IMessageStore, IMessageInbox, IMessageOutbox, IM
         return Task.CompletedTask;
     }
 
+    public Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task<IReadOnlyList<Envelope>> LoadOutgoingAsync(Uri destination)
     {
         return Task.FromResult((IReadOnlyList<Envelope>)Array.Empty<Envelope>());

--- a/src/Wolverine/Transports/Local/DurableLocalQueue.cs
+++ b/src/Wolverine/Transports/Local/DurableLocalQueue.cs
@@ -21,6 +21,10 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
     private readonly IMessageSerializer _serializer;
     private readonly DurabilitySettings _settings;
     private readonly RetryBlock<Envelope> _storeAndEnqueue;
+
+    // GH-4319. The local durable queue was the last per-message inbox INSERT that never batched: every
+    // publish opened its own pooled connection for one row. Null when StoreIncomingBatchSize is 1.
+    private readonly EnvelopeStoreCoalescer? _storeCoalescer;
     private DurableReceiver? _receiver;
     private Restarter? _restarter;
 
@@ -68,6 +72,14 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         _receiver = new DurableReceiver(endpoint, runtime, Pipeline);
 
         _storeAndEnqueue = new RetryBlock<Envelope>((e, _) => storeAndEnqueueAsync(e), _logger, _runtime.Cancellation);
+
+        if (_settings.StoreIncomingBatchSize > 1)
+        {
+            _storeCoalescer = new EnvelopeStoreCoalescer(
+                envelopes => _inbox.StoreIncomingAsync(envelopes),
+                envelope => _inbox.StoreIncomingAsync(envelope),
+                _settings.StoreIncomingBatchSize, Uri, _logger);
+        }
     }
 
     public CircuitBreaker? CircuitBreaker { get; }
@@ -184,6 +196,13 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
         receiver?.Latch();
         await _storeAndEnqueue.DrainAsync();
 
+        // The RetryBlock's own action awaits the coalescer, so draining it already covers any flush the
+        // block itself started. This catches a flush that a caller abandoned mid-await.
+        if (_storeCoalescer != null)
+        {
+            await _storeCoalescer.DrainAsync();
+        }
+
         if (receiver != null)
             await receiver.DrainAsync();
     }
@@ -280,8 +299,20 @@ internal class DurableLocalQueue : ISendingAgent, IListenerCircuit, ILocalQueue
                 ? TransportConstants.AnyNode
                 : _settings.AssignedNodeNumber;
 
+            // The ancillary store has to be stamped BEFORE the envelope joins a batch: both
+            // DelegatingMessageInbox and MultiTenantedMessageStore group the batched overload by
+            // Store/TenantId, and they can only group on what is already on the envelope.
             assignAncillaryStoreIfNeeded(envelope);
-            await _inbox.StoreIncomingAsync(envelope);
+
+            if (_storeCoalescer != null)
+            {
+                await _storeCoalescer.StoreAsync(envelope);
+            }
+            else
+            {
+                await _inbox.StoreIncomingAsync(envelope);
+            }
+
             envelope.WasPersistedInInbox = true;
         }
         catch (DuplicateIncomingEnvelopeException e)


### PR DESCRIPTION
Closes #4319.

The GH-3492/3711/4026 waves batched the listener-arrival inbox `INSERT` and the mark-as-handled `UPDATE`. Three per-message round trips were left behind, and all three now coalesce through `EnvelopeStoreCoalescer`, the insert-side twin of `InboxCompletionCoalescer`:

1. **`DurableLocalQueue`'s inbox `INSERT`** — one pooled connection for one row on every single publish
2. **`DurableSendingAgent`'s non-transactional outbox `INSERT`**
3. **`MarkSuccessfulAsync(Envelope)`'s single-row `DELETE`** — even though `DeleteOutgoingAsync(Envelope[])` already existed for the batched sends

## There is no timer, and adding one would be a bug

The outbox store **gates the send**: `DurableSendingAgent` stores the envelope and only then posts it to the sender. A max-age window in front of that delays *delivery*, not bookkeeping — GH-3490 measured that exact shape at a **5,767ms transit p50**. So a lone write flushes immediately and batches form only from concurrency, behind a flush that was already in flight.

## Measured

New broker-free rig lane (`src/Testing/KafkaPerfRig`, role `local-queue`): one process publishes into a durable local queue on PostgreSQL and handles it, isolating exactly the round trip this changes. In-build A/B via `RIG_STORE_BATCH=1`, two rounds per arm, interleaved.

**Saturated** (`RIG_PUBLISHERS=16`):

| cell | r1 | r2 | mean | publish p50 | publish p99 |
|---|---|---|---|---|---|
| `RIG_STORE_BATCH=1` (before) | 7,297/s | 7,413/s | **7,355/s** | 2.29ms | 3.69ms |
| default 100 (after) | 9,156/s | 9,164/s | **9,160/s** | **1.70ms** | **2.71ms** |

**+24.5% throughput, and latency down 26% at p50 / 27% at p99.** Round spread inside each arm is 1.6% and 0.1% against a 24% gap.

Latency moving *down* is the point, not a bonus — it is the direct evidence that this is not the GH-3490 shape. Batching that forms from concurrency takes pressure off the connection pool; a windowed one would have moved p50 the other way.

**Trickle** (8/s) — the safety cell:

| cell | r1 | r2 | mean |
|---|---|---|---|
| before | 2.091ms | 2.057ms | **2.07ms** |
| after | 2.094ms | 2.130ms | **2.11ms** |

**No measurable change.** At 8/s publishes are ~125ms apart, nothing is concurrent, every write goes straight down the per-envelope path. The 0.04ms gap is inside the *before* arm's own round-to-round spread (0.034ms).

Worth knowing: **coalescing only happens where the application publishes concurrently.** A single awaited publish loop never has two writes in flight, forms no batches, pays nothing and gains nothing. A rig cell at `RIG_PUBLISHERS=1` would measure this as a null result — correctly and uselessly. That is documented in the lane so nobody re-derives it.

## Failure semantics

A failed batch falls back to one envelope at a time, and **the exception reaches its own caller**. That is the one place this differs from `InboxCompletionCoalescer`, and it is deliberate: the batched `StoreIncomingAsync` runs in an explicit transaction and rolls back whole on a duplicate key, so `DurableLocalQueue`'s `DuplicateIncomingEnvelopeException` catch still fires for exactly the envelope that collided, and one poisoned envelope cannot fail its neighbours.

## The interface addition

`IMessageOutbox` gains `StoreOutgoingAsync(IReadOnlyList<Envelope>, int)` as a **default interface method** whose default is the existing one-at-a-time loop — so an implementer that does not override it loses the batching and nothing else.

Overridden by `MessageDatabase<T>` (the real batch), `NullMessageStore`, and both wrapping stores: `DelegatingMessageOutbox` groups by ancillary store and `MultiTenantedMessageStore` by tenant, because a batch spanning two databases has to be split before it reaches either. Oracle, RavenDB and CosmosDB take the safe default. The inbox and delete batch forms already grouped correctly, so the local-queue half needed no store changes at all.

## Also: a latent SqlServerTests flake this surfaced

`external_message_tables` drops the `outside` schema between tests, but `end_to_end_default_variable_message_types` listens on **`outgoing`**`.incoming1` — which nothing ever cleaned. A row that run failed to consume stayed there forever, and the next run's `SingleEnvelope<Message2>()` saw it too:

```
System.Exception : Received 4 messages of type Message2
```

from a test that published exactly one. It cost a full main-vs-branch baseline to attribute, so the fixture now drops both schemas and the reason is in a comment.

## Verification

- `CoreTests` — **24/24** across the new suites (`coalesced_envelope_storage_4319`, `coalesced_outbox_storage_4319`) plus the existing GH-3711 and GH-3926 durability tests
- `./build.sh PersistenceTests` — **113/113**, 0 retries
- `SqlServerTests` — **436/436**, run twice, plus a **436/436 baseline on `main`** to attribute the flake above
- Full `wolverine.slnx -c Release -f net9.0` — clean, **0 warnings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)