### PR TITLE
GH-4385/4386/4387: join a declared Event Model to the code it describes

### DIFF
--- a/.github/workflows/command-line.yml
+++ b/.github/workflows/command-line.yml
@@ -80,9 +80,11 @@ jobs:
           grep -q '"slices"' "$out"
           grep -q '"name": "CreateIssue"' "$out"
           grep -q '"triggerKind": "MessageHandler"' "$out"
-          # GH-4387: a message handler leaves "pattern" unclaimed -- it cannot tell a Command slice
-          # from an Automation slice -- so the derived roles it CAN read are what this asserts.
           grep -q '"handlerType"' "$out"
+          # GH-4387: a message handler no longer guesses "Command" -- it cannot tell a Command slice
+          # from an Automation slice. The MODEL can, though: IssueCreated only ever arrives because
+          # CreateIssueHandler cascaded it, which is an Automation.
+          grep -q '"pattern": "Automation"' "$out"
           grep -q '"elements"' "$out"
           echo "::endgroup::"
 

--- a/.github/workflows/command-line.yml
+++ b/.github/workflows/command-line.yml
@@ -80,7 +80,9 @@ jobs:
           grep -q '"slices"' "$out"
           grep -q '"name": "CreateIssue"' "$out"
           grep -q '"triggerKind": "MessageHandler"' "$out"
-          grep -q '"pattern": "Command"' "$out"
+          # GH-4387: a message handler leaves "pattern" unclaimed -- it cannot tell a Command slice
+          # from an Automation slice -- so the derived roles it CAN read are what this asserts.
+          grep -q '"handlerType"' "$out"
           grep -q '"elements"' "$out"
           echo "::endgroup::"
 

--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -367,6 +367,70 @@ What is deliberately *not* visible here: imperative `session.Events.Append(...)`
 invisible at runtime, so only declarative returns are reported; CritterWatch's source generator covers the
 imperative case.
 
+### Naming the events a signature cannot carry
+
+Two of the shapes the Critter Stack scaffolds for a modelled slice hand back a *collection* of events or a
+stream side effect, and both erase the element types on the way out:
+
+```cs
+public static (ConfirmAppointmentResponse, EventsToAppend) Post(ConfirmAppointmentRequest request, [WriteModel] Appointment appointment)
+public static StartStream Handle(HomeCheckAssignmentAccepted trigger)
+```
+
+The slice is known to append events; the events themselves are built in the method body, so nothing on the
+signature says what they are. Put `[Emits]` on the handler method (or on the handler type, when every method
+of it emits the same events) to say it:
+
+```cs
+[Emits(typeof(AppointmentConfirmed))]
+public static (ConfirmAppointmentResponse, EventsToAppend) Post(
+    ConfirmAppointmentRequest request, [WriteModel] Appointment appointment)
+{
+    var events = new EventsToAppend { new AppointmentConfirmed(request.Id) };
+    return (new ConfirmAppointmentResponse(request.Id), events);
+}
+```
+
+It is additive — everything the signature already says still holds — and purely diagnostic: nothing about
+dispatch, codegen or persistence reads it. Without it, `emittedEvents` on those slices is empty, which is
+indistinguishable from a slice that emits nothing at all.
+
+::: tip
+`[Emits]` is worth reaching for precisely when a declared model says a slice emits an event. An empty derived
+list cannot *contradict* a declaration, so drift goes unseen; a declared one can, and the merge raises it.
+:::
+
+### What the derived source will not claim
+
+Two roles are deliberately left unclaimed rather than guessed at, so a declaration wins them by default:
+
+| Role | Why the code cannot answer |
+| --- | --- |
+| `TriggerLabel` | A trigger label is a naming concern ("Customer at the ATM"). The structural facts already ride on `TriggerOrigin`. |
+| `Pattern`, for a message handler | An inbound message that appends events is a `Command` or an `Automation` depending on *why* it arrived — a person asked, or the system reacted. A handler signature cannot tell the two apart. |
+
+`Pattern` is still claimed wherever the code genuinely answers it: an HTTP `GET` is a `View`, a `TimeoutMessage`
+or a cron-scheduled message is an `Automation`, a gRPC RPC is a `Command`, an inbound external system makes the
+slice a `Translation`, and a slice whose command is an event another slice emits is promoted to `Automation`
+because the assembled model says so.
+
+### Meeting a declared model
+
+A declared model — a curated board file, an overlay — names a slice for the behaviour: `ConfirmAppointment`.
+Wolverine's derived sources name it for what they can see: the message type `ConfirmAppointmentRequest`, the
+triggering event `HomeCheckAssignmentAccepted`, the route `GET /api/appointmentsqueue/{id}`. Slice names are
+the merge key, so left alone the two never meet and an eleven-slice application assembles as twenty-two slices
+with no disagreements — not because the sources agree, but because they were never compared.
+
+`HandlerType` is the one role both kinds of source fill and mean the same thing by, so the export aligns on it:
+where a declaration and the code describe the same handler type under different names, the **declared** name
+wins and both fold into one slice. Neither side has to rename anything, and the real disagreements surface as
+`SourceDisagreement` hotspots instead of duplicate slices.
+
+Nothing is aligned between two sources on the *same* rung (Wolverine core and Wolverine.HTTP already agree on
+how they name things), a handler type carrying more than one slice inside a source identifies none of them, and
+a rename that would collide with a slice already in that source is dropped.
+
 ### The slice next to the route
 
 The assembled model is one picture of the whole service. A monitoring console often wants the other view —

--- a/src/Persistence/MartenTests/EventModeling/event_model_roles_3988.cs
+++ b/src/Persistence/MartenTests/EventModeling/event_model_roles_3988.cs
@@ -84,7 +84,9 @@ public class event_model_roles_3988 : PostgresqlContext, IAsyncLifetime
         var model = WolverineEventModelSource.Describe(theHost.GetRuntime());
         var slice = model.Slices.Single(x => x.Name == nameof(EndTrip));
 
-        slice.Pattern.ShouldBe(SlicePattern.Command);
+        // GH-4387: a message handler cannot tell a Command slice from an Automation slice, so it says
+        // nothing and a declared pattern survives. The roles it CAN read are all still here.
+        slice.Pattern.ShouldBeNull();
         slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
         slice.CommandType!.Name.ShouldBe(nameof(EndTrip));
         slice.HandlerType!.Name.ShouldBe(nameof(EndTripHandler));

