### PR TITLE
GH-4369: batch StoreOutgoingAsync for Oracle, RavenDB and Cosmos DB

### DIFF
--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Outgoing.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Outgoing.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Text;
 using Oracle.ManagedDataAccess.Client;
 using Weasel.Oracle;
 using Wolverine.Oracle.Util;
@@ -53,6 +54,75 @@ internal partial class OracleMessageStore
         {
             await conn.CloseAsync();
         }
+    }
+
+    /// <summary>
+    /// GH-4369. One <c>INSERT ALL</c> for the whole batch instead of one INSERT per envelope --
+    /// deliberately not Oracle array binding, which does not carry a BLOB bind as cleanly and turns a
+    /// duplicate row into a partial-apply that has to be unpicked.
+    ///
+    /// <para>
+    /// An <c>INSERT ALL</c> is one statement, so ORA-00001 fails the whole batch and nothing is
+    /// written. That is the right shape: the caller's coalescer then stores each envelope on its own,
+    /// where <see cref="StoreOutgoingAsync(Envelope, int)" />'s existing ORA-00001 swallow makes the
+    /// duplicate idempotent exactly as it was before this overload existed. The batch is a fast path,
+    /// never the only path.
+    /// </para>
+    /// </summary>
+    public async Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        if (HasDisposed || envelopes.Count == 0) return;
+
+        if (envelopes.Count == 1)
+        {
+            await StoreOutgoingAsync(envelopes[0], ownerId);
+            return;
+        }
+
+        await using var conn = await _dataSource.OpenConnectionAsync(_cancellation);
+        await using var cmd = conn.CreateCommand("");
+
+        var sql = new StringBuilder("INSERT ALL");
+        for (var i = 0; i < envelopes.Count; i++)
+        {
+            var envelope = envelopes[i];
+
+            sql.Append($" INTO {SchemaName}.{DatabaseConstants.OutgoingTable} ({DatabaseConstants.OutgoingFields}) ")
+                .Append($"VALUES (:body_{i}, :id_{i}, :ownerId_{i}, :destination_{i}, :deliverBy_{i}, :attempts_{i}, :messageType_{i})");
+
+            cmd.Parameters.Add(new OracleParameter($"body_{i}", OracleDbType.Blob)
+            {
+                Value = EnvelopeSerializer.Serialize(envelope)
+            });
+            cmd.With($"id_{i}", envelope.Id);
+            cmd.With($"ownerId_{i}", ownerId);
+            cmd.With($"destination_{i}", envelope.Destination!.ToString());
+            cmd.Parameters.Add(new OracleParameter($"deliverBy_{i}", OracleDbType.TimeStampTZ)
+            {
+                Value = (object?)envelope.DeliverBy ?? DBNull.Value
+            });
+            cmd.With($"attempts_{i}", envelope.Attempts);
+            cmd.With($"messageType_{i}", envelope.MessageType!);
+        }
+
+        // INSERT ALL is a multi-table insert and needs a driving query; SELECT 1 FROM dual runs it once
+        sql.Append(" SELECT 1 FROM dual");
+        cmd.CommandText = sql.ToString();
+
+        try
+        {
+            await cmd.ExecuteNonQueryAsync(_cancellation);
+        }
+        finally
+        {
+            await conn.CloseAsync();
+        }
+
+        // Deliberately NOT stamping WasPersistedInOutbox here. Neither Oracle store path has ever set
+        // it -- while OracleQueueSender reads it to decide whether to skip a store -- so setting it on
+        // the batch path alone would make batched and unbatched sends behave differently on a flag
+        // that gates a write. Whether Oracle should set it at all is a real question, and a separate
+        // one from this round-trip change. Filed rather than fixed in passing.
     }
 
     public async Task DeleteOutgoingAsync(Envelope[] envelopes)

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.Outbox.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.Outbox.cs
@@ -41,6 +41,106 @@ public partial class CosmosDbMessageStore : IMessageOutbox
         await _container.UpsertItemAsync(outgoing, new PartitionKey(outgoing.PartitionKey));
     }
 
