### PR TITLE
Close the MartenOps gap with Marten's own IDocumentOperations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,6 @@ JasperSamples
 
 .nuke/build.schema.json
 .claude/scheduled_tasks.lock
+
+# git worktrees created inside the repo
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -541,6 +541,33 @@
   optimistic-concurrency safe: the replace is guarded by the ETag of the read and retried on a 412
   (a peer bumped the sequence first) or a 409 (a peer created the missing sequence document first).
 
+### WolverineFx.Marten
+
+- **`MartenOps` closes the gap with Marten's own `IDocumentOperations`.** `MartenOps` covered
+  store/insert/update/delete plus `StartStream`, so a handler wanting any of the rest of Marten's
+  session API had to inject an `IDocumentSession` and give up being a pure function. Added side
+  effects for everything on `IDocumentOperations` that fits the synchronous `IMartenOp` shape:
+  `HardDelete` (document or `string`/`Guid`/`int`/`long` id) and `HardDeleteWhere`,
+  `UndoDeleteWhere`, `InsertObjects` and `DeleteObjects` alongside the existing `StoreObjects`,
+  `UpdateExpectedVersion` / `UpdateRevision` / `TryUpdateRevision`, `Patch` and `PatchWhere` over
+  Marten's fluent patch API, `QueueSqlCommand` in both its `?` and custom-placeholder forms, and
+  `Append` (optionally with an expected stream version) and `ArchiveStream` for a stream that
+  already exists. `QueueOperation(IStorageOperation)` and `Events.OverwriteEvent` are deliberately
+  left to a hand-written `IMartenOp`.
+- **Tenant scoping is one mechanism instead of an overload per factory.** The existing pattern is a
+  `tenantId` overload on each factory - 12 extra methods for the original 6 ops, and the parameter
+  lands in a different position depending on the method because `params` has to come last. Every op
+  now implements `ITenantedMartenOp`, and a single generic `ForTenant()` extension scopes it while
+  preserving the concrete return type, so it still chains with `With()`. The existing overloads are
+  untouched.
+- **Two invariants moved to construction time.** Marten's `HardDelete<T>()` and `Patch<T>()` have no
+  `object`-typed id overload to fall back on the way `Delete<T>()` does, so an id type they cannot
+  dispatch is now rejected by the factory rather than surfacing inside `SaveChangesAsync()` long
+  after the handler returned a side effect that looked valid. And `Append` / `ArchiveStream`
+  discriminate Guid identity from string identity on `StreamId == Guid.Empty` - the same sentinel
+  `StartStream<T>` uses - so both refuse `Guid.Empty` and an empty stream key instead of silently
+  taking the wrong branch.
+
 ### Dependencies
 
 - JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator and JasperFx.SourceGenerator to

--- a/docs/guide/durability/marten/operations.md
+++ b/docs/guide/durability/marten/operations.md
@@ -123,6 +123,23 @@ public static DeleteDocWhere<TempRecord> Handle(CleanupTenant command)
 
 All existing method signatures are unchanged — the tenant overloads are purely additive.
 
+### Scoping Any Operation to a Tenant <Badge type="tip" text="6.35" />
+
+Rather than growing a parallel `tenantId` overload for every factory method, any `MartenOps`
+operation can be pointed at a tenant with `ForTenant()`:
+
+```csharp
+public static IMartenOp Handle(ArchiveTenantOrder command)
+{
+    return MartenOps.ArchiveStream(command.OrderId).ForTenant(command.TenantId);
+}
+```
+
+`ForTenant()` returns the same operation with its concrete type intact, so it composes with the
+fluent `With()` methods and can still be returned as a specific type. It works on every built-in
+operation and on your own `IMartenOp` implementations as soon as they implement
+`ITenantedMartenOp`.
+
 There's also a specific helper for starting a new event stream as shown below:
 
 <!-- snippet: sample_using_start_stream_side_effect -->
@@ -183,6 +200,160 @@ type of `IMartenOp` is a side effect.
 
 Like any other "side effect", you could technically return this as the main return type of a method or as part of a
 tuple.
