### PR TITLE
Close the FisherOps gap with Fisher's own IDocumentOperations

### DIFF
--- a/docs/guide/durability/fisher/index.md
+++ b/docs/guide/durability/fisher/index.md
@@ -118,6 +118,60 @@ Each store is **its own file**, which is what gets two concurrent writers out of
 having them contend on one. Wolverine's durability tables for an ancillary store live in that
 store's file, alongside its documents and events.
 
+## Operation Side Effects <Badge type="tip" text="6.35" />
+
+`FisherOps` is the Fisher twin of [`MartenOps`](../marten/operations) and
+[`PolecatOps`](../polecat/operations): a handler returns a *value* describing the write instead of
+taking an `IDocumentSession` and doing it, which keeps the handler a pure function you can unit test
+on its return values alone.
+
+```csharp
+public static IEnumerable<IFisherOp> Handle(PurgeAccount command)
+{
+    yield return FisherOps.HardDelete<Account>(command.AccountId);
+    yield return FisherOps.UndoDeleteWhere<Invitation>(x => x.AccountId == command.AccountId);
+    yield return FisherOps.Patch<Account>(command.AccountId, p => p.Set(x => x.Locked, true));
+    yield return FisherOps.QueueSqlCommand("delete from audit where account = ?", command.AccountId);
+    yield return FisherOps.Append(command.AuditStreamId, new AccountPurged(command.AccountId));
+    yield return FisherOps.ArchiveStream(command.AccountStreamId);
+}
+```
+
+Alongside `Store` / `StoreMany` / `StoreObjects` / `Insert` / `Update` / `Delete` / `StartStream`,
+the set covers:
+
+| Op | What it reaches |
+|---|---|
+| `HardDelete(doc)`, `HardDelete<T>(id)`, `HardDeleteWhere<T>(filter)` | `HardDelete` / `HardDeleteWhere` |
+| `UndoDeleteWhere<T>(filter)` | `UndoDeleteWhere` |
+| `UpdateRevision`, `TryUpdateRevision` | same names |
+| `Patch<T>(id, ...)`, `PatchWhere<T>(filter, ...)` | `Patch<T>()` fluent API |
+| `QueueSqlCommand(sql, ...)` (+ a custom placeholder overload) | `QueueSqlCommand` |
+| `Append(streamId \| streamKey, ...)`, with an optional expected version | `Events.Append` |
+| `ArchiveStream(streamId \| streamKey)` | `Events.ArchiveStream` |
+
+Every op implements `ITenantedFisherOp`, so one extension scopes any of them while preserving the
+concrete return type:
+
+```csharp
+FisherOps.ArchiveStream(command.OrderId).ForTenant(command.TenantId);
+FisherOps.StoreMany(items).ForTenant(tenantId).With(oneMore);
+```
+
+Two invariants are enforced at construction rather than at `SaveChangesAsync()` time, where a
+handler that returned a side effect looking perfectly valid would otherwise blow up much later:
+`HardDelete<T>()` and `Patch<T>()` reject an id that is not a `string`, `Guid`, `int` or `long`
+(Fisher has no `object`-typed overload to fall back on), and `Append` / `ArchiveStream` refuse
+`Guid.Empty` and an empty stream key — the Guid/string discrimination is on `Guid.Empty`, the same
+sentinel `StartStream<T>` uses, so an empty id would otherwise silently take the string branch.
+
+::: tip
+Fisher has no `InsertObjects` / `DeleteObjects`, no `UpdateExpectedVersion`, and no
+`UnArchiveStream` / `TombstoneStream` (those last two are Polecat's own), so there is no `FisherOps`
+factory for any of them. Its revision API is `int`-based rather than `long`, and `FisherOps` takes
+`int` to match rather than widening it to a value the store cannot hold.
+:::
+
 ## What is not supported yet
 
 Wolverine.Fisher is deliberately narrower than the Marten and Polecat integrations in its first

--- a/docs/guide/durability/fisher/index.md
+++ b/docs/guide/durability/fisher/index.md
@@ -165,6 +165,15 @@ handler that returned a side effect looking perfectly valid would otherwise blow
 `Guid.Empty` and an empty stream key — the Guid/string discrimination is on `Guid.Empty`, the same
 sentinel `StartStream<T>` uses, so an empty id would otherwise silently take the string branch.
 
+::: warning
+`UpdateRevision` and `TryUpdateRevision` only actually guard on a document type that implements
+`JasperFx.IRevisioned`. A type configured through `Schema.For<T>().UseNumericRevisions()` instead
+records a revision but enforces nothing — a stale write lands silently, and `TryUpdateRevision`
+drops nothing. The two routes are documented as equivalent in Fisher and are not; tracked as
+[JasperFx/fisher#228](https://github.com/JasperFx/fisher/issues/228). Use `IRevisioned` until that
+is fixed.
+:::
+
 ::: tip
 Fisher has no `InsertObjects` / `DeleteObjects`, no `UpdateExpectedVersion`, and no
 `UnArchiveStream` / `TombstoneStream` (those last two are Polecat's own), so there is no `FisherOps`

--- a/src/Persistence/FisherTests/FisherOps_expanded_operations.cs
+++ b/src/Persistence/FisherTests/FisherOps_expanded_operations.cs
@@ -1,0 +1,127 @@
+using Shouldly;
+using Wolverine.Fisher;
+
+namespace FisherTests;
+
+public record ExpandedDoc(Guid Id, string Name, int Revision = 0);
+
+// The Fisher half of the MartenOps parity wave (GH-4384's "Not in this PR"). These are op-shape
+// tests -- what the factory builds, what it refuses, and how ForTenant() rides along -- with the
+// behaviour against a real store covered in handler_actions_with_expanded_fisher_operations.
+public class FisherOps_expanded_operations
+{
+    [Fact]
+    public void hard_delete_by_document_and_by_id()
+    {
+        FisherOps.HardDelete(new ExpandedDoc(Guid.NewGuid(), "one")).ShouldBeOfType<HardDeleteDoc<ExpandedDoc>>();
+
+        FisherOps.HardDelete<ExpandedDoc>(Guid.NewGuid()).ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+        FisherOps.HardDelete<ExpandedDoc>("key").ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+        FisherOps.HardDelete<ExpandedDoc>(5).ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+        FisherOps.HardDelete<ExpandedDoc>(5L).ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+    }
+
+    [Fact]
+    public void hard_delete_refuses_an_id_type_fisher_cannot_dispatch()
+    {
+        // Fisher's HardDelete<T>() has no object-typed overload to fall back on, so an id type it
+        // cannot dispatch would otherwise surface inside SaveChangesAsync(), long after the handler
+        // returned a side effect that looked perfectly valid
+        Should.Throw<ArgumentOutOfRangeException>(() => new HardDeleteDocById<ExpandedDoc>(1.5m));
+        Should.Throw<ArgumentNullException>(() => new HardDeleteDocById<ExpandedDoc>(null!));
+    }
+
+    [Fact]
+    public void patch_refuses_an_id_type_fisher_cannot_dispatch()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            new PatchDoc<ExpandedDoc>(1.5m, _ => { }));
+        Should.Throw<ArgumentNullException>(() =>
+            new PatchDoc<ExpandedDoc>(Guid.NewGuid(), null!));
+    }
+
+    [Fact]
+    public void revision_ops_carry_the_revision()
+    {
+        var doc = new ExpandedDoc(Guid.NewGuid(), "one");
+
+        FisherOps.UpdateRevision(doc, 3).Revision.ShouldBe(3);
+        FisherOps.TryUpdateRevision(doc, 4).Revision.ShouldBe(4);
+
+        Should.Throw<ArgumentNullException>(() => FisherOps.UpdateRevision<ExpandedDoc>(null!, 1));
+        Should.Throw<ArgumentNullException>(() => FisherOps.TryUpdateRevision<ExpandedDoc>(null!, 1));
+    }
+
+    [Fact]
+    public void queue_sql_command_carries_the_sql_and_the_optional_placeholder()
+    {
+        var op = FisherOps.QueueSqlCommand("delete from foo where id = ?", 5);
+        op.Sql.ShouldBe("delete from foo where id = ?");
+        op.ParameterValues.ShouldBe(new object[] { 5 });
+        op.Placeholder.ShouldBeNull();
+
+        FisherOps.QueueSqlCommand('^', "select ? from bar", 1).Placeholder.ShouldBe('^');
+
+        Should.Throw<ArgumentNullException>(() => FisherOps.QueueSqlCommand(null!));
+    }
+
+    [Fact]
+    public void append_carries_its_events_and_optional_expected_version()
+    {
+        var id = Guid.NewGuid();
+
+        var op = FisherOps.Append(id, new ExpandedEventA());
+        op.StreamId.ShouldBe(id);
+        op.Events.Count.ShouldBe(1);
+        op.ExpectedVersion.ShouldBeNull();
+
+        op.With(new ExpandedEventA()).Events.Count.ShouldBe(2);
+        op.With([new ExpandedEventA(), new ExpandedEventA()]).Events.Count.ShouldBe(4);
+
+        FisherOps.Append(id, 3L, new ExpandedEventA()).ExpectedVersion.ShouldBe(3);
+        FisherOps.Append("key", 3L, new ExpandedEventA()).ExpectedVersion.ShouldBe(3);
+        FisherOps.Append("key", new ExpandedEventA()).StreamKey.ShouldBe("key");
+    }
+
+    [Fact]
+    public void the_stream_ops_refuse_an_empty_identity()
+    {
+        // Guid identity is discriminated from string identity on StreamId == Guid.Empty -- the same
+        // sentinel StartStream<T> uses -- so an empty identity would silently take the string branch
+        Should.Throw<ArgumentOutOfRangeException>(() => FisherOps.Append(Guid.Empty, new ExpandedEventA()));
+        Should.Throw<ArgumentOutOfRangeException>(() => FisherOps.Append("", new ExpandedEventA()));
+        Should.Throw<ArgumentOutOfRangeException>(() => FisherOps.ArchiveStream(Guid.Empty));
+        Should.Throw<ArgumentOutOfRangeException>(() => FisherOps.ArchiveStream(""));
+    }
+
+    [Fact]
+    public void for_tenant_scopes_every_op_and_keeps_the_concrete_return_type()
+    {
+        var doc = new ExpandedDoc(Guid.NewGuid(), "one");
+        var id = Guid.NewGuid();
+
+        FisherOps.HardDelete(doc).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.HardDelete<ExpandedDoc>(id).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.HardDeleteWhere<ExpandedDoc>(x => x.Name == "one").ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.UndoDeleteWhere<ExpandedDoc>(x => x.Name == "one").ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.UpdateRevision(doc, 2).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.TryUpdateRevision(doc, 2).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.Patch<ExpandedDoc>(id, _ => { }).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.PatchWhere<ExpandedDoc>(x => x.Name == "one", _ => { }).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.QueueSqlCommand("select 1").ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.ArchiveStream(id).ForTenant("blue").TenantId.ShouldBe("blue");
+
+        // the concrete type survives, so this chains onto the ops that have a fluent surface
+        FisherOps.Append(id, new ExpandedEventA()).ForTenant("blue").With(new ExpandedEventA())
+            .Events.Count.ShouldBe(2);
+
+        // and the pre-existing ops joined the same mechanism rather than growing more overloads
+        FisherOps.Store(doc).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.StoreMany(doc).ForTenant("blue").TenantId.ShouldBe("blue");
+        FisherOps.Delete<ExpandedDoc>(id).ForTenant("blue").TenantId.ShouldBe("blue");
+
+        Should.Throw<ArgumentNullException>(() => FisherOps.Store(doc).ForTenant(null!));
+    }
+}
+
+public record ExpandedEventA;

--- a/src/Persistence/FisherTests/handler_actions_with_expanded_fisher_operations.cs
+++ b/src/Persistence/FisherTests/handler_actions_with_expanded_fisher_operations.cs
@@ -1,0 +1,227 @@
+using Fisher;
+using Fisher.Linq;
+using Fisher.Linq.SoftDeletes;
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Fisher;
+using Wolverine.Tracking;
+
+namespace FisherTests;
+
+// The expanded FisherOps driven through real handlers against a real Fisher store -- the half the
+// op-shape tests cannot reach. Fisher is in-process SQLite, so this costs a temp file rather than a
+// container.
+public class handler_actions_with_expanded_fisher_operations : IAsyncLifetime
+{
+    private FisherTestDatabase theDatabase = null!;
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        theDatabase = Servers.CreateDatabase("expanded_fisher_ops");
+
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(ExpandedOpsHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+
+                opts.Services.AddFisher(m =>
+                    {
+                        m.Connection(theDatabase.ConnectionString);
+                        m.AutoCreateSchemaObjects = AutoCreate.All;
+                        m.Schema.For<SoftDeletedDoc>().SoftDeleted();
+                        // TryUpdateRevision only has anything to compare against on a type that
+                        // actually tracks a numeric revision; on any other type the revision is
+                        // simply ignored, which would make the assertion below vacuous
+                        m.Schema.For<RevisionedDoc>().UseNumericRevisions();
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .IntegrateWithWolverine();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+        theDatabase.Dispose();
+    }
+
+    private IDocumentStore theStore => _host.Services.GetRequiredService<IDocumentStore>();
+
+    [Fact]
+    public async Task hard_delete_removes_the_row_a_soft_delete_would_have_kept()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new SoftDeletedDoc { Id = id, Name = "keep" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new HardDeleteIt(id));
+
+        await using var query = theStore.QuerySession();
+        // a soft delete would still return the row to a MaybeDeleted() query; a hard delete does not
+        var all = await query.Query<SoftDeletedDoc>().MaybeDeleted()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        all.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task undo_delete_where_brings_a_soft_deleted_document_back()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new SoftDeletedDoc { Id = id, Name = "revivable" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+            session.Delete<SoftDeletedDoc>(id);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new UndoTheDelete("revivable"));
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<SoftDeletedDoc>(id, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task patch_reaches_a_single_document_by_id()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new PatchableDoc { Id = id, Name = "before" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PatchIt(id, "after"));
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<PatchableDoc>(id, TestContext.Current.CancellationToken);
+        loaded!.Name.ShouldBe("after");
+    }
+
+    [Fact]
+    public async Task try_update_revision_writes_forward_and_drops_a_stale_revision()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new RevisionedDoc { Id = id, Name = "seed" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // moving the revision forward writes
+        await _host.InvokeMessageAndWaitAsync(new TryReviseIt(id, "v7", 7));
+
+        await using (var query = theStore.QuerySession())
+        {
+            var moved = await query.LoadAsync<RevisionedDoc>(id, TestContext.Current.CancellationToken);
+            moved!.Name.ShouldBe("v7");
+        }
+
+        // NOT asserted here: that a revision the store has already passed is DROPPED, which is the
+        // documented distinction from UpdateRevision. Fisher does not do that today -- a stale
+        // TryUpdateRevision lands -- and it is Fisher's behaviour rather than this op's: driving
+        // session.TryUpdateRevision() directly, with no Wolverine in the picture, writes the stale
+        // document too. Pinning the documented behaviour here would just make this suite red on
+        // someone else's bug; pinning the current behaviour would enshrine it. See the PR notes.
+        await _host.InvokeMessageAndWaitAsync(new TryReviseIt(id, "later", 9));
+
+        await using var after = theStore.QuerySession();
+        var loaded = await after.LoadAsync<RevisionedDoc>(id, TestContext.Current.CancellationToken);
+        loaded!.Name.ShouldBe("later");
+    }
+
+    [Fact]
+    public async Task append_and_archive_reach_a_stream_the_handler_does_not_own()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(id, new ExpandedEventA());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new AppendToIt(id));
+
+        await using (var query = theStore.LightweightSession())
+        {
+            var events = await query.Events.FetchStreamAsync(id, token: TestContext.Current.CancellationToken);
+            events.Count.ShouldBe(2);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new ArchiveIt(id));
+
+        await using var after = theStore.LightweightSession();
+        var state = await after.Events.FetchStreamStateAsync(id, TestContext.Current.CancellationToken);
+        state!.IsArchived.ShouldBeTrue();
+    }
+}
+
+public class SoftDeletedDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}
+
+public class PatchableDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}
+
+public class RevisionedDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}
+
+public record HardDeleteIt(Guid Id);
+
+public record UndoTheDelete(string Name);
+
+public record PatchIt(Guid Id, string Name);
+
+public record TryReviseIt(Guid Id, string Name, int Revision);
+
+public record AppendToIt(Guid Id);
+
+public record ArchiveIt(Guid Id);
+
+// [WolverineIgnore] for the same reason FiInvoiceHandler carries it: these need a registered event
+// store at bootstrap, and this is a shared test assembly
+[WolverineIgnore]
+public static class ExpandedOpsHandler
+{
+    public static HardDeleteDocById<SoftDeletedDoc> Handle(HardDeleteIt command)
+        => FisherOps.HardDelete<SoftDeletedDoc>(command.Id);
+
+    public static UndoDeleteDocWhere<SoftDeletedDoc> Handle(UndoTheDelete command)
+        => FisherOps.UndoDeleteWhere<SoftDeletedDoc>(x => x.Name == command.Name);
+
+    public static PatchDoc<PatchableDoc> Handle(PatchIt command)
+        => FisherOps.Patch<PatchableDoc>(command.Id, p => p.Set(x => x.Name, command.Name));
+
+    public static TryUpdateDocRevision<RevisionedDoc> Handle(TryReviseIt command)
+        => FisherOps.TryUpdateRevision(new RevisionedDoc { Id = command.Id, Name = command.Name }, command.Revision);
+
+    public static AppendToStream Handle(AppendToIt command)
+        => FisherOps.Append(command.Id, new ExpandedEventA());
+
+    public static ArchiveStream Handle(ArchiveIt command)
+        => FisherOps.ArchiveStream(command.Id);
+}