+    // Azure Cosmos DB's own limits on a TransactionalBatch: at most 100 operations, and 2MB of
+    // payload. The operation cap is not the binding one here -- an Envelope body can be 100KB, so a
+    // full batch of 100 would be 10MB. The byte budget is deliberately under the documented 2MB to
+    // leave room for the JSON envelope around each body.
+    private const int MaximumBatchOperations = 100;
+    private const int MaximumBatchBytes = 1_500_000;
+
+    /// <summary>
+    /// GH-4369. A TransactionalBatch is ONE request to Cosmos instead of one per envelope, which is
+    /// the round trip that costs most on this store -- every upsert is a network call with its own RU
+    /// charge.
+    ///
+    /// <para>
+    /// A transactional batch must be single-partition, so this groups by partition key rather than
+    /// assuming one. In practice a coalesced batch comes from a single <c>DurableSendingAgent</c> and
+    /// therefore a single destination, which IS the partition key -- but "in practice" is not a
+    /// constraint the storage layer gets to rely on.
+    /// </para>
+    ///
+    /// <para>
+    /// Both Cosmos batch limits are enforced up front rather than discovered as a 413 at runtime. A
+    /// batch that fails for any other reason surfaces to the caller, whose coalescer retries each
+    /// envelope on its own -- and an upsert is idempotent, so a partially-observed failure cannot
+    /// double-write.
+    /// </para>
+    /// </summary>
+    public async Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        if (envelopes.Count == 0) return;
+
+        if (envelopes.Count == 1)
+        {
+            await StoreOutgoingAsync(envelopes[0], ownerId);
+            return;
+        }
+
+        var messages = new List<OutgoingMessage>(envelopes.Count);
+        foreach (var envelope in envelopes)
+        {
+            messages.Add(new OutgoingMessage(envelope) { OwnerId = ownerId });
+        }
+
+        foreach (var partition in messages.GroupBy(x => x.PartitionKey))
+        {
+            foreach (var chunk in chunkForBatching(partition))
+            {
+                if (chunk.Count == 1)
+                {
+                    await _container.UpsertItemAsync(chunk[0], new PartitionKey(chunk[0].PartitionKey));
+                    continue;
+                }
+
+                var batch = _container.CreateTransactionalBatch(new PartitionKey(partition.Key));
+                foreach (var message in chunk)
+                {
+                    batch.UpsertItem(message);
+                }
+
+                using var response = await batch.ExecuteAsync();
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new CosmosException(
+                        $"Failed to store a batch of {chunk.Count} outgoing envelopes at partition {partition.Key}",
+                        response.StatusCode, 0, response.ActivityId, response.RequestCharge);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Split one partition's messages into batches that respect BOTH Cosmos limits. A single message
+    /// larger than the byte budget goes out on its own and is left to the upsert path, which has no
+    /// batch limit to breach.
+    /// </summary>
+    private static IEnumerable<List<OutgoingMessage>> chunkForBatching(IEnumerable<OutgoingMessage> messages)
+    {
+        var current = new List<OutgoingMessage>();
+        var bytes = 0L;
+
+        foreach (var message in messages)
+        {
+            var size = message.Body?.Length ?? 0;
+
+            if (current.Count > 0 && (current.Count == MaximumBatchOperations || bytes + size > MaximumBatchBytes))
+            {
+                yield return current;
+                current = new List<OutgoingMessage>();
+                bytes = 0;
+            }
+
+            current.Add(message);
+            bytes += size;
+        }
+
+        if (current.Count > 0)
+        {
+            yield return current;
+        }
+    }
+
     public async Task DeleteOutgoingAsync(Envelope[] envelopes)
     {
         foreach (var envelope in envelopes)

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Outbox.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Outbox.cs
@@ -30,6 +30,27 @@ public partial class RavenDbMessageStore : IMessageOutbox
         await session.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// GH-4369. One session, one SaveChangesAsync: RavenDB sends everything staged in a session as a
+    /// single batch command, so this is one HTTP round trip for the whole batch instead of one per
+    /// envelope. Exactly the shape <see cref="DeleteOutgoingAsync(Envelope[])" /> below has always had.
+    /// </summary>
+    public async Task StoreOutgoingAsync(IReadOnlyList<Envelope> envelopes, int ownerId)
+    {
+        if (envelopes.Count == 0) return;
+
+        using var session = _store.OpenAsyncSession();
+        foreach (var envelope in envelopes)
+        {
+            await session.StoreAsync(new OutgoingMessage(envelope)
+            {
+                OwnerId = ownerId
+            });
+        }
+
+        await session.SaveChangesAsync();
+    }
+
     public async Task DeleteOutgoingAsync(Envelope[] envelopes)
     {
         using var session = _store.OpenAsyncSession();

--- a/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
+++ b/src/Testing/KafkaPerfRig/KafkaPerfRig.csproj
@@ -19,6 +19,10 @@
         <ProjectReference Include="..\..\Transports\Redis\Wolverine.Redis\Wolverine.Redis.csproj" />
         <ProjectReference Include="..\..\Transports\Azure\Wolverine.AzureServiceBus\Wolverine.AzureServiceBus.csproj" />
         <ProjectReference Include="..\..\Persistence\Wolverine.Postgresql\Wolverine.Postgresql.csproj" />
+        <!-- GH-4369: the outbox-store lane A/Bs StoreOutgoingAsync per store -->
+        <ProjectReference Include="..\..\Persistence\Wolverine.SqlServer\Wolverine.SqlServer.csproj" />
+        <ProjectReference Include="..\..\Persistence\Oracle\Wolverine.Oracle\Wolverine.Oracle.csproj" />
+        <ProjectReference Include="..\..\Persistence\Wolverine.RavenDb\Wolverine.RavenDb.csproj" />
         <ProjectReference Include="..\..\Wolverine.RuntimeCompilation\Wolverine.RuntimeCompilation.csproj" />
     </ItemGroup>
 

--- a/src/Testing/KafkaPerfRig/OutboxStoreLane.cs
+++ b/src/Testing/KafkaPerfRig/OutboxStoreLane.cs
@@ -1,0 +1,230 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Wolverine;
+using Wolverine.Oracle;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RavenDb;
+using Wolverine.SqlServer;
+
+namespace KafkaPerfRig;
+
+/// <summary>
+/// GH-4369. A direct A/B of <c>IMessageOutbox.StoreOutgoingAsync</c>, one store at a time.
+///
+/// <para>
+/// Deliberately NOT an end-to-end cell. GH-4319's <c>local-queue</c> lane measures a whole publish
+/// path because that is what it changed; GH-4369 changes exactly one method on three stores, so the
+/// honest instrument is that method against the real database. An end-to-end cell would bury a
+/// per-store round-trip change under broker time and tell you less.
+/// </para>
+///
+/// <para>
+/// Each round stores a fresh batch of <c>RIG_STORE_BATCH</c> envelopes twice — once as N calls to the
+/// single-envelope overload (the pre-GH-4369 shape for these stores, and still the default-interface
+/// behaviour for any store that does not override the batch), once as one call to the batch overload.
+/// The two arms alternate order round to round so neither is systematically advantaged by cache
+/// warmth. Envelopes are distinct objects per arm, so neither arm is ever writing rows the other
+/// already wrote.
+/// </para>
+///
+/// <para>
+/// <c>RIG_STORE</c>: postgresql (default) | sqlserver | oracle | ravendb. Cosmos DB is absent on
+/// purpose — the only Cosmos available here is the emulator, and GH-4331 is the standing lesson about
+/// quoting numbers an emulator produced.
+/// </para>
+/// </summary>
+public static class OutboxStoreLane
+{
+    public static async Task RunAsync(RigConfig cfg)
+    {
+        var store = Environment.GetEnvironmentVariable("RIG_STORE") ?? "postgresql";
+        var batchSize = cfg.StoreIncomingBatchSize > 0 ? cfg.StoreIncomingBatchSize : 100;
+        var rounds = envInt("RIG_ROUNDS", 20);
+        var warmup = envInt("RIG_WARMUP_ROUNDS", 5);
+
+        using var host = await buildHostAsync(store, cfg);
+        var messageStore = host.Services.GetRequiredService<IMessageStore>();
+        var outbox = messageStore.Outbox;
+        var admin = messageStore.Admin;
+
+        await admin.ClearAllAsync();
+
+        Console.WriteLine(
+            $"[rig] outbox-store: store={store} batch={batchSize} rounds={rounds} (+{warmup} warmup)");
+
+        var sequential = new List<double>();
+        var batched = new List<double>();
+
+        for (var round = 0; round < rounds + warmup; round++)
+        {
+            var measured = round >= warmup;
+
+            // Alternate which arm goes first so neither one systematically owns the cold cache
+            if (round % 2 == 0)
+            {
+                var a = await timeSequentialAsync(outbox, batchSize);
+                var b = await timeBatchedAsync(outbox, batchSize);
+                if (measured) { sequential.Add(a); batched.Add(b); }
+            }
+            else
+            {
+                var b = await timeBatchedAsync(outbox, batchSize);
+                var a = await timeSequentialAsync(outbox, batchSize);
+                if (measured) { sequential.Add(a); batched.Add(b); }
+            }
+
+            // Keep the table from growing across rounds; a table that gets steadily larger is a
+            // confound that would flatter whichever arm runs first
+            await admin.ClearAllAsync();
+        }
+
+        var summary = new Dictionary<string, object>
+        {
+            ["store"] = store,
+            ["batchSize"] = batchSize,
+            ["rounds"] = rounds,
+            ["sequential_ms"] = describe(sequential),
+            ["batched_ms"] = describe(batched),
+            ["speedup_at_p50"] = Math.Round(percentile(sequential, 50) / Math.Max(percentile(batched, 50), 0.0001), 2)
+        };
+
+        Directory.CreateDirectory(cfg.OutDir);
+        var json = JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(Path.Combine(cfg.OutDir, $"outbox-store-{store}.json"), json);
+        Console.WriteLine(json);
+
+        await host.StopAsync();
+    }
+
+    private static async Task<double> timeSequentialAsync(IMessageOutbox outbox, int count)
+    {
+        var envelopes = buildEnvelopes(count);
+        var start = Stopwatch.GetTimestamp();
+        foreach (var envelope in envelopes)
+        {
+            await outbox.StoreOutgoingAsync(envelope, 1);
+        }
+
+        return Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+    }
+
+    private static async Task<double> timeBatchedAsync(IMessageOutbox outbox, int count)
+    {
+        var envelopes = buildEnvelopes(count);
+        var start = Stopwatch.GetTimestamp();
+        await outbox.StoreOutgoingAsync(envelopes, 1);
+        return Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+    }
+
+    private static Envelope[] buildEnvelopes(int count)
+    {
+        var destination = new Uri("rig://outbox");
+        var envelopes = new Envelope[count];
+        for (var i = 0; i < count; i++)
+        {
+            envelopes[i] = new Envelope
+            {
+                Id = Guid.NewGuid(),
+                Destination = destination,
+                MessageType = "rig.outbox.message",
+                ContentType = "application/json",
+                Data = System.Text.Encoding.UTF8.GetBytes(Payloads.Small),
+                Status = EnvelopeStatus.Outgoing,
+                OwnerId = 1
+            };
+        }
+
+        return envelopes;
+    }
+
+    private static Task<IHost> buildHostAsync(string store, RigConfig cfg)
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning))
+            .UseWolverine(opts =>
+            {
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.ApplicationAssembly = typeof(LocalRigHandlers).Assembly;
+
+                switch (store)
+                {
+                    case "sqlserver":
+                        opts.PersistMessagesWithSqlServer(Servers.SqlServerConnectionString, cfg.PostgresSchema);
+                        break;
+
+                    case "oracle":
+                        opts.PersistMessagesWithOracle(Servers.OracleConnectionString);
+                        break;
+
+                    case "ravendb":
+                        opts.Services.AddSingleton<IDocumentStore>(_ =>
+                        {
+                            var documentStore = new DocumentStore
+                            {
+                                Urls = [Environment.GetEnvironmentVariable("RIG_RAVEN_URL") ?? "http://localhost:8080"],
+                                Database = "rig_outbox"
+                            };
+                            documentStore.Initialize();
+
+                            // RavenDB will not create the database on first use the way the SQL stores
+                            // create their schema, and Wolverine's own startup queries it immediately
+                            try
+                            {
+                                documentStore.Maintenance.Server.Send(
+                                    new CreateDatabaseOperation(new DatabaseRecord("rig_outbox")));
+                            }
+                            catch (ConcurrencyException)
+                            {
+                                // Already there
+                            }
+
+                            return documentStore;
+                        });
+                        opts.UseRavenDbPersistence();
+                        break;
+
+                    default:
+                        opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, cfg.PostgresSchema);
+                        break;
+                }
+            });
+
+        return builder.StartAsync();
+    }
+
+    private static Dictionary<string, double> describe(List<double> values)
+    {
+        return new Dictionary<string, double>
+        {
+            ["p50"] = percentile(values, 50),
+            ["p95"] = percentile(values, 95),
+            ["min"] = values.Count == 0 ? 0 : Math.Round(values.Min(), 3),
+            ["max"] = values.Count == 0 ? 0 : Math.Round(values.Max(), 3),
+            ["mean"] = values.Count == 0 ? 0 : Math.Round(values.Average(), 3)
+        };
+    }
+
+    private static double percentile(List<double> values, double p)
+    {
+        if (values.Count == 0) return 0;
+        var sorted = values.OrderBy(x => x).ToArray();
+        var index = (int)Math.Ceiling(p / 100.0 * sorted.Length) - 1;
+        return Math.Round(sorted[Math.Clamp(index, 0, sorted.Length - 1)], 3);
+    }
+
+    private static int envInt(string name, int fallback)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(raw, out var value) ? value : fallback;
+    }
+}

