### PR TITLE
GH-4371: Oracle stamps WasPersistedInOutbox, so its move path is reachable

### DIFF
--- a/src/Persistence/Oracle/OracleTests/Transport/outgoing_move_path_4371.cs
+++ b/src/Persistence/Oracle/OracleTests/Transport/outgoing_move_path_4371.cs
@@ -1,0 +1,132 @@
+using IntegrationTests;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Oracle;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Configuration;
+using Wolverine.Oracle;
+using Wolverine.Oracle.Transport;
+using Wolverine.Persistence.Durability;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace OracleTests.Transport;
+
+/// <summary>
+/// GH-4371. <see cref="OracleQueueSender.SendAsync(Envelope)" /> branches on
+/// <c>envelope.WasPersistedInOutbox</c>: when the row is already in the outgoing table it MOVES it
+/// into the queue table -- one transaction, insert and delete together -- and otherwise it writes
+/// straight to the queue table and leaves the outgoing row to be deleted separately afterwards.
+///
+/// <para>
+/// No Oracle store path ever set that flag, so the move branch was unreachable and every durable
+/// send took the two-step route: insert into the queue table, then delete from outgoing under a
+/// separate connection. A crash between those two leaves the message in the queue AND in outgoing,
+/// where the durability agent recovers it and sends it a second time. Every
+/// <c>MessageDatabase&lt;T&gt;</c> store (PostgreSQL, SQL Server, MySQL, SQLite) has always stamped
+/// the flag; Oracle alone did not.
+/// </para>
+/// </summary>
+[Collection("oracle")]
+public class outgoing_move_path_4371 : IAsyncLifetime
+{
+    private IHost theHost = null!;
+    private OracleTransport theTransport = null!;
+    private OracleQueue theQueue = null!;
+    private IMessageStore theMessageStore = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithOracle(Servers.OracleConnectionString, "WOLVERINE")
+                    .EnableMessageTransport();
+                opts.ListenToOracleQueue("gh4371");
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync();
+
+        theTransport = theHost.GetRuntime().Options.Transports.GetOrCreate<OracleTransport>();
+        theQueue = theTransport.Queues["gh4371"];
+        theMessageStore = theHost.GetRuntime().Storage;
+
+        await theQueue.PurgeAsync(NullLogger.Instance);
+        await theMessageStore.Admin.ClearAllAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private static Envelope outgoing()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Status = EnvelopeStatus.Outgoing;
+        envelope.WasPersistedInOutbox.ShouldBeFalse("precondition: a fresh envelope has not been stored");
+        return envelope;
+    }
+
+    /// <summary>
+    /// The flag is what the sender branches on, so the store has to set it. This is the whole defect
+    /// in one assertion.
+    /// </summary>
+    [Fact]
+    public async Task storing_one_outgoing_envelope_marks_it_as_persisted()
+    {
+        var envelope = outgoing();
+
+        await theMessageStore.Outbox.StoreOutgoingAsync(envelope, 1);
+
+        envelope.WasPersistedInOutbox.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// GH-4369 added the batched overload; it has to stamp the flag for the same reason, or a
+    /// coalesced send silently drops back to the two-step route that a single send now avoids.
+    /// </summary>
+    [Fact]
+    public async Task storing_a_batch_of_outgoing_envelopes_marks_them_all_as_persisted()
+    {
+        var envelopes = Enumerable.Range(0, 5).Select(_ => outgoing()).ToArray();
+
+        await theMessageStore.Outbox.StoreOutgoingAsync(envelopes, 1);
+
+        envelopes.ShouldAllBe(x => x.WasPersistedInOutbox);
+    }
+
+    /// <summary>
+    /// The behaviour the flag buys, end to end: a durable send of an already-stored envelope leaves
+    /// the queue row present and the outgoing row GONE, because one transaction did both. Before the
+    /// fix the outgoing row survived the send and waited on a separate DELETE.
+    /// </summary>
+    [Fact]
+    public async Task a_durable_send_moves_the_row_out_of_outgoing()
+    {
+        theQueue.Mode = EndpointMode.Durable;
+
+        var envelope = outgoing();
+        envelope.Destination = theQueue.Uri;
+
+        await theMessageStore.Outbox.StoreOutgoingAsync(envelope, 1);
+        (await theMessageStore.Admin.AllOutgoingAsync()).Count.ShouldBe(1);
+
+        var sender = new OracleQueueSender(theQueue, theQueue.DataSource, null);
+
+        // The no-token overload deliberately: it is the one that branches on WasPersistedInOutbox.
+        // SendAsync(envelope, token) is the "write directly to the queue table" arm underneath it, so
+        // calling that instead would test the wrong half of the very branch this test is about.
+#pragma warning disable xUnit1051
+        await sender.SendAsync(envelope);
+#pragma warning restore xUnit1051
+
+        (await theQueue.CountAsync()).ShouldBe(1);
+        (await theMessageStore.Admin.AllOutgoingAsync())
+            .ShouldBeEmpty("the send should have moved the row, not copied it");
+    }
+}

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Outgoing.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleMessageStore.Outgoing.cs
@@ -48,12 +48,21 @@ internal partial class OracleMessageStore
         }
         catch (OracleException e) when (e.Number == 1)
         {
-            // Idempotent
+            // Idempotent -- the row is in the outgoing table either way, which is what the flag below
+            // reports, so a duplicate insert still counts as persisted
         }
         finally
         {
             await conn.CloseAsync();
         }
