### PR TITLE
GH-4200: let the HTTP transport answer to insecure http:// addresses too

### DIFF
--- a/docs/guide/http/transport.md
+++ b/docs/guide/http/transport.md
@@ -53,6 +53,10 @@ using var host = await Host.CreateDefaultBuilder()
     .StartAsync();
 ```
 
+Both `https://` and `http://` destinations are supported. Plain `http` is the normal shape for services
+talking to each other inside a container network or over localhost, where TLS is terminated elsewhere;
+prefer `https` for anything crossing a trust boundary.
+
 ## Security and Authentication
 
 Since the HTTP transport uses standard ASP.NET Core Minimal API endpoints, you can use **all of ASP.NET Core's

--- a/src/Http/Wolverine.Http.Tests/Transport/insecure_http_uri_4200.cs
+++ b/src/Http/Wolverine.Http.Tests/Transport/insecure_http_uri_4200.cs
@@ -1,0 +1,96 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine.Http.Transport;
+using Wolverine.Transports;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Http.Tests.Transport;
+
+// GH-4200. The HTTP transport declares the scheme "https", and TransportCollection keys every transport
+// by exactly one scheme, so `ToHttpEndpoint("http://some-api:80/")` built the endpoint happily and then
+// died registering the subscription with "Unknown Transport scheme 'http'". A plain http:// destination
+// is ordinary — services talking over a container network, a sidecar on localhost — and no other
+// transport owns that scheme.
+//
+// The transport's existing ["http"] constructor argument looks like it addresses this and does not: it
+// is the TAGS parameter, which has nothing to do with scheme resolution.
+public class insecure_http_uri_4200
+{
+    [Fact]
+    public void the_transport_answers_to_http_as_well_as_https()
+    {
+        var transport = new HttpTransport();
+
+        transport.Protocol.ShouldBe("https");
+        transport.AdditionalProtocols.ShouldContain("http");
+    }
+
+    [Fact]
+    public void get_or_create_endpoint_accepts_an_insecure_uri()
+    {
+        ITransport transport = new HttpTransport();
+
+        // The scheme guard on TransportBase rejected anything but the declared Protocol
+        var endpoint = transport.GetOrCreateEndpoint("http://some-api:80/".ToUri());
+
+        endpoint.Uri.Scheme.ShouldBe("http");
+    }
+
+    [Fact]
+    public void the_scheme_guard_still_rejects_an_unrelated_scheme()
+    {
+        ITransport transport = new HttpTransport();
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            transport.GetOrCreateEndpoint("ftp://some-api:80/".ToUri()));
+    }
+
+    [Fact]
+    public void transport_collection_resolves_the_insecure_scheme()
+    {
+        var options = new WolverineOptions();
+        options.Transports.GetOrCreate<HttpTransport>();
+
+        options.Transports.ForScheme("http").ShouldBeOfType<HttpTransport>();
+        options.Transports.ForScheme("https").ShouldBeOfType<HttpTransport>();
+    }
+
+    [Fact]
+    public void an_aliased_transport_is_still_enumerated_exactly_once()
+    {
+        // The alias is resolved by a fallback scan rather than a second dictionary key precisely so that
+        // the transport is not double-initialized and its endpoints not double-counted.
+        var options = new WolverineOptions();
+        options.Transports.GetOrCreate<HttpTransport>();
+
+        options.Transports.OfType<HttpTransport>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public void an_unknown_scheme_still_fails()
+    {
+        var options = new WolverineOptions();
+        options.Transports.ForScheme("nonsense").ShouldBeNull();
+    }
+
+    // The reporter's actual line. Subscribing is what threw, not building the endpoint.
+    [Fact]
+    public async Task publish_to_an_insecure_http_endpoint()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.PublishAllMessages().ToHttpEndpoint("http://some-api:80/");
+            }).StartAsync(TestContext.Current.CancellationToken);
+
+        var endpoint = host.GetRuntime().Options.Transports
+            .OfType<HttpTransport>()
+            .Single()
+            .Endpoints()
+            .Single();
+
+        endpoint.Uri.ShouldBe("http://some-api:80/".ToUri());
+    }
+}

--- a/src/Http/Wolverine.Http/Transport/HttpTransport.cs
+++ b/src/Http/Wolverine.Http/Transport/HttpTransport.cs
@@ -15,6 +15,14 @@ public class HttpTransport : TransportBase<HttpEndpoint>
     }
 
     /// <summary>
+    ///     GH-4200. `https` is the declared protocol, but a plain `http://…` destination is perfectly
+    ///     ordinary — services talking to each other over a container network, or a sidecar on localhost —
+    ///     and no other transport owns that scheme. Without this, ToHttpEndpoint("http://…") built the
+    ///     endpoint happily and then died on the subscription with "Unknown Transport scheme 'http'".
+    /// </summary>
+    public override IEnumerable<string> AdditionalProtocols => ["http"];
+
+    /// <summary>
     /// Name of the transport's own <see cref="IHttpClientFactory"/> client, registered by
     /// <c>AddWolverineHttp()</c>. Transport sends resolve it whenever the destination has no named client
     /// of its own, so envelope traffic carries transport configuration instead of inheriting whatever the