+
+## Hard Deletes and Undoing Soft Deletes <Badge type="tip" text="6.35" />
+
+For a [soft-deleted](https://martendb.io/documents/deletes.html#soft-deletes) document type,
+`MartenOps.Delete()` only marks the document as deleted. Use `MartenOps.HardDelete()` to remove
+the underlying database row, and `MartenOps.UndoDeleteWhere()` to reverse a soft deletion:
+
+```csharp
+// Hard delete by document
+public static IMartenOp Handle(PurgeInvoice command, Invoice invoice)
+{
+    return MartenOps.HardDelete(invoice);
+}
+
+// Hard delete by id - string, Guid, int, and long ids are all supported
+public static IMartenOp Handle(PurgeInvoiceById command)
+{
+    return MartenOps.HardDelete<Invoice>(command.InvoiceId);
+}
+
+// Hard delete everything matching a filter
+public static IMartenOp Handle(PurgeOldInvoices command)
+{
+    return MartenOps.HardDeleteWhere<Invoice>(x => x.CreatedAt < command.Cutoff);
+}
+
+// Bring soft-deleted documents back
+public static IMartenOp Handle(RestoreInvoices command)
+{
+    return MartenOps.UndoDeleteWhere<Invoice>(x => x.CustomerId == command.CustomerId);
+}
+```
+
+::: warning
+Marten's `HardDelete<T>()` only accepts `string`, `Guid`, `int`, and `long` identities — it has no
+`object` overload to fall back on the way `Delete<T>()` does. Passing anything else (a strongly
+typed id, say) throws an `ArgumentOutOfRangeException` from the `MartenOps` factory rather than
+failing later inside `SaveChangesAsync()`.
+:::
+
+## Mixed Document Batches <Badge type="tip" text="6.35" />
+
+`MartenOps.InsertObjects()` and `MartenOps.DeleteObjects()` are the insert and delete counterparts
+of `StoreObjects()`, and support the same fluent `With()` methods:
+
+```csharp
+public static IMartenOp Handle(CreateOrder command)
+{
+    return MartenOps.InsertObjects(new Order { Id = command.OrderId })
+        .With(new AuditLog { Action = "Created" });
+}
+```
+
+Where `StoreObjects()` upserts, `InsertObjects()` will fail the transaction if any of the documents
+already exist.
+
+## Revision-Checked Updates <Badge type="tip" text="6.35" />
+
+For document types using Marten's [numeric revisioning](https://martendb.io/documents/concurrency.html),
+these operations carry the expected revision into the update:
+
+```csharp
+// Fails with a ConcurrencyException if the stored revision is >= the supplied one
+public static IMartenOp Handle(ReviseInvoice command, Invoice invoice)
+{
+    return MartenOps.UpdateRevision(invoice, command.Revision);
+}
+
+// Same check, but silently does nothing instead of throwing
+public static IMartenOp Handle(MaybeReviseInvoice command, Invoice invoice)
+{
+    return MartenOps.TryUpdateRevision(invoice, command.Revision);
+}
+
+// The Guid-versioned equivalent for types using Marten's optimistic concurrency
+public static IMartenOp Handle(UpdateInvoice command, Invoice invoice)
+{
+    return MartenOps.UpdateExpectedVersion(invoice, command.Version);
+}
+```
+
+## Patching <Badge type="tip" text="6.35" />
+
+`MartenOps.Patch()` and `MartenOps.PatchWhere()` wrap Marten's
+[patching API](https://martendb.io/documents/patching.html), so a handler can modify a stored
+document without loading it first. The lambda is applied to Marten's fluent patch expression when
+the side effect executes:
+
+```csharp
+// Patch a single document by id
+public static IMartenOp Handle(MarkInvoicePaid command)
+{
+    return MartenOps.Patch<Invoice>(command.InvoiceId, x => x.Set(i => i.Paid, true));
+}
+
+// Patch every document matching a filter
+public static IMartenOp Handle(ReassignInvoices command)
+{
+    return MartenOps.PatchWhere<Invoice>(
+        x => x.CustomerId == command.OldCustomerId,
+        x => x.Set(i => i.CustomerId, command.NewCustomerId));
+}
+```
+
+As with `HardDelete()`, the by-id overloads accept `string`, `Guid`, `int`, and `long` identities.
+
+## Raw SQL <Badge type="tip" text="6.35" />
+
+`MartenOps.QueueSqlCommand()` enlists a raw SQL statement into the same batched unit of work as the
+rest of the handler's Marten operations, so it commits or rolls back with them. Use `?` for
+positional parameters, or supply your own placeholder character:
+
+```csharp
+public static IMartenOp Handle(RecordInvoiceMetric command)
+{
+    return MartenOps.QueueSqlCommand(
+        "insert into invoice_metrics (invoice_id, amount) values (?, ?)",
+        command.InvoiceId, command.Amount);
+}
+```
+
+## Appending to and Archiving an Existing Stream <Badge type="tip" text="6.35" />
+
+`MartenOps.StartStream()` covers new streams. To append to a stream that already exists, or to
+archive one, use `MartenOps.Append()` and `MartenOps.ArchiveStream()`:
+
+```csharp
+// Append to a stream, by Guid id or string key
+public static IMartenOp Handle(RecordShipment command)
+{
+    return MartenOps.Append(command.OrderId, new OrderShipped(command.ShippedAt));
+}
+
+// Append with an optimistic concurrency check on the stream version
+public static IMartenOp Handle(RecordShipmentAtVersion command)
+{
+    return MartenOps.Append(command.OrderId, command.ExpectedVersion,
+        new OrderShipped(command.ShippedAt));
+}
+
+// Archive a completed stream
+public static IMartenOp Handle(CloseOrder command)
+{
+    return MartenOps.ArchiveStream(command.OrderId);
+}
+```
+
+::: tip
+If the handler is working on an aggregate of its own, prefer the
+[aggregate handler workflow](/guide/durability/marten/event-sourcing) — `[WriteAggregate]` and the
+`Events` return type give you the aggregate state and its concurrency protection as well. These
+side effects are for the other case: touching some *other* stream from a handler that has no
+aggregate of its own.
+:::
 
 ## Data Requirements <Badge type="tip" text="5.13" />
 

--- a/src/Persistence/MartenTests/MartenOps_expanded_operations.cs
+++ b/src/Persistence/MartenTests/MartenOps_expanded_operations.cs
@@ -1,0 +1,130 @@
+using Shouldly;
+using Wolverine.Marten;
+
+namespace MartenTests;
+
+public record ExpandedOpsDoc(string Id, int Number);
+
+public record ExpandedOpsEvent(string Name);
+
+public class MartenOps_expanded_operations
+{
+    [Fact]
+    public void hard_delete_by_id_rejects_an_id_type_Marten_cannot_dispatch()
+    {
+        // Marten's HardDelete<T>() has no object-typed overload, so a strong-typed id has to be
+        // refused up front rather than at SaveChangesAsync() time
+        Should.Throw<ArgumentOutOfRangeException>(() => new HardDeleteDocById<ExpandedOpsDoc>(1.5m));
+        Should.Throw<ArgumentNullException>(() => new HardDeleteDocById<ExpandedOpsDoc>(null!));
+    }
+
+    [Fact]
+    public void patch_by_id_rejects_an_id_type_Marten_cannot_dispatch()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new PatchDoc<ExpandedOpsDoc>(1.5m, x => x.Set(d => d.Number, 5)));
+    }
+
+    [Fact]
+    public void insert_and_delete_objects_track_their_documents()
+    {
+        var insert = MartenOps.InsertObjects(new ExpandedOpsDoc("one", 1))
+            .With(new ExpandedOpsDoc("two", 2))
+            .With([new ExpandedOpsDoc("three", 3), new ExpandedOpsDoc("four", 4)]);
+
+        insert.Documents.Count.ShouldBe(4);
+
+        var delete = MartenOps.DeleteObjects(new ExpandedOpsDoc("one", 1))
+            .With(new ExpandedOpsDoc("two", 2));
+
+        delete.Documents.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void revision_ops_carry_the_expected_revision()
+    {
+        MartenOps.UpdateRevision(new ExpandedOpsDoc("one", 1), 5).Revision.ShouldBe(5);
+        MartenOps.TryUpdateRevision(new ExpandedOpsDoc("one", 1), 5).Revision.ShouldBe(5);
+
+        var version = Guid.NewGuid();
+        MartenOps.UpdateExpectedVersion(new ExpandedOpsDoc("one", 1), version).Version.ShouldBe(version);
+    }
+
+    [Fact]
+    public void queue_sql_command_captures_the_sql_and_parameters()
+    {
+        var op = MartenOps.QueueSqlCommand("delete from mt_doc_target where id = ?", 5);
+
+        op.Sql.ShouldBe("delete from mt_doc_target where id = ?");
+        op.ParameterValues.ShouldBe([5]);
+        op.Placeholder.ShouldBeNull();
+
+        MartenOps.QueueSqlCommand('^', "delete from mt_doc_target where id = ^", 5)
+            .Placeholder.ShouldBe('^');
+    }
+
+    [Fact]
+    public void append_captures_the_stream_identity_and_expected_version()
+    {
+        var streamId = Guid.NewGuid();
+
+        var byId = MartenOps.Append(streamId, new ExpandedOpsEvent("one"));
+        byId.StreamId.ShouldBe(streamId);
+        byId.StreamKey.ShouldBe(string.Empty);
+        byId.ExpectedVersion.ShouldBeNull();
+        byId.Events.Count.ShouldBe(1);
+
+        var byKey = MartenOps.Append("blue", 3, new ExpandedOpsEvent("one"))
+            .With(new ExpandedOpsEvent("two"));
+        byKey.StreamKey.ShouldBe("blue");
+        byKey.StreamId.ShouldBe(Guid.Empty);
+        byKey.ExpectedVersion.ShouldBe(3);
+        byKey.Events.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void append_and_archive_refuse_an_empty_stream_identity()
+    {
+        // Both ops discriminate Guid identity from string identity on StreamId == Guid.Empty,
+        // so an empty identity would silently take the wrong branch
+        Should.Throw<ArgumentOutOfRangeException>(() => MartenOps.Append(Guid.Empty, new ExpandedOpsEvent("one")));
+        Should.Throw<ArgumentOutOfRangeException>(() => MartenOps.Append("", new ExpandedOpsEvent("one")));
+        Should.Throw<ArgumentOutOfRangeException>(() => MartenOps.ArchiveStream(Guid.Empty));
+        Should.Throw<ArgumentOutOfRangeException>(() => MartenOps.ArchiveStream(""));
+    }
+
+    [Fact]
+    public void archive_stream_captures_the_stream_identity()
+    {
+        var streamId = Guid.NewGuid();
+
+        MartenOps.ArchiveStream(streamId).StreamId.ShouldBe(streamId);
+        MartenOps.ArchiveStream("blue").StreamKey.ShouldBe("blue");
+    }
+
+    [Fact]
+    public void for_tenant_scopes_any_op_without_losing_its_concrete_type()
+    {
+        // The generic ForTenant() is the single tenant mechanism for every op, so a new op does
+        // not have to grow a parallel set of tenantId overloads to be tenant-aware
+        MartenOps.Store(new ExpandedOpsDoc("one", 1)).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.HardDelete<ExpandedOpsDoc>("one").ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.HardDeleteWhere<ExpandedOpsDoc>(x => x.Number > 1).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.UndoDeleteWhere<ExpandedOpsDoc>(x => x.Number > 1).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.InsertObjects(new ExpandedOpsDoc("one", 1)).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.DeleteObjects(new ExpandedOpsDoc("one", 1)).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.UpdateRevision(new ExpandedOpsDoc("one", 1), 2).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.Patch<ExpandedOpsDoc>("one", x => x.Set(d => d.Number, 5)).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.QueueSqlCommand("select 1").ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.Append(Guid.NewGuid(), new ExpandedOpsEvent("one")).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.ArchiveStream(Guid.NewGuid()).ForTenant("blue").TenantId.ShouldBe("blue");
+        MartenOps.StartStream<ExpandedOpsDoc>(Guid.NewGuid(), new ExpandedOpsEvent("one"))
+            .ForTenant("blue").TenantId.ShouldBe("blue");
+    }
+
+    [Fact]
+    public void for_tenant_will_not_take_a_null_tenant_id()
+    {
+        Should.Throw<ArgumentNullException>(() => MartenOps.Store(new ExpandedOpsDoc("one", 1)).ForTenant(null!));
+    }
+}

--- a/src/Persistence/MartenTests/handler_actions_with_expanded_marten_operations.cs
+++ b/src/Persistence/MartenTests/handler_actions_with_expanded_marten_operations.cs
@@ -1,0 +1,456 @@
+using IntegrationTests;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Linq.SoftDeletes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Marten;
+using Wolverine.Tracking;
+
+namespace MartenTests;
+
+/// <summary>
+/// Coverage for the IMartenOp side effects that reach the parts of Marten's
+/// IDocumentOperations that MartenOps did not previously expose: hard deletes, soft delete
+/// reversal, mixed insert/delete batches, revisioned updates, patching, raw SQL, and appending
+/// to or archiving an existing event stream.
+/// </summary>
+public class handler_actions_with_expanded_marten_operations : PostgresqlContext, IAsyncLifetime
+{
+    private IHost _host = null!;
+    private IDocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(ExpandedMartenOpsHandler));
+
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Services
+                    .AddMarten(m =>
+                    {
+                        m.Connection(Servers.PostgresConnectionString);
+                        m.DatabaseSchemaName = "expanded_marten_ops";
+                        m.Schema.For<SoftDeletedThing>().SoftDeleted();
+                        m.Projections.Snapshot<ThingTotals>(SnapshotLifecycle.Inline);
+                    })
+                    .IntegrateWithWolverine();
+
+                opts.Policies.AutoApplyTransactions();
+            }).StartAsync();
+
+        _store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        await _store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(SoftDeletedThing));
+        await _store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(RevisionedThing));
+        await _store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(PatchableThing));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task hard_delete_by_id_removes_the_row_of_a_soft_deleted_document_type()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new SoftDeletedThing { Id = "hard" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new HardDeleteThing("hard"));
+
+        await using var query = _store.QuerySession();
+        var all = await query.Query<SoftDeletedThing>().Where(x => x.MaybeDeleted())
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        all.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task hard_delete_the_document_itself_removes_the_row()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new SoftDeletedThing { Id = "hard-doc" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new HardDeleteThingDocument("hard-doc"));
+
+        await using var query = _store.QuerySession();
+        var all = await query.Query<SoftDeletedThing>().Where(x => x.MaybeDeleted())
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        all.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task hard_delete_where_removes_the_matching_rows()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new SoftDeletedThing { Id = "hw-1", Number = 1 });
+            session.Store(new SoftDeletedThing { Id = "hw-2", Number = 2 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new HardDeleteThingsAbove(1));
+
+        await using var query = _store.QuerySession();
+        var remaining = await query.Query<SoftDeletedThing>().Where(x => x.MaybeDeleted())
+            .Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
+
+        remaining.ShouldBe(["hw-1"]);
+    }
+
+    [Fact]
+    public async Task undo_delete_where_brings_a_soft_deleted_document_back()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new SoftDeletedThing { Id = "undo", Number = 7 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            session.Delete<SoftDeletedThing>("undo");
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var query = _store.QuerySession())
+        {
+            (await query.Query<SoftDeletedThing>().Where(x => x.Id == "undo")
+                .ToListAsync(TestContext.Current.CancellationToken)).ShouldBeEmpty();
+
+            (await query.Query<SoftDeletedThing>().Where(x => x.IsDeleted())
+                .ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(1);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new UndoDeleteThings(7));
+
+        await using var after = _store.QuerySession();
+        (await after.Query<SoftDeletedThing>().Where(x => x.Id == "undo")
+            .ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task insert_objects_writes_every_document()
+    {
+        await _host.InvokeMessageAndWaitAsync(new InsertMixedThings("io-1", 3));
+
+        await using var query = _store.QuerySession();
+        (await query.LoadAsync<SoftDeletedThing>("io-1", TestContext.Current.CancellationToken)).ShouldNotBeNull();
+        (await query.LoadAsync<PatchableThing>("io-1", TestContext.Current.CancellationToken))!.Number.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task delete_objects_deletes_every_document()
+    {
+        await _host.InvokeMessageAndWaitAsync(new InsertMixedThings("do-1", 3));
+        await _host.InvokeMessageAndWaitAsync(new DeleteMixedThings("do-1"));
+
+        await using var query = _store.QuerySession();
+
+        // SoftDeletedThing is soft deleted, so DeleteObjects leaves the row behind but filtered
+        // out of queries - unlike the HardDelete ops above
+        (await query.Query<SoftDeletedThing>().Where(x => x.Id == "do-1")
+            .ToListAsync(TestContext.Current.CancellationToken)).ShouldBeEmpty();
+        (await query.Query<SoftDeletedThing>().Where(x => x.MaybeDeleted())
+            .ToListAsync(TestContext.Current.CancellationToken)).Count.ShouldBe(1);
+
+        (await query.LoadAsync<PatchableThing>("do-1", TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task update_revision_advances_the_stored_revision()
+    {
+        await _host.InvokeMessageAndWaitAsync(new SetThingRevision("rev-1", 5, 1));
+        await _host.InvokeMessageAndWaitAsync(new SetThingRevision("rev-1", 9, 2));
+
+        await using var query = _store.QuerySession();
+        var doc = await query.LoadAsync<RevisionedThing>("rev-1", TestContext.Current.CancellationToken);
+
+        doc!.Number.ShouldBe(9);
+        doc.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task update_revision_going_backwards_is_a_concurrency_failure()
+    {
+        await _host.InvokeMessageAndWaitAsync(new SetThingRevision("rev-2", 5, 3));
+
+        await Should.ThrowAsync<ConcurrencyException>(() =>
+            _host.InvokeMessageAndWaitAsync(new SetThingRevision("rev-2", 9, 2)));
+    }
+
+    [Fact]
+    public async Task try_update_revision_going_backwards_is_silently_ignored()
+    {
+        await _host.InvokeMessageAndWaitAsync(new SetThingRevision("rev-3", 5, 3));
+        await _host.InvokeMessageAndWaitAsync(new TrySetThingRevision("rev-3", 9, 2));
+
+        await using var query = _store.QuerySession();
+        var doc = await query.LoadAsync<RevisionedThing>("rev-3", TestContext.Current.CancellationToken);
+
+        doc!.Number.ShouldBe(5);
+        doc.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task patch_by_id_changes_only_the_patched_property()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new PatchableThing { Id = "patch-1", Number = 1, Name = "original" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PatchThingNumber("patch-1", 42));
+
+        await using var query = _store.QuerySession();
+        var doc = await query.LoadAsync<PatchableThing>("patch-1", TestContext.Current.CancellationToken);
+
+        doc!.Number.ShouldBe(42);
+        doc.Name.ShouldBe("original");
+    }
+
+    [Fact]
+    public async Task patch_where_changes_every_matching_document()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new PatchableThing { Id = "pw-1", Number = 1, Name = "keep" });
+            session.Store(new PatchableThing { Id = "pw-2", Number = 2, Name = "keep" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PatchThingsAbove(1, "patched"));
+
+        await using var query = _store.QuerySession();
+        (await query.LoadAsync<PatchableThing>("pw-1", TestContext.Current.CancellationToken))!.Name.ShouldBe("keep");
+        (await query.LoadAsync<PatchableThing>("pw-2", TestContext.Current.CancellationToken))!.Name
+            .ShouldBe("patched");
+    }
+
+    [Fact]
+    public async Task queue_sql_command_runs_in_the_same_unit_of_work()
+    {
+        await using (var session = _store.LightweightSession())
+        {
+            session.Store(new PatchableThing { Id = "sql-1", Number = 1, Name = "sql" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var table = _store.Options.FindOrResolveDocumentType(typeof(PatchableThing)).TableName.QualifiedName;
+        await _host.InvokeMessageAndWaitAsync(new DeleteThingWithSql(table, "sql-1"));
+
+        await using var query = _store.QuerySession();
+        (await query.LoadAsync<PatchableThing>("sql-1", TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task append_to_an_existing_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream<ThingTotals>(streamId, new ThingIncremented(1));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new IncrementThingStream(streamId, 4));
+
+        await using var query = _store.QuerySession();
+        var totals = await query.LoadAsync<ThingTotals>(streamId, TestContext.Current.CancellationToken);
+
+        totals!.Total.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task append_to_an_existing_stream_with_a_stale_expected_version()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream<ThingTotals>(streamId, new ThingIncremented(1), new ThingIncremented(2));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await Should.ThrowAsync<ConcurrencyException>(() =>
+            _host.InvokeMessageAndWaitAsync(new IncrementThingStreamAtVersion(streamId, 4, 1)));
+    }
+
+    [Fact]
+    public async Task archive_an_existing_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream<ThingTotals>(streamId, new ThingIncremented(1));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new ArchiveThingStream(streamId));
+
+        await using var query = _store.QuerySession();
+        var state = await query.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
+
+        state!.IsArchived.ShouldBeTrue();
+    }
+}
+
+public record HardDeleteThing(string Id);
+
+public record HardDeleteThingDocument(string Id);
+
+public record HardDeleteThingsAbove(int Number);
+
+public record UndoDeleteThings(int Number);
+
+public record InsertMixedThings(string Id, int Number);
+
+public record DeleteMixedThings(string Id);
+
+public record SetThingRevision(string Id, int Number, int Revision);
+
+public record TrySetThingRevision(string Id, int Number, int Revision);
+
+public record PatchThingNumber(string Id, int Number);
+
+public record PatchThingsAbove(int Number, string Name);
+
+public record DeleteThingWithSql(string TableName, string Id);
+
+public record IncrementThingStream(Guid StreamId, int Amount);
+
+public record IncrementThingStreamAtVersion(Guid StreamId, int Amount, long ExpectedVersion);
+
+public record ArchiveThingStream(Guid StreamId);
+
+public static class ExpandedMartenOpsHandler
+{
+    public static IMartenOp Handle(HardDeleteThing command)
+    {
+        return MartenOps.HardDelete<SoftDeletedThing>(command.Id);
+    }
+
+    public static async Task<IMartenOp> Handle(HardDeleteThingDocument command, IDocumentSession session)
+    {
+        var doc = await session.LoadAsync<SoftDeletedThing>(command.Id);
+        return MartenOps.HardDelete(doc!);
+    }
+
+    public static IMartenOp Handle(HardDeleteThingsAbove command)
+    {
+        return MartenOps.HardDeleteWhere<SoftDeletedThing>(x => x.Number > command.Number);
+    }
+
+    public static IMartenOp Handle(UndoDeleteThings command)
+    {
+        return MartenOps.UndoDeleteWhere<SoftDeletedThing>(x => x.Number == command.Number);
+    }
+
+    public static IMartenOp Handle(InsertMixedThings command)
+    {
+        return MartenOps.InsertObjects(
+            new SoftDeletedThing { Id = command.Id },
+            new PatchableThing { Id = command.Id, Number = command.Number });
+    }
+
+    public static async Task<IMartenOp> Handle(DeleteMixedThings command, IDocumentSession session)
+    {
+        var soft = await session.LoadAsync<SoftDeletedThing>(command.Id);
+        var patchable = await session.LoadAsync<PatchableThing>(command.Id);
+
+        return MartenOps.DeleteObjects(soft!, patchable!);
+    }
+
+    public static IMartenOp Handle(SetThingRevision command)
+    {
+        return MartenOps.UpdateRevision(
+            new RevisionedThing { Id = command.Id, Number = command.Number }, command.Revision);
+    }
+
+    public static IMartenOp Handle(TrySetThingRevision command)
+    {
+        return MartenOps.TryUpdateRevision(
+            new RevisionedThing { Id = command.Id, Number = command.Number }, command.Revision);
+    }
+
+    public static IMartenOp Handle(PatchThingNumber command)
+    {
+        return MartenOps.Patch<PatchableThing>(command.Id, x => x.Set(d => d.Number, command.Number));
+    }
+
+    public static IMartenOp Handle(PatchThingsAbove command)
+    {
+        return MartenOps.PatchWhere<PatchableThing>(x => x.Number > command.Number,
+            x => x.Set(d => d.Name, command.Name));
+    }
+
+    public static IMartenOp Handle(DeleteThingWithSql command)
+    {
+        return MartenOps.QueueSqlCommand($"delete from {command.TableName} where id = ?", command.Id);
+    }
+
+    public static IMartenOp Handle(IncrementThingStream command)
+    {
+        return MartenOps.Append(command.StreamId, new ThingIncremented(command.Amount));
+    }
+
+    public static IMartenOp Handle(IncrementThingStreamAtVersion command)
+    {
+        return MartenOps.Append(command.StreamId, command.ExpectedVersion, new ThingIncremented(command.Amount));
+    }
+
+    public static IMartenOp Handle(ArchiveThingStream command)
+    {
+        return MartenOps.ArchiveStream(command.StreamId);
+    }
+}
+
+public class SoftDeletedThing
+{
+    public string Id { get; set; } = null!;
+    public int Number { get; set; }
+}
+
+public class PatchableThing
+{
+    public string Id { get; set; } = null!;
+    public int Number { get; set; }
+    public string Name { get; set; } = null!;
+}
+
+public class RevisionedThing : IRevisioned
+{
+    public string Id { get; set; } = null!;
+    public int Number { get; set; }
+    public int Version { get; set; }
+}
+
+public record ThingIncremented(int Amount);
+
+public class ThingTotals
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+
+    public void Apply(ThingIncremented e)
+    {
+        Total += e.Amount;
+    }
+}

--- a/src/Persistence/Wolverine.Marten/IMartenOp.cs
+++ b/src/Persistence/Wolverine.Marten/IMartenOp.cs
@@ -28,6 +28,39 @@ public interface IMartenOp : ISideEffect
 
 #endregion
 
+/// <summary>
+/// A Marten side effect that can be pointed at a tenant other than the one the current
+/// session belongs to
+/// </summary>
+public interface ITenantedMartenOp : IMartenOp
+{
+    /// <summary>
+    /// Optional tenant id. When set, the operation is applied through IDocumentSession.ForTenant()
+    /// </summary>
+    string? TenantId { get; set; }
+}
+
+public static class MartenOpExtensions
+{
+    /// <summary>
+    /// Scope this Marten side effect to a specific tenant, as an alternative to the
+    /// tenantId overloads on the MartenOps factory methods
+    /// </summary>
+    /// <param name="op"></param>
+    /// <param name="tenantId"></param>
+    /// <returns>The same op, so this can be chained onto a MartenOps call</returns>
+    public static TOp ForTenant<TOp>(this TOp op, string tenantId) where TOp : ITenantedMartenOp
+    {
+        if (tenantId == null)
+        {
+            throw new ArgumentNullException(nameof(tenantId));
+        }
+
+        op.TenantId = tenantId;
+        return op;
+    }
+}
+
 internal class MartenOpPolicy : IChainPolicy
 {
     public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IServiceContainer container)
@@ -110,7 +143,7 @@ internal class ForEachMartenOpFrame : SyncFrame
 /// <summary>
 /// Access to Marten related side effect return values from message handlers
 /// </summary>
-public static class MartenOps
+public static partial class MartenOps
 {
     /// <summary>
     /// Return a side effect of storing the specified document in Marten
@@ -509,7 +542,7 @@ public interface IStartStream : IMartenOp
     IReadOnlyList<object> Events { get; }
 }
 
-public class StartStream<T> : IStartStream where T : class
+public class StartStream<T> : IStartStream, ITenantedMartenOp where T : class
 {
     public string StreamKey { get; } = string.Empty;
     public Guid StreamId { get; }
@@ -723,7 +756,7 @@ public class DeleteDoc<T> : DocumentOp where T : notnull
     }
 }
 
-public class DeleteDocById<T> : IMartenOp where T : notnull
+public class DeleteDocById<T> : ITenantedMartenOp where T : notnull
 {
     private readonly object _id;
 
@@ -766,7 +799,7 @@ public class DeleteDocById<T> : IMartenOp where T : notnull
     }
 }
 
-public class DeleteDocWhere<T> : IMartenOp where T : notnull
+public class DeleteDocWhere<T> : ITenantedMartenOp where T : notnull
 {
     private readonly Expression<Func<T, bool>> _expression;
 
@@ -792,7 +825,7 @@ public class DeleteDocWhere<T> : IMartenOp where T : notnull
     }
 }
 
-public abstract class DocumentOp : IMartenOp
+public abstract class DocumentOp : ITenantedMartenOp
 {
     public object Document { get; }
 
@@ -823,7 +856,7 @@ public abstract class DocumentOp : IMartenOp
     public abstract void Execute(IDocumentSession session);
 }
 
-public interface IDocumentsOp : IMartenOp
+public interface IDocumentsOp : ITenantedMartenOp
 {
     IReadOnlyList<object> Documents { get; }
 }

--- a/src/Persistence/Wolverine.Marten/MartenOps.Documents.cs
+++ b/src/Persistence/Wolverine.Marten/MartenOps.Documents.cs
@@ -1,0 +1,613 @@
+using System.Linq.Expressions;
+using JasperFx.Events;
+using Marten;
+using Marten.Patching;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+/// Document side effects that round out the parity with Marten's own
+/// <see cref="IDocumentOperations" />: hard deletes, soft delete reversal, mixed
+/// insert/delete batches, revision-checked updates, patching, and raw SQL.
+/// </summary>
+public static partial class MartenOps
+{
+    /// <summary>
+    /// Return a side effect of "hard" deleting the specified document in Marten, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    /// <param name="document"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static HardDeleteDoc<T> HardDelete<T>(T document) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new HardDeleteDoc<T>(document);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Marten, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static HardDeleteDocById<T> HardDelete<T>(string id) where T : notnull
+    {
+        return new HardDeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Marten, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static HardDeleteDocById<T> HardDelete<T>(Guid id) where T : notnull
+    {
+        return new HardDeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Marten, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static HardDeleteDocById<T> HardDelete<T>(int id) where T : notnull
+    {
+        return new HardDeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Marten, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    /// <param name="id"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static HardDeleteDocById<T> HardDelete<T>(long id) where T : notnull
+    {
+        return new HardDeleteDocById<T>(id);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting every document matching the provided filter,
+    /// deleting the underlying database rows even for a soft-deleted document type
+    /// </summary>
+    /// <param name="expression"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static HardDeleteDocWhere<T> HardDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+    {
+        return new HardDeleteDocWhere<T>(expression);
+    }
+
+    /// <summary>
+    /// Return a side effect of reversing the soft deletion of every document of a
+    /// soft-deleted document type matching the provided filter
+    /// </summary>
+    /// <param name="expression"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static UndoDeleteDocWhere<T> UndoDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+    {
+        return new UndoDeleteDocWhere<T>(expression);
+    }
+
+    /// <summary>
+    /// Return a side effect of inserting an enumerable of potentially mixed document types in
+    /// Marten. Unlike <see cref="StoreObjects(object[])" /> this will fail on the next
+    /// SaveChangesAsync() if any of the documents already exist
+    /// </summary>
+    /// <param name="documents"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static InsertObjects InsertObjects(params object[] documents)
+    {
+        if (documents == null)
+        {
+            throw new ArgumentNullException(nameof(documents));
+        }
+
+        return new InsertObjects(documents);
+    }
+
+    /// <summary>
+    /// Return a side effect of deleting an enumerable of potentially mixed document types in Marten
+    /// </summary>
+    /// <param name="documents"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static DeleteObjects DeleteObjects(params object[] documents)
+    {
+        if (documents == null)
+        {
+            throw new ArgumentNullException(nameof(documents));
+        }
+
+        return new DeleteObjects(documents);
+    }
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Marten while asserting that
+    /// the currently stored version matches the supplied version. Causes a ConcurrencyException
+    /// on SaveChangesAsync() if the stored version has moved on
+    /// </summary>
+    /// <param name="document"></param>
+    /// <param name="version"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static UpdateDocExpectedVersion<T> UpdateExpectedVersion<T>(T document, Guid version) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new UpdateDocExpectedVersion<T>(document, version);
+    }
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Marten with a new revision.
+    /// Causes a ConcurrencyException on SaveChangesAsync() if the stored revision is greater
+    /// than or equal to the supplied revision
+    /// </summary>
+    /// <param name="document"></param>
+    /// <param name="revision"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static UpdateDocRevision<T> UpdateRevision<T>(T document, long revision) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new UpdateDocRevision<T>(document, revision);
+    }
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Marten with a new revision,
+    /// silently doing nothing if the stored revision is greater than or equal to the supplied
+    /// revision
+    /// </summary>
+    /// <param name="document"></param>
+    /// <param name="revision"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static TryUpdateDocRevision<T> TryUpdateRevision<T>(T document, long revision) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new TryUpdateDocRevision<T>(document, revision);
+    }
+
+    /// <summary>
+    /// Return a side effect of patching the single document of type T with the given id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="configure">Applied to Marten's fluent patch API when the side effect executes</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static PatchDoc<T> Patch<T>(string id, Action<IPatchExpression<T>> configure) where T : notnull
+    {
+        return new PatchDoc<T>(id, configure);
+    }
+
+    /// <summary>
+    /// Return a side effect of patching the single document of type T with the given id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="configure">Applied to Marten's fluent patch API when the side effect executes</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static PatchDoc<T> Patch<T>(Guid id, Action<IPatchExpression<T>> configure) where T : notnull
+    {
+        return new PatchDoc<T>(id, configure);
+    }
+
+    /// <summary>
+    /// Return a side effect of patching the single document of type T with the given id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="configure">Applied to Marten's fluent patch API when the side effect executes</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static PatchDoc<T> Patch<T>(int id, Action<IPatchExpression<T>> configure) where T : notnull
+    {
+        return new PatchDoc<T>(id, configure);
+    }
+
+    /// <summary>
+    /// Return a side effect of patching the single document of type T with the given id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="configure">Applied to Marten's fluent patch API when the side effect executes</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static PatchDoc<T> Patch<T>(long id, Action<IPatchExpression<T>> configure) where T : notnull
+    {
+        return new PatchDoc<T>(id, configure);
+    }
+
+    /// <summary>
+    /// Return a side effect of patching every document of type T matching the provided filter
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <param name="configure">Applied to Marten's fluent patch API when the side effect executes</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static PatchDoc<T> PatchWhere<T>(Expression<Func<T, bool>> filter, Action<IPatchExpression<T>> configure)
+        where T : notnull
+    {
+        return new PatchDoc<T>(filter, configure);
+    }
+
+    /// <summary>
+    /// Return a side effect of enlisting a raw SQL command into the same batched unit of work
+    /// as the rest of the Wolverine handler's Marten operations. Use "?" placeholders to denote
+    /// parameter values
+    /// </summary>
+    /// <param name="sql"></param>
+    /// <param name="parameterValues"></param>
+    /// <returns></returns>
+    public static QueueSqlCommandOp QueueSqlCommand(string sql, params object[] parameterValues)
+    {
+        return new QueueSqlCommandOp(sql, parameterValues);
+    }
+
+    /// <summary>
+    /// Return a side effect of enlisting a raw SQL command into the same batched unit of work
+    /// as the rest of the Wolverine handler's Marten operations, using a custom placeholder
+    /// character for the positional parameters
+    /// </summary>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameterValues"></param>
+    /// <returns></returns>
+    public static QueueSqlCommandOp QueueSqlCommand(char placeholder, string sql, params object[] parameterValues)
+    {
+        return new QueueSqlCommandOp(sql, parameterValues) { Placeholder = placeholder };
+    }
+}
+
+public class HardDeleteDoc<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public HardDeleteDoc(T document) : base(document)
+    {
+        _document = document;
+    }
+
+    public HardDeleteDoc(T document, string tenantId) : base(document, tenantId)
+    {
+        _document = document;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).HardDelete(_document);
+    }
+}
+
+public class HardDeleteDocById<T> : ITenantedMartenOp where T : notnull
+{
+    private readonly object _id;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public HardDeleteDocById(object id)
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        // Unlike Delete<T>(), Marten's HardDelete<T>() has no object-typed overload to fall back
+        // on, so an id type it cannot dispatch would only blow up inside Execute() - long after
+        // the handler returned a side effect that looked perfectly valid. Reject it at the point
+        // of construction, where the caller can still see it in a unit test.
+        if (id is not (string or Guid or long or int))
+        {
+            throw new ArgumentOutOfRangeException(nameof(id),
+                $"Marten can only hard delete by string, Guid, long, or int id, but got {id.GetType().FullName}");
+        }
+
+        _id = id;
+    }
+
+    public HardDeleteDocById(object id, string tenantId) : this(id)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        switch (_id)
+        {
+            case string idAsString:
+                target.HardDelete<T>(idAsString);
+                break;
+            case Guid idAsGuid:
+                target.HardDelete<T>(idAsGuid);
+                break;
+            case long idAsLong:
+                target.HardDelete<T>(idAsLong);
+                break;
+            case int idAsInt:
+                target.HardDelete<T>(idAsInt);
+                break;
+        }
+    }
+}
+
+public class HardDeleteDocWhere<T> : ITenantedMartenOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public HardDeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public HardDeleteDocWhere(Expression<Func<T, bool>> expression, string tenantId) : this(expression)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.HardDeleteWhere(_expression);
+    }
+}
+
+public class UndoDeleteDocWhere<T> : ITenantedMartenOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public UndoDeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public UndoDeleteDocWhere(Expression<Func<T, bool>> expression, string tenantId) : this(expression)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.UndoDeleteWhere(_expression);
+    }
+}
+
+public class InsertObjects : DocumentsOp
+{
+    public InsertObjects(params object[] documents) : base(documents) { }
+
+    public InsertObjects(IList<object> documents) : this(documents.ToArray()) { }
+
+    public InsertObjects(string tenantId, params object[] documents) : base(tenantId, documents) { }
+
+    public InsertObjects With(object[] documents)
+    {
+        Documents.AddRange(documents);
+        return this;
+    }
+
+    public InsertObjects With(object document)
+    {
+        Documents.Add(document);
+        return this;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).InsertObjects(Documents);
+    }
+}
+
+public class DeleteObjects : DocumentsOp
+{
+    public DeleteObjects(params object[] documents) : base(documents) { }
+
+    public DeleteObjects(IList<object> documents) : this(documents.ToArray()) { }
+
+    public DeleteObjects(string tenantId, params object[] documents) : base(tenantId, documents) { }
+
+    public DeleteObjects With(object[] documents)
+    {
+        Documents.AddRange(documents);
+        return this;
+    }
+
+    public DeleteObjects With(object document)
+    {
+        Documents.Add(document);
+        return this;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).DeleteObjects(Documents);
+    }
+}
+
+public class UpdateDocExpectedVersion<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public UpdateDocExpectedVersion(T document, Guid version) : base(document)
+    {
+        _document = document;
+        Version = version;
+    }
+
+    public Guid Version { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).UpdateExpectedVersion(_document, Version);
+    }
+}
+
+public class UpdateDocRevision<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public UpdateDocRevision(T document, long revision) : base(document)
+    {
+        _document = document;
+        Revision = revision;
+    }
+
+    public long Revision { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).UpdateRevision(_document, Revision);
+    }
+}
+
+public class TryUpdateDocRevision<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public TryUpdateDocRevision(T document, long revision) : base(document)
+    {
+        _document = document;
+        Revision = revision;
+    }
+
+    public long Revision { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).TryUpdateRevision(_document, Revision);
+    }
+}
+
+public class PatchDoc<T> : ITenantedMartenOp where T : notnull
+{
+    private readonly Action<IPatchExpression<T>> _configure;
+    private readonly Expression<Func<T, bool>>? _filter;
+    private readonly object? _id;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public PatchDoc(object id, Action<IPatchExpression<T>> configure)
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        // Same story as HardDeleteDocById: Marten's Patch<T>() overloads cover string, Guid,
+        // long, and int only, so fail fast rather than at SaveChangesAsync() time.
+        if (id is not (string or Guid or long or int))
+        {
+            throw new ArgumentOutOfRangeException(nameof(id),
+                $"Marten can only patch by string, Guid, long, or int id, but got {id.GetType().FullName}");
+        }
+
+        _id = id;
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    public PatchDoc(Expression<Func<T, bool>> filter, Action<IPatchExpression<T>> configure)
+    {
+        _filter = filter ?? throw new ArgumentNullException(nameof(filter));
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+
+        var expression = _filter != null
+            ? target.Patch(_filter)
+            : _id switch
+            {
+                string idAsString => target.Patch<T>(idAsString),
+                Guid idAsGuid => target.Patch<T>(idAsGuid),
+                long idAsLong => target.Patch<T>(idAsLong),
+                int idAsInt => target.Patch<T>(idAsInt),
+                _ => throw new ArgumentOutOfRangeException(nameof(_id))
+            };
+
+        _configure(expression);
+    }
+}
+
+public class QueueSqlCommandOp : ITenantedMartenOp
+{
+    public QueueSqlCommandOp(string sql, params object[] parameterValues)
+    {
+        Sql = sql ?? throw new ArgumentNullException(nameof(sql));
+        ParameterValues = parameterValues ?? throw new ArgumentNullException(nameof(parameterValues));
+    }
+
+    public string Sql { get; }
+
+    public object[] ParameterValues { get; }
+
+    /// <summary>
+    /// Optional override of the "?" character that denotes a positional parameter in the SQL
+    /// </summary>
+    public char? Placeholder { get; set; }
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant.
+    /// Note that this only routes the command to that tenant's database in a
+    /// database-per-tenant setup; it does not add any tenant filtering to the SQL itself
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+
+        if (Placeholder.HasValue)
+        {
+            target.QueueSqlCommand(Placeholder.Value, Sql, ParameterValues);
+        }
+        else
+        {
+            target.QueueSqlCommand(Sql, ParameterValues);
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Marten/MartenOps.Events.cs
+++ b/src/Persistence/Wolverine.Marten/MartenOps.Events.cs
@@ -1,0 +1,215 @@
+using JasperFx.Core;
+using Marten;
+
+namespace Wolverine.Marten;
+
+/// <summary>
+/// Event store side effects beyond starting a new stream: appending to a stream that already
+/// exists, and archiving one.
+/// </summary>
+/// <remarks>
+/// Appending to the stream the handler is *already* working on belongs in the aggregate handler
+/// workflow ([WriteAggregate] / IEventStream&lt;T&gt; / the Events return type), which also gives
+/// you the aggregate state and its concurrency protection. These side effects are for the other
+/// case: touching some *other* stream from a handler that has no aggregate of its own.
+/// </remarks>
+public static partial class MartenOps
+{
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by Guid identity
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="events"></param>
+    /// <returns></returns>
+    public static AppendToStream Append(Guid streamId, params object[] events)
+    {
+        return new AppendToStream(streamId, events);
+    }
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by string key
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <param name="events"></param>
+    /// <returns></returns>
+    public static AppendToStream Append(string streamKey, params object[] events)
+    {
+        return new AppendToStream(streamKey, events);
+    }
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by Guid identity,
+    /// asserting that the stream is at the supplied version or the transaction is aborted with
+    /// a ConcurrencyException
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="expectedVersion"></param>
+    /// <param name="events"></param>
+    /// <returns></returns>
+    public static AppendToStream Append(Guid streamId, long expectedVersion, params object[] events)
+    {
+        return new AppendToStream(streamId, events) { ExpectedVersion = expectedVersion };
+    }
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by string key,
+    /// asserting that the stream is at the supplied version or the transaction is aborted with
+    /// a ConcurrencyException
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <param name="expectedVersion"></param>
+    /// <param name="events"></param>
+    /// <returns></returns>
+    public static AppendToStream Append(string streamKey, long expectedVersion, params object[] events)
+    {
+        return new AppendToStream(streamKey, events) { ExpectedVersion = expectedVersion };
+    }
+
+    /// <summary>
+    /// Return a side effect of archiving an event stream by Guid identity
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <returns></returns>
+    public static ArchiveStream ArchiveStream(Guid streamId)
+    {
+        return new ArchiveStream(streamId);
+    }
+
+    /// <summary>
+    /// Return a side effect of archiving an event stream by string key
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <returns></returns>
+    public static ArchiveStream ArchiveStream(string streamKey)
+    {
+        return new ArchiveStream(streamKey);
+    }
+}
+
+public class AppendToStream : ITenantedMartenOp
+{
+    public AppendToStream(Guid streamId, params object[] events)
+    {
+        if (streamId == Guid.Empty)
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamId), "The stream id cannot be Guid.Empty");
+        }
+
+        StreamId = streamId;
+        Events.AddRange(events);
+    }
+
+    public AppendToStream(string streamKey, params object[] events)
+    {
+        if (streamKey.IsEmpty())
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamKey), "The stream key cannot be null or empty");
+        }
+
+        StreamKey = streamKey;
+        Events.AddRange(events);
+    }
+
+    public string StreamKey { get; } = string.Empty;
+
+    public Guid StreamId { get; }
+
+    /// <summary>
+    /// Optional optimistic concurrency check. When set, Marten will abort the transaction if
+    /// the stream is not at this version
+    /// </summary>
+    public long? ExpectedVersion { get; set; }
+
+    public List<object> Events { get; } = new();
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public AppendToStream With(object @event)
+    {
+        Events.Add(@event);
+        return this;
+    }
+
+    public AppendToStream With(object[] events)
+    {
+        Events.AddRange(events);
+        return this;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+
+        if (StreamId == Guid.Empty)
+        {
+            if (ExpectedVersion.HasValue)
+            {
+                target.Events.Append(StreamKey, ExpectedVersion.Value, Events.ToArray());
+            }
+            else
+            {
+                target.Events.Append(StreamKey, Events.ToArray());
+            }
+        }
+        else
+        {
+            if (ExpectedVersion.HasValue)
+            {
+                target.Events.Append(StreamId, ExpectedVersion.Value, Events.ToArray());
+            }
+            else
+            {
+                target.Events.Append(StreamId, Events.ToArray());
+            }
+        }
+    }
+}
+
+public class ArchiveStream : ITenantedMartenOp
+{
+    public ArchiveStream(Guid streamId)
+    {
+        if (streamId == Guid.Empty)
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamId), "The stream id cannot be Guid.Empty");
+        }
+
+        StreamId = streamId;
+    }
+
+    public ArchiveStream(string streamKey)
+    {
+        if (streamKey.IsEmpty())
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamKey), "The stream key cannot be null or empty");
+        }
+
+        StreamKey = streamKey;
+    }
+
+    public string StreamKey { get; } = string.Empty;
+
+    public Guid StreamId { get; }
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+
+        if (StreamId == Guid.Empty)
+        {
+            target.Events.ArchiveStream(StreamKey);
+        }
+        else
+        {
+            target.Events.ArchiveStream(StreamId);
+        }
+    }
+}


