### PR TITLE
GH-4119: broker resource setup honors ResourceMigrationFailureMode

### DIFF
--- a/docs/guide/durability/managing.md
+++ b/docs/guide/durability/managing.md
@@ -57,6 +57,13 @@ Note that Wolverine already serializes migrations across processes with a global
 migration once after a short delay, so a genuine race between two nodes starting at the same instant is resolved
 without this setting.
 
+The same setting governs **broker** resources — the queues, topics, and subscriptions a transport provisions. Both
+`resources setup` and `AddResourceSetupOnStartup()` sweep those, and by default a broker object that cannot be
+provisioned fails the sweep, so a deploy step that provisions ahead of its hosts cannot exit 0 having created nothing.
+`ContinueOnFailures` is the setting for a host whose broker topology is owned externally and whose broker may not
+expose an administration API at all — an Azure Service Bus emulator, for instance, with its queues declared in the
+emulator's own configuration. Such a host logs the provisioning failure and starts.
+
 ## Disable Automatic Storage Migration
 
 To disable the automatic storage migration, just flip this flag:

--- a/src/Testing/CoreTests/Transports/BrokerResourceSetupTests.cs
+++ b/src/Testing/CoreTests/Transports/BrokerResourceSetupTests.cs
@@ -1,4 +1,5 @@
 using CoreTests.Runtime;
+using JasperFx;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Wolverine.Configuration;
@@ -55,6 +56,40 @@ public class BrokerResourceSetupTests
         await new BrokerResource(transportWith(endpoints), theRuntime).Setup(CancellationToken.None);
 
         endpoints.ShouldAllBe(x => x.WasSetUp);
+    }
+
+    /// <summary>
+    ///     GH-4119. This resource is swept by BOTH `resources setup` and JasperFx's
+    ///     AddResourceSetupOnStartup() hosted service, and those two want opposite things from a broker that
+    ///     cannot be provisioned. A host whose broker topology is externally owned — the reported case was an
+    ///     Azure Service Bus emulator, which has no administration API at all — died at startup on the throw
+    ///     above, once per endpoint, and never reached "Application started". Same failure policy Wolverine
+    ///     already applies to its own message storage migration, so one knob governs both.
+    /// </summary>
+    [Fact]
+    public async Task continues_past_a_setup_failure_when_the_failure_mode_says_to()
+    {
+        theRuntime.Options.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+
+        var failing = new StubBrokerEndpoint { WillFail = true };
+        var succeeding = new StubBrokerEndpoint();
+
+        var resource = new BrokerResource(transportWith(failing, succeeding), theRuntime);
+
+        await resource.Setup(CancellationToken.None);
+
+        // and every other endpoint is still attempted, exactly as under FailFast
+        succeeding.WasSetUp.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task fail_fast_is_still_the_default()
+    {
+        theRuntime.Options.ResourceMigrationFailureMode.ShouldBe(ResourceMigrationFailureMode.FailFast);
+
+        var resource = new BrokerResource(transportWith(new StubBrokerEndpoint { WillFail = true }), theRuntime);
+
+        await Should.ThrowAsync<AggregateException>(() => resource.Setup(CancellationToken.None));
     }
 
     private static IBrokerTransport transportWith(params StubBrokerEndpoint[] endpoints)

--- a/src/Wolverine/Transports/BrokerResource.cs
+++ b/src/Wolverine/Transports/BrokerResource.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using JasperFx.Core;
 using Microsoft.Extensions.Logging;
 using JasperFx.Resources;
@@ -101,11 +102,35 @@ public class BrokerResource : IStatefulResource
             }
         }
 
-        if (failures.Count != 0)
+        if (failures.Count == 0)
         {
-            throw new AggregateException(
-                $"Unable to set up {failures.Count} of the {_transport.Name} broker endpoints", failures);
+            return;
         }