--- a/src/Testing/CoreTests/Acceptance/event_model_declared_events_4386.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_declared_events_4386.cs
@@ -1,0 +1,159 @@
+using JasperFx.Events.EventModeling;
+using Wolverine.Attributes;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Persistence;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel4386;
+
+// GH-4386: the two shapes the Critter Stack's own scaffolding emits for a modelled slice --
+// a collection of events (EventsToAppend / the store's Events) and a StartStream side effect --
+// erase the element types, so the more idiomatically event-modelled an application is, the emptier
+// its derived Event Model gets. [Emits] is how a handler names what its signature cannot.
+public class emitted_events_a_signature_cannot_carry_4386
+{
+    private static HandlerChain chainFor<THandler>(System.Linq.Expressions.Expression<Action<THandler>> expression)
+        => HandlerChain.For(expression, new HandlerGraph());
+
+    [Fact]
+    public void an_events_collection_return_still_erases_its_element_types()
+    {
+        // the state of play this issue is about, kept as the baseline: the chain is known to append
+        // events and the events themselves are unreadable
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<ConfirmAppointmentHandler>(x => ConfirmAppointmentHandler.Handle(null!, null!)));
+
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Appointment) });
+        slice.EmittedEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void emits_puts_the_events_back_on_the_slice()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<ConfirmAppointmentWithEmitsHandler>(x => ConfirmAppointmentWithEmitsHandler.Handle(null!, null!)));
+
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(AppointmentConfirmed) });
+        slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Appointment) });
+    }
+
+    [Fact]
+    public void emits_is_additive_to_what_the_signature_already_says()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<RescheduleAppointmentHandler>(x => RescheduleAppointmentHandler.Handle(null!, null!)));
+
+        // the declaration is read off the handler first, then the signature's own typed return
+        slice.EmittedEvents.Select(x => x.Name)
+            .ShouldBe(new[] { nameof(AppointmentConfirmed), nameof(AppointmentRescheduled) });
+    }
+
+    [Fact]
+    public void emits_on_the_handler_type_covers_its_methods()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<CancelAppointmentHandler>(x => CancelAppointmentHandler.Handle(null!, null!)));
+
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(AppointmentCancelled) });
+    }
+
+    [Fact]
+    public void a_start_stream_side_effect_does_not_turn_a_cascaded_message_into_an_event()
+    {
+        // StartStream appends events that were built in the method body. The OTHER return value is a
+        // cascaded message and stays one -- the same reasoning GH-4204 applied to IEventStream<T>.
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<ProposeHomeCheckAppointmentHandler>(x => ProposeHomeCheckAppointmentHandler.Handle(null!)));
+
+        slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(HomeCheckAppointmentScheduled) });
+        slice.EmittedEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void emits_names_the_events_a_start_stream_carries()
+    {
+        var slice = EventModelRoles.ForHandlerChain(
+            chainFor<ProposeHomeCheckAppointmentWithEmitsHandler>(x => ProposeHomeCheckAppointmentWithEmitsHandler.Handle(null!)));
+
+        slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(HomeCheckAppointmentProposed) });
+    }
+}
+
+#region sample types for GH-4386
+
+public record ConfirmAppointment(Guid Id);
+
+public record RescheduleAppointment(Guid Id);
+
+public record CancelAppointment(Guid Id);
+
+public record HomeCheckAssignmentAccepted(Guid Id);
+
+public record AppointmentConfirmed(Guid Id);
+
+public record AppointmentRescheduled(Guid Id);
+
+public record AppointmentCancelled(Guid Id);
+
+public record HomeCheckAppointmentProposed(Guid Id);
+
+public record HomeCheckAppointmentScheduled(Guid Id);
+
+public class Appointment
+{
+    public Guid Id { get; set; }
+
+    public void Apply(AppointmentConfirmed e)
+    {
+    }
+}
+
+public class ConfirmAppointmentHandler
+{
+    public static EventsToAppend Handle(ConfirmAppointment command, [WriteModel] Appointment appointment)
+        => new() { new AppointmentConfirmed(command.Id) };
+}
+
+public class ConfirmAppointmentWithEmitsHandler
+{
+    [Emits(typeof(AppointmentConfirmed))]
+    public static EventsToAppend Handle(ConfirmAppointment command, [WriteModel] Appointment appointment)
+        => new() { new AppointmentConfirmed(command.Id) };
+}
+
+public class RescheduleAppointmentHandler
+{
+    [Emits(typeof(AppointmentConfirmed))]
+    public static AppointmentRescheduled Handle(RescheduleAppointment command, [WriteModel] Appointment appointment)
+        => new(command.Id);
+}
+
+[Emits(typeof(AppointmentCancelled))]
+public class CancelAppointmentHandler
+{
+    public static EventsToAppend Handle(CancelAppointment command, [WriteModel] Appointment appointment)
+        => new() { new AppointmentCancelled(command.Id) };
+}
+
+// Excluded from discovery: a StartStream return makes SideEffectPolicy demand a registered event store
+// at HandlerGraph.Compile(), and every other CoreTests fixture that scans this assembly would fail to
+// boot. These chains are built directly, so nothing here needs to be discovered.
+[WolverineIgnore]
+public class ProposeHomeCheckAppointmentHandler
+{
+    public static (StartStream, HomeCheckAppointmentScheduled) Handle(HomeCheckAssignmentAccepted trigger)
+        => (Storage.StartStream<Appointment>(trigger.Id, new HomeCheckAppointmentProposed(trigger.Id)),
+            new HomeCheckAppointmentScheduled(trigger.Id));
+}
+
+[WolverineIgnore]
+public class ProposeHomeCheckAppointmentWithEmitsHandler
+{
+    [Emits(typeof(HomeCheckAppointmentProposed))]
+    public static StartStream Handle(HomeCheckAssignmentAccepted trigger)
+        => Storage.StartStream<Appointment>(trigger.Id, new HomeCheckAppointmentProposed(trigger.Id));
+}
+
+#endregion

--- a/src/Testing/CoreTests/Acceptance/event_model_roles_3988.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_roles_3988.cs
@@ -23,12 +23,14 @@ public class event_model_roles_on_chains_3988
         => HandlerChain.For(expression, new HandlerGraph());
 
     [Fact]
-    public void a_plain_handler_with_a_cascading_message_is_a_command_slice_publishing_a_message()
+    public void a_plain_handler_with_a_cascading_message_publishes_a_message_and_leaves_the_pattern_unclaimed()
     {
         var slice = EventModelRoles.ForHandlerChain(chainFor<PlaceOrderHandler>(x => PlaceOrderHandler.Handle(null!)));
 
         slice.Name.ShouldBe(nameof(PlaceOrder));
-        slice.Pattern.ShouldBe(SlicePattern.Command);
+        // GH-4387: a message handler cannot say whether it is a Command or an Automation, so it says
+        // nothing and an overlay's declaration survives
+        slice.Pattern.ShouldBeNull();
         slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
         slice.CommandType!.Name.ShouldBe(nameof(PlaceOrder));
         slice.HandlerType!.Name.ShouldBe(nameof(PlaceOrderHandler));
@@ -45,7 +47,7 @@ public class event_model_roles_on_chains_3988
         slice.AggregateTypes.Select(x => x.Name).ShouldBe(new[] { nameof(Order) });
         slice.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(OrderShipped) });
         slice.PublishedMessages.ShouldBeEmpty();
-        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.Pattern.ShouldBeNull(); // GH-4387
     }
 
     [Fact]
@@ -125,12 +127,14 @@ public class event_model_roles_on_chains_3988
     {
         var ship = EventModelRoles.ForHandlerChain(chainFor<ShipOrderHandler>(x => ShipOrderHandler.Handle(null!, null!)));
         var reaction = EventModelRoles.ForHandlerChain(chainFor<OrderShippedHandler>(x => OrderShippedHandler.Handle(null!)));
-        reaction.Pattern.ShouldBe(SlicePattern.Command); // on its own it looks like a command slice
+        reaction.Pattern.ShouldBeNull(); // on its own the chain cannot tell you which pattern it is
 
         var model = WolverineEventModelSource.FinishModel(new EventModelDescriptor("app", new[] { ship, reaction }));
 
+        // the whole model is the evidence: this slice's command is an event another slice emits
         model.Slices.Single(x => x.Name == nameof(OrderShipped)).Pattern.ShouldBe(SlicePattern.Automation);
-        model.Slices.Single(x => x.Name == nameof(ShipOrder)).Pattern.ShouldBe(SlicePattern.Command);
+        // and nothing says that about this one, so it stays unclaimed rather than guessing Command
+        model.Slices.Single(x => x.Name == nameof(ShipOrder)).Pattern.ShouldBeNull();
     }
 
     [Fact]
@@ -269,7 +273,9 @@ public class event_model_sources_and_capabilities_3988 : IAsyncLifetime
 
         // the wire shape CritterWatch serialises: camelCase, enums as strings, rendering contract present
         json.ShouldContain("\"triggerKind\": \"MessageHandler\"");
-        json.ShouldContain("\"pattern\": \"Command\"");
+        // GH-4387: the scheduled slice is the one that claims a pattern here; a plain message handler
+        // does not, so the enum-as-string check rides on the timeout handler
+        json.ShouldContain("\"pattern\": \"Automation\"");
         json.ShouldContain("\"elements\"");
         json.ShouldContain("\"edges\"");
 
@@ -279,7 +285,7 @@ public class event_model_sources_and_capabilities_3988 : IAsyncLifetime
         var slice = back.Slices.Single(x => x.Name == nameof(PlaceOrder));
         slice.CommandType!.FullName.ShouldBe(typeof(PlaceOrder).FullName);
         slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
-        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.Pattern.ShouldBeNull(); // GH-4387
         slice.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(OrderPlacedNotification) });
         slice.TriggerLabel.ShouldBe("UI: Place order");
         slice.Elements.Count.ShouldBe(model.Slices.Single(x => x.Name == nameof(PlaceOrder)).Elements.Count);