### PR DESCRIPTION
## What

`MartenOps` covered store / insert / update / delete plus `StartStream`, but a handler that wanted
any of the rest of Marten's session API had to take an `IDocumentSession` and give up being a pure
function — which is most of the reason the side effect model exists. This adds side effects for
everything on `IDocumentOperations` that fits the synchronous `IMartenOp` shape:

| New op | Marten call it reaches |
|---|---|
| `HardDelete(doc)`, `HardDelete<T>(id)`, `HardDeleteWhere<T>(filter)` | `HardDelete` / `HardDeleteWhere` |
| `UndoDeleteWhere<T>(filter)` | `UndoDeleteWhere` |
| `InsertObjects(...)`, `DeleteObjects(...)` | `InsertObjects` / `DeleteObjects` |
| `UpdateExpectedVersion`, `UpdateRevision`, `TryUpdateRevision` | same names |
| `Patch<T>(id, ...)`, `PatchWhere<T>(filter, ...)` | `Patch<T>()` fluent API |
| `QueueSqlCommand(sql, ...)` (+ custom placeholder overload) | `QueueSqlCommand` |
| `Append(streamId \| streamKey, ...)`, with an optional expected version | `Events.Append` |
| `ArchiveStream(streamId \| streamKey)` | `Events.ArchiveStream` |

