### PR TITLE
GH-4339: bind [FromQuery]/[FromHeader]/[FromRoute] on a middleware Finally

### DIFF
--- a/src/Http/Wolverine.Http.Tests/finally_query_header_route_binding_4339.cs
+++ b/src/Http/Wolverine.Http.Tests/finally_query_header_route_binding_4339.cs
@@ -1,0 +1,119 @@
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Wolverine.ComplianceTests;
+using WolverineWebApi;
+
+namespace Wolverine.Http.Tests;
+
+// GH-4339: the third and last door into the GH-4308/GH-4314 silent-misbind class. A
+// [FromQuery]/[FromHeader]/[FromRoute] parameter on a MIDDLEWARE Finally method got no HTTP binding
+// at all: MiddlewarePolicy builds those MethodCalls without chain.ApplyParameterMatching (every
+// sibling method kind -- Before, After, AfterCommit, OnException -- gets it), and they are nested
+// inside the try/finally wrapper frame rather than laid out in Middleware, so neither the
+// route-variable loop in HttpChain.DetermineFrames nor the GH-4314 postprocessor pass reached them.
+// JasperFx's name-then-type fallback then bound `audit` AND `trace` to httpContext.TraceIdentifier --
+// verified in the generated source before the fix -- while a parsed type died at codegen instead.
+public class finally_query_header_route_binding_4339 : IntegrationContext
+{
+    public finally_query_header_route_binding_4339(AppFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task finally_from_query_and_from_header_parameters_bind_from_the_wire()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/finally-query-header?audit=abc&attempts=3");
+            x.WithRequestHeader("x-trace", "t-42");
+        });
+
+        (await recorded(recorder, 2)).ShouldHaveTheSameElementsAs(
+            "Action", "Finally: audit=abc, attempts=3, trace=t-42");
+    }
+
+    [Fact]
+    public async Task absent_values_stay_absent_instead_of_binding_to_an_unrelated_variable()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        // The regression: with nothing on the wire, both string parameters used to receive
+        // httpContext.TraceIdentifier, so this recorded a GUID-ish trace id in each slot.
+        await Scenario(x => x.Get.Url("/middleware/finally-query-header"));
+
+        (await recorded(recorder, 2)).ShouldHaveTheSameElementsAs(
+            "Action", "Finally: audit=null, attempts=0, trace=null");
+    }
+
+    // The finals are built in two different places depending on whether the middleware also has a
+    // Before: MiddlewarePolicy.wrapBeforeFrame for this one, buildFinals for the test above. Both had
+    // to be fixed, and only a shape of each proves it.
+    [Fact]
+    public async Task a_middleware_that_also_has_a_before_binds_its_finally_the_same_way()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        await Scenario(x =>
+        {
+            x.Get.Url("/middleware/finally-with-before-query-header?audit=xyz");
+            x.WithRequestHeader("x-trace", "t-7");
+        });
+
+        (await recorded(recorder, 3)).ShouldHaveTheSameElementsAs(
+            "Before", "Action", "FinallyWithBefore: audit=xyz, trace=t-7");
+    }
+
+    // The GH-4308 half. A parsed route-bindable type has no same-typed variable to fall back to, so
+    // this shape did not compile at all -- it failed `codegen preview` on WolverineWebApi, which is
+    // why the endpoint also stays in the Nuke CodegenPreviewCommand's path.
+    [Fact]
+    public async Task finally_from_route_parameter_binds_the_parsed_route_value()
+    {
+        var recorder = Host.Services.GetRequiredService<Recorder>();
+        recorder.Actions.Clear();
+
+        await Scenario(x => x.Get.Url("/middleware/finally-route/1234"));
+
+        (await recorded(recorder, 2)).ShouldHaveTheSameElementsAs("Action", "FinallyRoute: 1234");
+    }
+
+    // Both halves of the contract have to make the same claim, which is the whole point of this wave:
+    // the generated code now reads these from the wire, so OpenAPI has to say so.
+    [Fact]
+    public void the_bound_finally_parameters_are_described_in_the_openapi_document()
+    {
+        var chain = HttpChains.ChainFor("GET", "/middleware/finally-query-header").ShouldNotBeNull();
+        var description = chain.CreateApiDescription("GET");
+
+        var parameters = description.ParameterDescriptions
+            .Select(x => $"{x.Source.Id}:{x.Name}")
+            .ToArray();
+
+        parameters.ShouldContain("Query:audit");
+        parameters.ShouldContain("Query:attempts");
+        parameters.ShouldContain("Header:x-trace");
+    }
+
+    // A middleware Finally runs on the way out of the generated Handle method -- which is AFTER the
+    // response body has been written, so the in-memory host can complete the Alba scenario before the
+    // finally block has appended anything. Reading recorder.Actions the instant Scenario() returns is
+    // therefore a race, and it is one that only shows up once a previous test has already warmed this
+    // chain's compiled code: cold, codegen makes the request slow enough that the finally always wins.
+    // Bisected out of a 2-in-5 intermittent failure, so wait for the effect rather than assume it.
+    private static async Task<IReadOnlyList<string>> recorded(Recorder recorder, int count)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (recorder.Actions.Count < count && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
+
+        return recorder.Actions.ToArray();
+    }
+}