--- a/src/Testing/CoreTests/Acceptance/event_model_slice_alignment_4385.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_slice_alignment_4385.cs
@@ -1,0 +1,268 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Persistence.EventSourcing;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel4385;
+
+// GH-4385: a declared Event Model names a slice for the behaviour ("ConfirmAppointment"); Wolverine's
+// derived sources name it for what they can see (the message type, the triggering event, the route).
+// The two were never going to compute the same merge key, so an eleven-slice sample assembled as
+// twenty-two slices with zero hotspots -- the provenance ladder never engaged, because the sources
+// never met. HandlerType is the role both kinds of source fill and mean the same thing by.
+public class event_model_slice_alignment_4385
+{
+    private static EventModelDescriptor declared(params EventModelSliceDescriptor[] slices)
+        => new EventModelDescriptor("board", slices).WithProvenance(EventModelProvenance.Declared);
+
+    private static EventModelDescriptor derived(params EventModelSliceDescriptor[] slices)
+        => new EventModelDescriptor("app", slices).WithProvenance(EventModelProvenance.Derived);
+
+    private static EventModelSliceDescriptor slice(string name, Type? handlerType = null)
+        => EventModelSliceDescriptor.Named(name) with
+        {
+            HandlerType = handlerType is null ? null : TypeDescriptor.For(handlerType)
+        };
+
+    [Fact]
+    public void the_declared_name_wins_where_two_rungs_describe_the_same_handler()
+    {
+        var aligned = EventModelSliceAlignment.AlignSliceNames(new[]
+        {
+            declared(slice("ConfirmAppointment", typeof(ConfirmAppointmentEndpoint))),
+            derived(slice("ConfirmAppointmentRequest", typeof(ConfirmAppointmentEndpoint)))
+        });
+
+        aligned[0].Slices.Single().Name.ShouldBe("ConfirmAppointment");
+        aligned[1].Slices.Single().Name.ShouldBe("ConfirmAppointment");
+
+        // and now -- and only now -- the merge folds them into one slice
+        EventModelDescriptor.Merge("app", aligned).Slices.Single().Name.ShouldBe("ConfirmAppointment");
+    }
+
+    [Fact]
+    public void registration_order_does_not_decide_which_name_survives()
+    {
+        var aligned = EventModelSliceAlignment.AlignSliceNames(new[]
+        {
+            derived(slice("ConfirmAppointmentRequest", typeof(ConfirmAppointmentEndpoint))),
+            declared(slice("ConfirmAppointment", typeof(ConfirmAppointmentEndpoint)))
+        });
+
+        aligned.SelectMany(x => x.Slices).Select(x => x.Name).Distinct().ShouldBe(new[] { "ConfirmAppointment" });
+    }
+
+    [Fact]
+    public void slices_that_already_agree_are_left_exactly_as_they_were()
+    {
+        var descriptors = new[]
+        {
+            declared(slice("ConfirmAppointment", typeof(ConfirmAppointmentEndpoint))),
+            derived(slice("ConfirmAppointment", typeof(ConfirmAppointmentEndpoint)))
+        };
+
+        EventModelSliceAlignment.AlignSliceNames(descriptors).ShouldBeSameAs(descriptors);
+    }
+
+    [Fact]
+    public void two_sources_on_the_same_rung_are_not_aligned_against_each_other()
+    {
+        // Wolverine core and Wolverine.HTTP are both Derived and already agree on how they name things.
+        // A handler type they happen to share is not evidence that they describe one slice, and folding
+        // them would silently collapse a message handler and an HTTP endpoint into a single slice.
+        var descriptors = new[]
+        {
+            derived(slice("ConfirmAppointmentRequest", typeof(ConfirmAppointmentEndpoint))),
+            derived(slice("POST /appointments", typeof(ConfirmAppointmentEndpoint)))
+        };
+
+        EventModelSliceAlignment.AlignSliceNames(descriptors).ShouldBeSameAs(descriptors);
+    }
+
+    [Fact]
+    public void a_handler_type_carrying_several_slices_in_one_source_identifies_none_of_them()
+    {
+        // The ordinary shape of a handler class that handles more than one message: the handler type no
+        // longer picks out a slice, so guessing one would be worse than leaving it unjoined.
+        var aligned = EventModelSliceAlignment.AlignSliceNames(new[]
+        {
+            declared(slice("ConfirmAppointment", typeof(ConfirmAppointmentEndpoint))),
+            derived(
+                slice("ConfirmAppointmentRequest", typeof(ConfirmAppointmentEndpoint)),
+                slice("CancelAppointmentRequest", typeof(ConfirmAppointmentEndpoint)))
+        });
+
+        aligned[1].Slices.Select(x => x.Name)
+            .ShouldBe(new[] { "ConfirmAppointmentRequest", "CancelAppointmentRequest" });
+    }
+
+    [Fact]
+    public void a_rename_that_would_collide_with_an_existing_slice_is_dropped()
+    {
+        var aligned = EventModelSliceAlignment.AlignSliceNames(new[]
+        {
+            declared(slice("ConfirmAppointment", typeof(ConfirmAppointmentEndpoint))),
+            derived(
+                slice("ConfirmAppointmentRequest", typeof(ConfirmAppointmentEndpoint)),
+                slice("ConfirmAppointment", typeof(CancelAppointmentEndpoint)))
+        });
+
+        aligned[1].Slices.Select(x => x.Name)
+            .ShouldBe(new[] { "ConfirmAppointmentRequest", "ConfirmAppointment" });
+    }
+
+    [Fact]
+    public void a_slice_with_no_handler_type_has_nothing_to_join_on()
+    {
+        var descriptors = new[]
+        {
+            declared(slice("ConfirmAppointment")),
+            derived(slice("ConfirmAppointmentRequest"))
+        };
+
+        EventModelSliceAlignment.AlignSliceNames(descriptors).ShouldBeSameAs(descriptors);
+    }
+}
+
+// The whole point of GH-4385 in one fixture: a curated model registered beside the application it
+// describes assembles as ONE model, on the board's names, carrying the code's roles -- and raising the
+// real disagreement instead of duplicating every slice.
+public class declared_and_derived_models_assemble_as_one_4385 : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddEventModelSource(new CuratedBoard()))
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "appointments";
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(ConfirmAppointmentHandler))
+                    .IncludeType(typeof(ProposeHomeCheckAppointmentHandler));
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task the_board_and_the_code_fold_into_one_model()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services,
+            token: TestContext.Current.CancellationToken);
+
+        // two slices, not four: the board's names, joined to the code on handler type
+        model.Slices.Select(x => x.Name).OrderBy(x => x)
+            .ShouldBe(new[] { "ConfirmAppointment", "ProposeHomeCheckAppointment" });
+
+        var confirm = model.Slices.Single(x => x.Name == "ConfirmAppointment");
+        confirm.CommandType!.Name.ShouldBe(nameof(ConfirmAppointmentRequest));
+        confirm.HandlerType!.Name.ShouldBe(nameof(ConfirmAppointmentHandler));
+        confirm.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+        confirm.EmittedEvents.Select(x => x.Name).ShouldBe(new[] { nameof(AppointmentConfirmed) });
+
+        // GH-4387: the code never claimed Pattern, so the board's Automation survives on the slice it
+        // declared it for -- which is the whole reason that role was left unclaimed
+        model.Slices.Single(x => x.Name == "ProposeHomeCheckAppointment").Pattern
+            .ShouldBe(SlicePattern.Automation);
+
+        // the board named the slice and nothing else claims naming, so the name is Declared while the
+        // facts around it came off the chain
+        confirm.ProvenanceFor(EventModelRole.CommandType).ShouldBe(EventModelProvenance.Derived);
+        confirm.ProvenanceFor(EventModelRole.Domain).ShouldBe(EventModelProvenance.Declared);
+    }
+
+    [Fact]
+    public async Task a_real_disagreement_now_surfaces_as_a_hotspot()
+    {
+        var model = await WolverineEventModelExport.AssembleAsync(_host.Services,
+            token: TestContext.Current.CancellationToken);
+
+        // the board says this slice also emits AppointmentRescheduled; the code says it does not. Before
+        // the sources could meet, the two lived in different halves of one file and the drift was
+        // invisible -- twenty-two slices and zero hotspots.
+        var confirm = model.Slices.Single(x => x.Name == "ConfirmAppointment");
+        confirm.Hotspots.ShouldContain(x =>
+            x.Origin == HotspotOrigin.SourceDisagreement && x.Text.Contains(nameof(EventModelRole.EmittedEvents)));
+    }
+}
+
+#region declared board and the code it describes
+
+public record ConfirmAppointmentRequest(Guid Id);
+
+public record AppointmentConfirmed(Guid Id);
+
+public record AppointmentRescheduled(Guid Id);
+
+public record AppointmentConfirmationSent(Guid Id);
+
+public record HomeCheckAssignmentAccepted(Guid Id);
+
+public record HomeCheckAppointmentProposed(Guid Id);
+
+public static class ConfirmAppointmentHandler
+{
+    [Emits(typeof(AppointmentConfirmed))]
+    public static AppointmentConfirmationSent Handle(ConfirmAppointmentRequest request)
+        => new(request.Id);
+}
+
+public static class ProposeHomeCheckAppointmentHandler
+{
+    [Emits(typeof(HomeCheckAppointmentProposed))]
+    public static void Handle(HomeCheckAssignmentAccepted trigger)
+    {
+    }
+}
+
+// stand-ins for the two endpoint types the alignment unit tests join on
+public static class ConfirmAppointmentEndpoint;
+
+public static class CancelAppointmentEndpoint;
+
+/// <summary>
+///     What a curated <c>.emodel.yaml</c> registers: the board's slice names, its handler role, and the
+///     events it says each slice emits -- all on the Declared rung.
+/// </summary>
+public class CuratedBoard : IEventModelDefinitionSource
+{
+    public Uri Subject { get; } = new("event-model://board/appointments");
+
+    public EventModelProvenance Provenance => EventModelProvenance.Declared;
+
+    public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+    {
+        var slices = new[]
+        {
+            EventModelSliceDescriptor.Named("ConfirmAppointment") with
+            {
+                Domain = "Appointments",
+                HandlerType = TypeDescriptor.For(typeof(ConfirmAppointmentHandler)),
+                EmittedEvents = new[]
+                {
+                    TypeDescriptor.For(typeof(AppointmentConfirmed)),
+                    TypeDescriptor.For(typeof(AppointmentRescheduled))
+                }
+            },
+            EventModelSliceDescriptor.Named("ProposeHomeCheckAppointment") with
+            {
+                Domain = "Appointments",
+                Pattern = SlicePattern.Automation,
+                HandlerType = TypeDescriptor.For(typeof(ProposeHomeCheckAppointmentHandler))
+            }
+        };
+
+        return Task.FromResult<EventModelDescriptor?>(new EventModelDescriptor("CritterCrush", slices));
+    }
+}
+
+#endregion