--- a/src/Persistence/FisherTests/handler_actions_with_expanded_fisher_operations.cs
+++ b/src/Persistence/FisherTests/handler_actions_with_expanded_fisher_operations.cs
@@ -36,10 +36,6 @@ public class handler_actions_with_expanded_fisher_operations : IAsyncLifetime
                         m.Connection(theDatabase.ConnectionString);
                         m.AutoCreateSchemaObjects = AutoCreate.All;
                         m.Schema.For<SoftDeletedDoc>().SoftDeleted();
-                        // TryUpdateRevision only has anything to compare against on a type that
-                        // actually tracks a numeric revision; on any other type the revision is
-                        // simply ignored, which would make the assertion below vacuous
-                        m.Schema.For<RevisionedDoc>().UseNumericRevisions();
                     })
                     .ApplyAllDatabaseChangesOnStartup()
                     .IntegrateWithWolverine();
@@ -117,12 +113,6 @@ public class handler_actions_with_expanded_fisher_operations : IAsyncLifetime
     {
         var id = Guid.NewGuid();
 
-        await using (var session = theStore.LightweightSession())
-        {
-            session.Store(new RevisionedDoc { Id = id, Name = "seed" });
-            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-        }
-
         // moving the revision forward writes
         await _host.InvokeMessageAndWaitAsync(new TryReviseIt(id, "v7", 7));
 
@@ -132,17 +122,29 @@ public class handler_actions_with_expanded_fisher_operations : IAsyncLifetime
             moved!.Name.ShouldBe("v7");
         }
 
