### PR TITLE
GH-4232: a Native AOT app with any external transport died building its first route

### DIFF
--- a/src/Testing/CoreTests/Runtime/Routing/intrinsic_serializer_routes_through_the_cache_4232.cs
+++ b/src/Testing/CoreTests/Runtime/Routing/intrinsic_serializer_routes_through_the_cache_4232.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Runtime.RemoteInvocation;
+using Wolverine.Runtime.Routing;
+using Wolverine.Runtime.Serialization;
+using Wolverine.Tracking;
+using Wolverine.Transports.Local;
+using Xunit;
+
+namespace CoreTests.Runtime.Routing;
+
+// GH-4232. IntrinsicSerializer seeds the framework's own ISerializable types into its cache by DIRECT
+// construction, because closing IntrinsicSerializer<T> reflectively throws MissingMethodException in a
+// Native AOT image — the closed generic's constructor metadata is trimmed. MessageRoute closed the
+// generic itself instead of asking the cache, so every AOT-published app that configured ANY external
+// endpoint died during startup building the route for Acknowledgement / FailureAcknowledgement, even
+// though a perfectly good instance was already sitting in that cache.
+//
+// The AOT publish smoke could not catch it because it only dispatched locally and so never built an
+// external route; it now configures a sending endpoint (verified: reverting the MessageRoute fix makes
+// that native binary exit non-zero again). This test is the cheap JIT-side guard on the same invariant:
+// route construction must go THROUGH the cache, which is observable as reference equality.
+public class intrinsic_serializer_routes_through_the_cache_4232
+{
+    [Fact]
+    public async Task a_route_for_a_framework_serializable_type_reuses_the_seeded_serializer()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.GetRuntime();
+
+        var route = MessageRoute.For(typeof(FailureAcknowledgement), new LocalQueue("gh-4232"), runtime);
+
+        // Not merely "a serializer for the right type" — the very instance the constructor seeded.
+        // A route that closes the open generic itself produces a fresh one, which is the AOT crash.
+        route.Serializer.ShouldBeSameAs(
+            IntrinsicSerializer.Instance.SerializerFor(typeof(FailureAcknowledgement)));
+    }
+
+    [Fact]
+    public async Task routes_for_the_same_message_type_share_one_serializer()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine().StartAsync(TestContext.Current.CancellationToken);
+
+        var runtime = host.GetRuntime();
+
+        var first = MessageRoute.For(typeof(Acknowledgement), new LocalQueue("gh-4232-one"), runtime);
+        var second = MessageRoute.For(typeof(Acknowledgement), new LocalQueue("gh-4232-two"), runtime);
+
+        first.Serializer.ShouldBeSameAs(second.Serializer);
+    }
+}

--- a/src/Testing/Wolverine.AotSmoke.Publish/Program.cs
+++ b/src/Testing/Wolverine.AotSmoke.Publish/Program.cs
@@ -10,6 +10,7 @@ using JasperFx.CodeGeneration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Wolverine;
+using Wolverine.Transports.Tcp;
 
 var isCli = args.Length > 0 && args[0] is "codegen" or "describe" or "help" or "?";
 
@@ -20,6 +21,15 @@ var builder = Host.CreateDefaultBuilder(args)
         opts.ApplicationAssembly = typeof(AotPublishPingHandler).Assembly;
         opts.Durability.Mode = DurabilityMode.Solo;
         opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(AotPublishPingHandler));