Deliberately left out: `QueueOperation(IStorageOperation)` and `Events.OverwriteEvent(IEvent)`. Both
are low-level enough that a hand-written `IMartenOp` is the better answer, and neither reads as
handler material.

## One tenant mechanism instead of another round of overloads

The existing tenant support is a `tenantId` overload per factory method — 12 extra methods for the 6
original ops. Repeating that here would have added roughly 26 more. Instead every op now implements
`ITenantedMartenOp`, and a single generic extension does the scoping while preserving the concrete
return type:

```csharp
MartenOps.ArchiveStream(command.OrderId).ForTenant(command.TenantId);
MartenOps.StoreMany(items).ForTenant(tenantId).With(oneMore);
```

The existing `tenantId` overloads are untouched, so this is purely additive. `ForTenant()` works on
user-written ops as soon as they implement `ITenantedMartenOp`.

## Two invariants moved to construction time

- Marten's `HardDelete<T>()` and `Patch<T>()` have no `object`-typed id overload to fall back on the
  way `Delete<T>()` does. An id type they cannot dispatch is now rejected by the factory with an
  `ArgumentOutOfRangeException`, rather than surfacing inside `SaveChangesAsync()` long after the
  handler returned a side effect that looked valid.
- `Append` and `ArchiveStream` discriminate Guid identity from string identity on
  `StreamId == Guid.Empty` (the same sentinel `StartStream<T>` uses), so an empty identity would
  silently take the wrong branch. Both now refuse `Guid.Empty` and an empty stream key.

## Tests

59 passing in `MartenTests` across the new and pre-existing MartenOps classes:

- `MartenOps_expanded_operations` — 10 unit tests over the op shapes, the rejected id types, the
  empty-identity guards, and `ForTenant()` across every op.
- `handler_actions_with_expanded_marten_operations` — 15 integration tests driving each op through a
  real handler and asserting against Postgres, including the soft-delete/hard-delete distinction,
  the `UpdateRevision` vs `TryUpdateRevision` concurrency behaviour, and a stale expected version on
  `Append`.

## Also

- Docs for all of the above in `docs/guide/durability/marten/operations.md`, badged 6.34.
- `.gitignore` entry for `.claude/worktrees/`.

## Not in this PR

`Wolverine.Polecat` and `Wolverine.Fisher` carry the same op model and have the same gaps. Worth a
follow-up, but the ops there have to be checked against each store's own capabilities rather than
copied across.