+
+        // GH-4371. OracleQueueSender.SendAsync branches on this to decide between MOVING the row from
+        // outgoing into the queue table in one transaction and writing the queue row separately. Oracle
+        // never set it, so the move branch was unreachable and every durable send took the two-step
+        // route -- where a crash between the queue insert and the outgoing delete leaves the message in
+        // both, and the durability agent sends it again. Every MessageDatabase<T> store has always set
+        // this; Oracle alone did not.
+        envelope.WasPersistedInOutbox = true;
     }
 
     /// <summary>
@@ -118,11 +127,13 @@ internal partial class OracleMessageStore
             await conn.CloseAsync();
         }
 
-        // Deliberately NOT stamping WasPersistedInOutbox here. Neither Oracle store path has ever set
-        // it -- while OracleQueueSender reads it to decide whether to skip a store -- so setting it on
-        // the batch path alone would make batched and unbatched sends behave differently on a flag
-        // that gates a write. Whether Oracle should set it at all is a real question, and a separate
-        // one from this round-trip change. Filed rather than fixed in passing.
+        // GH-4371 settled the question this deliberately left open: Oracle does stamp the flag, on
+        // every store path, exactly as MessageDatabase<T> does. A coalesced send has to reach the same
+        // move branch a single send reaches.
+        foreach (var envelope in envelopes)
+        {
+            envelope.WasPersistedInOutbox = true;
+        }
     }
 
     public async Task DeleteOutgoingAsync(Envelope[] envelopes)
@@ -209,6 +220,10 @@ internal partial class OracleMessageStore
             {
                 // Idempotent
             }
+
+            // GH-4371, same reasoning as the connection-owning overload above, and the same place
+            // MessageDatabase<T>.StoreOutgoingAsync(DbTransaction, Envelope[]) sets it
+            envelope.WasPersistedInOutbox = true;
         }
     }
 }

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.Outbox.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.Outbox.cs
@@ -39,6 +39,12 @@ public partial class CosmosDbMessageStore : IMessageOutbox
         };
 
         await _container.UpsertItemAsync(outgoing, new PartitionKey(outgoing.PartitionKey));
+
+        // GH-4371. Nothing on Cosmos DB reads this today -- there is no Cosmos queue transport -- but
+        // the flag means "this envelope is in the outbox", and a store that has written the row and
+        // reports otherwise is wrong. Oracle carried exactly that lie until its queue sender's move
+        // branch turned out to have been unreachable for its whole life.
+        envelope.WasPersistedInOutbox = true;
     }
 
     // Azure Cosmos DB's own limits on a TransactionalBatch: at most 100 operations, and 2MB of
@@ -107,6 +113,11 @@ public partial class CosmosDbMessageStore : IMessageOutbox
                         response.StatusCode, 0, response.ActivityId, response.RequestCharge);
                 }
             }
+        }
+
+        foreach (var envelope in envelopes)
+        {
+            envelope.WasPersistedInOutbox = true;
         }
     }
 

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Outbox.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.Outbox.cs
@@ -28,6 +28,12 @@ public partial class RavenDbMessageStore : IMessageOutbox
         
         await session.StoreAsync(outgoing);
         await session.SaveChangesAsync();
+
+        // GH-4371. Nothing on RavenDB reads this today -- there is no RavenDB queue transport -- but
+        // the flag means "this envelope is in the outbox", and a store that has written the row and
+        // reports otherwise is wrong. Oracle carried exactly that lie until its queue sender's move
+        // branch turned out to have been unreachable for its whole life.
+        envelope.WasPersistedInOutbox = true;
     }
 
     /// <summary>
@@ -49,6 +55,11 @@ public partial class RavenDbMessageStore : IMessageOutbox
         }
 
         await session.SaveChangesAsync();
