### PR TITLE
Fix the slot-coverage lottery behind the native-ack partitioning flake

### DIFF
--- a/src/Testing/Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs
+++ b/src/Testing/Wolverine.ComplianceTests/Partitioning/NativeAckPartitionedProcessing.cs
@@ -68,12 +68,16 @@ public static class NativeAckPartitionedProcessing
     /// One factory per host, not one bus per host: an <see cref="IMessageBus" /> is scoped and is not built to
     /// be shared across concurrent invocations, so each parallel publisher below resolves its own.
     /// </param>
+    /// <param name="slotCount">
+    /// The topology's slot count, for callers that go on to assert <see cref="AssertEverySlotWasUsed" />. Leave
+    /// it at zero when slot coverage is not asserted.
+    /// </param>
     public static async Task<IReadOnlyList<(string GroupId, int Sequence)>> PumpOutLettersAsync(
-        IReadOnlyList<Func<IMessageBus>> busSources, int groupCount, int messagesPerGroup)
+        IReadOnlyList<Func<IMessageBus>> busSources, int groupCount, int messagesPerGroup, int slotCount = 0)
     {
         var published = new ConcurrentQueue<(string, int)>();
 
-        var groups = Enumerable.Range(0, groupCount).Select(_ => Guid.NewGuid().ToString()).ToArray();
+        var groups = buildGroupIds(groupCount, slotCount);
 
         await Parallel.ForEachAsync(groups, async (groupId, _) =>
         {
@@ -90,6 +94,43 @@ public static class NativeAckPartitionedProcessing
         });
 
         return published.ToArray();
+    }
+
+    /// <summary>
+    /// The group ids for one run. When <paramref name="slotCount" /> is supplied, the first id drawn for each
+    /// slot is one that hashes to it, so every slot is guaranteed at least one group; any remaining ids are
+    /// free. Ids stay freshly random either way, so runs do not reuse group ids.
+    /// </summary>
+    /// <remarks>
+    /// Purely random ids do not cover the slots reliably, and the shortfall is not rare: 24 random ids over 6
+    /// slots leave at least one slot empty 7.5% of the time by simulation, measured at 8.5% (17 of 200 runs)
+    /// against the real broker. That is a property of the birthday problem rather than of the system under
+    /// test, and it was the whole of the 6.34.0 gate flake. Seeding one id per slot removes the lottery without
+    /// weakening <see cref="AssertEverySlotWasUsed" />: the assertion still fails if routing does not land a
+    /// group on the slot its group id hashes to.
+    /// </remarks>
+    private static string[] buildGroupIds(int groupCount, int slotCount)
+    {
+        var groups = new List<string>(groupCount);
+
+        // Mirrors PartitionedMessagingExtensions.SlotForSending(), which is what actually picks the slot.
+        for (var slot = 0; slot < Math.Min(slotCount, groupCount); slot++)
+        {
+            string candidate;
+            do
+            {
+                candidate = Guid.NewGuid().ToString();
+            } while (Math.Abs(candidate.GetDeterministicHashCode() % slotCount) != slot);
+
+            groups.Add(candidate);
+        }
+
+        while (groups.Count < groupCount)
+        {
+            groups.Add(Guid.NewGuid().ToString());
+        }
+
+        return groups.ToArray();
     }
 
     /// <summary>
@@ -142,6 +183,11 @@ public static class NativeAckPartitionedProcessing
     /// Every slot in the topology must have actually executed something, otherwise a "no concurrency"
     /// result would be trivially satisfied by everything landing on one slot.
     /// </summary>
