### PR TITLE
Bump to 6.34.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.33.0</Version>
+        <Version>6.34.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Version bump only — `<Version>` in `Directory.Build.props`, 6.33.0 -> 6.34.0. Release notes go on the GitHub release, not in the repo (see #4347).

70 commits since V6.33.0: the GH-4316 performance wave, recurring cron-scheduled messages (#4307), Native AOT that boots end to end, and a long run of clustering/transport fixes.

## Local gates, all green

Run against this exact tree (only delta from main is the version line):

| Gate | Result |
|---|---|
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |
| CoreTests | 2877 |
| MessageRoutingTests | 25 |
| PersistenceTests | 113 |
| HttpTests | 1030 |
| CIRabbitMQ | 519 (1 retry) |
| CISqlServer | 458 (1 retry) |
| CIMarten | 306 |
| CIMartenDistribution | 207 |
| CIMartenTenancy | 138 |
| CIOracle | 182 |
| CIMySql | 203 |
| CISqlite | 236 |
| CIEfCore | 427 |
| CICosmosDb | 130 |
| CIRedis | 246 |
| CIAotSmoke | static round-trip + AI + native publish/boot/dispatch |
| CIAWSSqs | 257 |
| CIAzureServiceBus | 333 |

~7,700 tests, 0 failures, 2 flaky retries (both noted below).

## Not covered locally

Kafka, NATS, Pulsar, MQTT, PubSub, Polecat shards, RavenDb (Pulsar holds port 8080), SNS, S3, Blob Storage, Grpc, Otel, Fisher.

## Flaky retries worth tracking

- `Wolverine.RabbitMQ.Tests.native_ack_global_partitioning_cluster.no_two_messages_of_a_group_execute_concurrently_across_a_storage_free_cluster` — passed on attempt 2
- `SqlServerTests.Transport.data_operations.move_to_incoming` — passed on attempt 2

Neither blocks the cut; the second sits in a durability path this release changed, so it is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)