### PR TITLE
GH-4333: pooled Envelope body above the LOH threshold, additive

### DIFF
--- a/src/Extensions/Wolverine.MemoryPack/Internal/MemoryPackMessageSerializer.cs
+++ b/src/Extensions/Wolverine.MemoryPack/Internal/MemoryPackMessageSerializer.cs
@@ -36,6 +36,8 @@ internal class MemoryPackMessageSerializer : IMessageSerializer
 
     public object ReadFromData(Type messageType, Envelope envelope)
     {
-        return MemoryPackSerializer.Deserialize(messageType, envelope.Data, _options)!;
+        // GH-4333: MemoryPack reads a span natively, so there is no reason to make a pooled
+        // payload materialize an array first
+        return MemoryPackSerializer.Deserialize(messageType, envelope.Body.Span, _options)!;
     }
 }

--- a/src/Extensions/Wolverine.MessagePack/Internal/MessagePackMessageSerializer.cs
+++ b/src/Extensions/Wolverine.MessagePack/Internal/MessagePackMessageSerializer.cs
@@ -33,6 +33,8 @@ internal class MessagePackMessageSerializer : IMessageSerializer
 
     public object ReadFromData(Type messageType, Envelope envelope)
     {
-        return MessagePackSerializer.Deserialize(messageType, envelope.Data, _options)!;
+        // GH-4333: MessagePack reads ReadOnlyMemory natively, so there is no reason to make a pooled
+        // payload materialize an array first
+        return MessagePackSerializer.Deserialize(messageType, envelope.Body, _options)!;
     }
 }