+    /// <remarks>
+    /// Callers must pass the slot count to <see cref="PumpOutLettersAsync" /> as well, so the run's group ids
+    /// actually reach every slot. Without that this assertion is a coin flip on the group ids rather than a
+    /// statement about routing -- see <c>buildGroupIds</c>.
+    /// </remarks>
     public static void AssertEverySlotWasUsed(int numberOfSlots)
     {
         var destinations = Ledger.Handled.Select(x => x.Destination).Distinct().ToArray();

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_global_partitioning_cluster.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/native_ack_global_partitioning_cluster.cs
@@ -177,7 +177,8 @@ public class native_ack_global_partitioning_cluster : IAsyncLifetime
         assertSlotsAreNativeAckWithNoCompanionQueue(node1, baseName, slotCount);
 
         var published = await NativeAckPartitionedProcessing.PumpOutLettersAsync(
-            [node1.MessageBus, node2.MessageBus, node3.MessageBus], groupCount: 24, messagesPerGroup: 4);
+            [node1.MessageBus, node2.MessageBus, node3.MessageBus], groupCount: 24, messagesPerGroup: 4,
+            slotCount: slotCount);
 
         (await NativeAckPartitionedProcessing.WaitForCompletionAsync(published, 90.Seconds()))
             .ShouldBeTrue("Not every published letter was handled inside the timeout");


### PR DESCRIPTION
## What flaked

`native_ack_global_partitioning_cluster.no_two_messages_of_a_group_execute_concurrently_across_a_storage_free_cluster` failed on attempt 1 and passed on attempt 2 during the 6.34.0 release gate (`Wolverine.RabbitMQ.Tests`: 518 clean, 1 on retry, 519 total).

The failure was `AssertEverySlotWasUsed`:

```
destinations.Length should be 6 but was 5
Expected all 6 slots to be used. Saw: naclust3, naclust6, naclust1, naclust4, naclust2
```

That is the **coverage** assertion, and it runs *last*. The three assertions that state the actual guarantee — `AssertNoIntraGroupConcurrency`, `AssertEveryLetterWasHandled`, `AssertGroupsNeverStraddleSlots` — had all already passed. **This was not a race in slot ownership or handoff.**

## Why

The fixture drew 24 group ids as `Guid.NewGuid().ToString()`, and slot selection is `Math.Abs(groupId.GetDeterministicHashCode() % 6)` (`PartitionedMessagingExtensions.SlotForSending`). 24 random balls into 6 bins leave a bin empty roughly 7.5% of the time. The assertion was testing the draw, not the routing.

## Reproduction

200 runs of the single test against the docker-compose broker:

| | |
|---|---|
| Failures | **17 / 200 = 8.5%** |
| Predicted by simulating the same hash (200k trials) | 7.52% |
| Failures that were `AssertEverySlotWasUsed` | 17 / 17 |
| Failures at exactly 5-of-6 coverage | 17 / 17 |
| Intra-group concurrency violations | **0** |

The hash itself is uniform (600k Guids → 100304 / 100133 / 99641 / 99745 / 100040 / 100137), so there is no routing skew hiding under the arithmetic.

## The fix

`PumpOutLettersAsync` takes an optional slot count. When supplied, the first id drawn for each slot is one that hashes to that slot, so every slot is guaranteed at least one group; the remaining ids are free, and ids stay freshly random per run.

This makes the coverage assertion **stronger**, not weaker — it now fails if routing does not land a group on the slot its group id hashes to, which is exactly what a green run then demonstrates. Raising the group count instead would only have shrunk the lottery.

Callers that do not assert slot coverage (`sends_go_through_the_broker_even_when_this_node_owns_every_slot`, `webhook_flood_ledger_red_baseline`) pass no slot count and take the identical path as before. `webhook_flood_native_ack_chaos` builds its own skewed entity stream over hundreds of entities, so it was never exposed.

## Verification

- **200/200 passes** after the change (under the old 8.5% rate, P(0 in 200) ≈ 2×10⁻⁸).
- `Wolverine.ComplianceTests`, `Wolverine.RabbitMQ.Tests` and `SlowTests` build clean, 0 warnings, `-f net9.0`.
- The full supervised `CIRabbitMQ` lane was not run locally — a gate sweep was occupying the repo at the time. CI covers it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)