+
+        // GH-4119: the same failure policy Wolverine already applies to its own message storage migration
+        // on startup (WolverineRuntime.HostService), and for the same reason -- this resource is swept by
+        // BOTH `resources setup` and JasperFx's AddResourceSetupOnStartup() hosted service, and those two
+        // want opposite things from an unprovisionable broker. FailFast (the default) keeps the behavior
+        // above: a deploy step that provisions ahead of its hosts must not exit 0 having created nothing.
+        // ContinueOnFailures is for the host that treats its broker topology as externally owned -- an
+        // Azure Service Bus emulator with no administration API at all, queues declared in the emulator's
+        // own config -- where an unreachable admin endpoint is an expected fact about the environment
+        // rather than a reason to refuse to start.
+        //
+        // Deliberately NOT keyed off AutoProvision. AddResourceSetupOnStartup() is the documented way to
+        // provision a broker WITHOUT AutoProvision (see the Redis listener's own error message), so
+        // skipping the resource whenever AutoProvision is off would break that supported path.
+        if (_runtime.Options.ResourceMigrationFailureMode == ResourceMigrationFailureMode.ContinueOnFailures)
+        {
+            _runtime.Logger.LogError(new AggregateException(failures),
+                "Unable to set up {Count} of the {Name} broker endpoints. Continuing anyway because ResourceMigrationFailureMode is ContinueOnFailures.",
+                failures.Count, _transport.Name);
+
+            return;
+        }
+
+        throw new AggregateException(
+            $"Unable to set up {failures.Count} of the {_transport.Name} broker endpoints", failures);
     }
 
     public async Task<IRenderable> DetermineStatus(CancellationToken token)


### PR DESCRIPTION
Closes #4119.

## The problem

`BrokerResource` is swept by **both** `resources setup` and JasperFx's `AddResourceSetupOnStartup()` hosted service, and those two want opposite things from a broker that cannot be provisioned.

Since ddb3bca32 made `Setup` throw — correctly, so a deploy step that provisions ahead of its hosts cannot exit 0 having created nothing — a host whose broker topology is externally owned dies at startup instead. The reported case is an Azure Service Bus emulator, which has **no administration API at all**: eight endpoints each log a failure and the host never reaches `Application started`. On 6.23.1 the same failures were logged and the host ran.

## The fix

`Setup` now applies the same failure policy Wolverine already applies to its own message storage migration in `WolverineRuntime.HostService`:

- **`FailFast`** (the default) — throws exactly as today. `resources setup` stays strict, which is the whole point of ddb3bca32.
- **`ContinueOnFailures`** — logs the aggregate and starts. This is the setting for a host that treats its broker topology as externally owned.

One knob governs both kinds of resource, which is what an operator would expect from a setting called `ResourceMigrationFailureMode`. Every endpoint is still attempted before either outcome, so `ContinueOnFailures` still provisions everything it can.

## Why not the issue's first suggestion

The issue proposed skipping the resource unless `AutoProvision` is on — "a transport that never asked to provision shouldn't be able to fail provisioning." **That can't work.** `AddResourceSetupOnStartup()` is the documented way to provision a broker *without* `AutoProvision`; Wolverine's own Redis listener says so in its error message when a consumer group is missing:

> Enable AutoProvision() or run AddResourceSetupOnStartup() to create it.

Keying off `AutoProvision` would break that supported path for everyone relying on it. Flagging this explicitly since the suggestion was mine — worth knowing the option is closed off, not merely passed over.

The second suggestion (throw for the command, not for the startup sweep) is closer to what landed, but the resource has no way to tell which caller invoked it — and an explicit policy setting is better than an implicit one keyed on call site.

## Testing

Two tests added to the existing `BrokerResourceSetupTests`, alongside the three that already pin the `FailFast` behavior. Swapping the two enum values in the fix fails four of the five, so both directions are pinned, not just the new one.

Local: `CoreTests` 2879/2881 (2 pre-existing skips), `dotnet build wolverine.slnx -c Release -f net9.0` 0 warnings / 0 errors. Docs updated in the storage-management guide, where the setting is already documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