--- a/src/Wolverine/TransportCollection.cs
+++ b/src/Wolverine/TransportCollection.cs
@@ -77,9 +77,19 @@ public class TransportCollection : IEnumerable<ITransport>, IAsyncDisposable
 
     public ITransport? ForScheme(string scheme)
     {
-        return _transports.TryGetValue(scheme.ToLowerInvariant(), out var transport)
-            ? transport
-            : null;
+        var key = scheme.ToLowerInvariant();
+        if (_transports.TryGetValue(key, out var transport))
+        {
+            return transport;
+        }
+
+        // GH-4200: a transport may answer to more than one scheme -- HTTP declares `https` but `http://…`
+        // is an ordinary address on a container network. Deliberately a fallback scan rather than extra
+        // dictionary keys: registering one transport under several keys would make it appear twice in
+        // this collection's own enumeration, double-initializing it and double-counting its endpoints in
+        // AllEndpoints(). The scan only runs on a miss, which previously threw outright, and there are
+        // never more than a handful of transports.
+        return _transports.Values.FirstOrDefault(x => x.AdditionalProtocols.Contains(key));
     }
 
     public void Add(ITransport transport)

--- a/src/Wolverine/Transports/ITransport.cs
+++ b/src/Wolverine/Transports/ITransport.cs
@@ -29,6 +29,19 @@ public interface ITransport
     public string Protocol { get; }
 
     /// <summary>
+    ///     Additional URI schemes this transport answers to besides <see cref="Protocol" />, for a broker whose
+    ///     addresses legitimately come in more than one scheme. The HTTP transport is the motivating case
+    ///     (GH-4200): it declares <c>https</c>, but <c>http://…</c> is an ordinary address inside a container
+    ///     network, and there is no separate transport to own that scheme.
+    ///
+    ///     Empty by default. Implement it on a <see cref="TransportBase{TEndpoint}" /> subclass by OVERRIDING
+    ///     the virtual there, not by re-declaring this member -- a derived transport that does not re-list
+    ///     <see cref="ITransport" /> in its own base list inherits the base class's interface map, and a
+    ///     matching method it declares would silently never be called.
+    /// </summary>
+    IEnumerable<string> AdditionalProtocols => [];
+
+    /// <summary>
     ///     Strictly a diagnostic name for this transport type
     /// </summary>
     public string Name { get; }

--- a/src/Wolverine/Transports/TransportBase.cs
+++ b/src/Wolverine/Transports/TransportBase.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core;
 using JasperFx.Descriptors;
 using JasperFx.Resources;
 using Wolverine.Configuration;
@@ -34,6 +35,14 @@ public abstract class TransportBase<TEndpoint> : ITransport, ITagged where TEndp
 
     public string Protocol { get; }
 
+    /// <summary>
+    ///     See <see cref="ITransport.AdditionalProtocols" />. Declared here as a virtual rather than left to the
+    ///     interface's default implementation for the same reason as
+    ///     <see cref="TryResolveListenerAddress" />: a derived transport inherits this class's interface map,
+    ///     so an override it declares against the interface default would never be called.
+    /// </summary>
+    public virtual IEnumerable<string> AdditionalProtocols => [];
+
     public IEnumerable<Endpoint> Endpoints()
     {
         return endpoints();
@@ -64,9 +73,10 @@ public abstract class TransportBase<TEndpoint> : ITransport, ITagged where TEndp
 
     public Endpoint GetOrCreateEndpoint(Uri uri)
     {
-        if (uri.Scheme != Protocol)
+        if (uri.Scheme != Protocol && !AdditionalProtocols.Contains(uri.Scheme))
         {
-            throw new ArgumentOutOfRangeException($"Uri must have scheme '{Protocol}', but received {uri.Scheme}");
+            var accepted = new[] { Protocol }.Concat(AdditionalProtocols).Select(x => $"'{x}'").Join(" or ");
+            throw new ArgumentOutOfRangeException($"Uri must have scheme {accepted}, but received {uri.Scheme}");
         }
 
         return findEndpointByUri(uri);


### PR DESCRIPTION
Closes #4200.

## The problem

`TransportCollection` keys every transport by exactly one scheme, and the HTTP transport declares `https`. So the reporter's line built the endpoint happily and then died registering the subscription:

```
System.InvalidOperationException: Unknown Transport scheme 'http'
```

A plain `http://` destination is ordinary — services talking over a container network, or a sidecar on localhost with TLS terminated elsewhere — and no other transport owns that scheme.

One trap worth flagging: `HttpTransport`'s existing `["http"]` constructor argument *looks* like it already covers this. It doesn't — that's the **tags** parameter, unrelated to scheme resolution.

## The fix

`ITransport` gains `AdditionalProtocols`, empty by default, which `HttpTransport` overrides with `"http"`. The reporter guessed this was generic rather than HTTP-specific, and it is — the concept sits on the interface so any transport with legitimately multi-scheme addresses can opt in.

Two deliberate choices:

- **`TransportBase` declares it as a `virtual`**, not left to the interface's default implementation — the same reason `TryResolveListenerAddress` is a virtual there. A derived transport inherits the base class's interface map, so an override written against the interface default would silently never be called.
- **`ForScheme` consults aliases only on a dictionary miss** (a case that previously threw outright) rather than registering one transport under several keys. Extra keys would make the transport appear **twice** in `TransportCollection`'s own enumeration — double-initializing it and double-counting its endpoints in `AllEndpoints()`. There's a test pinning that.

The scheme guard in `TransportBase.GetOrCreateEndpoint` accepts the aliases and now names every accepted scheme when it rejects one.

## Testing

Seven tests, including the reporter's exact `ToHttpEndpoint("http://some-api:80/")` line end to end through a booted host. Both halves of the fix were reverted independently to confirm the tests catch them — the reporter's case fails under either. Also covered: an unrelated scheme is still rejected, an unknown scheme still resolves to null, and the aliased transport is enumerated exactly once.

Local: `CoreTests` 2877/2879, `Wolverine.Http.Tests` 1045/1055 (pre-existing skips), `dotnet build wolverine.slnx -c Release -f net9.0` 0 warnings / 0 errors. Docs note added to the HTTP transport page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