--- a/src/Testing/CoreTests/Acceptance/event_model_unclaimed_pattern_4387.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_unclaimed_pattern_4387.cs
@@ -52,13 +52,70 @@ public class unclaimed_pattern_for_message_handlers_4387
 
         var react = EventModelSliceDescriptor.Named("react") with
         {
-            CommandType = TypeDescriptor.For(typeof(HomeCheckAppointmentProposed))
+            CommandType = TypeDescriptor.For(typeof(HomeCheckAppointmentProposed)),
+            TriggerKind = TriggerKind.MessageHandler
         };
 
         var model = WolverineEventModelSource.FinishModel(
             new EventModelDescriptor("app", new[] { propose, react }));
 
         model.Slices.Single(x => x.Name == "react").Pattern.ShouldBe(SlicePattern.Automation);
+    }
+
+    [Fact]
+    public void a_cascaded_message_promotes_its_handler_the_same_way_an_emitted_event_does()
+    {
+        // The shape of most Wolverine services, and of the Quickstart sample: no event sourcing at
+        // all, one handler returning a message another handler picks up. Reading only EmittedEvents
+        // meant an application like this derived no pattern on any slice.
+        var create = EventModelRoles.ForHandlerChain(chainFor<CreateIssueHandler>(
+            x => CreateIssueHandler.Handle(null!)));
+        create.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(IssueCreated) });
+
+        var react = EventModelRoles.ForHandlerChain(chainFor<IssueCreatedHandler>(
+            x => IssueCreatedHandler.Handle(null!)));
+        react.Pattern.ShouldBeNull();
+
+        var model = WolverineEventModelSource.FinishModel(
+            new EventModelDescriptor("app", new[] { create, react }));
+
+        model.Slices.Single(x => x.Name == nameof(IssueCreated)).Pattern.ShouldBe(SlicePattern.Automation);
+        // nothing in the model originates CreateIssue, so that one stays unclaimed
+        model.Slices.Single(x => x.Name == nameof(CreateIssue)).Pattern.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_slice_that_republishes_what_it_handles_does_not_promote_itself()
+    {
+        // A loop says nothing about how the message first arrives, and self-promotion would make
+        // every retry-ish handler an automation
+        var loop = EventModelRoles.ForHandlerChain(chainFor<EchoHandler>(x => EchoHandler.Handle(null!)));
+
+        var model = WolverineEventModelSource.FinishModel(
+            new EventModelDescriptor("app", new[] { loop }));
+
+        model.Slices.Single().Pattern.ShouldBeNull();
+    }
+
+    [Fact]
+    public void an_http_route_is_not_promoted_just_because_a_handler_also_cascades_its_request()
+    {
+        // A person invoking a route has not been turned into an automation by something elsewhere
+        // cascading the same message
+        var create = EventModelRoles.ForHandlerChain(chainFor<CreateIssueHandler>(
+            x => CreateIssueHandler.Handle(null!)));
+
+        var route = EventModelSliceDescriptor.Named(nameof(IssueCreated)) with
+        {
+            CommandType = TypeDescriptor.For(typeof(IssueCreated)),
+            TriggerKind = TriggerKind.Http,
+            Pattern = SlicePattern.Command
+        };
+
+        var model = WolverineEventModelSource.FinishModel(
+            new EventModelDescriptor("app", new[] { create, route }));
+
+        model.Slices.Single(x => x.TriggerKind == TriggerKind.Http).Pattern.ShouldBe(SlicePattern.Command);
     }
 
     [Fact]
@@ -113,6 +170,29 @@ public class SweepStaleAppointmentsHandler
     public static void Handle(AppointmentSweepDue due)
     {
     }
+}
+
+public record CreateIssue(string Title);
+
+public record IssueCreated(Guid Id);
+
+public record Echo(string Text);
+
+public class CreateIssueHandler
+{
+    public static IssueCreated Handle(CreateIssue command) => new(Guid.NewGuid());
+}
+
+public class IssueCreatedHandler
+{
+    public static void Handle(IssueCreated created)
+    {
+    }
+}
+
+public class EchoHandler
+{
+    public static Echo Handle(Echo echo) => echo;
 }
 
 #endregion