--- a/src/Extensions/Wolverine.Newtonsoft/NewtonsoftSerializer.cs
+++ b/src/Extensions/Wolverine.Newtonsoft/NewtonsoftSerializer.cs
@@ -37,10 +37,12 @@ public class NewtonsoftSerializer : IMessageSerializer
 
     public object ReadFromData(Type messageType, Envelope envelope)
     {
-        using var stream = new MemoryStream(envelope.Data!)
-        {
-            Position = 0
-        };
+        // GH-4333: read straight out of the body rather than through Data, which on a pooled payload
+        // would materialize the whole thing into an array purely to wrap it in a stream
+        var body = envelope.Body;
+        using var stream = System.Runtime.InteropServices.MemoryMarshal.TryGetArray(body, out var segment)
+            ? new MemoryStream(segment.Array!, segment.Offset, segment.Count, writable: false)
+            : new MemoryStream(body.ToArray());
 
         using var streamReader = new StreamReader(stream, Encoding.UTF8, true, _bufferSize, true);
         using var jsonReader = new JsonTextReader(streamReader)

--- a/src/Testing/Benchmarks/PayloadCopyBenchmarks.cs
+++ b/src/Testing/Benchmarks/PayloadCopyBenchmarks.cs
@@ -130,4 +130,71 @@ public class PayloadCopyBenchmarks
     {
         return EnvelopeSerializer.Serialize(_emptyBodied);
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GH-4333 AS SHIPPED — MEASURED (net9.0 --job short --inProcess):
+    //
+    //   size    before (Data=ToArray)      after (CopyBodyFrom+Body)   legacy reader (Data)
+    //    1 KB     110 ns / 1,584 B           116 ns / 1,584 B            119 ns / 1,584 B
+    //   12 KB     649 ns / 12,848 B          685 ns / 12,848 B           811 ns / 12,848 B
+    //  100 KB  13,464 ns / 102,974 B         999 ns /   536 B         18,658 ns / 102,974 B
+    //                Gen0/1/2 3.30 each      no Gen1/Gen2                Gen0/1/2 3.30 each
+    //
+    // At 100 KB: 13.5x faster, allocation down to 0.5%, and the Gen1/Gen2 collections are GONE --
+    // that is the large-object heap being escaped, which is the entire point of the gate.
+    //
+    // Below the gate the two arms allocate byte-for-byte the same, because they ARE the same code:
+    // CopyBodyFrom under Envelope.PooledBodyThreshold is body.ToArray(). The small time difference
+    // there is the after-arm also calling Reset(), which the before-arm does not.
+    //
+    // The third column is the honest cost of the escape hatch. A caller that reads Data on a pooled
+    // envelope pays rent + copy + materialize instead of one copy -- 38% slower at 100 KB. That is why
+    // every first-party read path (EnvelopeSerializer, System.Text.Json, Newtonsoft, MessagePack,
+    // MemoryPack) was moved onto Body: a custom IMessageSerializer taking byte[] is the only shape
+    // that still lands in that column, and only above 85 KB.
+    // ───────────────────────────────────────────────────────────────────────── The two above are the isolated primitives; these are the real receive path
+    // through Envelope, which is what actually runs. The gate at Envelope.PooledBodyThreshold (85,000
+    // bytes, the LOH boundary) is the point: at 1 KB and 12 KB these two arms must be the same code,
+    // and at 100 KB the pooled arm must stop allocating.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The pre-GH-4333 receive path: assign a fresh array to Envelope.Data.
+    /// </summary>
+    [Benchmark(Description = "Envelope receive: Data = ToArray (before)")]
+    public int EnvelopeReceiveBefore()
+    {
+        var envelope = new Envelope { Data = _brokerBuffer.AsSpan().ToArray() };
+        return envelope.Data!.Length;
+    }
+
+    /// <summary>
+    /// The shipped receive path: CopyBodyFrom, then read the payload through Body the way the durable
+    /// insert and the JSON deserializer now do. Reset returns the rental, which is what the runtime
+    /// does when the envelope is finished.
+    /// </summary>
+    [Benchmark(Description = "Envelope receive: CopyBodyFrom + Body (after)")]
+    public int EnvelopeReceiveAfter()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(_brokerBuffer);
+        var length = envelope.Body.Length;
+        envelope.Reset();
+        return length;
+    }
+
+    /// <summary>
+    /// The escape hatch's cost. A caller that reads Data on a pooled envelope pays the materializing
+    /// copy -- which is exactly what it paid before GH-4333, so legacy code cannot regress, only fail
+    /// to improve. Worth measuring so that claim is a number rather than an assurance.
+    /// </summary>
+    [Benchmark(Description = "Envelope receive: CopyBodyFrom + Data (legacy reader)")]
+    public int EnvelopeReceiveMaterialized()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(_brokerBuffer);
+        var length = envelope.Data!.Length;
+        envelope.Reset();
+        return length;
+    }
 }