--- a/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
+++ b/src/Http/Wolverine.Http/HttpChain.ApiDescription.cs
@@ -638,7 +638,14 @@ public partial class HttpChain
     /// </summary>
     private void fillChainBoundParameters(ApiDescription apiDescription)
     {
-        foreach (var call in Postprocessors.OfType<MethodCall>())
+        // GH-4339: a middleware type's Finally methods are the second binder that is derived from the
+        // method signature rather than from a produced variable. They are nested inside the try/finally
+        // wrapper frames rather than laid out in Middleware, so they were described by nothing at all --
+        // which was self-consistent only while the generated code did not read them either. Now that the
+        // codegen pass binds them, the description has to make the same claim or the two halves split.
+        // FinallyCalls() is the single enumeration both sides use. A value another binder already
+        // described is de-duplicated by addChainBoundParameter on the way in.
+        foreach (var call in Postprocessors.OfType<MethodCall>().Concat(FinallyCalls()))
         {
             foreach (var parameter in call.Method.GetParameters())
             {

--- a/src/Http/Wolverine.Http/HttpChain.Codegen.cs
+++ b/src/Http/Wolverine.Http/HttpChain.Codegen.cs
@@ -170,6 +170,20 @@ public partial class HttpChain
             }
         }
 
+        // GH-4339: a middleware type's Finally calls are nested INSIDE the try/finally wrapper frames
+        // below, not laid out in Middleware, so the `frame is MethodCall` loop that follows never sees
+        // them -- and unlike every sibling method kind (Before, After, AfterCommit, OnException), they
+        // are built without chain.ApplyParameterMatching. Both omissions together left a
+        // [FromQuery]/[FromHeader]/[FromRoute] parameter on a Finally with no binding at all, so
+        // JasperFx's name-then-type fallback either died on a parsed type or, worse, silently handed the
+        // parameter an unrelated variable of the same type (httpContext.TraceIdentifier for a string).
+        // Bound here from the method signature, exactly as GH-4308/GH-4314 bind postprocessors, so an
+        // unattributed parameter still resolves the way it does today.
+        foreach (var finallyCall in FinallyCalls())
+        {
+            tryApplyHttpBindingsFromSignature(finallyCall);
+        }
+
         var index = 0;
         foreach (var frame in Middleware)
         {
@@ -239,7 +253,7 @@ public partial class HttpChain
         // [FromQuery]/[FromHeader] per tryDescribePostprocessorBinding.
         foreach (var call in Postprocessors.OfType<MethodCall>().Concat(PostCommitPostprocessors.OfType<MethodCall>()))
         {
-            tryApplyHttpBindingsToPostprocessor(call);
+            tryApplyHttpBindingsFromSignature(call);
         }
 
         foreach (var frame in Postprocessors) yield return frame;
@@ -248,7 +262,37 @@ public partial class HttpChain
         foreach (var frame in PostCommitPostprocessors) yield return frame;
     }
 
-    private void tryApplyHttpBindingsToPostprocessor(MethodCall call)
+    /// <summary>
+    /// GH-4339: every <see cref="MethodCall" /> this chain will generate into a <c>finally</c> block.
+    /// They live nested one level inside the wrapper frames in <see cref="IChain.Middleware" /> --
+    /// <see cref="Wolverine.Middleware.TryFinallyWrapperFrame" /> for a middleware type's Finally methods, and
+    /// <see cref="Wolverine.Middleware.TryCatchFinallyFrame" /> once that middleware (or the endpoint type) also contributes
+    /// OnException methods -- so walking Middleware does not reach them. Both the codegen binding pass
+    /// and the OpenAPI description side enumerate them from here so the two cannot drift apart. The
+    /// endpoint type's own Finally methods are already parameter-matched by
+    /// <c>Chain.ApplyImpliedMiddlewareFromHandlers</c>; they come back through here too, and both
+    /// consumers are idempotent for an argument that is already bound.
+    /// </summary>
+    internal IEnumerable<MethodCall> FinallyCalls()
+    {
+        // Both frame types are qualified because JasperFx.CodeGeneration.Frames has its own,
+        // unrelated TryFinallyWrapperFrame and that namespace is imported here.
+        foreach (var frame in Middleware)
+        {
+            switch (frame)
+            {
+                case Wolverine.Middleware.TryFinallyWrapperFrame wrapper:
+                    foreach (var call in wrapper.Finallys.OfType<MethodCall>()) yield return call;
+                    break;
+
+                case Wolverine.Middleware.TryCatchFinallyFrame tryCatchFinally:
+                    foreach (var call in tryCatchFinally.FinallyBlocks.OfType<MethodCall>()) yield return call;
+                    break;
+            }
+        }
+    }
+
+    private void tryApplyHttpBindingsFromSignature(MethodCall call)
     {
         var parameters = call.Method.GetParameters();
         for (var i = 0; i < call.Arguments.Length; i++)

--- a/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
+++ b/src/Http/WolverineWebApi/MiddlewareEndpoints.cs
@@ -235,3 +235,76 @@ public class ShortCircuitFinallyEndpoints
         return "ok";
     }
 }