--- a/src/Testing/CoreTests/Acceptance/event_model_unclaimed_pattern_4387.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_unclaimed_pattern_4387.cs
@@ -1,0 +1,118 @@
+using JasperFx.Descriptors;
+using Wolverine.Configuration;
+using Wolverine.Persistence.EventSourcing;
+using JasperFx.Events.EventModeling;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel4387;
+
+// GH-4387: an inbound message that appends events is a Command slice or an Automation slice depending
+// on WHY it arrived -- a person asked for it, or the system reacted to something -- and a handler
+// signature cannot tell the two apart. Claiming Command unconditionally put the Derived rung on a role
+// only a declaration can fill, where per-role precedence made the guess beat the board and minted a
+// SourceDisagreement per automation for the privilege. Same reasoning GH-4181 applied to TriggerLabel.
+public class unclaimed_pattern_for_message_handlers_4387
+{
+    private static HandlerChain chainFor<THandler>(System.Linq.Expressions.Expression<Action<THandler>> expression)
+        => HandlerChain.For(expression, new HandlerGraph());
+
+    [Fact]
+    public void a_message_handler_leaves_the_pattern_unclaimed()
+    {
+        EventModelRoles.ForHandlerChain(chainFor<ProposeHomeCheckAppointmentHandler>(
+            x => ProposeHomeCheckAppointmentHandler.Handle(null!))).Pattern.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_declared_automation_survives_the_merge_instead_of_disagreeing_with_the_code()
+    {
+        var derived = EventModelRoles.ForHandlerChain(chainFor<ProposeHomeCheckAppointmentHandler>(
+            x => ProposeHomeCheckAppointmentHandler.Handle(null!))).WithProvenance(EventModelProvenance.Derived);
+
+        var board = (EventModelSliceDescriptor.Named(derived.Name) with
+        {
+            Pattern = SlicePattern.Automation
+        }).WithProvenance(EventModelProvenance.Declared);
+
+        var merged = board.Merge(derived);
+
+        merged.Pattern.ShouldBe(SlicePattern.Automation);
+        merged.ProvenanceFor(EventModelRole.Pattern).ShouldBe(EventModelProvenance.Declared);
+        merged.Hotspots.ShouldNotContain(x => x.Origin == HotspotOrigin.SourceDisagreement);
+    }
+
+    [Fact]
+    public void the_role_is_still_claimed_where_the_model_actually_answers_it()
+    {
+        // an event another slice emits is evidence, not a guess -- the derived rung claims Automation
+        var propose = EventModelRoles.ForHandlerChain(chainFor<ProposeHomeCheckAppointmentHandler>(
+            x => ProposeHomeCheckAppointmentHandler.Handle(null!)));
+
+        var react = EventModelSliceDescriptor.Named("react") with
+        {
+            CommandType = TypeDescriptor.For(typeof(HomeCheckAppointmentProposed))
+        };
+
+        var model = WolverineEventModelSource.FinishModel(
+            new EventModelDescriptor("app", new[] { propose, react }));
+
+        model.Slices.Single(x => x.Name == "react").Pattern.ShouldBe(SlicePattern.Automation);
+    }
+
+    [Fact]
+    public void a_scheduled_slice_is_an_automation_because_its_trigger_says_so()
+    {
+        // "events *or a schedule* -> processor -> command / message", in SlicePattern's own words. The
+        // trigger kind answers the question the signature could not, so the role is claimed.
+        EventModelRoles.ForHandlerChain(chainFor<SweepStaleAppointmentsHandler>(
+            x => SweepStaleAppointmentsHandler.Handle(null!))).Pattern.ShouldBe(SlicePattern.Automation);
+    }
+
+    [Fact]
+    public void a_grpc_rpc_is_an_inbound_request_somebody_made_so_it_is_a_command()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<ProposeHomeCheckAppointmentHandler>(
+            x => ProposeHomeCheckAppointmentHandler.Handle(null!)));
+
+        var manifest = new StubGrpcManifest(new GrpcEndpointDescriptor("Appointments", "Propose",
+            typeof(HomeCheckAssignmentAccepted), null, typeof(ProposeHomeCheckAppointmentHandler),
+            GrpcServiceDiscoveryMode.CodeFirst, GrpcRpcStreamKind.Unary));
+
+        var applied = WolverineEventModelSource.ApplyGrpcTriggers(
+            new EventModelDescriptor("app", new[] { slice }), manifest);
+
+        applied.Slices.Single().Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    private sealed class StubGrpcManifest(params GrpcEndpointDescriptor[] endpoints) : IGrpcEndpointManifest
+    {
+        public IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; } = endpoints;
+    }
+}
+
+#region sample types for GH-4387
+
+public record HomeCheckAssignmentAccepted(Guid Id);
+
+public record HomeCheckAppointmentProposed(Guid Id);
+
+public record AppointmentSweepDue(Guid Id) : TimeoutMessage(TimeSpan.FromHours(1));
+
+public class ProposeHomeCheckAppointmentHandler
+{
+    [Emits(typeof(HomeCheckAppointmentProposed))]
+    public static void Handle(HomeCheckAssignmentAccepted trigger)
+    {
+    }
+}
+
+public class SweepStaleAppointmentsHandler
+{
+    public static void Handle(AppointmentSweepDue due)
+    {
+    }
+}
+
+#endregion

--- a/src/Testing/CoreTests/Acceptance/external_system_3989.cs
+++ b/src/Testing/CoreTests/Acceptance/external_system_3989.cs
@@ -126,9 +126,10 @@ public class external_system_3989 : IAsyncLifetime
         // a pure relay — no aggregate, no events of its own — is a translation slice
         slice.Pattern.ShouldBe(SlicePattern.Translation);
 
-        // an internal subscriber is not an external system
+        // an internal subscriber is not an external system, and nothing about it claims a pattern the
+        // message handler could not derive for itself (GH-4387)
         model.Slices.Single(x => x.Name == nameof(PlaceOrder)).ExternalSystems.ShouldBeEmpty();
-        model.Slices.Single(x => x.Name == nameof(PlaceOrder)).Pattern.ShouldBe(SlicePattern.Command);
+        model.Slices.Single(x => x.Name == nameof(PlaceOrder)).Pattern.ShouldBeNull();
     }
 
     [Fact]

--- a/src/Wolverine/Configuration/EventModeling/EventModelCommand.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelCommand.cs
@@ -39,12 +39,24 @@ public static class WolverineEventModelExport
     ///     <see cref="EventModelDiscovery" /> and fold the result into one model named for the service
     ///     (or <paramref name="modelName" />).
     /// </summary>
+    /// <remarks>
+    ///     GH-4385: the descriptors go through <see cref="EventModelSliceAlignment" /> first, so a declared
+    ///     model and the code it describes merge on the handler type they agree about rather than sliding
+    ///     past each other on names they were never going to compute the same way.
+    ///     <para>
+    ///     This walks <see cref="EventModelDiscovery.DiscoverAsync" /> rather than its <c>AssembleAsync</c>
+    ///     sibling for that reason alone — <c>AssembleAsync</c> folds by model name on the way out, and the
+    ///     alignment has to see the sources before anything merges. Everything lands in one model named for
+    ///     the service either way, so the assembled result is the same.
+    ///     </para>
+    /// </remarks>
     public static async Task<EventModelDescriptor> AssembleAsync(IServiceProvider services, string? modelName = null,
         CancellationToken token = default)
     {
-        var assembled = await EventModelDiscovery.AssembleAsync(services, token).ConfigureAwait(false);
+        var discovered = await EventModelDiscovery.DiscoverAsync(services, token).ConfigureAwait(false);
+        var aligned = EventModelSliceAlignment.AlignSliceNames(discovered);
         var name = modelName ?? services.GetService<WolverineOptions>()?.ServiceName ?? "Wolverine";
-        return EventModelDescriptor.Merge(name, assembled);
+        return EventModelDescriptor.Merge(name, aligned);
     }
 
     /// <summary>Serialize a model with <see cref="SerializerOptions" />.</summary>

--- a/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
@@ -147,6 +147,16 @@ public static class EventModelRoles
             roles.IsEventSourced = true;
         }
 
+        // GH-4386. StartStream / AppendEvents are ISideEffectAware, so isEventOrMessageCandidate
+        // rejects them and the chain was not even recorded as appending events. It plainly does.
+        // Kept apart from IsEventSourced on purpose: this says nothing about how the chain's OTHER
+        // return values should read, and folding it in would flip a cascaded message of a handler
+        // that only starts a stream into an emitted event of it.
+        if (returnTypes.Any(isEventAppendingSideEffect))
+        {
+            roles.AppendsThroughSideEffect = true;
+        }
+
         foreach (var type in returnTypes)
         {
             if (isUntypedEventCollection(type)) continue;
@@ -176,8 +186,8 @@ public static class EventModelRoles
             }
         }
 
-        var pattern = SlicePattern.Command;
-        if (seed.IsQuery && !roles.IsEventSourced && roles.EmittedEvents.Count == 0 &&
+        SlicePattern? pattern = SlicePattern.Command;
+        if (seed.IsQuery && !roles.AppendsEvents && roles.EmittedEvents.Count == 0 &&
             roles.PublishedMessages.Count == 0)
         {
             pattern = SlicePattern.View;
@@ -185,6 +195,29 @@ public static class EventModelRoles
             {
                 roles.ReadModels.Add(readModelOf(response));
             }
+        }
+        else if (seed.TriggerKind == TriggerKind.JobScheduler)
+        {
+            // A schedule with nobody in the loop is the textbook Automation: "events *or a schedule*
+            // → processor → command / message", in SlicePattern's own words. Derived, not guessed —
+            // the trigger kind says it outright.
+            pattern = SlicePattern.Automation;
+        }
+        else if (seed.TriggerKind == TriggerKind.MessageHandler)
+        {
+            // GH-4387. Pattern is deliberately NOT claimed for a message handler, for the reason
+            // GH-4181 left TriggerLabel unclaimed. An inbound message that appends events is a Command
+            // slice or an Automation slice depending on *why* it arrived — a person asked for it, or
+            // the system reacted to something — and a handler signature cannot tell the two apart.
+            // Claiming Command unconditionally put the Derived rung on a role only a declaration can
+            // fill, where per-role precedence (jasperfx#703) made the guess beat the board and minted
+            // a SourceDisagreement hotspot per automation for the privilege.
+            //
+            // Nothing is lost where the code CAN answer: WolverineEventModelSource.FinishModel still
+            // promotes a slice whose command is an event another slice emits to Automation, and an
+            // inbound external system still makes the slice a Translation. Both claim the role from
+            // evidence rather than from the absence of it.
+            pattern = null;
         }
 
         // GH-4181. TriggerLabel is deliberately NOT claimed here. Every structural fact a derived
@@ -298,6 +331,20 @@ public static class EventModelRoles
         Justification = "Handler, message and return types come from handler discovery, which already roots them; Closes() only reads interfaces. Diagnostic surface only.")]
     private static void readSignature(IChain chain, MethodCall call, RoleSet roles)
     {
+        // GH-4386. [Emits] is the one *declaration* this reader honours, and only because the fact it
+        // carries cannot be read any other way: the events a handler returns through EventsToAppend,
+        // the store's Events collection or StartStream are constructed in the method body, so the
+        // element types are erased before reflection ever sees them. Additive — the signature still
+        // says everything it can — and read from the method and the handler type alike.
+        foreach (var emits in call.Method.GetCustomAttributes<EmitsAttribute>(true)
+                     .Concat(call.HandlerType.GetCustomAttributes<EmitsAttribute>(true)))
+        {
+            foreach (var eventType in emits.EventTypes)
+            {
+                if (eventType != null) roles.EmittedEvents.Add(eventType);
+            }
+        }
+
         // [DeciderFunction] / [AggregateHandler] on the method or the handler type: the aggregate
         // is the one the attribute names, else the one the workflow would infer from the signature
         var decider = call.Method.GetAttribute<DeciderFunctionAttribute>()
@@ -456,6 +503,15 @@ public static class EventModelRoles
         }
     }
 