+
+        // GH-4232: an EXTERNAL sending endpoint, which is what makes the host build real
+        // MessageRoutes at startup -- including routes for the framework's own ISerializable
+        // reply types. Closing IntrinsicSerializer<FailureAcknowledgement> reflectively on that
+        // path threw MissingMethodException in a native image, so every AOT app with any external
+        // transport died at startup. A purely local smoke never builds one of these routes, which
+        // is exactly why this shipped unseen past GH-4287. No listener is needed -- nothing is
+        // actually sent, the route construction is the thing under test.
+        opts.PublishAllMessages().ToPort(59_999);
 
         if (!isCli)
         {

--- a/src/Wolverine/Runtime/Routing/MessageRoute.cs
+++ b/src/Wolverine/Runtime/Routing/MessageRoute.cs
@@ -71,7 +71,12 @@ public class MessageRoute : IMessageRoute, IMessageInvoker
 
         if (messageType.CanBeCastTo(typeof(ISerializable)))
         {
-            Serializer = typeof(IntrinsicSerializer<>).CloseAndBuildAs<IMessageSerializer>(messageType);
+            // GH-4232: through the cache, never closing the generic here. IntrinsicSerializer seeds the
+            // framework's own ISerializable types by direct construction because the reflective close
+            // throws MissingMethodException under Native AOT -- and this route is built for
+            // FailureAcknowledgement on any app with an external endpoint, so closing it here killed
+            // every AOT-published app at startup.
+            Serializer = IntrinsicSerializer.Instance.SerializerFor(messageType);
         }
         else if (WolverineSystemPart.WithinDescription)
         {

--- a/src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/IntrinsicSerializer.cs
@@ -40,46 +40,46 @@ public class IntrinsicSerializer : IMessageSerializer
 
     public string ContentType => MimeType;
 
-    // IntrinsicSerializer<T> closes over the message type via reflection so
-    // user message types that implement ISerializable can be serialized without
-    // an additional registration. The CloseAndBuildAs<T> escape valve is
-    // dynamic-code-by-design; suppressing at the leaf rather than annotating
-    // IMessageSerializer keeps the cascade contained. AOT-clean apps avoid
-    // this path: their message types implement ISerializable AND get
-    // pre-discovered into _inner before any message is processed (the AOT
-    // pillar's source-generated registration story will land that
-    // pre-discovery — see #2746 / the AOT publishing guide).
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Closed generic resolved from runtime message type; AOT consumers pre-discover into _inner. See AOT guide.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050",
-        Justification = "Closed generic resolved from runtime message type; AOT consumers pre-discover into _inner. See AOT guide.")]
+    // Serialization goes through SerializerFor, which is the single place that may close
+    // IntrinsicSerializer<T> over a runtime message type and the only place carrying the
+    // dynamic-code suppression for it.
     public byte[] Write(Envelope envelope)
     {
-        var messageType = envelope.Message!.GetType();
-        if (_inner.TryFind(messageType, out var serializer))
-        {
-            return serializer.Write(envelope);
-        }
-
-        serializer = typeof(IntrinsicSerializer<>).CloseAndBuildAs<IMessageSerializer>(messageType);
-        _inner = _inner.AddOrUpdate(messageType, serializer);
-        return serializer.Write(envelope);
+        return SerializerFor(envelope.Message!.GetType()).Write(envelope);
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Closed generic resolved from messageType; AOT consumers pre-discover into _inner. See AOT guide.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050",
-        Justification = "Closed generic resolved from messageType; AOT consumers pre-discover into _inner. See AOT guide.")]
     public object ReadFromData(Type messageType, Envelope envelope)
+    {
+        return SerializerFor(messageType).ReadFromData(envelope.Data!);
+    }
+
+    /// <summary>
+    ///     The <see cref="IntrinsicSerializer{T}" /> for this message type, from the cache when it is already
+    ///     known and by closing the open generic when it is not.
+    ///
+    ///     GH-4232: every caller has to come through here rather than closing the generic itself. The
+    ///     framework's own ISerializable types are seeded into the cache by DIRECT construction in the
+    ///     constructor above precisely because the reflective close throws MissingMethodException under
+    ///     Native AOT, and a caller that skips the cache throws for those types even though a perfectly
+    ///     good instance is sitting in it. <see cref="Wolverine.Runtime.Routing.MessageRoute" /> did exactly
+    ///     that, so every AOT-published app with any external endpoint died building the route for
+    ///     FailureAcknowledgement -- past the GH-4287 fixes, and past the boot the AOT publish smoke asserts,
+    ///     because that smoke only dispatches locally and never builds an external route.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Closed generic resolved from a runtime message type; the framework's own types are pre-seeded and AOT consumers pre-discover the rest into _inner. See AOT guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Closed generic resolved from a runtime message type; the framework's own types are pre-seeded and AOT consumers pre-discover the rest into _inner. See AOT guide.")]
+    internal IMessageSerializer SerializerFor(Type messageType)
     {
         if (_inner.TryFind(messageType, out var serializer))
         {
-            return serializer.ReadFromData(envelope.Data!);
+            return serializer;
         }
 
         serializer = typeof(IntrinsicSerializer<>).CloseAndBuildAs<IMessageSerializer>(messageType);
         _inner = _inner.AddOrUpdate(messageType, serializer);
-        return serializer.ReadFromData(envelope.Data!);
+        return serializer;
     }
 
     public object ReadFromData(byte[] data)