+// GH-4339: the same silent-misbind class as GH-4308/GH-4314, one door further in. A [FromQuery] /
+// [FromHeader] / [FromRoute] parameter on a MIDDLEWARE Finally method was never given an HTTP
+// binding: MiddlewarePolicy.buildFinals creates the MethodCall without chain.ApplyParameterMatching,
+// and the call is nested inside TryFinallyWrapperFrame, so neither the route-variable loop in
+// HttpChain.DetermineFrames nor the GH-4314 postprocessor pass ever reached it. JasperFx's
+// name-then-type fallback then handed the parameter an unrelated variable of the same type. A
+// Finally on the ENDPOINT type is unaffected -- Chain.ApplyImpliedMiddlewareFromHandlers already
+// runs those through ApplyParameterMatching.
+//
+// Both middleware shapes matter, because the finals are built in two different places: a middleware
+// WITH a Before goes through MiddlewarePolicy.wrapBeforeFrame, one WITHOUT goes through buildFinals.
+public class FinallyQueryHeaderMiddleware
+{
+    public static void Finally(Recorder recorder, [FromQuery] string? audit, [FromQuery] int attempts,
+        [FromHeader(Name = "x-trace")] string? trace)
+    {
+        recorder.Actions.Add($"Finally: audit={audit ?? "null"}, attempts={attempts}, trace={trace ?? "null"}");
+    }
+}
+
+public class FinallyWithBeforeQueryHeaderMiddleware
+{
+    public static void Before(Recorder recorder)
+    {
+        recorder.Actions.Add("Before");
+    }
+
+    public static void Finally(Recorder recorder, [FromQuery] string? audit,
+        [FromHeader(Name = "x-trace")] string? trace)
+    {
+        recorder.Actions.Add($"FinallyWithBefore: audit={audit ?? "null"}, trace={trace ?? "null"}");
+    }
+}
+
+// The GH-4308 half: a parsed route-bindable type on a Finally. Nothing produces a `long`, so this
+// shape died at codegen with an UnResolvableVariableException rather than binding wrongly -- which
+// also means this endpoint keeps the Nuke CodegenPreviewCommand guarding it.
+public class FinallyRouteMiddleware
+{
+    public static void Finally(Recorder recorder, [FromRoute] long orderId)
+    {
+        recorder.Actions.Add($"FinallyRoute: {orderId}");
+    }
+}
+
+public class FinallyBindingEndpoints
+{
+    // The `string` return is deliberate bait for the name-then-type fallback, exactly as in the
+    // GH-4314 postprocessor endpoint.
+    [Wolverine.Attributes.Middleware(typeof(FinallyQueryHeaderMiddleware))]
+    [WolverineGet("/middleware/finally-query-header")]
+    public string Get(Recorder recorder)
+    {
+        recorder.Actions.Add("Action");
+        return "ok";
+    }
+
+    [Wolverine.Attributes.Middleware(typeof(FinallyWithBeforeQueryHeaderMiddleware))]
+    [WolverineGet("/middleware/finally-with-before-query-header")]
+    public string GetWithBefore(Recorder recorder)
+    {
+        recorder.Actions.Add("Action");
+        return "ok";
+    }
+
+    [Wolverine.Attributes.Middleware(typeof(FinallyRouteMiddleware))]
+    [WolverineGet("/middleware/finally-route/{orderId:long}")]
+    public string GetRoute(Recorder recorder)
+    {
+        recorder.Actions.Add("Action");
+        return "ok";
+    }
+}

