### PR TITLE
GH-4320: fixed-arity batched inserts on PostgreSQL

### DIFF
--- a/src/Persistence/PostgresqlTests/batched_insert_plan_stability_4320.cs
+++ b/src/Persistence/PostgresqlTests/batched_insert_plan_stability_4320.cs
@@ -1,0 +1,134 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.Postgresql;
+using Wolverine.RDBMS;
+using Xunit;
+
+namespace PostgresqlTests;
+
+/// <summary>
+/// GH-4320. The batched durability inserts used to emit one <c>insert ... values (@p0..@p8);</c> per
+/// envelope, so a 100-envelope flush was ~900 parameters and a command whose text grew with the batch.
+/// <c>unnest</c> makes it one statement at fixed arity, measured ~1.35x faster on the insert.
+///
+/// <para>
+/// These tests assert the structural property rather than the timing: one command text and one
+/// parameter count for every batch size. That is what the correctness suites cannot see, and it is
+/// what would silently regress if someone reintroduced a per-envelope loop.
+/// </para>
+///
+/// <para>
+/// Note the class name is a historical artifact worth keeping honest: GH-4320 predicted the win would
+/// come from Npgsql's <c>MaxAutoPrepare</c> and the SQL Server plan cache finally hitting. It did not.
+/// Wolverine never sets <c>Max Auto Prepare</c> and Npgsql defaults it off, and switching it on erases
+/// the fixed-arity advantage rather than amplifying it. The win is the smaller command and the
+/// parameter count. Stability of the command text is still the right thing to assert -- it is the
+/// mechanism -- but not for the reason originally given.
+/// </para>
+/// </summary>
+[Collection("marten")]
+public class batched_insert_plan_stability_4320 : PostgresqlContext, IAsyncLifetime
+{
+    private PostgresqlMessageStore theStore = null!;
+    private IHost theHost = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PersistMessagesWithPostgresql(Servers.PostgresConnectionString, "plan_cache_4320");
+            }).StartAsync();
+
+        theStore = (PostgresqlMessageStore)theHost.Services
+            .GetRequiredService<IMessageStore>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theHost.StopAsync();
+        theHost.Dispose();
+    }
+
+    private static IReadOnlyList<Envelope> incoming(int count)
+    {
+        var list = new List<Envelope>();
+        for (var i = 0; i < count; i++)
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.Status = EnvelopeStatus.Incoming;
+            list.Add(envelope);
+        }
+
+        return list;
+    }
+
+    private static Envelope[] outgoing(int count)
+    {
+        return Enumerable.Range(0, count).Select(_ =>
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.Status = EnvelopeStatus.Outgoing;
+            return envelope;
+        }).ToArray();
+    }
+
+    /// <summary>
+    /// The whole point, stated directly: three different batch sizes, one command text. Before
+    /// GH-4320 these three differed from each other in both text and parameter count.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 5)]
+    [InlineData(5, 100)]
+    [InlineData(1, 100)]
+    public void the_incoming_batch_command_text_does_not_vary_with_batch_size(int a, int b)
+    {
+        using var first = theStore.TestingOnlyBuildBatchedIncoming(incoming(a));
+        using var second = theStore.TestingOnlyBuildBatchedIncoming(incoming(b));
+
+        second.CommandText.ShouldBe(first.CommandText);
+    }
+
+    [Theory]
+    [InlineData(1, 5)]
+    [InlineData(5, 100)]
+    [InlineData(1, 100)]
+    public void the_outgoing_batch_command_text_does_not_vary_with_batch_size(int a, int b)
+    {
+        using var first = theStore.TestingOnlyBuildBatchedOutgoing(outgoing(a), 1);
+        using var second = theStore.TestingOnlyBuildBatchedOutgoing(outgoing(b), 1);
+
+        second.CommandText.ShouldBe(first.CommandText);
+    }
+
+    /// <summary>
+    /// Fixed arity is the mechanism, and it is worth asserting separately: it is also what keeps the
+    /// batch clear of the SQL Server 2100-parameter ceiling that the per-envelope shape walks towards.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(500)]
+    public void the_incoming_batch_uses_one_parameter_per_column_regardless_of_size(int count)
+    {
+        using var command = theStore.TestingOnlyBuildBatchedIncoming(incoming(count));
+
+        command.Parameters.Count.ShouldBe(9);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(500)]
+    public void the_outgoing_batch_uses_one_parameter_per_column_regardless_of_size(int count)
+    {
+        using var command = theStore.TestingOnlyBuildBatchedOutgoing(outgoing(count), 1);
+
+        command.Parameters.Count.ShouldBe(7);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.BatchedInserts.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.BatchedInserts.cs
@@ -1,0 +1,159 @@
+using System.Data.Common;
+using Npgsql;
+using NpgsqlTypes;
+using Wolverine.RDBMS;
+
+namespace Wolverine.Postgresql;
+
+/// <summary>
+/// GH-4320. Fixed-arity batched inserts: <c>unnest</c> of one array per column, so a 100-envelope batch
+/// is 7-9 parameters rather than ~700-900. The same shape the scheduled-promotion path has used since
+/// GH-4209.
+///
+/// <para>
+/// <b>MEASURED at ~1.35x on the batched insert</b> (in-build A/B against the legacy shape, varying batch
+/// sizes: 1.318 -> 0.988ms and 1.057 -> 0.771ms). The win is the smaller command and the parameter
+/// count -- binding 900 parameters client-side and parsing them server-side is simply more work than
+/// binding 9.
+/// </para>
+///
+/// <para>
+/// <b>It is NOT the plan-cache win the issue predicted, and that prediction did not survive
+/// measurement.</b> GH-4320 argued that unique-per-batch-size command text defeats Npgsql's
+/// <c>MaxAutoPrepare</c>. Two things turned out to be wrong with that. Wolverine never sets
+/// <c>Max Auto Prepare</c> and Npgsql defaults it to 0, so no Wolverine command was being auto-prepared
+/// either way; and when it IS switched on, the advantage of fixed arity largely disappears (0.97x and
+/// 1.19x over the legacy shape at varying batch sizes -- noise). Prepared-statement reuse was never
+/// where the cost was.
+/// </para>
+///
+/// <para>
+/// The structural benefit that does hold independently of any measurement: parameter count no longer
+/// scales with batch size, so a batch cannot walk towards a provider's parameter ceiling.
+/// </para>
+///
+/// <para>
+/// Every parameter is typed EXPLICITLY. That is not defensive style: #4356 broke SQL Server by letting
+/// a helper infer a type, and array parameters are worse for inference than scalars -- an all-null
+/// <c>timestamptz[]</c> has nothing to infer from at all.
+/// </para>
+/// </summary>
+internal partial class PostgresqlMessageStore
+{
+    private string? _batchedIncomingSql;
+    private string? _batchedOutgoingSql;
+
+    private string batchedIncomingSql()
+    {
+        return _batchedIncomingSql ??=
+            $"insert into {QuotedTableNameFor(DatabaseConstants.IncomingTable)}({DatabaseConstants.IncomingFields}) " +
+            "select * from unnest(@bodies, @ids, @statuses, @owners, @executions, @attempts, @types, @destinations, @keeps)";
+    }
+
+    private string batchedOutgoingSql()
+    {
+        return _batchedOutgoingSql ??=
+            $"insert into {QuotedTableNameFor(DatabaseConstants.OutgoingTable)}({DatabaseConstants.OutgoingFields}) " +
+            "select * from unnest(@bodies, @ids, @owners, @destinations, @deliverBys, @attempts, @types)";
+    }
+
+    protected override DbCommand BuildBatchedIncomingCommand(IReadOnlyList<Envelope> envelopes)
+    {
+        var count = envelopes.Count;
+
+        var bodies = new byte[count][];
+        var ids = new Guid[count];
+        var statuses = new string[count];
+        var owners = new int[count];
+        var executions = new DateTimeOffset?[count];
+        var attempts = new int[count];
+        var types = new string[count];
+        var destinations = new string?[count];
+        var keeps = new DateTimeOffset?[count];
+
+        for (var i = 0; i < count; i++)
+        {
+            var envelope = envelopes[i];
+
+            // Same rule the per-envelope builder applies: a handled envelope stores no body
+            bodies[i] = envelope.Status == EnvelopeStatus.Handled
+                ? []
+                : Runtime.Serialization.EnvelopeSerializer.Serialize(envelope);
+
+            ids[i] = envelope.Id;
+            statuses[i] = envelope.Status.ToString();
+            owners[i] = envelope.OwnerId;
+            executions[i] = envelope.ScheduledTime;
+            attempts[i] = envelope.Attempts;
+            types[i] = envelope.MessageType!;
+            destinations[i] = envelope.Destination?.ToString();
+            keeps[i] = envelope.KeepUntil;
+        }
+
+        var command = new NpgsqlCommand(batchedIncomingSql());
+        add(command, "bodies", NpgsqlDbType.Array | NpgsqlDbType.Bytea, bodies);
+        add(command, "ids", NpgsqlDbType.Array | NpgsqlDbType.Uuid, ids);
+        add(command, "statuses", NpgsqlDbType.Array | NpgsqlDbType.Varchar, statuses);
+        add(command, "owners", NpgsqlDbType.Array | NpgsqlDbType.Integer, owners);
+        add(command, "executions", NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, executions);
+        add(command, "attempts", NpgsqlDbType.Array | NpgsqlDbType.Integer, attempts);
+        add(command, "types", NpgsqlDbType.Array | NpgsqlDbType.Varchar, types);
+        add(command, "destinations", NpgsqlDbType.Array | NpgsqlDbType.Varchar, destinations);
+        add(command, "keeps", NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, keeps);
+
+        return command;
+    }
+
+    protected override DbCommand BuildBatchedOutgoingCommand(Envelope[] envelopes, int ownerId)
+    {
+        var count = envelopes.Length;
+
+        var bodies = new byte[count][];
+        var ids = new Guid[count];
+        var owners = new int[count];
+        var destinations = new string[count];
+        var deliverBys = new DateTimeOffset?[count];
+        var attempts = new int[count];
+        var types = new string[count];
+
+        for (var i = 0; i < count; i++)
+        {
+            var envelope = envelopes[i];
+
+            bodies[i] = Runtime.Serialization.EnvelopeSerializer.Serialize(envelope);
+            ids[i] = envelope.Id;
+            owners[i] = ownerId;
+            destinations[i] = envelope.Destination!.ToString();
+            deliverBys[i] = envelope.DeliverBy;
+            attempts[i] = envelope.Attempts;
+            types[i] = envelope.MessageType!;
+        }
+
+        var command = new NpgsqlCommand(batchedOutgoingSql());
+        add(command, "bodies", NpgsqlDbType.Array | NpgsqlDbType.Bytea, bodies);
+        add(command, "ids", NpgsqlDbType.Array | NpgsqlDbType.Uuid, ids);
+        add(command, "owners", NpgsqlDbType.Array | NpgsqlDbType.Integer, owners);
+        add(command, "destinations", NpgsqlDbType.Array | NpgsqlDbType.Varchar, destinations);
+        add(command, "deliverBys", NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, deliverBys);
+        add(command, "attempts", NpgsqlDbType.Array | NpgsqlDbType.Integer, attempts);
+        add(command, "types", NpgsqlDbType.Array | NpgsqlDbType.Varchar, types);
+
+        return command;
+    }
+
+    /// <summary>
+    /// The plan-stability tests assert on the command text and parameter count, which is the property a
+    /// plan cache actually keys on and the one thing the correctness suites cannot see. Exposed rather
+    /// than reflected at, so the assertion breaks loudly if the shape is refactored away.
+    /// </summary>
+    internal DbCommand TestingOnlyBuildBatchedIncoming(IReadOnlyList<Envelope> envelopes)
+        => BuildBatchedIncomingCommand(envelopes);
+
+    internal DbCommand TestingOnlyBuildBatchedOutgoing(Envelope[] envelopes, int ownerId)
+        => BuildBatchedOutgoingCommand(envelopes, ownerId);
+
+    private static void add(NpgsqlCommand command, string name, NpgsqlDbType type, object value)
+    {
+        command.Parameters.Add(new NpgsqlParameter(name, type) { Value = value });
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.cs
@@ -29,7 +29,7 @@ using Table = Weasel.Postgresql.Tables.Table;
 
 namespace Wolverine.Postgresql;
 
-internal class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConnectionBudgetProbe
+internal partial class PostgresqlMessageStore : MessageDatabase<NpgsqlConnection>, IConnectionBudgetProbe
 {
     /// <summary>
     /// Row-count threshold below which <see cref="FetchCountsAsync"/> abandons the cheap

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
@@ -264,11 +264,24 @@ public abstract partial class MessageDatabase<T>
         }
     }
 
+    /// <summary>
+    /// GH-4320. The batched inbox INSERT, as one command. Virtual because the default shape -- one
+    /// <c>insert ... values (@p0..@p8);</c> per envelope -- makes both the command text and the
+    /// parameter count scale with the batch size. A provider that can express the batch at FIXED arity
+    /// overrides this; PostgreSQL does, with <c>unnest</c>, and measures ~1.35x faster on the insert.
+    /// The saving is the smaller command and the parameter count, not plan caching -- see the note on
+    /// PostgresqlMessageStore.BatchedInserts for why the plan-cache premise did not survive measurement.
+    /// </summary>
+    protected virtual DbCommand BuildBatchedIncomingCommand(IReadOnlyList<Envelope> envelopes)
+    {
+        return DatabasePersistence.BuildIncomingStorageCommand(envelopes, this);
+    }
+
     public async Task StoreIncomingAsync(IReadOnlyList<Envelope> envelopes)
     {
         if (envelopes.Count == 0) return;
 
-        await using var cmd = DatabasePersistence.BuildIncomingStorageCommand(envelopes, this);
+        await using var cmd = BuildBatchedIncomingCommand(envelopes);
 
         await using var conn = await _dataSource.OpenConnectionAsync(_cancellation);
         try

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
@@ -71,7 +71,7 @@ public abstract partial class MessageDatabase<T>
         if (HasDisposed || envelopes.Count == 0) return;
 
         var array = envelopes as Envelope[] ?? envelopes.ToArray();
-        var command = DatabasePersistence.BuildOutgoingStorageCommand(array, ownerId, this);
+        var command = BuildBatchedOutgoingCommand(array, ownerId);
 
         await using var conn = await DataSource.OpenConnectionAsync(_cancellation);
 
@@ -89,6 +89,16 @@ public abstract partial class MessageDatabase<T>
         {
             envelope.WasPersistedInOutbox = true;
         }
+    }
+
+    /// <summary>
+    /// GH-4320. Virtual for the same reason as <c>BuildBatchedIncomingCommand</c>: the default emits one
+    /// values-clause per envelope, so both the command text and the parameter count scale with the
+    /// batch size.
+    /// </summary>
+    protected virtual DbCommand BuildBatchedOutgoingCommand(Envelope[] envelopes, int ownerId)
+    {
+        return DatabasePersistence.BuildOutgoingStorageCommand(envelopes, ownerId, this);
     }
 
     protected abstract string

--- a/src/Testing/KafkaPerfRig/OutboxStoreLane.cs
+++ b/src/Testing/KafkaPerfRig/OutboxStoreLane.cs
@@ -13,6 +13,7 @@ using Wolverine;
 using Wolverine.Oracle;
 using Wolverine.Persistence.Durability;
 using Wolverine.Postgresql;
+using Wolverine.RDBMS;
 using Wolverine.RavenDb;
 using Wolverine.SqlServer;
 
@@ -52,6 +53,14 @@ public static class OutboxStoreLane
         var rounds = envInt("RIG_ROUNDS", 20);
         var warmup = envInt("RIG_WARMUP_ROUNDS", 5);
 
+        // GH-4320. A CONSTANT batch size is the wrong shape for testing the plan-cache claim: at a fixed
+        // size even the per-envelope form has stable command text and can be auto-prepared like anything
+        // else. The defect is that its text varies WITH the batch size -- and a coalescer produces varying
+        // sizes by construction, because batches form from whatever concurrency happened to be in flight.
+        // RIG_VARY_BATCH=1 walks the size the way real traffic does, which is the only way the difference
+        // between "one cached plan" and "a new plan per size" can show up at all.
+        var varyBatch = envInt("RIG_VARY_BATCH", 0) == 1;
+
         using var host = await buildHostAsync(store, cfg);
         var messageStore = host.Services.GetRequiredService<IMessageStore>();
         var outbox = messageStore.Outbox;
@@ -64,23 +73,35 @@ public static class OutboxStoreLane
 
         var sequential = new List<double>();
         var batched = new List<double>();
+        var legacyBatch = new List<double>();
+
+        var sizes = new Random(20260906);
 
         for (var round = 0; round < rounds + warmup; round++)
         {
             var measured = round >= warmup;
+
+            // Deterministic seed: both arms see the SAME sequence of sizes, so the comparison stays fair
+            // while the sizes themselves vary the way a coalescer's do.
+            if (varyBatch)
+            {
+                batchSize = sizes.Next(2, 101);
+            }
 
             // Alternate which arm goes first so neither one systematically owns the cold cache
             if (round % 2 == 0)
             {
                 var a = await timeSequentialAsync(outbox, batchSize);
                 var b = await timeBatchedAsync(outbox, batchSize);
-                if (measured) { sequential.Add(a); batched.Add(b); }
+                var c = await timeLegacyBatchAsync(messageStore, batchSize);
+                if (measured) { sequential.Add(a); batched.Add(b); if (c > 0) legacyBatch.Add(c); }
             }
             else
             {
+                var c = await timeLegacyBatchAsync(messageStore, batchSize);
                 var b = await timeBatchedAsync(outbox, batchSize);
                 var a = await timeSequentialAsync(outbox, batchSize);
-                if (measured) { sequential.Add(a); batched.Add(b); }
+                if (measured) { sequential.Add(a); batched.Add(b); if (c > 0) legacyBatch.Add(c); }
             }
 
             // Keep the table from growing across rounds; a table that gets steadily larger is a
@@ -91,11 +112,16 @@ public static class OutboxStoreLane
         var summary = new Dictionary<string, object>
         {
             ["store"] = store,
-            ["batchSize"] = batchSize,
+            ["batchSize"] = varyBatch ? "varying 2-100" : batchSize.ToString(),
             ["rounds"] = rounds,
             ["sequential_ms"] = describe(sequential),
+            ["legacy_batch_ms"] = describe(legacyBatch),
             ["batched_ms"] = describe(batched),
-            ["speedup_at_p50"] = Math.Round(percentile(sequential, 50) / Math.Max(percentile(batched, 50), 0.0001), 2)
+            ["speedup_at_p50_vs_sequential"] =
+                Math.Round(percentile(sequential, 50) / Math.Max(percentile(batched, 50), 0.0001), 2),
+            ["speedup_at_p50_vs_legacy_batch"] = legacyBatch.Count == 0
+                ? 0
+                : Math.Round(percentile(legacyBatch, 50) / Math.Max(percentile(batched, 50), 0.0001), 2)
         };
 
         Directory.CreateDirectory(cfg.OutDir);
@@ -113,6 +139,40 @@ public static class OutboxStoreLane
         foreach (var envelope in envelopes)
         {
             await outbox.StoreOutgoingAsync(envelope, 1);
+        }
+
+        return Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+    }
+
+    /// <summary>
+    /// GH-4320's before-shape, executed IN THIS BUILD. The shared
+    /// <c>DatabasePersistence.BuildOutgoingStorageCommand</c> still emits one values-clause per envelope,
+    /// which is exactly what PostgreSQL used to run, so this arm is the old plan-cache-defeating command
+    /// against the same database in the same process as the new one.
+    ///
+    /// <para>
+    /// This exists because comparing across sessions is not sound: the same sequential arm measured
+    /// 57.30ms while eight orphaned emulator containers were resident and 29.6ms once they were gone.
+    /// An in-build arm is immune to that.
+    /// </para>
+    /// </summary>
+    private static async Task<double> timeLegacyBatchAsync(IMessageStore store, int count)
+    {
+        if (store is not IMessageDatabase database) return 0;
+
+        var envelopes = buildEnvelopes(count);
+        var start = Stopwatch.GetTimestamp();
+
+        await using var command = DatabasePersistence.BuildOutgoingStorageCommand(envelopes, 1, database);
+        await using var conn = await database.DataSource.OpenConnectionAsync();
+        try
+        {
+            command.Connection = conn;
+            await command.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            await conn.CloseAsync();
         }
 
         return Stopwatch.GetElapsedTime(start).TotalMilliseconds;

--- a/src/Testing/KafkaPerfRig/README.md
+++ b/src/Testing/KafkaPerfRig/README.md
@@ -106,6 +106,38 @@ Watch the machine before trusting a round here. These runs had eight orphaned Co
 containers resident, which is visible in the p95 spread (PostgreSQL sequential p95 319ms against a
 57ms p50) even though the p50 gap is far too large to be noise.
 
+### Fixed-arity batched inserts (GH-4320) — measured 2026-09-06: premise REFUTED, change kept
+
+Same `outbox-store` role, with two additions: an in-build **legacy-shape arm** that runs
+`DatabasePersistence.BuildOutgoingStorageCommand` (the per-envelope values-clause form) against the
+same database in the same process, and `RIG_VARY_BATCH=1`.
+
+`RIG_VARY_BATCH` exists because of a flaw found in this harness while using it. **A constant batch
+size cannot test a plan-cache claim at all**: at a fixed size even the per-envelope form has stable
+command text and is auto-prepared like anything else. The defect GH-4320 described is that the text
+varies *with* the batch size — and a coalescer produces varying sizes by construction. The flag walks
+the size from 2 to 100 on a fixed seed so both arms see the same sequence.
+
+| cell (varying batch size, legacy → fixed arity) | r1 | r2 |
+|---|---|---|
+| `Max Auto Prepare` unset — **Wolverine's default** | 1.318 → 0.988ms, **1.33x** | 1.057 → 0.771ms, **1.37x** |
+| `Max Auto Prepare=20` | 1.100 → 1.138ms, 0.97x | 1.179 → 0.987ms, 1.19x |
+
+**The change is a consistent ~1.35x on the batched insert, and the reason GH-4320 gave for it is
+wrong.** Two things sank the plan-cache premise. Wolverine never sets `Max Auto Prepare` and Npgsql
+defaults it to 0, so no Wolverine command was being auto-prepared either way. And when it *is* switched
+on, the fixed-arity advantage disappears into noise rather than growing — prepared-statement reuse was
+never where the cost was. The saving is the smaller command and the parameter count: binding 900
+parameters client-side and parsing them server-side is more work than binding 9.
+
+Kept anyway, on the measurement rather than the theory. The structural benefit that holds regardless:
+parameter count no longer scales with batch size, so a batch cannot walk towards a provider's
+parameter ceiling.
+
+⚠️ **Do not compare absolute numbers across sessions here.** The same sequential arm measured 57.30ms
+with eight orphaned emulator containers resident and 29.6ms once they were gone. That is why the legacy
+arm is built into the run.
+
 ### Durable local queue (GH-4319) — measured 2026-09-06
 
 The only lane with no broker in it: one process publishes into a durable local queue backed by


### PR DESCRIPTION
Closes #4320.

The shared builder emits one `insert ... values (@p0..@p8);` per envelope, so a 100-envelope batch is ~900 parameters and a command whose text grows with the batch size. PostgreSQL now expresses both batched inserts as a single `unnest` of one array per column — **9 parameters for the inbox, 7 for the outbox, whatever the batch size**. Same shape the scheduled-promotion path has used since GH-4209.

## Measured — and the issue's stated reason is wrong

In-build A/B against the legacy shape, same process, same database, varying batch sizes:

| cell (legacy → fixed arity) | r1 | r2 |
|---|---|---|
| `Max Auto Prepare` unset — **Wolverine's default** | 1.318 → 0.988 ms, **1.33x** | 1.057 → 0.771 ms, **1.37x** |
| `Max Auto Prepare=20` | 1.100 → 1.138 ms, 0.97x | 1.179 → 0.987 ms, 1.19x |

**~1.35x on the batched insert. But GH-4320 predicted this would come from plan caching, and that did not survive measurement.** Two things sank it:

- **Wolverine never sets `Max Auto Prepare` anywhere**, and Npgsql defaults it to 0 — so no Wolverine command was being auto-prepared either way.
- When it *is* switched on, the fixed-arity advantage **disappears into noise rather than growing** (0.97x, 1.19x).

Prepared-statement reuse was never where the cost was. The win is the smaller command and the parameter count: binding 900 parameters client-side and parsing them server-side is more work than binding 9. **Kept on the measurement, not the theory** — and the code comments, tests and rig ledger all now say so rather than repeating the original claim.

## A flaw in my own harness, found while using it

The first rounds of this were measured the wrong way. **A constant batch size cannot test a plan-cache claim at all**: at a fixed size even the per-envelope form has stable command text and is auto-prepared like anything else. The defect described in the issue is that the text varies *with* the batch size — and a coalescer produces varying sizes by construction, because batches form from whatever concurrency was in flight.

`RIG_VARY_BATCH=1` now walks the size 2–100 on a fixed seed so both arms see the same sequence. The lane also gained an **in-build legacy arm**, because comparing across sessions is not sound here: the same sequential arm measured 57.30 ms with eight orphaned emulator containers resident and 29.6 ms once they were gone.

## Safety

Every parameter is typed **explicitly**. #4356 broke SQL Server by letting a helper infer a type, and arrays are worse for inference than scalars — an all-null `timestamptz[]` has nothing to infer from at all.

Other providers are untouched: `BuildBatchedIncomingCommand` and `BuildBatchedOutgoingCommand` are virtual and default to today's builder, so a provider that does not override keeps exactly the shape it has.

## Not doing the SQL Server TVP half

It needs a new user-defined table type — a schema object and a migration — and the reason it was proposed did not survive measurement. The structural benefit that *does* hold independently is that parameter count no longer scales with batch size, so a batch cannot walk towards the 2100-parameter ceiling. That is worth revisiting on its own terms rather than as a perf story, so I have left it out rather than shipping a migration on a refuted premise.

## Verification

- `PostgresqlTests` — **596/597** (1 skipped)
- `./build.sh PersistenceTests` — **113/113**, 0 retries
- 12 new plan-stability tests asserting one command text and one parameter count across batch sizes — the structural property the correctness suites cannot see
- Full `wolverine.slnx -c Release -f net9.0` clean, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)