@@ -107,10 +107,6 @@ public class IntrinsicSerializer : IMessageSerializer
     /// Tolerates duplicates and a null source.
     /// </remarks>
     /// <param name="messageTypes">Message types to resolve and cache.</param>
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Pre-populating the IntrinsicSerializer<T> cache at handler-graph compile time; same suppression as Write/ReadFromData. See AOT guide / #2769.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050",
-        Justification = "Pre-populating the IntrinsicSerializer<T> cache at handler-graph compile time; same suppression as Write/ReadFromData. See AOT guide / #2769.")]
     internal void Prepopulate(IEnumerable<Type>? messageTypes)
     {
         if (messageTypes == null) return;
@@ -119,10 +115,7 @@ public class IntrinsicSerializer : IMessageSerializer
         {
             if (messageType == null) continue;
             if (!messageType.CanBeCastTo(typeof(ISerializable))) continue;
-            if (_inner.TryFind(messageType, out _)) continue;
-
-            var serializer = typeof(IntrinsicSerializer<>).CloseAndBuildAs<IMessageSerializer>(messageType);
-            _inner = _inner.AddOrUpdate(messageType, serializer);
+            SerializerFor(messageType);
         }
     }
 }


### PR DESCRIPTION
Closes #4232.

## The crash

`MessageRoute` closed `IntrinsicSerializer<T>` over the message type itself instead of asking `IntrinsicSerializer`'s cache for it. That cache exists **precisely because** the reflective close throws `MissingMethodException` in a native image — GH-4287 seeded the framework's own `ISerializable` types into it by *direct construction* for exactly that reason. So the route threw for `Acknowledgement` / `FailureAcknowledgement` even though a working instance was sitting in the cache one field away.

Those routes are built during startup as soon as an app configures **any external sending endpoint**, which is why this killed every AOT-published app with a transport:

```
System.MissingMethodException: No parameterless constructor defined for type
'IntrinsicSerializer`1[Wolverine.Runtime.RemoteInvocation.FailureAcknowledgement]'
   at JasperFx.Core.Reflection.TypeExtensions.CloseAndBuildAs[T](Type, Type[])
   at Wolverine.Runtime.Routing.MessageRoute..ctor(Type, Endpoint, IWolverineRuntime)
   at Wolverine.Runtime.ExplicitRouting.<FindRoutes>d__0.MoveNext()
```

Reproduced on `main` in a **real `PublishAot` binary** built from the reporter's stack (Wolverine + Wolverine.MQTT). That same binary now boots and shuts down cleanly.

## The fix

`SerializerFor(Type)` is now the single place allowed to close the open generic, and the single place carrying the dynamic-code suppression for it. `Write`, `ReadFromData` and `Prepopulate` were three copies of the same cache-miss block and now delegate — which is why their suppressions are **removed** rather than duplicated: they no longer reflect, and leaving the justifications behind would tell a future reader they do.

## Why GH-4287 missed it, and why this one won't

The AOT publish smoke only dispatched **locally**, so it never built an external route. It now configures a sending endpoint. Verified both directions: reverting the `MessageRoute` fix makes that native binary exit non-zero again with the exact `MissingMethodException` above.

Two `CoreTests` give the same invariant fast JIT-side coverage — a route's serializer must be the very instance the constructor seeded, not a fresh close — and both also fail under that revert.

## On the warnings half of the report

A real `PublishAot` of Wolverine **+ Wolverine.MQTT** now emits **zero IL warnings**. The seven in the original report were all JasperFx's and are gone as of 2.63.2. The only two left anywhere are in the smoke project's own `RunJasperFxCommands` call, which is correctly annotated upstream and is the documented "don't use the CLI from a native binary" path.

## Verification

- Reporter-shape MQTT app: `PublishAot` → 0 IL warnings, native binary boots + shuts down, exit 0
- `Wolverine.AotSmoke.Publish`: publishes and runs, exit 0; fails as expected when the fix is reverted
- `CoreTests` 2877/2879 (2 pre-existing skips)
- `dotnet build wolverine.slnx -c Release -f net9.0` → 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)