--- a/src/Testing/CoreTests/Runtime/pooled_envelope_body_4333.cs
+++ b/src/Testing/CoreTests/Runtime/pooled_envelope_body_4333.cs
@@ -1,0 +1,221 @@
+using System.Buffers;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime.Serialization;
+using Xunit;
+
+namespace CoreTests.Runtime;
+
+public record PooledBodyMessage(string Name);
+
+/// <summary>
+/// GH-4333. A large payload is copied into a pooled array on the receive path instead of a fresh
+/// large-object-heap allocation. The copy was never optional -- a broker client's buffer dies with
+/// its callback -- so what changes is where the bytes land and who owns them.
+///
+/// <para>
+/// The rules that make this safe are all about lifetime, so they are what this file tests:
+/// <c>Data</c> hands back an INDEPENDENT array that survives the buffer going home, <c>Body</c> does
+/// not copy, and the buffer is only ever returned at <c>Reset</c>. Never returning is a missed
+/// optimization; returning early hands a live buffer to the next renter, so every rule here is
+/// biased towards holding on.
+/// </para>
+/// </summary>
+public class pooled_envelope_body_4333
+{
+    private static byte[] payload(int size)
+    {
+        var bytes = new byte[size];
+        Random.Shared.NextBytes(bytes);
+        return bytes;
+    }
+
+    private static readonly int Small = Envelope.PooledBodyThreshold - 1;
+    private static readonly int Large = Envelope.PooledBodyThreshold;
+
+    [Fact]
+    public void a_small_payload_is_not_pooled_and_behaves_exactly_as_before()
+    {
+        var bytes = payload(Small);
+        var envelope = new Envelope();
+
+        envelope.CopyBodyFrom(bytes);
+
+        // Below the gate the envelope holds a plain array, which is the shape every existing caller
+        // has always seen -- Data does not have to materialize anything
+        envelope.Data.ShouldBe(bytes);
+        envelope.Body.ToArray().ShouldBe(bytes);
+        envelope.Data.ShouldBeSameAs(envelope.Data);
+    }
+
+    [Fact]
+    public void a_large_payload_round_trips_through_the_pooled_path()
+    {
+        var bytes = payload(Large);
+        var envelope = new Envelope();
+
+        envelope.CopyBodyFrom(bytes);
+
+        envelope.Body.Length.ShouldBe(bytes.Length);
+        envelope.Body.ToArray().ShouldBe(bytes);
+        envelope.Data.ShouldBe(bytes);
+    }
+
+    /// <summary>
+    /// The whole point of the pooled path: reading the body does not copy it.
+    /// </summary>
+    [Fact]
+    public void body_does_not_copy()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        var first = envelope.Body;
+        var second = envelope.Body;
+
+        first.Span.Overlaps(second.Span).ShouldBeTrue("Body handed back two different buffers");
+    }
+
+    /// <summary>
+    /// The safety rule that lets the buffer go back at all. A caller who reads Data is allowed to
+    /// stash the result, so it must not be an array the pool can hand to somebody else.
+    /// </summary>
+    [Fact]
+    public void data_materializes_an_array_that_outlives_the_pooled_buffer()
+    {
+        var bytes = payload(Large);
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(bytes);
+
+        var stashed = envelope.Data!;
+
+        // The runtime decides this envelope is finished; the rental goes home
+        envelope.Reset();
+
+        stashed.ShouldBe(bytes, "the array handed out by Data was the pooled buffer, not a copy of it");
+    }
+
+    [Fact]
+    public void data_materializes_only_once()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        envelope.Data.ShouldBeSameAs(envelope.Data);
+    }
+
+    [Fact]
+    public void reset_clears_the_body()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        envelope.Reset();
+
+        // Deliberately not asserting on Body here: after Reset there is no payload AND no message, and
+        // Body falls through to Data, which serializes on demand and therefore throws when there is
+        // nothing to serialize -- exactly as Data has always done. MessagePayloadSize answers the
+        // question this test is actually asking without tripping that path.
+        envelope.MessagePayloadSize.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Body is NOT a plain field read: with no payload yet it falls through to Data, which serializes
+    /// the message on demand. That behaviour is load-bearing -- EnvelopeSerializer writes from Body, so
+    /// if Body reported "empty" for an unserialized message every persisted envelope would carry an
+    /// empty payload.
+    /// </summary>
+    [Fact]
+    public void body_serializes_an_unserialized_message_on_demand_exactly_as_data_does()
+    {
+        var envelope = new Envelope(new PooledBodyMessage("hello"))
+        {
+            Serializer = new SystemTextJsonSerializer(new System.Text.Json.JsonSerializerOptions())
+        };
+
+        var fromBody = envelope.Body.ToArray();
+
+        fromBody.ShouldNotBeEmpty();
+        fromBody.ShouldBe(envelope.Data!);
+    }
+
+    /// <summary>
+    /// Reset returns the rental, so calling it twice must not return the same buffer twice -- a
+    /// double-return corrupts the pool for every later renter.
+    /// </summary>
+    [Fact]
+    public void reset_is_idempotent()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        envelope.Reset();
+        Should.NotThrow(() => envelope.Reset());
+    }
+
+    /// <summary>
+    /// Assigning Data replaces the payload outright, so the rental it replaces has to go back rather
+    /// than be silently dropped.
+    /// </summary>
+    [Fact]
+    public void assigning_data_over_a_pooled_body_releases_the_rental()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        var replacement = payload(16);
+        envelope.Data = replacement;
+
+        envelope.Data.ShouldBeSameAs(replacement);
+        envelope.Body.ToArray().ShouldBe(replacement);
+        Should.NotThrow(() => envelope.Reset());
+    }
+
+    [Fact]
+    public void copying_a_second_body_releases_the_first_rental()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        var second = payload(Large);
+        envelope.CopyBodyFrom(second);
+
+        envelope.Body.ToArray().ShouldBe(second);
+        Should.NotThrow(() => envelope.Reset());
+    }
+
+    [Fact]
+    public void message_payload_size_does_not_force_a_materialization()
+    {
+        var envelope = new Envelope();
+        envelope.CopyBodyFrom(payload(Large));
+
+        envelope.MessagePayloadSize.ShouldBe(Large);
+    }
+
+    /// <summary>
+    /// The persisted-envelope path reads the body rather than Data, so a pooled payload survives a
+    /// durable round trip without ever being materialized on the way out.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void envelope_serializer_round_trips_a_pooled_body(bool large)
+    {
+        var bytes = payload(large ? Large : Small);
+
+        var envelope = new Envelope
+        {
+            Id = Guid.NewGuid(),
+            MessageType = "some.message",
+            ContentType = "application/json",
+            Destination = new Uri("rabbitmq://queue/incoming")
+        };
+        envelope.CopyBodyFrom(bytes);
+
+        var serialized = EnvelopeSerializer.Serialize(envelope);
+        var read = EnvelopeSerializer.Deserialize(serialized);
+
+        read.Data.ShouldBe(bytes);
+    }
+}