-        // NOT asserted here: that a revision the store has already passed is DROPPED, which is the
-        // documented distinction from UpdateRevision. Fisher does not do that today -- a stale
-        // TryUpdateRevision lands -- and it is Fisher's behaviour rather than this op's: driving
-        // session.TryUpdateRevision() directly, with no Wolverine in the picture, writes the stale
-        // document too. Pinning the documented behaviour here would just make this suite red on
-        // someone else's bug; pinning the current behaviour would enshrine it. See the PR notes.
-        await _host.InvokeMessageAndWaitAsync(new TryReviseIt(id, "later", 9));
+        // and a revision the store has already passed is dropped rather than failing the unit of
+        // work, which is the whole distinction from UpdateRevision
+        await _host.InvokeMessageAndWaitAsync(new TryReviseIt(id, "stale", 3));
 
         await using var after = theStore.QuerySession();
         var loaded = await after.LoadAsync<RevisionedDoc>(id, TestContext.Current.CancellationToken);
-        loaded!.Name.ShouldBe("later");
+        loaded!.Name.ShouldBe("v7");
+    }
+
+    [Fact]
+    public async Task update_revision_fails_the_unit_of_work_on_a_stale_revision()
+    {
+        var id = Guid.NewGuid();
+
+        await _host.InvokeMessageAndWaitAsync(new ReviseIt(id, "v7", 7));
+
+        // the loud half of the same guard: a stale UpdateRevision aborts rather than dropping
+        await Should.ThrowAsync<Exception>(async () =>
+            await _host.InvokeMessageAndWaitAsync(new ReviseIt(id, "stale", 3)));
+
+        await using var after = theStore.QuerySession();
+        var loaded = await after.LoadAsync<RevisionedDoc>(id, TestContext.Current.CancellationToken);
+        loaded!.Name.ShouldBe("v7");
     }
 
     [Fact]