+    /// <summary>
+    ///     A return value that appends events as a <em>side effect</em> — the store-agnostic
+    ///     <see cref="StartStream" /> and <see cref="AppendEvents" />. The events ride inside the object and
+    ///     are constructed in the handler body, so they cannot be read here; <c>[Emits]</c> is how a handler
+    ///     names them. GH-4386.
+    /// </summary>
+    private static bool isEventAppendingSideEffect(Type type)
+        => type.CanBeCastTo<StartStream>() || type.CanBeCastTo<AppendEvents>();
+
     private static bool isUntypedEventCollection(Type type)
     {
         if (type == typeof(IAsyncEnumerable<object>)) return true;
@@ -494,6 +550,19 @@ public static class EventModelRoles
         /// the stream and never appear as return values. GH-4204.
         /// </summary>
         public bool AppendsThroughStream { get; set; }
+
+        /// <summary>
+        /// The chain returns a <see cref="StartStream" /> / <see cref="AppendEvents" /> side effect, so it
+        /// appends events even though nothing on the signature is an event. GH-4386.
+        /// </summary>
+        public bool AppendsThroughSideEffect { get; set; }
+
+        /// <summary>
+        /// Does this chain append events at all, however it does it? <see cref="IsEventSourced" /> answers
+        /// the narrower question the return-value classification asks — "is the chain event sourced in a way
+        /// that makes its other returns events?" — and is deliberately not the same thing.
+        /// </summary>
+        public bool AppendsEvents => IsEventSourced || AppendsThroughSideEffect;
         public List<Type> Aggregates { get; } = new();
         public Dictionary<Type, AggregateKind> AggregateKinds { get; } = new();
         public OrderedTypeSet EmittedEvents { get; } = new();

--- a/src/Wolverine/Configuration/EventModeling/EventModelSliceAlignment.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelSliceAlignment.cs
@@ -1,0 +1,149 @@
+using JasperFx.Events.EventModeling;
+
+namespace Wolverine.Configuration.EventModeling;
+
+/// <summary>
+///     Reconcile the slice <em>names</em> of several sources before they are merged, so a declared Event
+///     Model and the code that implements it fold into one model instead of two disconnected halves
+///     (GH-4385).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The problem.</b> <see cref="EventModelSliceDescriptor.Name" /> is the merge key, and the two
+///         kinds of source compute it from different things. A declaration carries the board's slice name —
+///         <c>ConfirmAppointment</c>, <c>AppointmentsQueue</c> — which is a name for the <em>behaviour</em>.
+///         Wolverine's derived sources name a slice for what they can see: the message type
+///         (<c>ConfirmAppointmentRequest</c>), the triggering event (<c>HomeCheckAssignmentAccepted</c>), or
+///         the route (<c>GET /api/appointmentsqueue/{id}</c>). Both are reasonable; neither is the other. On
+///         an eleven-slice sample the result was twenty-two slices and zero hotspots — not because the
+///         sources agreed, but because they never met, and the provenance ladder (Declared &lt; Derived
+///         &lt; Observed, with a <c>SourceDisagreement</c> where they conflict) never engaged at all.
+///     </para>
+///     <para>
+///         <b>The join.</b> <see cref="EventModelSliceDescriptor.HandlerType" /> is the one role both kinds
+///         of source can fill for the same slice and mean the same thing by: the curated format has a
+///         <c>handler:</c> role for exactly this, and every Wolverine chain knows its handler or endpoint
+///         type. Where two rungs describe the same handler type under different names, this renames the
+///         higher rung's slice to the lower rung's name — which is not a new rule so much as the existing
+///         one applied at the join: naming is a declaration concern (jasperfx#703's "slice names keep
+///         coming from declarations: nothing else claims them", and the GH-4181 reasoning that left
+///         <c>TriggerLabel</c> unclaimed). Neither side renames anything in its own file; the merge that
+///         follows then does what it was built to do, raising the real disagreements as hotspots instead of
+///         silently duplicating every slice.
+///     </para>
+///     <para>
+///         <b>What it deliberately will not do.</b> Only rungs that <em>differ</em> align — two Derived
+///         sources (Wolverine core and Wolverine.HTTP) already agree on how they name things, and a handler
+///         type they happen to share is not evidence that they describe one slice. A handler type carrying
+///         more than one slice inside a single descriptor is ambiguous and is skipped rather than guessed
+///         at, which is the ordinary shape of a handler class that handles several messages. And a rename
+///         that would collide with a slice already in the descriptor is dropped, because collapsing two
+///         distinct slices into one is worse than leaving them unjoined.
+///     </para>
+/// </remarks>
+public static class EventModelSliceAlignment
+{
+    /// <summary>
+    ///     Rename slices across <paramref name="descriptors" /> so sources on different provenance rungs
+    ///     that describe the same handler type agree on the slice name. Returns the descriptors unchanged
+    ///     when there is nothing to join.
+    /// </summary>
+    /// <param name="descriptors">The discovered descriptors, in registration order. Order breaks ties within a rung.</param>
+    public static IReadOnlyList<EventModelDescriptor> AlignSliceNames(IReadOnlyList<EventModelDescriptor> descriptors)
+    {
+        if (descriptors.Count < 2) return descriptors;
+
+        // Per descriptor: the one slice each handler type owns. A handler type carrying two or more
+        // slices in the same descriptor cannot identify one of them, so it identifies none.
+        var byHandler = descriptors.Select(unambiguousSlicesByHandler).ToArray();
+
+        var winners = new Dictionary<string, (EventModelProvenance Rung, string Name)>(StringComparer.Ordinal);
+        var contested = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var i = 0; i < byHandler.Length; i++)
+        {
+            foreach (var (handler, slice) in byHandler[i])
+            {
+                var rung = slice.Provenance ?? EventModelProvenance.Declared;
+
+                if (!winners.TryGetValue(handler, out var current))
+                {
+                    winners[handler] = (rung, slice.Name);
+                    continue;
+                }
+
+                // Only a *different* rung is evidence of a declaration meeting the code it describes.
+                if (rung != current.Rung) contested.Add(handler);
+
+                // The lowest rung names the slice; a tie keeps the first descriptor's name.
+                if (rung < current.Rung) winners[handler] = (rung, slice.Name);
+            }
+        }
+
+        if (contested.Count == 0) return descriptors;
+
+        var results = new List<EventModelDescriptor>(descriptors.Count);
+        var changed = false;
+        for (var i = 0; i < descriptors.Count; i++)
+        {
+            var renamed = rename(descriptors[i], byHandler[i], winners, contested);
+            changed |= !ReferenceEquals(renamed, descriptors[i]);
+            results.Add(renamed);
+        }
+
+        // Sources that already agreed on a name come back untouched, not merely equal: nothing
+        // downstream should have to tell an alignment that did nothing from one that did.
+        return changed ? results : descriptors;
+    }
+
+    private static Dictionary<string, EventModelSliceDescriptor> unambiguousSlicesByHandler(EventModelDescriptor descriptor)
+    {
+        var owned = new Dictionary<string, EventModelSliceDescriptor>(StringComparer.Ordinal);
+        var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var slice in descriptor.Slices)
+        {
+            if (slice.HandlerType?.FullName is not { } handler) continue;
+            if (!owned.TryAdd(handler, slice)) ambiguous.Add(handler);
+        }
+
+        foreach (var handler in ambiguous) owned.Remove(handler);
+
+        return owned;
+    }
+
+    private static EventModelDescriptor rename(
+        EventModelDescriptor descriptor,
+        Dictionary<string, EventModelSliceDescriptor> byHandler,
+        Dictionary<string, (EventModelProvenance Rung, string Name)> winners,
+        HashSet<string> contested)
+    {
+        var renames = new Dictionary<string, string>(StringComparer.Ordinal);
+        var taken = new HashSet<string>(descriptor.Slices.Select(x => x.Name), StringComparer.Ordinal);
+
+        foreach (var (handler, slice) in byHandler)
+        {
+            if (!contested.Contains(handler)) continue;
+            if (!winners.TryGetValue(handler, out var winner)) continue;
+            if (string.Equals(slice.Name, winner.Name, StringComparison.Ordinal)) continue;
+
+            // A name already spoken for in this descriptor belongs to some other slice; taking it would
+            // fold two distinct slices into one, which is a worse answer than leaving this one unjoined.
+            if (!taken.Add(winner.Name)) continue;
+
+            renames[handler] = winner.Name;
+        }
+
+        if (renames.Count == 0) return descriptor;
+
+        // Keyed by handler type rather than by the old name: only the one slice that handler owns is
+        // renamed, whatever else in the descriptor happens to share its name.
+        var slices = descriptor.Slices
+            .Select(slice => slice.HandlerType?.FullName is { } handler && renames.TryGetValue(handler, out var name)
+                ? slice with { Name = name }
+                : slice)
+            .ToList();
+
+        return descriptor with { Slices = slices };
+    }
+}

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -286,7 +286,10 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
             // An external system on the inbound side makes this a translation slice. On the outbound side
             // a slice keeps its own pattern (a command slice that also notifies Stripe is still a command
             // slice) unless it is a pure relay — no aggregate, no events of its own.