+
+        foreach (var envelope in envelopes)
+        {
+            envelope.WasPersistedInOutbox = true;
+        }
     }
 
     public async Task DeleteOutgoingAsync(Envelope[] envelopes)

--- a/src/Testing/Wolverine.ComplianceTests/MessageStoreCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/MessageStoreCompliance.cs
@@ -259,6 +259,38 @@ public abstract class MessageStoreCompliance : IAsyncLifetime
         stored.SentAt.ShouldBe(envelope.SentAt);
     }
 
+    /// <summary>
+    /// GH-4371. <c>WasPersistedInOutbox</c> is not decoration: the database-queue senders
+    /// (PostgreSQL, SQL Server, MySQL, SQLite, Oracle) branch on it to decide between MOVING the row
+    /// from outgoing into the queue table in one transaction and writing the queue row separately and
+    /// deleting outgoing afterwards. Oracle never set it, so its move branch was unreachable for as
+    /// long as it existed -- and nothing in the suite noticed, because nothing held the stores to the
+    /// contract. This is that check. Every store runs it, including the ones with no queue transport
+    /// today: a store that has written the row and reports otherwise is simply wrong, and the next
+    /// queue transport should not have to rediscover that.
+    /// </summary>
+    [Fact]
+    public async Task storing_outgoing_envelopes_marks_them_as_persisted_in_the_outbox()
+    {
+        var single = ObjectMother.Envelope();
+        single.Status = EnvelopeStatus.Outgoing;
+        single.WasPersistedInOutbox.ShouldBeFalse("precondition: a fresh envelope has not been stored");
+
+        await thePersistence.Outbox.StoreOutgoingAsync(single, 111);
+        single.WasPersistedInOutbox.ShouldBeTrue();
+
+        var batch = new List<Envelope>();
+        for (var i = 0; i < 3; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.Status = EnvelopeStatus.Outgoing;
+            batch.Add(envelope);
+        }
+
+        await thePersistence.Outbox.StoreOutgoingAsync(batch, 111);
+        batch.ShouldAllBe(x => x.WasPersistedInOutbox);
+    }
+
     [Fact]
     public async Task store_an_empty_batch_of_outgoing_envelopes_is_a_no_op()
     {


### PR DESCRIPTION
Closes #4371.

`OracleQueueSender.SendAsync` branches on `envelope.WasPersistedInOutbox`:

```csharp
if (_queue.Mode == EndpointMode.Durable && envelope.WasPersistedInOutbox)
{
    await MoveFromOutgoingToQueueAsync(envelope, CancellationToken.None);   // one transaction
}
else
{
    await SendAsync(envelope, CancellationToken.None);                       // write queue row only
}
```

**No Oracle store path ever set that flag**, so the move branch was unreachable for its entire life. Every durable Oracle queue send took the two-step route instead: insert the queue row on one connection, then delete the outgoing row on another. A crash between those two leaves the message in **both** tables, where the durability agent recovers the outgoing row and sends it a second time — the duplicate `MoveFromOutgoingToQueueAsync` exists to prevent.

Every `MessageDatabase<T>` store — PostgreSQL, SQL Server, MySQL, SQLite — has always stamped the flag, and all four of their queue senders read it. Oracle alone did not.

## Reproduced before fixing

`outgoing_move_path_4371` fails three ways on the old code and passes on the new:

| assertion | before |
|---|---|
| flag is true after a single store | **false** |
| flag is true after a batched store | **false** |
| the durable send left the outgoing table empty | **"should be empty but had"** |

The third is the one that matters — it proves the move branch was never taken.

## The durable fix is a compliance test, not an Oracle test

This survived because **nothing held the stores to the contract**. So the check went into the shared suite: `storing_outgoing_envelopes_marks_them_as_persisted_in_the_outbox` runs for **every** store, single and batched.

RavenDB and Cosmos DB now stamp it too. Neither has a queue transport reading it today, but the flag means "this envelope is in the outbox" — a store that has written the row and reports otherwise is simply wrong, and the next queue transport shouldn't have to rediscover that the hard way.

Oracle stamps on all three of its store paths: the connection-owning overload, the transactional one, and the batched one added by #4370.

## Verification

- `OracleTests` — **182/182**, exercising the move path for the first time
- new outbox compliance, green on **all seven stores**: PostgreSQL 32, SQL Server 24, MySQL 17, SQLite 16, Oracle 19, RavenDB 16, Cosmos DB 8 (real emulator)
- `./build.sh PersistenceTests` — **113/113**, 0 retries
- Full `wolverine.slnx -c Release -f net9.0` — clean, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)