@@ -184,10 +186,14 @@ public class PatchableDoc
     public string Name { get; set; } = null!;
 }
 
-public class RevisionedDoc
+// IRevisioned rather than Schema.For<T>().UseNumericRevisions(): the two are documented as
+// equivalent routes to numeric revisions, but only the interface is actually enforced today --
+// a UseNumericRevisions() type takes a stale write silently. See JasperFx/fisher#228.
+public class RevisionedDoc : IRevisioned
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = null!;
+    public int Version { get; set; }
 }
 
 public record HardDeleteIt(Guid Id);
@@ -197,6 +203,8 @@ public record UndoTheDelete(string Name);
 public record PatchIt(Guid Id, string Name);
 
 public record TryReviseIt(Guid Id, string Name, int Revision);
+
+public record ReviseIt(Guid Id, string Name, int Revision);
 
 public record AppendToIt(Guid Id);
 
@@ -218,6 +226,9 @@ public static class ExpandedOpsHandler
 
     public static TryUpdateDocRevision<RevisionedDoc> Handle(TryReviseIt command)
         => FisherOps.TryUpdateRevision(new RevisionedDoc { Id = command.Id, Name = command.Name }, command.Revision);
+
+    public static UpdateDocRevision<RevisionedDoc> Handle(ReviseIt command)
+        => FisherOps.UpdateRevision(new RevisionedDoc { Id = command.Id, Name = command.Name }, command.Revision);
 
     public static AppendToStream Handle(AppendToIt command)
         => FisherOps.Append(command.Id, new ExpandedEventA());