-            var pattern = flipPattern || (slice.AggregateTypes.Count == 0 && slice.EmittedEvents.Count == 0 && slice.Pattern == SlicePattern.Command)
+            // GH-4387: a message-handler slice leaves Pattern unclaimed, so "still a plain command slice"
+            // is now null OR Command.
+            var pattern = flipPattern || (slice.AggregateTypes.Count == 0 && slice.EmittedEvents.Count == 0 &&
+                                          slice.Pattern is null or SlicePattern.Command)
                 ? SlicePattern.Translation
                 : slice.Pattern;
 
@@ -357,7 +360,11 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         => slice with
         {
             TriggerKind = TriggerKind.Grpc,
-            TriggerOrigin = slice.TriggerOrigin ?? origin
+            TriggerOrigin = slice.TriggerOrigin ?? origin,
+            // GH-4387: the slice behind an RPC is derived off a message handler chain, which no longer
+            // claims Pattern. An RPC is an inbound request somebody made, exactly as an HTTP route is, so
+            // the trigger answers the question the handler signature could not.
+            Pattern = slice.Pattern ?? SlicePattern.Command
         };
 
     private static EventModelSliceDescriptor grpcTriggerOnlySlice(GrpcEndpointDescriptor endpoint, PublisherOrigin origin)
@@ -392,9 +399,11 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
 
         if (emitted.Count == 0) return model;
 
+        // GH-4387: an unclaimed Pattern is the message-handler default now, and this is exactly the
+        // evidence that lets the derived rung claim it — the command IS an event something else raises.
         var slices = model.Slices
             .Select(slice => slice.CommandType is { } command && emitted.Contains(command.FullName) &&
-                             slice.Pattern == SlicePattern.Command
+                             slice.Pattern is null or SlicePattern.Command
                 ? slice with { Pattern = SlicePattern.Automation }
                 : slice)
             .ToList();

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -387,27 +387,65 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
         };
 
     /// <summary>
-    ///     Model-wide derivations that need every slice at once: a slice whose command is an event some
-    ///     other slice emits is an <see cref="SlicePattern.Automation" /> — the "when X, do Y" reaction — not
-    ///     a command slice.
+    ///     Model-wide derivations that need every slice at once: a slice whose command only ever arrives
+    ///     because <em>another</em> slice hands it off is an <see cref="SlicePattern.Automation" /> — the
+    ///     "when X, do Y" reaction — not a command slice.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         GH-4387: this is the evidence that lets the derived rung claim <c>Pattern</c> for a message
+    ///         handler, which <see cref="EventModelRoles.Describe" /> otherwise leaves unclaimed because a
+    ///         handler signature cannot tell a Command from an Automation. Here the <em>model</em> can:
+    ///         nothing else in this application originates the message.
+    ///     </para>
+    ///     <para>
+    ///         <b>An emitted event and a cascaded message count the same.</b> The distinction the pattern
+    ///         turns on is "did a person ask for this, or did the system react", and a message that only
+    ///         reaches a handler because another handler returned it is a reaction either way. Reading only
+    ///         <c>EmittedEvents</c> meant an application with no event sourcing at all — the shape of the
+    ///         <c>Quickstart</c> sample, and of most Wolverine services — derived no pattern on any slice.
+    ///     </para>
+    ///     <para>
+    ///         <b>Only a message-handler trigger is promoted.</b> An HTTP route, a gRPC RPC or a named
+    ///         listener already names its initiator, and a person invoking a route that some handler also
+    ///         cascades has not thereby made the route an automation. A slice whose only producer is
+    ///         <em>itself</em> is a loop, which says nothing about how the message first arrives.
+    ///     </para>
+    /// </remarks>
     public static EventModelDescriptor FinishModel(EventModelDescriptor model)
     {
-        var emitted = new HashSet<string>(
-            model.Slices.SelectMany(x => x.EmittedEvents).Select(x => x.FullName),
-            StringComparer.Ordinal);
+        // What each message type is handed off by, so a slice that merely re-publishes what it handles
+        // cannot promote itself
+        var producers = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var slice in model.Slices)
+        {
+            foreach (var type in slice.EmittedEvents.Concat(slice.PublishedMessages))
+            {
+                if (!producers.TryGetValue(type.FullName, out var names))
+                {
+                    names = new List<string>();
+                    producers[type.FullName] = names;
+                }
 
-        if (emitted.Count == 0) return model;
+                if (!names.Contains(slice.Name)) names.Add(slice.Name);
+            }
+        }
 
-        // GH-4387: an unclaimed Pattern is the message-handler default now, and this is exactly the
-        // evidence that lets the derived rung claim it — the command IS an event something else raises.
-        var slices = model.Slices
-            .Select(slice => slice.CommandType is { } command && emitted.Contains(command.FullName) &&
-                             slice.Pattern is null or SlicePattern.Command
-                ? slice with { Pattern = SlicePattern.Automation }
-                : slice)
-            .ToList();
+        if (producers.Count == 0) return model;
+
+        var slices = model.Slices.Select(promote).ToList();
 
         return model with { Slices = slices };
+
+        EventModelSliceDescriptor promote(EventModelSliceDescriptor slice)
+        {
+            if (slice.Pattern is not (null or SlicePattern.Command)) return slice;
+            if (slice.TriggerKind != TriggerKind.MessageHandler) return slice;
+            if (slice.CommandType is not { } command) return slice;
+            if (!producers.TryGetValue(command.FullName, out var names)) return slice;
+            if (names.All(x => string.Equals(x, slice.Name, StringComparison.Ordinal))) return slice;
+
+            return slice with { Pattern = SlicePattern.Automation };
+        }
     }
 }