--- a/src/Testing/KafkaPerfRig/Program.cs
+++ b/src/Testing/KafkaPerfRig/Program.cs
@@ -83,6 +83,10 @@ switch (role)
         await WolverineRedis.RunPublisherAsync(cfg);
         break;
 
+    case "outbox-store":
+        await OutboxStoreLane.RunAsync(cfg);
+        break;
+
     case "local-queue":
         await WolverineLocalQueue.RunAsync(cfg);
         break;

--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -74,6 +74,38 @@ two worktrees.
 **+159% (2.6x)**, rounds within 0.6% of each other. The durable Redis endpoint had been paying one
 inbox-insert round trip per message.
 
+### Outbox store, per store (GH-4369) — measured 2026-09-06
+
+Role `outbox-store`, selected with `RIG_STORE`. Not an end-to-end cell on purpose: GH-4369 changes
+exactly one method on three stores, so the honest instrument is that method against the real
+database. An end-to-end cell would bury a per-store round-trip change under broker time.
+
+Each round stores a fresh batch of `RIG_STORE_BATCH` (default 100) envelopes twice — once as N calls
+to the single-envelope overload (the pre-GH-4369 shape, and still the default-interface behaviour for
+any store that does not override the batch), once as one call to the batch overload. **The two arms
+alternate order round to round** so neither systematically owns the cold cache, each arm builds its
+own envelopes so neither is re-writing rows the other wrote, and the outgoing table is cleared
+between rounds so a steadily growing table cannot flatter whichever arm runs first. 20 rounds after
+5 warmup rounds.
+
+| store | sequential p50 | batched p50 | speedup |
+|---|---|---|---|
+| PostgreSQL — the control, batched since GH-4319 | 57.30ms | 2.46ms | **23.3x** |
+| Oracle — new `INSERT ALL` | 49.75ms | 3.81ms | **13.1x** |
+| RavenDB — new one-session batch | 348.81ms | 5.69ms | **61.4x** |
+
+PostgreSQL is in the table as a **control, not a result**: it already had the batch override, so it
+says the harness measures what it claims to. RavenDB is the largest because the un-batched path
+opened its own `IAsyncDocumentSession` — and therefore its own HTTP round trip — per envelope.
+
+**Cosmos DB is deliberately absent.** The only Cosmos here is the emulator, and GH-4331 above is the
+standing lesson about quoting a number an emulator produced. Its `TransactionalBatch` implementation
+is verified by the shared `MessageStoreCompliance` suite; it is not given a throughput claim.
+
+Watch the machine before trusting a round here. These runs had eight orphaned Cosmos emulator
+containers resident, which is visible in the p95 spread (PostgreSQL sequential p95 319ms against a
+57ms p50) even though the p50 gap is far too large to be noise.
+
 ### Durable local queue (GH-4319) — measured 2026-09-06
 
 The only lane with no broker in it: one process publishes into a durable local queue backed by