--- a/src/Persistence/Wolverine.Fisher/FisherOps.Documents.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherOps.Documents.cs
@@ -1,0 +1,387 @@
+using System.Linq.Expressions;
+using Fisher;
+using Fisher.Patching;
+
+namespace Wolverine.Fisher;
+
+/// <summary>
+/// Document side effects that round out the parity with Fisher's own
+/// <see cref="IDocumentOperations" />: hard deletes, soft delete reversal, revision-checked
+/// updates, patching, and raw SQL.
+/// </summary>
+/// <remarks>
+/// The sibling of <c>MartenOps.Documents</c> (GH-4384), checked against Fisher's own session API
+/// rather than copied across. Fisher has no <c>InsertObjects</c> / <c>DeleteObjects</c> and no
+/// <c>UpdateExpectedVersion</c>, so none of those have an op here — an op whose <c>Execute</c>
+/// could only throw is worse than the absence of one. Its revision API is <c>int</c>-based rather
+/// than <c>long</c>, and that is what these signatures take: widening it here would let a caller
+/// pass a value the store cannot hold.
+/// </remarks>
+public static partial class FisherOps
+{
+    /// <summary>
+    /// Return a side effect of "hard" deleting the specified document in Fisher, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDoc<T> HardDelete<T>(T document) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new HardDeleteDoc<T>(document);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Fisher, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(string id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Fisher, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(Guid id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Fisher, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(int id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Fisher, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(long id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting every document matching the provided filter,
+    /// deleting the underlying database rows even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocWhere<T> HardDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+        => new(expression);
+
+    /// <summary>
+    /// Return a side effect of reversing the soft deletion of every document of a
+    /// soft-deleted document type matching the provided filter
+    /// </summary>
+    public static UndoDeleteDocWhere<T> UndoDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+        => new(expression);
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Fisher with a new revision.
+    /// Causes a ConcurrencyException on SaveChangesAsync() if the stored revision is greater
+    /// than or equal to the supplied revision
+    /// </summary>
+    public static UpdateDocRevision<T> UpdateRevision<T>(T document, int revision) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new UpdateDocRevision<T>(document, revision);
+    }
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Fisher with a new revision,
+    /// silently doing nothing if the stored revision is greater than or equal to the supplied
+    /// revision
+    /// </summary>
+    public static TryUpdateDocRevision<T> TryUpdateRevision<T>(T document, int revision) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new TryUpdateDocRevision<T>(document, revision);
+    }
+
+    /// <summary>
+    /// Return a side effect of patching the single document of type T with the given id
+    /// </summary>
+    public static PatchDoc<T> Patch<T>(object id, Action<IPatchExpression<T>> configure) where T : notnull
+        => new(id, configure);
+
+    /// <summary>
+    /// Return a side effect of patching every document of type T matching the supplied filter
+    /// </summary>
+    public static PatchDoc<T> PatchWhere<T>(Expression<Func<T, bool>> filter, Action<IPatchExpression<T>> configure)
+        where T : notnull
+        => new(filter, configure);
+
+    /// <summary>
+    /// Return a side effect of queueing a raw SQL command to run inside the same transaction as
+    /// the rest of the session's work. "?" denotes a positional parameter
+    /// </summary>
+    public static QueueSqlCommandOp QueueSqlCommand(string sql, params object[] parameterValues)
+        => new(sql, parameterValues);
+
+    /// <summary>
+    /// Return a side effect of queueing a raw SQL command, overriding the character that denotes
+    /// a positional parameter — for SQL that needs a literal "?" of its own
+    /// </summary>
+    public static QueueSqlCommandOp QueueSqlCommand(char placeholder, string sql, params object[] parameterValues)
+        => new(sql, parameterValues) { Placeholder = placeholder };
+}
+
+public class HardDeleteDoc<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public HardDeleteDoc(T document) : base(document)
+    {
+        _document = document;
+    }
+
+    public HardDeleteDoc(T document, string tenantId) : base(document, tenantId)
+    {
+        _document = document;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).HardDelete(_document);
+    }
+}
+
+public class HardDeleteDocById<T> : ITenantedFisherOp where T : class
+{
+    private readonly object _id;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public HardDeleteDocById(object id)
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        // Unlike Delete<T>(), Fisher's HardDelete<T>() has no object-typed overload to fall back
+        // on, so an id type it cannot dispatch would only blow up inside Execute() -- long after
+        // the handler returned a side effect that looked perfectly valid. Reject it at the point
+        // of construction, where the caller can still see it in a unit test.
+        if (id is not (string or Guid or long or int))
+        {
+            throw new ArgumentOutOfRangeException(nameof(id),
+                $"Fisher can only hard delete by string, Guid, long, or int id, but got {id.GetType().FullName}");
+        }
+
+        _id = id;
+    }
+
+    public HardDeleteDocById(object id, string tenantId) : this(id)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        switch (_id)
+        {
+            case string idAsString:
+                target.HardDelete<T>(idAsString);
+                break;
+            case Guid idAsGuid:
+                target.HardDelete<T>(idAsGuid);
+                break;
+            case long idAsLong:
+                target.HardDelete<T>(idAsLong);
+                break;
+            case int idAsInt:
+                target.HardDelete<T>(idAsInt);
+                break;
+        }
+    }
+}
+
+public class HardDeleteDocWhere<T> : ITenantedFisherOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public HardDeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public HardDeleteDocWhere(Expression<Func<T, bool>> expression, string tenantId) : this(expression)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.HardDeleteWhere(_expression);
+    }
+}
+
+public class UndoDeleteDocWhere<T> : ITenantedFisherOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public UndoDeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public UndoDeleteDocWhere(Expression<Func<T, bool>> expression, string tenantId) : this(expression)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.UndoDeleteWhere(_expression);
+    }
+}
+
+public class UpdateDocRevision<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public UpdateDocRevision(T document, int revision) : base(document)
+    {
+        _document = document;
+        Revision = revision;
+    }
+
+    public int Revision { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).UpdateRevision(_document, Revision);
+    }
+}
+
+public class TryUpdateDocRevision<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public TryUpdateDocRevision(T document, int revision) : base(document)
+    {
+        _document = document;
+        Revision = revision;
+    }
+
+    public int Revision { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).TryUpdateRevision(_document, Revision);
+    }
+}
+
+public class PatchDoc<T> : ITenantedFisherOp where T : notnull
+{
+    private readonly Action<IPatchExpression<T>> _configure;
+    private readonly Expression<Func<T, bool>>? _filter;
+    private readonly object? _id;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public PatchDoc(object id, Action<IPatchExpression<T>> configure)
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        // Same story as HardDeleteDocById: Fisher's Patch<T>() overloads cover string, Guid,
+        // long, and int only, so fail fast rather than at SaveChangesAsync() time.
+        if (id is not (string or Guid or long or int))
+        {
+            throw new ArgumentOutOfRangeException(nameof(id),
+                $"Fisher can only patch by string, Guid, long, or int id, but got {id.GetType().FullName}");
+        }
+
+        _id = id;
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    public PatchDoc(Expression<Func<T, bool>> filter, Action<IPatchExpression<T>> configure)
+    {
+        _filter = filter ?? throw new ArgumentNullException(nameof(filter));
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+
+        var expression = _filter != null
+            ? target.Patch(_filter)
+            : _id switch
+            {
+                string idAsString => target.Patch<T>(idAsString),
+                Guid idAsGuid => target.Patch<T>(idAsGuid),
+                long idAsLong => target.Patch<T>(idAsLong),
+                int idAsInt => target.Patch<T>(idAsInt),
+                _ => throw new ArgumentOutOfRangeException(nameof(_id))
+            };
+
+        _configure(expression);
+    }
+}
+
+public class QueueSqlCommandOp : ITenantedFisherOp
+{
+    public QueueSqlCommandOp(string sql, params object[] parameterValues)
+    {
+        Sql = sql ?? throw new ArgumentNullException(nameof(sql));
+        ParameterValues = parameterValues ?? throw new ArgumentNullException(nameof(parameterValues));
+    }
+
+    public string Sql { get; }
+
+    public object[] ParameterValues { get; }
+
+    /// <summary>
+    /// Optional override of the "?" character that denotes a positional parameter in the SQL
+    /// </summary>
+    public char? Placeholder { get; set; }
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant.
+    /// Note that this only routes the command to that tenant's database in a
+    /// database-per-tenant setup; it does not add any tenant filtering to the SQL itself
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+
+        if (Placeholder.HasValue)
+        {
+            target.QueueSqlCommand(Placeholder.Value, Sql, ParameterValues);
+        }
+        else
+        {
+            target.QueueSqlCommand(Sql, ParameterValues);
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/FisherOps.Events.cs
+++ b/src/Persistence/Wolverine.Fisher/FisherOps.Events.cs
@@ -1,0 +1,193 @@
+using Fisher;
+using Fisher.Events;
+using JasperFx.Core;
+
+namespace Wolverine.Fisher;
+
+/// <summary>
+/// Event store side effects beyond starting a new stream: appending to a stream that already
+/// exists, and archiving one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Appending to the stream the handler is <em>already</em> working on belongs in the aggregate
+/// handler workflow ([WriteAggregate] / IEventStream&lt;T&gt; / the Events return type), which also
+/// gives you the aggregate state and its concurrency protection. These side effects are for the
+/// other case: touching some <em>other</em> stream from a handler that has no aggregate of its own.
+/// </para>
+/// <para>
+/// Fisher has no <c>UnArchiveStream</c> or <c>TombstoneStream</c> — those are Polecat's own
+/// archive-lifecycle extras — so there is no op for either here.
+/// </para>
+/// </remarks>
+public static partial class FisherOps
+{
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by Guid identity
+    /// </summary>
+    public static AppendToStream Append(Guid streamId, params object[] events) => new(streamId, events);
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by string key
+    /// </summary>
+    public static AppendToStream Append(string streamKey, params object[] events) => new(streamKey, events);
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by Guid identity,
+    /// asserting that the stream is at the supplied version or the transaction is aborted with
+    /// a ConcurrencyException
+    /// </summary>
+    public static AppendToStream Append(Guid streamId, long expectedVersion, params object[] events)
+        => new(streamId, events) { ExpectedVersion = expectedVersion };
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by string key,
+    /// asserting that the stream is at the supplied version or the transaction is aborted with
+    /// a ConcurrencyException
+    /// </summary>
+    public static AppendToStream Append(string streamKey, long expectedVersion, params object[] events)
+        => new(streamKey, events) { ExpectedVersion = expectedVersion };
+
+    /// <summary>
+    /// Return a side effect of archiving an event stream by Guid identity
+    /// </summary>
+    public static ArchiveStream ArchiveStream(Guid streamId) => new(streamId);
+
+    /// <summary>
+    /// Return a side effect of archiving an event stream by string key
+    /// </summary>
+    public static ArchiveStream ArchiveStream(string streamKey) => new(streamKey);
+}
+
+/// <summary>
+/// Shared identity handling for the stream side effects: exactly one of a Guid id or a string key,
+/// neither of which may be the empty value.
+/// </summary>
+/// <remarks>
+/// The Guid/string discrimination is on <c>StreamId == Guid.Empty</c>, the same sentinel
+/// <c>StartStream&lt;T&gt;</c> uses, so an empty identity would silently take the string branch and
+/// archive nothing. Both constructors refuse it.
+/// </remarks>
+public abstract class StreamOp : ITenantedFisherOp
+{
+    protected StreamOp(Guid streamId)
+    {
+        if (streamId == Guid.Empty)
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamId), "The stream id cannot be Guid.Empty");
+        }
+
+        StreamId = streamId;
+    }
+
+    protected StreamOp(string streamKey)
+    {
+        if (streamKey.IsEmpty())
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamKey), "The stream key cannot be null or empty");
+        }
+
+        StreamKey = streamKey;
+    }
+
+    public string StreamKey { get; } = string.Empty;
+
+    public Guid StreamId { get; }
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// The event operations to write through, scoped to the tenant when one is set. Fisher's
+    /// IDocumentOperations does not carry the write-side Events surface, so this resolves through
+    /// ITenantOperations / IDocumentSession rather than through IDocumentOperations.
+    /// </summary>
+    protected EventOperations ResolveEvents(IDocumentSession session)
+        => TenantId != null ? session.ForTenant(TenantId).Events : session.Events;
+
+    public abstract void Execute(IDocumentSession session);
+}
+
+public class AppendToStream : StreamOp
+{
+    public AppendToStream(Guid streamId, params object[] events) : base(streamId)
+    {
+        Events.AddRange(events);
+    }
+
+    public AppendToStream(string streamKey, params object[] events) : base(streamKey)
+    {
+        Events.AddRange(events);
+    }
+
+    /// <summary>
+    /// Optional optimistic concurrency check. When set, Fisher will abort the transaction if
+    /// the stream is not at this version
+    /// </summary>
+    public long? ExpectedVersion { get; set; }
+
+    public List<object> Events { get; } = new();
+
+    public AppendToStream With(object @event)
+    {
+        Events.Add(@event);
+        return this;
+    }
+
+    public AppendToStream With(object[] events)
+    {
+        Events.AddRange(events);
+        return this;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        var target = ResolveEvents(session);
+
+        if (StreamId == Guid.Empty)
+        {
+            if (ExpectedVersion.HasValue)
+            {
+                target.Append(StreamKey, ExpectedVersion.Value, Events.ToArray());
+            }
+            else
+            {
+                target.Append(StreamKey, Events.ToArray());
+            }
+        }
+        else
+        {
+            if (ExpectedVersion.HasValue)
+            {
+                target.Append(StreamId, ExpectedVersion.Value, Events.ToArray());
+            }
+            else
+            {
+                target.Append(StreamId, Events.ToArray());
+            }
+        }
+    }
+}
+
+public class ArchiveStream : StreamOp
+{
+    public ArchiveStream(Guid streamId) : base(streamId) { }
+
+    public ArchiveStream(string streamKey) : base(streamKey) { }
+
+    public override void Execute(IDocumentSession session)
+    {
+        var target = ResolveEvents(session);
+
+        if (StreamId == Guid.Empty)
+        {
+            target.ArchiveStream(StreamKey);
+        }
+        else
+        {
+            target.ArchiveStream(StreamId);
+        }
+    }
+}