--- a/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
+++ b/src/Transports/Azure/Wolverine.AzureServiceBus/Internal/AzureServiceBusEnvelopeMapper.cs
@@ -24,7 +24,11 @@ public class AzureServiceBusEnvelopeMapper : EnvelopeMapper<ServiceBusReceivedMe
     {
         MapProperty(x => x.ContentType!, (e, m) => e.ContentType = m.ContentType,
             (e, m) => m.ContentType = e.ContentType);
-        MapProperty(x => x.Data!, (e, m) => e.Data = m.Body.ToArray(), (e, m) => m.Body = new BinaryData(e.Data!));
+        // GH-4333: CopyBodyFrom on the way in so a large payload lands in a pooled buffer rather than on
+        // the LOH. The outgoing direction still needs a real array for BinaryData, and reading Data there
+        // materializes one exactly as before.
+        MapProperty(x => x.Data!, (e, m) => e.CopyBodyFrom(m.Body.ToMemory().Span),
+            (e, m) => m.Body = new BinaryData(e.Data!));
         MapProperty(x => x.Id, (e, m) =>
         {
             if (Guid.TryParse(m.MessageId, out var id))

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/WorkerQueueMessageConsumer.cs
@@ -165,7 +165,11 @@ internal class WorkerQueueMessageConsumer : AsyncDefaultBasicConsumer, IDisposab
 
         try
         {
-            envelope.Data = body.ToArray();
+            // GH-4333. The copy itself is not optional -- the RabbitMQ client's buffer is only valid for
+            // the duration of this callback -- but above Envelope.PooledBodyThreshold it lands in a
+            // pooled array instead of a fresh LOH allocation. Below the threshold this is byte-for-byte
+            // the ToArray() it replaces.
+            envelope.CopyBodyFrom(body.Span);
             _mapper.MapIncomingToEnvelope(envelope, properties);
 
             // GH-4012 item 4. Read AFTER the mapper so a custom envelope mapper cannot clear it -- this is

--- a/src/Wolverine/AssemblyAttributes.cs
+++ b/src/Wolverine/AssemblyAttributes.cs
@@ -12,6 +12,8 @@ using Wolverine.Attributes;
 [assembly: InternalsVisibleTo("MessageRoutingTests")]
 [assembly: InternalsVisibleTo("Wolverine.CritterWatch")]
 [assembly: InternalsVisibleTo("DataGenerator")]
+// GH-4333: the payload benchmarks measure the pooled receive path, which ends at Envelope.Reset()
+[assembly: InternalsVisibleTo("Benchmarks")]
 [assembly: InternalsVisibleTo("DiagnosticsTests")]
 [assembly: InternalsVisibleTo("PolicyTests")]
 [assembly: InternalsVisibleTo("CircuitBreakingTests")]

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -540,6 +540,10 @@ public partial class Envelope
     internal void Reset()
     {
         // Private backing fields (Envelope.cs)
+        // GH-4333: hand any pooled payload buffer back BEFORE dropping the reference to it. Reset is
+        // the one point the runtime has already decided this envelope is finished with -- the same
+        // decision that makes re-pooling the envelope itself safe.
+        releasePooledBody();
         _data = null;
         _deliverBy = null;
         _deliverWithin = null;

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Buffers;
+using System.Diagnostics;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.MultiTenancy;
@@ -16,6 +17,13 @@ public partial class Envelope : IHasTenantId
 {
     public static readonly string PingMessageType = "wolverine-ping";
     private byte[]? _data;
+
+    // GH-4333. Non-null only when a payload arrived over the pooled path, i.e. was at least
+    // PooledBodyThreshold bytes. _data and _pooledBody are never both meaningful: reading Data while
+    // this is set materializes an INDEPENDENT array into _data and leaves the rental in place, so a
+    // caller that stashed Data keeps working after the buffer goes back to the pool.
+    private byte[]? _pooledBody;
+    private int _pooledLength;
     private DateTimeOffset? _deliverBy;
 
     private TimeSpan? _deliverWithin;
@@ -162,6 +170,7 @@ public partial class Envelope : IHasTenantId
         {
             try
             {
+                releasePooledBody();
                 _data = await asyncMessaeSerializer.WriteAsync(this);
             }
             catch (Exception e)
@@ -183,6 +192,15 @@ public partial class Envelope : IHasTenantId
         {
             if (_data != null)
             {
+                return _data;
+            }
+
+            if (_pooledBody != null)
+            {
+                // GH-4333. Materialize ONCE into an independent array and keep it. The rental stays
+                // where it is: a caller who reads Data is allowed to stash the result, so the array they
+                // get back must not be one the pool can hand to somebody else.
+                _data = _pooledBody.AsSpan(0, _pooledLength).ToArray();
                 return _data;
             }
 
@@ -211,7 +229,96 @@ public partial class Envelope : IHasTenantId
 
             return _data;
         }
-        set => _data = value;
+        set
+        {
+            releasePooledBody();
+            _data = value;
+        }
+    }
+
+    /// <summary>
+    ///     GH-4333. The serialized message data as a <see cref="ReadOnlyMemory{T}" />, without forcing the
+    ///     copy that reading <see cref="Data" /> can. Prefer this on any hot path that only needs to READ
+    ///     the payload -- writing it to a broker, hashing it, measuring it.
+    /// </summary>
+    /// <remarks>
+    ///     The memory is only valid for the lifetime of this envelope. When the payload came in over the
+    ///     pooled path the underlying array goes back to <see cref="ArrayPool{T}" /> when the envelope is
+    ///     reset, and anything still holding this <c>ReadOnlyMemory</c> is then reading a buffer somebody
+    ///     else owns. To keep the bytes, read <see cref="Data" /> -- it materializes an independent array
+    ///     that outlives the pool.
+    /// </remarks>
+    public ReadOnlyMemory<byte> Body
+    {
+        get
+        {
+            if (_data != null)
+            {
+                return _data;
+            }
+
+            if (_pooledBody != null)
+            {
+                return _pooledBody.AsMemory(0, _pooledLength);
+            }
+
+            // No payload yet: fall through to Data, which serializes the message on demand exactly as it
+            // does for any other reader, and hand back whatever that produced
+            return Data ?? ReadOnlyMemory<byte>.Empty;
+        }
+    }
+
+    /// <summary>
+    ///     GH-4333. Payloads at or above this size are copied into a pooled buffer on the receive path
+    ///     instead of a fresh array.
+    /// </summary>
+    /// <remarks>
+    ///     85,000 bytes is the large-object-heap threshold, and it is the gate for a reason. Below it a
+    ///     per-message <c>byte[]</c> is a cheap gen-0 bump -- the measured prize at 1 KB is ~26ns, which
+    ///     does not pay for a rental, a length field and a lifetime to get wrong. At and above it the
+    ///     allocation changes character: it lands on the LOH, is not compacted, and drives gen-2
+    ///     collections. That is where pooling is worth its complexity, and nowhere else.
+    /// </remarks>
+    public const int PooledBodyThreshold = 85_000;
+
+    /// <summary>
+    ///     GH-4333. Take a copy of a broker's delivery buffer, using a pooled array when the payload is
+    ///     large enough to be worth it. The copy itself is not optional -- a client's buffer is only valid
+    ///     for the duration of its callback -- so this changes where the bytes land, not how many times
+    ///     they are copied.
+    /// </summary>
+    public void CopyBodyFrom(ReadOnlySpan<byte> body)
+    {
+        releasePooledBody();
+
+        if (body.Length < PooledBodyThreshold)
+        {
+            // Small payloads keep exactly the shape they have always had. No rental, no length field,
+            // no lifetime: the gate exists so the overwhelming majority of messages never meet any of it.
+            _data = body.ToArray();
+            return;
+        }
+
+        _data = null;
+        _pooledBody = ArrayPool<byte>.Shared.Rent(body.Length);
+        _pooledLength = body.Length;
+        body.CopyTo(_pooledBody);
+    }
+
+    /// <summary>
+    ///     Hand the pooled buffer back. Deliberately only called from <see cref="Reset" /> and from the
+    ///     <see cref="Data" /> setter -- both points where this envelope demonstrably no longer refers to
+    ///     the buffer. Never returning is merely a missed optimization; returning too early hands a live
+    ///     buffer to the next renter, so the bias is always towards not returning.
+    /// </summary>
+    private void releasePooledBody()
+    {
+        if (_pooledBody == null) return;
+
+        var buffer = _pooledBody;
+        _pooledBody = null;
+        _pooledLength = 0;
+        ArrayPool<byte>.Shared.Return(buffer);
     }
 
     private void assertMessage()
@@ -222,7 +329,9 @@ public partial class Envelope : IHasTenantId
         }
     }
 
-    internal int? MessagePayloadSize => _data?.Length;
+    // GH-4333: a pooled payload has a length even though _data is still null, and reading Data to find
+    // it out would force the very copy the pooled path exists to avoid
+    internal int? MessagePayloadSize => _data?.Length ?? (_pooledBody != null ? _pooledLength : null);
 
     /// <summary>
     ///     The actual message to be sent or being received

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -382,8 +382,12 @@ public static class EnvelopeSerializer
         writer.Write(count);
         writer.BaseStream.Position = endPosition;
 
-        writer.Write(env.Data!.Length);
-        writer.Write(env.Data);
+        // GH-4333: write straight from the body rather than through Data. On the pooled path Data would
+        // materialize an independent array first -- a full copy of the payload -- purely to hand it to a
+        // writer that only reads it. This is the copy the durable inbox insert used to pay per message.
+        var body = env.Body;
+        writer.Write(body.Length);
+        writer.Write(body.Span);
     }
 
     private static int writeHeaders(BinaryWriter writer, Envelope env)

--- a/src/Wolverine/Runtime/Serialization/SystemTextJsonSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/SystemTextJsonSerializer.cs
@@ -55,7 +55,10 @@ public class SystemTextJsonSerializer : IMessageSerializer
         Justification = "Default JSON serializer; AOT consumers wrap JsonSerializer with JsonTypeInfo. See AOT guide.")]
     public object ReadFromData(Type messageType, Envelope envelope)
     {
-        return JsonSerializer.Deserialize(envelope.Data, messageType, _options)!;
+        // GH-4333: deserialize from the body span. Passing envelope.Data here would materialize the
+        // whole payload into a fresh array first, which on a large message is exactly the LOH allocation
+        // the pooled receive path exists to avoid -- and STJ only ever reads it.
+        return JsonSerializer.Deserialize(envelope.Body.Span, messageType, _options)!;
     }
 
     public object ReadFromData(byte[]? data)


### PR DESCRIPTION
Closes #4333.

`Envelope.Data` is a `byte[]`, so every broker transport copies the client's delivery buffer per message. The copy is **not** optional — a client's buffer is only valid for the duration of its callback. But at 100 KB that copy is a large-object-heap allocation per message, and the LOH is not compacted.

Adds `Envelope.Body` (`ReadOnlyMemory<byte>`) and `Envelope.CopyBodyFrom(ReadOnlySpan<byte>)`. Above `Envelope.PooledBodyThreshold` the copy lands in an `ArrayPool` rental instead of a fresh array.

## Measured

Receive path through `Envelope`, net9.0 `--job short --inProcess`:

| size | before (`Data = ToArray`) | after (`CopyBodyFrom` + `Body`) | legacy reader (`Data`) |
|---|---|---|---|
| 1 KB | 110 ns / 1,584 B | 116 ns / 1,584 B | 119 ns / 1,584 B |
| 12 KB | 649 ns / 12,848 B | 685 ns / 12,848 B | 811 ns / 12,848 B |
| 100 KB | 13,464 ns / 102,974 B<br>Gen0/1/2 3.30 each | **999 ns / 536 B**<br>**no Gen1/Gen2** | 18,658 ns / 102,974 B<br>Gen0/1/2 3.30 each |

At 100 KB: **13.5x faster, allocation down to 0.5%, and the Gen1/Gen2 collections are gone.** That is the LOH being escaped.

## The gate is the design

85,000 bytes is the LOH boundary. **Below it, `CopyBodyFrom` *is* `body.ToArray()`** — the two arms allocate byte-for-byte the same because they are the same code, and the overwhelming majority of messages never meet a rental, a length field, or a lifetime to get wrong. The measured prize at 1 KB was ~26 ns, which does not pay for any of that.

(The small time difference below the gate is the after-arm also calling `Reset()`, which the before-arm does not.)

## Lifetime rules

These are what make it safe, and they're what the 13 new tests pin down:

- The rental is returned **only** in `Reset()` — the point the runtime has already decided the envelope is finished with, the same decision that makes re-pooling the envelope itself safe — and in the `Data` setter, which replaces the payload outright.
- **Never returning is a missed optimization; returning early hands a live buffer to the next renter.** Every rule biases towards holding on.
- `Data` materializes an **independent** array and caches it, so a caller that stashes it keeps working after the rental goes home.

## The escape hatch has an honest cost

The third column above is real: reading `Data` on a pooled envelope pays rent + copy + materialize rather than one copy — **38% slower at 100 KB**.

So every first-party read path moved onto `Body`: `EnvelopeSerializer` (the durable inbox insert), System.Text.Json, Newtonsoft, MessagePack, MemoryPack. A custom `IMessageSerializer` taking `byte[]` is the only shape left in that column, and only above 85 KB.

One subtlety worth knowing: `Body` is **not** a plain field read. With no payload yet it falls through to `Data`, which serializes the message on demand. That's load-bearing — `EnvelopeSerializer` writes from `Body`, so if `Body` reported "empty" for an unserialized message every persisted envelope would carry an empty payload. There's a test for exactly that.

Adopted on the receive side for **RabbitMQ** and **Azure Service Bus**. Other transports keep `ToArray` and are unaffected.

## Verification

| suite | result |
|---|---|
| `CoreTests` | 2868/2870 (2 skipped) |
| `RabbitmqTests` via `./build.sh` | **519/519**, 0 retries |
| `Wolverine.AzureServiceBus.Tests` | 381/381 |
| `PersistenceTests` via `./build.sh` | 113/113, 0 retries |
| MemoryPack / MessagePack | 3/3, 5/5 |
| new `pooled_envelope_body_4333` | 13/13 |

Full `wolverine.slnx -c Release -f net9.0` clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)