### PR TITLE
Bump JasperFx to 2.66.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
          (build/SupervisedTests.cs): class-partitioned parallel workers, per-lane environments,
          and honest retry reporting. Referenced ONLY by the build project. -->
     <PackageVersion Include="Bobcat.Supervisor" Version="0.8.0" />
-    <PackageVersion Include="JasperFx" Version="2.63.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.63.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.63.2" />
+    <PackageVersion Include="JasperFx" Version="2.66.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.66.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.1" />
     <!-- RuntimeCompiler is on its own 5.x line (the Roslyn compiler package) — not the 2.1.x
          family; it stays at 5.0.0. -->
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.63.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
     <PackageVersion Include="Marten" Version="9.32.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Moves all four JasperFx packages from 2.63.2 to 2.66.1 in `Directory.Packages.props`:

| Package | From | To |
| --- | --- | --- |
| `JasperFx` | 2.63.2 | 2.66.1 |
| `JasperFx.Events` | 2.63.2 | 2.66.1 |
| `JasperFx.Events.SourceGenerator` | 2.63.2 | 2.66.1 |
| `JasperFx.SourceGenerator` | 2.63.2 | 2.66.1 |

The two source-generator packages ship on the same line and move with the pair — leaving a generator
behind a runtime it emits against is the shape of a break that compiles.

`JasperFx.RuntimeCompiler` stays at 5.0.0; it is on its own 5.x line, as the comment beside it in the
props file says.

## Store alignment — worth knowing before this merges

A clean compile proves nothing here. `JasperFx.Events` interface additions break stores at *runtime*,
so what matters is which JasperFx each store package was built against:

| Package | Pinned here | Built against |
| --- | --- | --- |
| Marten 9.32.0 | current | JasperFx 2.63.0 |
| Marten **9.32.1** | — | JasperFx **2.66.0** |
| Polecat 5.23.0 | current | JasperFx 2.63.0 |
| Fisher 1.1.0 | current | JasperFx 2.63.0 |

Marten has a 2.66-aligned release available; Polecat and Fisher do not yet. I left all three pins
alone, because bundling a Marten bump into a JasperFx bump muddies both — but **Marten 9.32.0 →
9.32.1 is the obvious companion** if you want the store on the same rung, and Polecat/Fisher will
need their own releases before they are aligned rather than merely working.

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0` — 0 warnings, 0 errors.
- `CoreTests`: 2879 passed, 0 failed.
- `MartenTests`: green — the suite that would actually catch a store running against a newer
  JasperFx than it compiled with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