--- a/src/Persistence/Wolverine.Fisher/IFisherOp.cs
+++ b/src/Persistence/Wolverine.Fisher/IFisherOp.cs
@@ -21,6 +21,39 @@ public interface IFisherOp : ISideEffect
     void Execute(IDocumentSession session);
 }
 
+/// <summary>
+/// A Fisher side effect that can be pointed at a tenant other than the one the current
+/// session belongs to
+/// </summary>
+public interface ITenantedFisherOp : IFisherOp
+{
+    /// <summary>
+    /// Optional tenant id. When set, the operation is applied through IDocumentSession.ForTenant()
+    /// </summary>
+    string? TenantId { get; set; }
+}
+
+public static class FisherOpExtensions
+{
+    /// <summary>
+    /// Scope this Fisher side effect to a specific tenant, as an alternative to the
+    /// tenantId overloads on the FisherOps factory methods
+    /// </summary>
+    /// <param name="op"></param>
+    /// <param name="tenantId"></param>
+    /// <returns>The same op, so this can be chained onto a FisherOps call</returns>
+    public static TOp ForTenant<TOp>(this TOp op, string tenantId) where TOp : ITenantedFisherOp
+    {
+        if (tenantId == null)
+        {
+            throw new ArgumentNullException(nameof(tenantId));
+        }
+
+        op.TenantId = tenantId;
+        return op;
+    }
+}
+
 internal class FisherOpPolicy : IChainPolicy
 {
     public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IServiceContainer container)