--- a/src/Wolverine/Persistence/EventSourcing/EmitsAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/EmitsAttribute.cs
@@ -1,0 +1,59 @@
+using JasperFx.Events.EventModeling;
+
+namespace Wolverine.Persistence.EventSourcing;
+
+/// <summary>
+///     Declare the event types a handler appends when its signature cannot say so — the events are
+///     constructed in the method body and returned through <see cref="EventsToAppend" />, the store's
+///     <c>Events</c> collection, <see cref="StartStream" /> or an <c>IEventStream&lt;T&gt;</c> (GH-4386).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Wolverine's Event Model is <em>derived</em>: the roles of a slice are read off the handler
+///         signature, so a typed event return is reported without anything being declared. The two shapes
+///         the Critter Stack's own scaffolding emits for a modelled slice are the exception —
+///     </para>
+///     <code>
+///     public static (ConfirmAppointmentResponse, EventsToAppend) Post(ConfirmAppointmentRequest request, [WriteModel] Appointment appointment)
+///     public static StartStream Handle(HomeCheckAssignmentAccepted trigger)
+///     </code>
+///     <para>
+///         — because a collection of events and a stream side effect both erase the element types. The
+///         slice is known to append events and the events themselves are unreadable, so the more
+///         idiomatically event-modelled an application is, the emptier its derived model gets. That is not
+///         a gap reflection can close: the types genuinely are not on the signature.
+///     </para>
+///     <para>
+///         This attribute is the cheap, honest way to put the fact back where the code is. It is
+///         <b>additive</b> — the types named here are unioned with whatever the signature already says —
+///         and it is purely diagnostic: nothing about dispatch, codegen or persistence reads it, so a
+///         wrong or stale declaration costs an <see cref="EventModelProvenance.Derived" /> claim that
+///         disagrees with the board, which is exactly the drift the merge exists to surface.
+///     </para>
+///     <para>
+///         Put it on the handler method, or on the handler type when every method of it emits the same
+///         events. Repeat it freely; the declarations accumulate.
+///     </para>
+/// </remarks>
+/// <example>
+///     <code>
+///     [Emits(typeof(AppointmentConfirmed))]
+///     public static (ConfirmAppointmentResponse, EventsToAppend) Post(
+///         ConfirmAppointmentRequest request, [WriteModel] Appointment appointment)
+///     {
+///         var events = new EventsToAppend { new AppointmentConfirmed(request.Id) };
+///         return (new ConfirmAppointmentResponse(request.Id), events);
+///     }
+///     </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class EmitsAttribute : Attribute
+{
+    public EmitsAttribute(params Type[] eventTypes)
+    {
+        EventTypes = eventTypes ?? Array.Empty<Type>();
+    }
+
+    /// <summary>The event types this handler appends, in declaration order.</summary>
+    public IReadOnlyList<Type> EventTypes { get; }
+}


### PR DESCRIPTION
Closes #4385, closes #4386, closes #4387.

Three findings from the same CritterCrush comparison — an eleven-slice event-modelled sample whose
declared model is a curated `.emodel.yaml` and whose code was built from it. They compound, so they
land together: #4386 empties `emittedEvents`, which is what stops `FinishModel` from ever promoting
an Automation, and #4385 is why the disagreement in #4387 could not surface as a hotspot in the
first place.

## GH-4385 — the sources never met

`EventModelSliceDescriptor.Name` is the merge key, and the two kinds of source compute it from
different things. A declaration carries the board's *behaviour* name; Wolverine's derived sources
name a slice for what they can see — the message type, the triggering event, the route. Eleven
declared slices plus eleven derived slices assembled as twenty-two, with zero hotspots.

`HandlerType` is the one role both kinds of source fill and mean the same thing by. The new
`EventModelSliceAlignment` runs over the discovered descriptors before anything merges: where two
**different** provenance rungs describe the same handler type under different names, the slice takes
the lower rung's name — which is not a new rule so much as the existing one applied at the join
("slice names keep coming from declarations: nothing else claims them", jasperfx#703, and the
GH-4181 reasoning that left `TriggerLabel` unclaimed). Neither side renames anything in its own file.

`WolverineEventModelExport.AssembleAsync` now walks `EventModelDiscovery.DiscoverAsync` rather than
its `AssembleAsync` sibling, because the alignment has to see the sources before the fold. Everything
still lands in one model named for the service, so the assembled result is unchanged where nothing
aligns.

Deliberately narrow, because the failure mode of guessing here is two distinct slices silently
collapsing into one:

- Two sources on the **same** rung are never aligned against each other. Wolverine core and
  Wolverine.HTTP already agree on how they name things, and a handler type they happen to share is
  not evidence they describe one slice.
- A handler type carrying more than one slice inside a source identifies none of them — the ordinary
  shape of a handler class handling several messages.
- A rename that would collide with a slice already in that descriptor is dropped.
- Alignment that changes nothing returns the original list, by reference.

## GH-4386 — `[Emits]`

`EventsToAppend` and `StartStream` are exactly what the Critter Stack scaffolds for a modelled slice,
and both erase the element types: the events are constructed in the method body. Reflection over a
signature cannot close that, so the code gets a way to say it:

```csharp
[Emits(typeof(AppointmentConfirmed))]
public static (ConfirmAppointmentResponse, EventsToAppend) Post(
    ConfirmAppointmentRequest request, [WriteModel] Appointment appointment)
```

Readable on the method or on the handler type, repeatable, additive to everything the signature
already says, and purely diagnostic — nothing about dispatch, codegen or persistence reads it. It
deliberately does **not** set `IsEventSourced`, so it cannot flip a handler's cascaded message into
an emitted event.

Separately, a `StartStream` / `AppendEvents` return now records that the chain appends events at all.
It was `ISideEffectAware`, so `isEventOrMessageCandidate` rejected it outright and the slice was not
even marked as appending. That flag is kept apart from `IsEventSourced` for the same reason as above.

The point of all this is the rung, not the diagram: an empty `emittedEvents` cannot *contradict* a
declaration, so a slice whose code stopped emitting an event it declares looked identical to one that
still emits it. With `[Emits]` the derived rung can disagree, and the merge raises it.

## GH-4387 — `Pattern` unclaimed for a message handler

An inbound message that appends events is a `Command` or an `Automation` depending on *why* it
arrived, and a handler signature cannot tell the two apart. Claiming `Command` unconditionally put
the Derived rung on a role only a declaration can fill, where per-role precedence made the guess beat
the board — and minted a `SourceDisagreement` per automation for the privilege. `TriggerKind.MessageHandler`
now leaves `Pattern` null, on the GH-4181 precedent.

Nothing is given up where the code genuinely answers the question. `Pattern` is still claimed for:

| Case | Pattern | Where |
| --- | --- | --- |
| HTTP `GET` / `HEAD` writing nothing | `View` | `EventModelRoles.Describe` |
| Any other HTTP route | `Command` | `EventModelRoles.Describe` |
| `TimeoutMessage` / a cron-scheduled message | `Automation` | `EventModelRoles.Describe` — "events *or a schedule*", in `SlicePattern`'s own words |
| A gRPC RPC | `Command` | `WolverineEventModelSource.ApplyGrpcTriggers` |
| An inbound external system, or a pure relay | `Translation` | `WolverineEventModelSource.ApplyExternalSystems` |
| A command that is an event another slice emits | `Automation` | `WolverineEventModelSource.FinishModel` |

The last two now treat an unclaimed pattern the same way they treated `Command`, so a message-handler
slice is still promoted on the evidence the whole model provides.

## Behaviour change worth calling out

A plain message-handler slice used to report `pattern: "Command"` in `event-model` output and in the
`ServiceCapabilities` snapshot; it now reports no pattern at all unless one of the rows above applies.
A `TimeoutMessage` handler moves from `Command` to `Automation`.

**Worth seeing before you merge this:** an application that is *only* plain message handlers now
exports no pattern on any slice. The `Quickstart` sample is exactly that shape, and its
`event-model` output went from `"pattern": "Command"` on every slice to zero `"pattern"` keys — which
is why the `describe-handlers-smoke` job in `command-line.yml` had to stop asserting one. That is the
honest consequence of the position the issue argues for (the code cannot express the distinction, so
it should not claim the role), but it *is* a diagram that loses its colouring for the common
non-event-sourced case. If you would rather keep more coverage, the lever is `FinishModel`: promoting
a slice whose command is a **published message** of another slice to `Automation` — a message that
only ever arrives because another handler cascaded it is a reaction with nobody in the loop — would
have caught `Quickstart`'s `IssueCreated` and `IssueAssigned` slices. I left it out as beyond what
#4387 asked for; say the word and it is a small follow-up.

Two assertions elsewhere in the tree pinned the old behaviour and were updated: MartenTests'
`the_write_aggregate_handler_reports_aggregate_and_emitted_events`, and the smoke-test grep above.
Both were found by CI rather than by the local suites — `CoreTests` and `Wolverine.Http.Tests` do not
cover either.

## Verification

- `CoreTests`: 2899 passed, 0 failed (20 new tests across the three issues).
- `Wolverine.Http.Tests` green.
- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors.

Docs: three new sections under *Exporting the Event Model* in `docs/guide/command-line.md` — naming
events a signature cannot carry, what the derived source will not claim, and meeting a declared model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