--- a/src/Wolverine/Middleware/MiddlewarePolicy.cs
+++ b/src/Wolverine/Middleware/MiddlewarePolicy.cs
@@ -520,6 +520,16 @@ public class TryFinallyWrapperFrame : Frame
         creates.AddRange(inner.Creates.Select(x => new Variable(x.VariableType, x.Usage)));
     }
 
+    /// <summary>
+    ///     The middleware <c>Finally</c> calls generated inside this frame's <c>finally</c> block. Exposed
+    ///     because these are the only <see cref="MethodCall" />s in a chain's <see cref="IChain.Middleware" />
+    ///     that are NOT reachable by walking that list -- they are nested one level in here. A chain type that
+    ///     has to bind or describe every method call it will generate (Wolverine.HTTP does both) cannot see
+    ///     them otherwise, which is how GH-4339's silently-inert [FromQuery]/[FromHeader]/[FromRoute]
+    ///     parameters went unnoticed.
+    /// </summary>
+    public IReadOnlyList<Frame> Finallys => _finallys;
+
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         _inner.GenerateCode(method, writer);


### PR DESCRIPTION
Closes #4339. The last door into the GH-4308/GH-4314 silent-misbind class.

## The defect

A binding attribute on a **middleware** `Finally` parameter did nothing. Two structural gaps combined:

1. `MiddlewarePolicy` builds the `Finally` `MethodCall`s **without** `chain.ApplyParameterMatching`. Every sibling method kind gets it — `buildBefores`, `buildAfters`, `buildAfterCommits` and `BuildOnExceptionCalls` all call it — so `Finally` is the single omission. (A `Finally` on the *endpoint* type is unaffected: `Chain.ApplyImpliedMiddlewareFromHandlers` already matches those.)
2. The calls are nested inside `TryFinallyWrapperFrame` rather than laid out in `chain.Middleware`, so neither the route-variable loop in `HttpChain.DetermineFrames` nor the GH-4308/GH-4314 postprocessor binding pass could reach them — and `fillChainBoundParameters` never saw them either.

With no binding, JasperFx's name-then-type fallback took over. Verified in the generated source on `main`:

```csharp
finally
{
    FinallyQueryHeaderMiddleware.Finally(_recorder, httpContext.TraceIdentifier, httpContext.TraceIdentifier);
}
```

**Both** the `[FromQuery] string? audit` and the `[FromHeader("x-trace")] string? trace` parameter came out as the trace identifier. It compiles, it runs, it delivers wrong data. A parsed type (`int`, `long`) instead died at codegen with an `UnResolvableVariableException`, which is why `codegen preview` failed on the route shape before the fix.

## The fix

A new `TryFinallyWrapperFrame.Finallys` accessor exposes the nested calls (the only `MethodCall`s in a chain's `Middleware` not reachable by walking that list). `HttpChain.FinallyCalls()` enumerates them — including the `TryCatchFinallyFrame` shape, used once `OnException` methods are also in play — and the existing signature-driven binding pass is applied to each.

Deliberately the **narrow** rule, not full `ApplyParameterMatching`: only a parameter carrying an explicit attribute, or colliding with a route segment on a route-bindable type, is claimed. An unattributed parameter still resolves exactly as it does today, so no existing `Finally` changes behavior. Running the full strategy set would have let `JsonBodyParameterStrategy` claim an unattributed concrete parameter as the request body on a POST — a behavior change well beyond the reported defect.

The description side walks the same `FinallyCalls()` enumeration, so both halves make the same claim rather than trading one split-brain for the mirror-image one.

## Testing

Five tests over three new `WolverineWebApi` shapes:

- `[FromQuery]` (string and parsed `int`) + `[FromHeader]`, present and absent — the absent case is the one that used to record a trace id
- the same through a middleware that **also** has a `Before`, because the finals are built in a different place in that case (`wrapBeforeFrame` vs `buildFinals`) and both needed fixing
- a parsed `[FromRoute] long`, which also restores `codegen preview` as a guard on the shape
- the OpenAPI description

Each half was mutation-checked: disabling the codegen pass fails 4 of the 5, disabling the description change fails the 5th.

One note on the tests: a middleware `Finally` runs after the response body is written, so reading the recorder the instant `Scenario()` returns is a race — it only loses once a previous test has warmed the compiled chain. That was a 2-in-5 intermittent failure, bisected and fixed by waiting for the effect rather than assuming it, which is why the assertions go through a small `recorded(...)` helper.

Local: `Wolverine.Http.Tests` 1038/1038, `CoreTests` 2875/2875, `codegen preview` clean, `dotnet build wolverine.slnx -c Release -f net9.0` clean with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)