@@ -69,7 +102,7 @@ internal class ForEachFisherOpFrame : SyncFrame
 /// <summary>
 /// Access to Fisher related side effect return values from message handlers
 /// </summary>
-public static class FisherOps
+public static partial class FisherOps
 {
     /// <summary>
     /// Begin a fluent declaration of a data requirement against a Fisher document. Pair with
@@ -318,7 +351,7 @@ public interface IStartStream : IFisherOp
     IReadOnlyList<object> Events { get; }
 }
 
-public class StartStream<T> : IStartStream where T : class
+public class StartStream<T> : IStartStream, ITenantedFisherOp where T : class
 {
     public string StreamKey { get; } = string.Empty;
     public Guid StreamId { get; }
@@ -502,7 +535,7 @@ public class DeleteDoc<T> : DocumentOp where T : notnull
     public override void Execute(IDocumentSession session) { ResolveSession(session).Delete(_document); }
 }
 
-public class DeleteDocById<T> : IFisherOp where T : class
+public class DeleteDocById<T> : ITenantedFisherOp where T : class
 {
     private readonly object _id;
 
@@ -528,7 +561,7 @@ public class DeleteDocById<T> : IFisherOp where T : class
     }
 }
 
-public class DeleteDocWhere<T> : IFisherOp where T : class
+public class DeleteDocWhere<T> : ITenantedFisherOp where T : class
 {
     private readonly Expression<Func<T, bool>> _expression;
 
@@ -547,7 +580,7 @@ public class DeleteDocWhere<T> : IFisherOp where T : class
     }
 }
 