--- a/src/Testing/Wolverine.ComplianceTests/MessageStoreCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/MessageStoreCompliance.cs
@@ -209,6 +209,64 @@ public abstract class MessageStoreCompliance : IAsyncLifetime
         stored.SentAt.ShouldBe(envelope.SentAt);
     }
 
+    /// <summary>
+    /// GH-4319 added StoreOutgoingAsync(IReadOnlyList&lt;Envelope&gt;, int) as a DEFAULT interface
+    /// method, so a store that overrides it and a store that does not must be indistinguishable from
+    /// the outside. GH-4369 then gave Oracle, RavenDB and Cosmos DB real batch implementations. This
+    /// test is what holds them to the single-envelope path's behaviour -- every store runs it,
+    /// overridden or not.
+    /// </summary>
+    [Fact]
+    public async Task store_a_batch_of_outgoing_envelopes()
+    {
+        var envelopes = new List<Envelope>();
+        for (var i = 0; i < 10; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.Status = EnvelopeStatus.Outgoing;
+            envelope.SentAt = ((DateTimeOffset)DateTime.Today).ToUniversalTime();
+            envelopes.Add(envelope);
+        }
+
+        await thePersistence.Outbox.StoreOutgoingAsync(envelopes, 5890);
+
+        var stored = (await thePersistence.Admin.AllOutgoingAsync()).ToArray();
+
+        stored.Length.ShouldBe(envelopes.Count);
+        stored.Select(x => x.Id).OrderBy(x => x).ShouldBe(envelopes.Select(x => x.Id).OrderBy(x => x));
+        stored.ShouldAllBe(x => x.OwnerId == 5890);
+    }
+
+    /// <summary>
+    /// The batch has to be a fast path, never a different path. A caller that hands over one envelope
+    /// gets exactly what the single-envelope overload would have written -- this is also the shape a
+    /// coalescer produces constantly, since a lone write never waits for company.
+    /// </summary>
+    [Fact]
+    public async Task store_a_batch_of_one_outgoing_envelope()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Outgoing;
+        envelope.SentAt = ((DateTimeOffset)DateTime.Today).ToUniversalTime();
+
+        await thePersistence.Outbox.StoreOutgoingAsync(new[] { envelope }, 5890);
+
+        var stored = (await thePersistence.Admin.AllOutgoingAsync()).Single();
+
+        stored.Id.ShouldBe(envelope.Id);
+        stored.OwnerId.ShouldBe(5890);
+        stored.Status.ShouldBe(envelope.Status);
+        stored.SentAt.ShouldBe(envelope.SentAt);
+    }
+
+    [Fact]
+    public async Task store_an_empty_batch_of_outgoing_envelopes_is_a_no_op()
+    {
+        await thePersistence.Outbox.StoreOutgoingAsync(Array.Empty<Envelope>(), 5890);
+
+        (await thePersistence.Admin.AllOutgoingAsync()).ShouldBeEmpty();
+    }
+
     [Fact]
     public async Task mark_envelope_as_handled()
     {


### PR DESCRIPTION
Closes #4369.

#4368 added `StoreOutgoingAsync(IReadOnlyList<Envelope>, int)` as a default interface method whose default stores one at a time. These three stores were left on that default. They are now batched.

## Measured

New rig role `outbox-store`, selected with `RIG_STORE`. Deliberately **not** an end-to-end cell: this changes exactly one method on three stores, so the honest instrument is that method against the real database — an end-to-end cell would bury a per-store round-trip change under broker time.

Each round stores a fresh batch of 100 envelopes twice, once per arm, with the **arm order alternating** round to round, separate envelopes per arm, and the outgoing table cleared between rounds. 20 rounds after 5 warmup.

| store | sequential p50 | batched p50 | speedup |
|---|---|---|---|
| PostgreSQL — control, already batched | 57.30ms | 2.46ms | **23.3x** |
| Oracle — new `INSERT ALL` | 49.75ms | 3.81ms | **13.1x** |
| RavenDB — new one-session batch | 348.81ms | 5.69ms | **61.4x** |

PostgreSQL is in the table as a **control, not a result**: it already had the override, so it says the harness measures what it claims to. RavenDB is the largest because the un-batched path opened its own `IAsyncDocumentSession` — and therefore its own HTTP round trip — per envelope.

**Cosmos DB is deliberately unmeasured and gets no throughput claim.** The only Cosmos available here is the emulator, and GH-4331 is the standing lesson about quoting an emulator's numbers. Its implementation is held by the compliance suite instead.

## Per store

**Oracle** — one `INSERT ALL`, not array binding, which does not carry a BLOB bind as cleanly and turns a duplicate into a partial apply that has to be unpicked. One statement means `ORA-00001` fails the whole batch and writes nothing, which is the right shape: the caller's coalescer then stores each envelope alone, where the existing `ORA-00001` swallow makes the duplicate idempotent exactly as before. The batch is a fast path, never the only path.

**RavenDB** — one session, one `SaveChangesAsync`, which RavenDB sends as a single batch command. Precisely the shape `DeleteOutgoingAsync(Envelope[])` has always had.

**Cosmos DB** — `TransactionalBatch`, grouped by partition key rather than assuming one. In practice a coalesced batch comes from a single `DurableSendingAgent` and therefore a single destination, which *is* the partition key — but "in practice" is not a constraint the storage layer gets to rely on. **Both** Cosmos limits are enforced up front rather than discovered as a 413 at runtime: 100 operations, and a byte budget under the 2MB cap — the latter being the binding one, since an `Envelope` body can be 100KB and a full batch of 100 would be 10MB.

## Correctness

Three new tests in the shared `MessageStoreCompliance` suite, so **every** store runs them — overridden or not, which is exactly what a default interface method requires. Green on all seven:

| store | result |
|---|---|
| PostgreSQL | 28/28 |
| SQL Server | 21/21 |
| MySQL | 15/15 |
| SQLite | 14/14 |
| Oracle | 15/15 |
| RavenDB | 14/14 |
| Cosmos DB (real emulator) | 7/7 |

Full `wolverine.slnx -c Release -f net9.0` clean, 0 warnings.

## One thing left deliberately alone

Oracle does **not** stamp `WasPersistedInOutbox` on the new batch path. Neither Oracle store path has ever set it — while `OracleQueueSender` reads it to decide whether to skip a store — so setting it on the batch path alone would make batched and unbatched sends differ on a flag that gates a write. Whether Oracle should set it at all is a real question and a separate one, so it is flagged rather than fixed in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)