### PR TITLE
GH-4375: chunk batched durability commands under each provider's parameter ceiling

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlMessageStore.cs
@@ -29,6 +29,13 @@ namespace Wolverine.MySql;
 
 internal class MySqlMessageStore : MessageDatabase<MySqlConnection>
 {
+    /// <summary>
+    /// GH-4375. MySQL's placeholder count is a uint16 on the wire, so 65,535. A multi-row insert of
+    /// 65,536 parameters was accepted against the docker-compose MySQL, which means the practical limit
+    /// there is packet size rather than placeholder count -- this stays at the protocol number.
+    /// </summary>
+    public override int MaximumParameterCount => 65_535;
+
     private readonly string _findAtLargeEnvelopesSql;
 
     private ImHashMap<Type, IDatabaseSagaSchema> _sagaStorage = ImHashMap<Type, IDatabaseSagaSchema>.Empty;

--- a/src/Persistence/SqlServerTests/parameter_ceiling_4375.cs
+++ b/src/Persistence/SqlServerTests/parameter_ceiling_4375.cs
@@ -1,0 +1,196 @@
+using IntegrationTests;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Wolverine;
+using Wolverine.ComplianceTests;
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.RDBMS.Sagas;
+using Wolverine.SqlServer.Persistence;
+using Xunit;
+
+namespace SqlServerTests;
+
+/// <summary>
+/// GH-4375. The batched durability commands emit one values-clause per envelope, so parameter count
+/// scaled with the batch. SQL Server refuses more than 2,100 parameters in one command, and the
+/// transactional paths are NOT governed by any batch-size setting -- the array is however many
+/// messages the handler published inside the caller's transaction.
+///
+/// <para>
+/// Measured boundaries before the fix: outgoing succeeded at 349 envelopes (2,095 parameters) and
+/// failed at 350 (2,101); incoming succeeded at 233 (2,097) and failed at 234 (2,106). The failure was
+/// <c>SqlException: The incoming request has too many parameters</c> -- an error naming neither
+/// Wolverine nor message counts.
+/// </para>
+///
+/// <para>
+/// These tests deliberately use sizes FAR past the old boundary rather than 350 and 234. Asserting on
+/// the boundary alone would start passing again the moment the per-envelope parameter count changed,
+/// which is exactly the kind of silent regression the chunking exists to prevent.
+/// </para>
+/// </summary>
+[Collection("sqlserver")]
+public class parameter_ceiling_4375 : IAsyncLifetime
+{
+    private const string TheSchema = "ceiling_4375";
+    private SqlServerMessageStore theStore = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theStore = new SqlServerMessageStore(new DatabaseSettings
+        {
+            ConnectionString = Servers.SqlServerConnectionString, SchemaName = TheSchema
+        }, new DurabilitySettings(), NullLogger<SqlServerMessageStore>.Instance,
+            Array.Empty<SagaTableDefinition>());
+
+        await theStore.Admin.MigrateAsync();
+        await theStore.Admin.ClearAllAsync();
+    }
+
+    public async ValueTask DisposeAsync() => await theStore.DisposeAsync();
+
+    private static Envelope[] envelopes(int count, EnvelopeStatus status)
+    {
+        return Enumerable.Range(0, count).Select(_ =>
+        {
+            var envelope = ObjectMother.Envelope();
+            envelope.Status = status;
+            return envelope;
+        }).ToArray();
+    }
+
+    [Fact]
+    public void sql_server_reports_the_tightest_ceiling_wolverine_ships()
+    {
+        theStore.MaximumParameterCount.ShouldBe(2100);
+    }
+
+    /// <summary>
+    /// The chunk boundaries are computed from these constants, so a column added to either field list
+    /// without updating them would silently move every boundary one envelope past what fits -- which is
+    /// exactly the off-by-one this work hit, where the outgoing builder's shared owner_id parameter was
+    /// left out of the budget and chunked to precisely the size already known to fail.
+    /// </summary>
+    [Fact]
+    public void the_parameter_constants_match_what_the_builders_actually_add()
+    {
+        using var incoming = DatabasePersistence.BuildIncomingStorageCommand(
+            envelopes(1, EnvelopeStatus.Incoming), theStore);
+        incoming.Parameters.Count.ShouldBe(DatabaseConstants.IncomingParametersPerEnvelope);
+
+        using var one = DatabasePersistence.BuildOutgoingStorageCommand(
+            envelopes(1, EnvelopeStatus.Outgoing), 1, theStore);
+        using var two = DatabasePersistence.BuildOutgoingStorageCommand(
+            envelopes(2, EnvelopeStatus.Outgoing), 1, theStore);
+
+        // The difference between one and two envelopes is the per-envelope cost; what is left over in
+        // the single-envelope command is the shared part
+        (two.Parameters.Count - one.Parameters.Count)
+            .ShouldBe(DatabaseConstants.OutgoingParametersPerEnvelope);
+        (one.Parameters.Count - DatabaseConstants.OutgoingParametersPerEnvelope)
+            .ShouldBe(DatabaseConstants.OutgoingSharedParameters);
+    }
+
+    /// <summary>
+    /// The arithmetic that broke: the largest batch that fits must actually fit. Both are one envelope
+    /// under the measured failure points (350 outgoing, 234 incoming).
+    /// </summary>
+    [Fact]
+    public async Task the_largest_unchunked_batch_still_fits()
+    {
+        await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(TestContext.Current.CancellationToken);
+
+        await theStore.StoreOutgoingAsync(tx, envelopes(349, EnvelopeStatus.Outgoing));
+        await theStore.StoreIncomingAsync(tx, envelopes(233, EnvelopeStatus.Incoming));
+
+        await tx.CommitAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// 1,000 outgoing envelopes is 6,001 parameters unchunked -- nearly 3x the ceiling.
+    /// </summary>
+    [Fact]
+    public async Task a_transaction_can_publish_far_more_messages_than_the_parameter_ceiling_allows()
+    {
+        var outgoing = envelopes(1000, EnvelopeStatus.Outgoing);
+
+        await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(TestContext.Current.CancellationToken);
+
+        await theStore.StoreOutgoingAsync(tx, outgoing);
+        await tx.CommitAsync(TestContext.Current.CancellationToken);
+
+        var stored = await theStore.Admin.AllOutgoingAsync();
+        stored.Count.ShouldBe(outgoing.Length);
+        outgoing.ShouldAllBe(x => x.WasPersistedInOutbox);
+    }
+
+    /// <summary>
+    /// 1,000 incoming envelopes is 9,000 parameters unchunked -- over 4x the ceiling.
+    /// </summary>
+    [Fact]
+    public async Task a_transaction_can_receive_far_more_messages_than_the_parameter_ceiling_allows()
+    {
+        var incoming = envelopes(1000, EnvelopeStatus.Incoming);
+
+        await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(TestContext.Current.CancellationToken);
+
+        await theStore.StoreIncomingAsync(tx, incoming);
+        await tx.CommitAsync(TestContext.Current.CancellationToken);
+
+        var counts = await theStore.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(incoming.Length);
+    }
+
+    /// <summary>
+    /// Chunking must not cost the all-or-nothing guarantee. The caller owns the transaction, so
+    /// rolling it back has to leave nothing behind even though the write spanned several commands.
+    /// </summary>
+    [Fact]
+    public async Task a_rolled_back_transaction_leaves_nothing_behind_across_chunks()
+    {
+        var outgoing = envelopes(1000, EnvelopeStatus.Outgoing);
+
+        await using var conn = new SqlConnection(Servers.SqlServerConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using (var tx = await conn.BeginTransactionAsync(TestContext.Current.CancellationToken))
+        {
+            await theStore.StoreOutgoingAsync(tx, outgoing);
+            await tx.RollbackAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await theStore.Admin.AllOutgoingAsync()).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The connection-owning batch path is bounded by StoreOutgoingBatchSize today, but nothing stops
+    /// an application raising that setting past the ceiling.
+    /// </summary>
+    [Fact]
+    public async Task the_batched_outgoing_store_survives_a_batch_past_the_ceiling()
+    {
+        var outgoing = envelopes(1000, EnvelopeStatus.Outgoing);
+
+        await theStore.Outbox.StoreOutgoingAsync(outgoing, 5890);
+
+        (await theStore.Admin.AllOutgoingAsync()).Count.ShouldBe(outgoing.Length);
+    }
+
+    [Fact]
+    public async Task the_batched_incoming_store_survives_a_batch_past_the_ceiling()
+    {
+        var incoming = envelopes(1000, EnvelopeStatus.Incoming);
+
+        await theStore.Inbox.StoreIncomingAsync(incoming);
+
+        var counts = await theStore.Admin.FetchCountsAsync();
+        counts.Incoming.ShouldBe(incoming.Length);
+    }
+}

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.BatchedInserts.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlMessageStore.BatchedInserts.cs
@@ -40,6 +40,12 @@ namespace Wolverine.Postgresql;
 /// </summary>
 internal partial class PostgresqlMessageStore
 {
+    // GH-4375. PostgreSQL's wire protocol caps parameters at 65,535 (an int16 count).
+    public override int MaximumParameterCount => 65_535;
+
+    // GH-4320 moved both batched builders to unnest, so parameter count no longer scales with batch size
+    protected override bool BuildsFixedArityBatches => true;
+
     private string? _batchedIncomingSql;
     private string? _batchedOutgoingSql;
 

--- a/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
+++ b/src/Persistence/Wolverine.RDBMS/DatabaseConstants.cs
@@ -104,6 +104,28 @@ public class DatabaseConstants
     public static readonly string OutgoingFields =
         $"{Body}, {Id}, {OwnerId}, {Destination}, {DeliverBy}, {Attempts}, {MessageType}";
 
+    /// <summary>
+    /// GH-4375. Parameters the per-envelope builders add for ONE envelope. Used to work out how many
+    /// envelopes fit under a provider's parameter ceiling before a batch has to be split.
+    /// </summary>
+    /// <remarks>
+    /// Kept next to the field lists above because that is what they count, and pinned by
+    /// <c>batched_command_parameter_counts</c> so adding a column fails a test rather than silently
+    /// moving a chunk boundary. Outgoing is one fewer than its field list: <c>owner_id</c> is a single
+    /// shared parameter reused by every values-clause.
+    /// </remarks>
+    public const int IncomingParametersPerEnvelope = 9;
+
+    /// <inheritdoc cref="IncomingParametersPerEnvelope" />
+    public const int OutgoingParametersPerEnvelope = 6;
+
+    /// <summary>
+    /// Parameters the outgoing builder adds ONCE for the whole batch rather than per envelope: the
+    /// shared <c>owner_id</c>. Subtracted from the budget before dividing, or the chunk boundary lands
+    /// one envelope past what fits.
+    /// </summary>
+    public const int OutgoingSharedParameters = 1;
+
     public static readonly string DeadLetterFields =
         $"{Id}, {ExecutionTime}, {Body}, {MessageType}, {ReceivedAt}, {Source}, {ExceptionType}, {ExceptionMessage}, {SentAt}, {Replayable}";
 

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Incoming.cs
@@ -34,20 +34,34 @@ public abstract partial class MessageDatabase<T>
         return executeCommandBatch(builder, _cancellation);
     }
 
+    /// <summary>
+    /// GH-4375. Chunked for the same reason as the outgoing transactional path: this array is sized by
+    /// the caller's transaction rather than by any batch-size setting, and 234 envelopes was enough to
+    /// exceed SQL Server's 2,100-parameter ceiling.
+    /// </summary>
+    /// <remarks>
+    /// Chunks run on the CALLER'S transaction, so a duplicate in a later chunk still rolls the whole
+    /// thing back with the caller's other work -- the atomicity this had before, at more commands. The
+    /// exception still reports the whole batch, because a rolled-back multi-row insert cannot say which
+    /// row collided.
+    /// </remarks>
     public async Task StoreIncomingAsync(DbTransaction tx, Envelope[] envelopes)
     {
-        await using var cmd = DatabasePersistence.BuildIncomingStorageCommand(envelopes, this);
-
-        cmd.Transaction = tx;
-        cmd.Connection = tx.Connection;
-
-        try
+        foreach (var chunk in chunkByParameterLimit(envelopes, DatabaseConstants.IncomingParametersPerEnvelope))
         {
-            await cmd.ExecuteNonQueryAsync(_cancellation);
-        }
-        catch (Exception e) when (IsDuplicateEnvelopeException(e))
-        {
-            throw new DuplicateIncomingEnvelopeException(envelopes);
+            await using var cmd = DatabasePersistence.BuildIncomingStorageCommand(chunk.ToArray(), this);
+
+            cmd.Transaction = tx;
+            cmd.Connection = tx.Connection;
+
+            try
+            {
+                await cmd.ExecuteNonQueryAsync(_cancellation);
+            }
+            catch (Exception e) when (IsDuplicateEnvelopeException(e))
+            {
+                throw new DuplicateIncomingEnvelopeException(envelopes);
+            }
         }
     }
 
@@ -281,7 +295,14 @@ public abstract partial class MessageDatabase<T>
     {
         if (envelopes.Count == 0) return;
 
-        await using var cmd = BuildBatchedIncomingCommand(envelopes);
+        // GH-4375: this one already runs in an explicit transaction (see below), so chunking it keeps
+        // the all-or-nothing guarantee the duplicate handling below depends on. A provider that
+        // overrides BuildBatchedIncomingCommand with a fixed-arity form -- PostgreSQL, since GH-4320 --
+        // has no ceiling to hit and gets a single chunk regardless.
+        var chunks = BuildsFixedArityBatches
+            ? [new ArraySegment<Envelope>(envelopes as Envelope[] ?? envelopes.ToArray())]
+            : chunkByParameterLimit(envelopes as Envelope[] ?? envelopes.ToArray(),
+                DatabaseConstants.IncomingParametersPerEnvelope).ToArray();
 
         await using var conn = await _dataSource.OpenConnectionAsync(_cancellation);
         try
@@ -296,9 +317,14 @@ public abstract partial class MessageDatabase<T>
             await using var tx = await conn.BeginTransactionAsync(_cancellation);
             try
             {
-                cmd.Connection = conn;
-                cmd.Transaction = tx;
-                await cmd.ExecuteNonQueryAsync(_cancellation);
+                foreach (var chunk in chunks)
+                {
+                    await using var cmd = BuildBatchedIncomingCommand(chunk);
+                    cmd.Connection = conn;
+                    cmd.Transaction = tx;
+                    await cmd.ExecuteNonQueryAsync(_cancellation);
+                }
+
                 await tx.CommitAsync(_cancellation);
             }
             catch (Exception e) when (IsDuplicateEnvelopeException(e))

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.Outgoing.cs
@@ -5,13 +5,28 @@ namespace Wolverine.RDBMS;
 
 public abstract partial class MessageDatabase<T>
 {
+    /// <summary>
+    /// GH-4375. Chunked, because this array is NOT governed by any batch-size setting: it is however
+    /// many messages the handler published inside the caller's transaction. A handler that fans out to
+    /// 350 recipients used to fail on SQL Server with "The incoming request has too many parameters",
+    /// an error that mentions neither Wolverine nor message counts.
+    /// </summary>
+    /// <remarks>
+    /// Every chunk runs on the CALLER'S transaction, so the batch is still all-or-nothing exactly as it
+    /// was -- more commands, same atomicity.
+    /// </remarks>
     public async Task StoreOutgoingAsync(DbTransaction tx, Envelope[] envelopes)
     {
-        var cmd = DatabasePersistence.BuildOutgoingStorageCommand(envelopes, Durability.AssignedNodeNumber, this);
-        cmd.Connection = tx.Connection;
-        cmd.Transaction = tx;
+        foreach (var chunk in chunkByParameterLimit(envelopes, DatabaseConstants.OutgoingParametersPerEnvelope,
+                     DatabaseConstants.OutgoingSharedParameters))
+        {
+            await using var cmd = DatabasePersistence.BuildOutgoingStorageCommand(chunk.ToArray(),
+                Durability.AssignedNodeNumber, this);
+            cmd.Connection = tx.Connection;
+            cmd.Transaction = tx;
 
-        await cmd.ExecuteNonQueryAsync(_cancellation);
+            await cmd.ExecuteNonQueryAsync(_cancellation);
+        }
 
         foreach (var envelope in envelopes)
         {
@@ -71,14 +86,47 @@ public abstract partial class MessageDatabase<T>
         if (HasDisposed || envelopes.Count == 0) return;
 
         var array = envelopes as Envelope[] ?? envelopes.ToArray();
-        var command = BuildBatchedOutgoingCommand(array, ownerId);
+
+        // GH-4375: chunk so a large batch cannot exceed the provider's parameter ceiling, and run the
+        // chunks in one explicit transaction so the batch stays all-or-nothing. The coalescer that feeds
+        // this falls back to storing each envelope individually when a batch fails, which is only safe
+        // if a failed batch wrote nothing.
+        var chunks = BuildsFixedArityBatches
+            ? [new ArraySegment<Envelope>(array)]
+            : chunkByParameterLimit(array, DatabaseConstants.OutgoingParametersPerEnvelope,
+                DatabaseConstants.OutgoingSharedParameters).ToArray();
 
         await using var conn = await DataSource.OpenConnectionAsync(_cancellation);
 
         try
         {
-            command.Connection = conn;
-            await command.ExecuteNonQueryAsync(_cancellation);
+            if (chunks.Length == 1)
+            {
+                await using var single = BuildBatchedOutgoingCommand(chunks[0].ToArray(), ownerId);
+                single.Connection = conn;
+                await single.ExecuteNonQueryAsync(_cancellation);
+            }
+            else
+            {
+                await using var tx = await conn.BeginTransactionAsync(_cancellation);
+                try
+                {
+                    foreach (var chunk in chunks)
+                    {
+                        await using var command = BuildBatchedOutgoingCommand(chunk.ToArray(), ownerId);
+                        command.Connection = conn;
+                        command.Transaction = tx;
+                        await command.ExecuteNonQueryAsync(_cancellation);
+                    }
+
+                    await tx.CommitAsync(_cancellation);
+                }
+                catch
+                {
+                    await tx.RollbackAsync(_cancellation);
+                    throw;
+                }
+            }
         }
         finally
         {

--- a/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
+++ b/src/Persistence/Wolverine.RDBMS/MessageDatabase.cs
@@ -27,6 +27,60 @@ namespace Wolverine.RDBMS;
 public abstract partial class MessageDatabase<T> : DatabaseBase<T>,
     IMessageDatabase, IMessageInbox, IMessageOutbox, IMessageStoreAdmin, IDeadLetters, IScheduledMessages, ISagaSupport where T : DbConnection, new()
 {
+    /// <summary>
+    /// GH-4375. The most parameters this provider accepts in one command. Batched durability commands
+    /// are split so they never exceed it.
+    /// </summary>
+    /// <remarks>
+    /// The default is SQL Server's 2,100 -- the tightest limit of any provider Wolverine ships -- so a
+    /// provider that does not override it chunks more than it strictly needs to and is never wrong.
+    /// Getting this too LOW costs an extra round trip; getting it too high throws at the driver, so the
+    /// default leans the safe way.
+    ///
+    /// <para>
+    /// Measured against the containers in docker-compose, by walking a multi-row insert across the
+    /// boundary: SQL Server 2,100 (349 outgoing envelopes, 233 incoming), SQLite 32,766, MySQL at least
+    /// 65,536. PostgreSQL's wire protocol caps it at 65,535.
+    /// </para>
+    /// </remarks>
+    public virtual int MaximumParameterCount => 2100;
+
+    /// <summary>
+    /// GH-4375. True when this provider's batched builders use a FIXED number of parameters regardless
+    /// of batch size, so no amount of batching can approach <see cref="MaximumParameterCount" />.
+    /// PostgreSQL sets this, having moved to <c>unnest</c> in GH-4320.
+    /// </summary>
+    protected virtual bool BuildsFixedArityBatches => false;
+
+    /// <summary>
+    /// GH-4375. Split a batch so each slice stays under <see cref="MaximumParameterCount" />.
+    /// </summary>
+    /// <remarks>
+    /// Always yields at least one envelope per slice: a single envelope that cannot fit is a problem no
+    /// amount of chunking solves, and silently yielding nothing would drop messages.
+    /// </remarks>
+    protected IEnumerable<ArraySegment<Envelope>> chunkByParameterLimit(Envelope[] envelopes,
+        int parametersPerEnvelope, int sharedParameters = 0)
+    {
+        // The shared parameters have to come off the budget BEFORE the division. Leaving them out puts
+        // the chunk boundary exactly one envelope past what fits: the outgoing builder is 6N + 1 (owner
+        // is shared), so 2100/6 = 350 chunks to precisely the size that was already known to fail.
+        var budget = Math.Max(1, MaximumParameterCount - sharedParameters);
+        var perChunk = Math.Max(1, budget / Math.Max(1, parametersPerEnvelope));
+
+        if (envelopes.Length <= perChunk)
+        {
+            yield return new ArraySegment<Envelope>(envelopes);
+            yield break;
+        }
+
+        for (var offset = 0; offset < envelopes.Length; offset += perChunk)
+        {
+            yield return new ArraySegment<Envelope>(envelopes, offset,
+                Math.Min(perChunk, envelopes.Length - offset));
+        }
+    }
+
     // ReSharper disable once InconsistentNaming
     protected readonly CancellationToken _cancellation;
     private readonly string _outgoingEnvelopeSql;

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerMessageStore.cs
@@ -33,6 +33,13 @@ namespace Wolverine.SqlServer.Persistence;
 
 public class SqlServerMessageStore : MessageDatabase<SqlConnection>, IConnectionBudgetProbe
 {
+    /// <summary>
+    /// GH-4375. SQL Server's hard limit, and the tightest of any provider Wolverine ships. Measured:
+    /// 349 outgoing envelopes in one transaction succeed (2,095 parameters) and 350 fail (2,101); 233
+    /// incoming succeed (2,097) and 234 fail (2,106).
+    /// </summary>
+    public override int MaximumParameterCount => 2100;
+
     private readonly string _findAtLargeEnvelopesSql;
     private readonly string _scheduledLockId;
     private DatabaseServerId? _serverId;

--- a/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteMessageStore.cs
@@ -27,6 +27,13 @@ namespace Wolverine.Sqlite;
 
 internal class SqliteMessageStore : MessageDatabase<SqliteConnection>
 {
+    /// <summary>
+    /// GH-4375. SQLITE_MAX_VARIABLE_NUMBER, measured at 32,766 against the bundled SQLite 3.50.4 by
+    /// walking a multi-row insert to "too many SQL variables". Older SQLite builds default to 999, so
+    /// this is deliberately the measured value rather than the theoretical one.
+    /// </summary>
+    public override int MaximumParameterCount => 32_766;
+
     private readonly string _deleteOutgoingEnvelopesSql;
     private readonly string _discardAndReassignOutgoingSql;
     private readonly string _findAtLargeEnvelopesSql;


### PR DESCRIPTION
Closes #4375.

A handler that published 350 messages in one transaction failed on SQL Server with:

```
The incoming request has too many parameters. The server supports a maximum of 2100 parameters.
```

— an error naming neither Wolverine nor message counts.

## The boundaries, measured

| path | params/envelope | last size that worked | first size that failed |
|---|---|---|---|
| `StoreOutgoingAsync(tx, envelopes)` | 6N + 1 | 349 (2,095) | **350** (2,101) |
| `StoreIncomingAsync(tx, envelopes)` | 9N | 233 (2,097) | **234** (2,106) |

**The batch sizes that have knobs were never the problem** — both default to 100. The *transactional* paths have no knob at all: the array is however many messages the handler published inside the caller's transaction, and nothing chunked it.

Both are now split to stay under a per-provider `MaximumParameterCount`, with every chunk running on the **caller's** transaction, so the batch keeps exactly the atomicity it had — more commands, same all-or-nothing.

The connection-owning batch paths are chunked too, since nothing stops an application raising `StoreIncomingBatchSize` past the ceiling. The outgoing one gains an explicit transaction when it chunks, matching what the incoming one already did: the coalescer feeding it falls back to storing envelopes individually when a batch fails, which is only safe if a failed batch wrote nothing.

## Per-provider limits, measured rather than assumed

The issue asked to confirm the other providers rather than assume, so I walked a multi-row insert across the boundary on each:

| provider | limit | how it was established |
|---|---|---|
| SQL Server | **2,100** | the tightest, and the base-class default |
| SQLite | **32,766** | `SQLITE_MAX_VARIABLE_NUMBER` on the bundled 3.50.4 — comfortably clear, contrary to the 999 older builds use |
| MySQL | **65,535** | protocol uint16; 65,536 parameters were *accepted*, so the practical limit is packet size |
| PostgreSQL | **65,535** | wire protocol int16 count |

PostgreSQL additionally declares `BuildsFixedArityBatches`, because #4374 moved its batched builders to `unnest` — 9 and 7 parameters at any batch size — so it has no ceiling to approach and takes a single chunk.

The base-class default is SQL Server's 2,100 **deliberately**: a provider that does not override chunks more than it needs and is never wrong, where the opposite default throws at the driver.

## Two things the tests caught, not the design

**The first chunker was off by one, in the worst possible way.** It divided the limit by the per-envelope count and ignored *shared* parameters — so outgoing chunked at 2100/6 = 350, precisely the size already known to fail. Shared parameters now come off the budget before the division.

**`the_parameter_constants_match_what_the_builders_actually_add`** pins the per-envelope counts against the real builders, so adding a column to either field list fails a test rather than silently moving every chunk boundary one envelope past what fits.

The tests use **1,000 envelopes** rather than 350 and 234, per the issue's own note: asserting on the boundary alone would start passing again the moment the per-envelope parameter count changed.

## Verification

| suite | result |
|---|---|
| `SqlServerTests` | 456/458 (2 skipped) |
| `PostgresqlTests` | 594/595 (1 skipped) |
| `SqliteTests` | 235/236 (1 skipped) |
| `MySqlTests` | 203/203 |
| `./build.sh PersistenceTests` | 113/113, 0 retries |

Full `wolverine.slnx -c Release -f net9.0` clean, 0 warnings.

## Not covered

Oracle is unaffected — its transactional store is a per-envelope loop that issues one command each, so parameters never accumulate. Its own bind-variable limit was not established; the probe was too slow to be worth it, and nothing in Wolverine approaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)