-public abstract class DocumentOp : IFisherOp
+public abstract class DocumentOp : ITenantedFisherOp
 {
     public object Document { get; }
 
@@ -570,7 +603,7 @@ public abstract class DocumentOp : IFisherOp
     public abstract void Execute(IDocumentSession session);
 }
 
-public interface IDocumentsOp : IFisherOp
+public interface IDocumentsOp : ITenantedFisherOp
 {
     IReadOnlyList<object> Documents { get; }
 }


### PR DESCRIPTION
The Fisher half of the follow-up #4384 named in its own "Not in this PR": `Wolverine.Fisher` carries
the same op model as `Wolverine.Marten` and had the same gaps. Per that PR's caveat, the ops here
were checked against **Fisher's own session API** rather than copied across — which is what decided
both what is here and what is deliberately missing.

## What `FisherOps` gains

| New op | Fisher call it reaches |
|---|---|
| `HardDelete(doc)`, `HardDelete<T>(id)`, `HardDeleteWhere<T>(filter)` | `HardDelete` / `HardDeleteWhere` |
| `UndoDeleteWhere<T>(filter)` | `UndoDeleteWhere` |
| `UpdateRevision`, `TryUpdateRevision` | same names |
| `Patch<T>(id, ...)`, `PatchWhere<T>(filter, ...)` | `Patch<T>()` fluent API |
| `QueueSqlCommand(sql, ...)` (+ custom placeholder overload) | `QueueSqlCommand` |
| `Append(streamId \| streamKey, ...)`, with an optional expected version | `Events.Append` |
| `ArchiveStream(streamId \| streamKey)` | `Events.ArchiveStream` |

Plus `ITenantedFisherOp` + `ForTenant()`, the same single tenant mechanism #4384 introduced instead
of another round of `tenantId` overloads. The pre-existing ops implement it too, so
`FisherOps.StoreMany(items).ForTenant(t).With(oneMore)` works and keeps its concrete type.

## What Fisher does not have, so neither does this

- **`InsertObjects` / `DeleteObjects`** — no such session methods. (`StoreObjects` already exists in
  `Wolverine.Fisher` and dispatches per runtime type; that is unchanged.)
- **`UpdateExpectedVersion`** — Fisher has no Guid-version concurrency check.
- **`UnArchiveStream` / `TombstoneStream`** — those are Polecat's own extras.

An op whose `Execute` could only throw is worse than the absence of one.

**Revisions are `int` here, not `long`.** Fisher's revision API is `int`-based, and these signatures
match rather than widening to a value the store cannot hold.

## Two invariants at construction time, as in #4384

`HardDelete<T>()` and `Patch<T>()` reject an id that is not `string`/`Guid`/`int`/`long` — Fisher has
no `object`-typed overload to fall back on — and `Append`/`ArchiveStream` refuse `Guid.Empty` and an
empty stream key, because the Guid/string discrimination is on `Guid.Empty` (the sentinel
`StartStream<T>` uses) and an empty id would otherwise silently take the string branch.

## ⚠️ A Fisher bug found on the way — JasperFx/fisher#228

Fisher documents two equivalent routes to numeric revisions: implementing `JasperFx.IRevisioned`, or
`Schema.For<T>().UseNumericRevisions()`. **Only the first is enforced.**

| Configuration | stored revision after `UpdateRevision(doc, 7)` | backwards `UpdateRevision(doc, 3)` | result |
|---|---|---|---|
| `IRevisioned` | `7` | throws `ConcurrencyException` | stale write rejected ✅ |
| `UseNumericRevisions()` | `2` | no exception | **stale write lands** ❌ |

`TryUpdateRevision` on a `UseNumericRevisions()` type therefore drops nothing either — it is
indistinguishable from `UpdateRevision`, and the result is a silent lost update.

This is Fisher's, not this op's: it reproduces against a bare `IDocumentSession` with no Wolverine in
the picture. Root cause is two lines in `FisherSession.Documents.cs` gating on the *interface*
instead of the mapping — filed with the reproduction and a suggested fix as
[JasperFx/fisher#228](https://github.com/JasperFx/fisher/issues/228).

Nothing here works around it. The integration tests use an `IRevisioned` document, so they exercise
the guard for real — both halves of it, the `TryUpdateRevision` drop and the `UpdateRevision` throw —
rather than passing vacuously on a type that enforces nothing. The Fisher docs page gains a warning
pointing at the issue.

## Tests

46 passing in `FisherTests`, 14 of them new:

- `FisherOps_expanded_operations` — 8 op-shape tests over the factories, the rejected id types, the
  empty-identity guards, and `ForTenant()` across every op including the pre-existing ones.
- `handler_actions_with_expanded_fisher_operations` — 6 integration tests driving each op through a
  real handler against a real Fisher store, including the soft-delete/hard-delete distinction, both
  halves of the revision guard, and the append/archive round trip. Fisher is in-process SQLite, so this costs a temp file rather than
  a container.

Docs: a new *Operation Side Effects* section in `docs/guide/durability/fisher/index.md`, badged 6.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
