### PR TITLE
Close the PolecatOps gap with Polecat's own IDocumentOperations

### DIFF
--- a/docs/guide/durability/polecat/operations.md
+++ b/docs/guide/durability/polecat/operations.md
@@ -146,3 +146,95 @@ Wolverine will pick up on any return type that can be cast to `IEnumerable<IPole
 * `IEnumerable<IPolecatOp>`
 * `IPolecatOp[]`
 * `List<IPolecatOp>`
+
+## Scoping Any Operation to a Tenant <Badge type="tip" text="6.35" />
+
+The `tenantId` overloads above are one factory method per op. Every op also implements
+`ITenantedPolecatOp`, so a single extension does the scoping while preserving the concrete return
+type — which means it chains onto the ops that have a fluent surface of their own:
+
+```csharp
+PolecatOps.ArchiveStream(command.OrderId).ForTenant(command.TenantId);
+PolecatOps.StoreMany(items).ForTenant(tenantId).With(oneMore);
+```
+
+`ForTenant()` works on your own ops as soon as they implement `ITenantedPolecatOp`.
+
+## Hard Deletes and Undoing Soft Deletes <Badge type="tip" text="6.35" />
+
+For a soft-deleted document type, `PolecatOps.Delete()` marks the row deleted rather than removing
+it. `HardDelete` removes the row itself, and `UndoDeleteWhere` reverses a soft delete:
+
+```csharp
+public static IEnumerable<IPolecatOp> Handle(PurgeAccount command)
+{
+    yield return PolecatOps.HardDelete<Account>(command.AccountId);
+    yield return PolecatOps.HardDeleteWhere<AuditEntry>(x => x.AccountId == command.AccountId);
+    yield return PolecatOps.UndoDeleteWhere<Invitation>(x => x.AccountId == command.AccountId);
+}
+```
+
+`HardDelete<T>()` takes a document or an id — `string`, `Guid`, `int` or `long`. Polecat has no
+`object`-typed `HardDelete` overload to fall back on, so an id of any other type is rejected by the
+factory with an `ArgumentOutOfRangeException` rather than surfacing inside `SaveChangesAsync()` long
+after your handler returned a side effect that looked valid.
+
+## Version- and Revision-Checked Updates <Badge type="tip" text="6.35" />
+
+```csharp
+// aborts the transaction with a ConcurrencyException if the stored version has moved on
+PolecatOps.UpdateExpectedVersion(account, command.Version);
+
+// aborts if the stored revision is at or past this one
+PolecatOps.UpdateRevision(account, command.Revision);
+```
+
+## Raw SQL <Badge type="tip" text="6.35" />
+
+`QueueSqlCommand` runs inside the same transaction as the rest of the session's work, with `?`
+denoting a positional parameter:
+
+```csharp
+PolecatOps.QueueSqlCommand("update accounts set locked = 1 where id = ?", command.AccountId);
+```
+
+Scoping it to a tenant routes the command to that tenant's database in a database-per-tenant setup.
+It does **not** add any tenant filtering to the SQL itself.
+
+## Appending to and Archiving an Existing Stream <Badge type="tip" text="6.35" />
+
+Appending to the stream a handler is *already* working on belongs in the
+[aggregate handler workflow](./event-sourcing), which also hands you the aggregate state and its
+concurrency protection. These side effects are for the other case: touching some *other* stream from
+a handler that has no aggregate of its own.
+
+```csharp
+public static IEnumerable<IPolecatOp> Handle(CloseAccount command)
+{
+    yield return PolecatOps.Append(command.AuditStreamId, new AccountClosed(command.AccountId));
+
+    // optionally with an optimistic concurrency check
+    yield return PolecatOps.Append(command.LedgerStreamKey, command.ExpectedVersion, new LedgerSealed());
+
+    yield return PolecatOps.ArchiveStream(command.AccountStreamId);
+}
+```
+
+Both take a `Guid` stream id or a `string` stream key, and both refuse an empty identity — the
+Guid/string discrimination is on `Guid.Empty`, the same sentinel `StartStream<T>` uses, so an empty
+id would otherwise silently take the string branch and archive nothing.
+
+Polecat also carries an archive lifecycle Marten does not, and these have no `MartenOps`
+counterpart:
+
+```csharp
+PolecatOps.UnArchiveStream(command.StreamId);
+PolecatOps.TombstoneStream(command.StreamId);
+```
+
+::: tip
+Polecat has no `InsertObjects` / `DeleteObjects`, no `TryUpdateRevision`, no patching API, and no
+placeholder overload of `QueueSqlCommand`, so there is no `PolecatOps` factory for any of those —
+the ops here are checked against Polecat's own session API rather than copied across from
+[the Marten set](../marten/operations).
+:::

--- a/src/Persistence/PolecatTests/PolecatOps_expanded_operations.cs
+++ b/src/Persistence/PolecatTests/PolecatOps_expanded_operations.cs
@@ -1,0 +1,133 @@
+using Shouldly;
+using Wolverine.Polecat;
+
+namespace PolecatTests;
+
+public record ExpandedDoc(Guid Id, string Name);
+
+// The Polecat half of the MartenOps parity wave (GH-4384's "Not in this PR"). These are op-shape
+// tests -- what the factory builds, what it refuses, and how ForTenant() rides along -- with the
+// behaviour against a real store covered in handler_actions_with_expanded_polecat_operations.
+public class PolecatOps_expanded_operations
+{
+    [Fact]
+    public void hard_delete_by_document_and_by_id()
+    {
+        PolecatOps.HardDelete(new ExpandedDoc(Guid.NewGuid(), "one")).ShouldBeOfType<HardDeleteDoc<ExpandedDoc>>();
+
+        PolecatOps.HardDelete<ExpandedDoc>(Guid.NewGuid()).ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+        PolecatOps.HardDelete<ExpandedDoc>("key").ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+        PolecatOps.HardDelete<ExpandedDoc>(5).ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+        PolecatOps.HardDelete<ExpandedDoc>(5L).ShouldBeOfType<HardDeleteDocById<ExpandedDoc>>();
+    }
+
+    [Fact]
+    public void hard_delete_refuses_an_id_type_polecat_cannot_dispatch()
+    {
+        // Polecat's HardDelete<T>() has no object-typed overload to fall back on, so an id type it
+        // cannot dispatch would otherwise surface inside SaveChangesAsync(), long after the handler
+        // returned a side effect that looked perfectly valid
+        Should.Throw<ArgumentOutOfRangeException>(() => new HardDeleteDocById<ExpandedDoc>(1.5m));
+        Should.Throw<ArgumentNullException>(() => new HardDeleteDocById<ExpandedDoc>(null!));
+    }
+
+    [Fact]
+    public void version_and_revision_ops_carry_their_check()
+    {
+        var doc = new ExpandedDoc(Guid.NewGuid(), "one");
+        var version = Guid.NewGuid();
+
+        PolecatOps.UpdateExpectedVersion(doc, version).Version.ShouldBe(version);
+        PolecatOps.UpdateRevision(doc, 3).Revision.ShouldBe(3);
+
+        Should.Throw<ArgumentNullException>(() => PolecatOps.UpdateExpectedVersion<ExpandedDoc>(null!, version));
+        Should.Throw<ArgumentNullException>(() => PolecatOps.UpdateRevision<ExpandedDoc>(null!, 1));
+    }
+
+    [Fact]
+    public void queue_sql_command_carries_the_sql_and_its_parameters()
+    {
+        var op = PolecatOps.QueueSqlCommand("delete from foo where id = ?", 5);
+        op.Sql.ShouldBe("delete from foo where id = ?");
+        op.ParameterValues.ShouldBe(new object[] { 5 });
+
+        Should.Throw<ArgumentNullException>(() => PolecatOps.QueueSqlCommand(null!));
+    }
+
+    [Fact]
+    public void append_carries_its_events_and_optional_expected_version()
+    {
+        var id = Guid.NewGuid();
+
+        var op = PolecatOps.Append(id, new ExpandedEventA());
+        op.StreamId.ShouldBe(id);
+        op.Events.Count.ShouldBe(1);
+        op.ExpectedVersion.ShouldBeNull();
+
+        op.With(new ExpandedEventA()).Events.Count.ShouldBe(2);
+        op.With([new ExpandedEventA(), new ExpandedEventA()]).Events.Count.ShouldBe(4);
+
+        PolecatOps.Append(id, 3L, new ExpandedEventA()).ExpectedVersion.ShouldBe(3);
+        PolecatOps.Append("key", 3L, new ExpandedEventA()).ExpectedVersion.ShouldBe(3);
+        PolecatOps.Append("key", new ExpandedEventA()).StreamKey.ShouldBe("key");
+    }
+
+    [Fact]
+    public void the_archive_lifecycle_ops_include_polecats_own_extras()
+    {
+        var id = Guid.NewGuid();
+
+        // parity with MartenOps is the floor, not the ceiling: UnArchiveStream and TombstoneStream
+        // have no MartenOps counterpart because Marten has no such session API
+        PolecatOps.ArchiveStream(id).StreamId.ShouldBe(id);
+        PolecatOps.UnArchiveStream(id).StreamId.ShouldBe(id);
+        PolecatOps.TombstoneStream(id).StreamId.ShouldBe(id);
+
+        PolecatOps.ArchiveStream("key").StreamKey.ShouldBe("key");
+        PolecatOps.UnArchiveStream("key").StreamKey.ShouldBe("key");
+        PolecatOps.TombstoneStream("key").StreamKey.ShouldBe("key");
+    }
+
+    [Fact]
+    public void the_stream_ops_refuse_an_empty_identity()
+    {
+        // Guid identity is discriminated from string identity on StreamId == Guid.Empty -- the same
+        // sentinel StartStream<T> uses -- so an empty identity would silently take the string branch
+        Should.Throw<ArgumentOutOfRangeException>(() => PolecatOps.Append(Guid.Empty, new ExpandedEventA()));
+        Should.Throw<ArgumentOutOfRangeException>(() => PolecatOps.Append("", new ExpandedEventA()));
+        Should.Throw<ArgumentOutOfRangeException>(() => PolecatOps.ArchiveStream(Guid.Empty));
+        Should.Throw<ArgumentOutOfRangeException>(() => PolecatOps.UnArchiveStream(""));
+        Should.Throw<ArgumentOutOfRangeException>(() => PolecatOps.TombstoneStream(Guid.Empty));
+    }
+
+    [Fact]
+    public void for_tenant_scopes_every_op_and_keeps_the_concrete_return_type()
+    {
+        var doc = new ExpandedDoc(Guid.NewGuid(), "one");
+        var id = Guid.NewGuid();
+
+        PolecatOps.HardDelete(doc).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.HardDelete<ExpandedDoc>(id).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.HardDeleteWhere<ExpandedDoc>(x => x.Name == "one").ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.UndoDeleteWhere<ExpandedDoc>(x => x.Name == "one").ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.UpdateExpectedVersion(doc, Guid.NewGuid()).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.UpdateRevision(doc, 2).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.QueueSqlCommand("select 1").ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.ArchiveStream(id).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.UnArchiveStream(id).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.TombstoneStream(id).ForTenant("blue").TenantId.ShouldBe("blue");
+
+        // the concrete type survives, so this chains onto the ops that have a fluent surface
+        PolecatOps.Append(id, new ExpandedEventA()).ForTenant("blue").With(new ExpandedEventA())
+            .Events.Count.ShouldBe(2);
+
+        // and the pre-existing ops joined the same mechanism rather than growing more overloads
+        PolecatOps.Store(doc).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.StoreMany(doc).ForTenant("blue").TenantId.ShouldBe("blue");
+        PolecatOps.Delete<ExpandedDoc>(id).ForTenant("blue").TenantId.ShouldBe("blue");
+
+        Should.Throw<ArgumentNullException>(() => PolecatOps.Store(doc).ForTenant(null!));
+    }
+}
+
+public record ExpandedEventA;

--- a/src/Persistence/PolecatTests/handler_actions_with_expanded_polecat_operations.cs
+++ b/src/Persistence/PolecatTests/handler_actions_with_expanded_polecat_operations.cs
@@ -1,0 +1,172 @@
+using IntegrationTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Polecat.Attributes;
+using Polecat.Linq;
+using Polecat.Linq.SoftDeletes;
+using Shouldly;
+using Wolverine;
+using Wolverine.Attributes;
+using Wolverine.Polecat;
+using Wolverine.Tracking;
+
+namespace PolecatTests;
+
+// The expanded PolecatOps driven through real handlers against a real Polecat store -- the half the
+// op-shape tests cannot reach.
+public class handler_actions_with_expanded_polecat_operations : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(typeof(ExpandedPcOpsHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+                opts.Policies.AutoApplyTransactions();
+                opts.Services.AddPolecat(m =>
+                {
+                    m.ConnectionString = Servers.SqlServerConnectionString;
+                    m.DatabaseSchemaName = "pc_expanded_ops";
+                }).IntegrateWithWolverine();
+            }).StartAsync();
+
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private IDocumentStore theStore => _host.Services.GetRequiredService<IDocumentStore>();
+
+    [Fact]
+    public async Task hard_delete_removes_the_row_a_soft_delete_would_have_kept()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new PcSoftDeletedDoc { Id = id, Name = "keep" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PcHardDeleteIt(id));
+
+        await using var query = theStore.QuerySession();
+        // a soft delete would still return the row to a MaybeDeleted() query; a hard delete does not
+        var all = await query.Query<PcSoftDeletedDoc>().MaybeDeleted()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        all.ShouldNotContain(x => x.Id == id);
+    }
+
+    [Fact]
+    public async Task undo_delete_where_brings_a_soft_deleted_document_back()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new PcSoftDeletedDoc { Id = id, Name = "revivable" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+            session.Delete<PcSoftDeletedDoc>(id);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PcUndoTheDelete("revivable"));
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<PcSoftDeletedDoc>(id, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task append_reaches_a_stream_the_handler_does_not_own()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(id, new ExpandedEventA());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PcAppendToIt(id));
+
+        await using var query = theStore.LightweightSession();
+        var events = await query.Events.FetchStreamAsync(id, token: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task the_archive_lifecycle_round_trips()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(id, new ExpandedEventA());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await _host.InvokeMessageAndWaitAsync(new PcArchiveIt(id));
+
+        await using (var query = theStore.LightweightSession())
+        {
+            var state = await query.Events.FetchStreamStateAsync(id, TestContext.Current.CancellationToken);
+            state!.IsArchived.ShouldBeTrue();
+        }
+
+        // the half MartenOps has no counterpart for
+        await _host.InvokeMessageAndWaitAsync(new PcUnArchiveIt(id));
+
+        await using var after = theStore.LightweightSession();
+        var reopened = await after.Events.FetchStreamStateAsync(id, TestContext.Current.CancellationToken);
+        reopened!.IsArchived.ShouldBeFalse();
+    }
+}
+
+// Polecat configures soft delete by attribute, ISoftDeleted, or an all-documents policy -- there is
+// no Schema.For<T>().SoftDeleted() the way Marten has
+[SoftDeleted]
+public class PcSoftDeletedDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}
+
+public record PcHardDeleteIt(Guid Id);
+
+public record PcUndoTheDelete(string Name);
+
+public record PcAppendToIt(Guid Id);
+
+public record PcArchiveIt(Guid Id);
+
+public record PcUnArchiveIt(Guid Id);
+
+// [WolverineIgnore] for the same reason PcInvoiceHandler carries it: these need a registered event
+// store at bootstrap, and this is a shared test assembly
+[WolverineIgnore]
+public static class ExpandedPcOpsHandler
+{
+    public static HardDeleteDocById<PcSoftDeletedDoc> Handle(PcHardDeleteIt command)
+        => PolecatOps.HardDelete<PcSoftDeletedDoc>(command.Id);
+
+    public static UndoDeleteDocWhere<PcSoftDeletedDoc> Handle(PcUndoTheDelete command)
+        => PolecatOps.UndoDeleteWhere<PcSoftDeletedDoc>(x => x.Name == command.Name);
+
+    public static AppendToStream Handle(PcAppendToIt command)
+        => PolecatOps.Append(command.Id, new ExpandedEventA());
+
+    public static ArchiveStream Handle(PcArchiveIt command)
+        => PolecatOps.ArchiveStream(command.Id);
+
+    public static UnArchiveStream Handle(PcUnArchiveIt command)
+        => PolecatOps.UnArchiveStream(command.Id);
+}

--- a/src/Persistence/Wolverine.Polecat/IPolecatOp.cs
+++ b/src/Persistence/Wolverine.Polecat/IPolecatOp.cs
@@ -21,6 +21,39 @@ public interface IPolecatOp : ISideEffect
     void Execute(IDocumentSession session);
 }
 
+/// <summary>
+/// A Polecat side effect that can be pointed at a tenant other than the one the current
+/// session belongs to
+/// </summary>
+public interface ITenantedPolecatOp : IPolecatOp
+{
+    /// <summary>
+    /// Optional tenant id. When set, the operation is applied through IDocumentSession.ForTenant()
+    /// </summary>
+    string? TenantId { get; set; }
+}
+
+public static class PolecatOpExtensions
+{
+    /// <summary>
+    /// Scope this Polecat side effect to a specific tenant, as an alternative to the
+    /// tenantId overloads on the PolecatOps factory methods
+    /// </summary>
+    /// <param name="op"></param>
+    /// <param name="tenantId"></param>
+    /// <returns>The same op, so this can be chained onto a PolecatOps call</returns>
+    public static TOp ForTenant<TOp>(this TOp op, string tenantId) where TOp : ITenantedPolecatOp
+    {
+        if (tenantId == null)
+        {
+            throw new ArgumentNullException(nameof(tenantId));
+        }
+
+        op.TenantId = tenantId;
+        return op;
+    }
+}
+
 internal class PolecatOpPolicy : IChainPolicy
 {
     public void Apply(IReadOnlyList<IChain> chains, GenerationRules rules, IServiceContainer container)
@@ -81,7 +114,7 @@ internal class ForEachPolecatOpFrame : SyncFrame
 /// <summary>
 /// Access to Polecat related side effect return values from message handlers
 /// </summary>
-public static class PolecatOps
+public static partial class PolecatOps
 {
     /// <summary>
     /// Begin a fluent declaration of a data requirement against a Polecat document. Pair with
@@ -330,7 +363,7 @@ public interface IStartStream : IPolecatOp
     IReadOnlyList<object> Events { get; }
 }
 
-public class StartStream<T> : IStartStream where T : class
+public class StartStream<T> : IStartStream, ITenantedPolecatOp where T : class
 {
     public string StreamKey { get; } = string.Empty;
     public Guid StreamId { get; }
@@ -514,7 +547,7 @@ public class DeleteDoc<T> : DocumentOp where T : notnull
     public override void Execute(IDocumentSession session) { ResolveSession(session).Delete(_document); }
 }
 
-public class DeleteDocById<T> : IPolecatOp where T : class
+public class DeleteDocById<T> : ITenantedPolecatOp where T : class
 {
     private readonly object _id;
 
@@ -540,7 +573,7 @@ public class DeleteDocById<T> : IPolecatOp where T : class
     }
 }
 
-public class DeleteDocWhere<T> : IPolecatOp where T : class
+public class DeleteDocWhere<T> : ITenantedPolecatOp where T : class
 {
     private readonly Expression<Func<T, bool>> _expression;
 
@@ -559,7 +592,7 @@ public class DeleteDocWhere<T> : IPolecatOp where T : class
     }
 }
 
-public abstract class DocumentOp : IPolecatOp
+public abstract class DocumentOp : ITenantedPolecatOp
 {
     public object Document { get; }
 
@@ -582,7 +615,7 @@ public abstract class DocumentOp : IPolecatOp
     public abstract void Execute(IDocumentSession session);
 }
 
-public interface IDocumentsOp : IPolecatOp
+public interface IDocumentsOp : ITenantedPolecatOp
 {
     IReadOnlyList<object> Documents { get; }
 }

--- a/src/Persistence/Wolverine.Polecat/PolecatOps.Documents.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatOps.Documents.cs
@@ -1,0 +1,297 @@
+using System.Linq.Expressions;
+using Polecat;
+
+namespace Wolverine.Polecat;
+
+/// <summary>
+/// Document side effects that round out the parity with Polecat's own
+/// <see cref="IDocumentOperations" />: hard deletes, soft delete reversal, version- and
+/// revision-checked updates, and raw SQL.
+/// </summary>
+/// <remarks>
+/// The sibling of <c>MartenOps.Documents</c> (GH-4384), checked against Polecat's own session API
+/// rather than copied across. Polecat has no <c>InsertObjects</c> / <c>DeleteObjects</c>, no
+/// <c>TryUpdateRevision</c>, no patching API, and no placeholder overload of
+/// <c>QueueSqlCommand</c>, so none of those have an op here — an op whose <c>Execute</c> could only
+/// throw is worse than the absence of one.
+/// </remarks>
+public static partial class PolecatOps
+{
+    /// <summary>
+    /// Return a side effect of "hard" deleting the specified document in Polecat, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDoc<T> HardDelete<T>(T document) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new HardDeleteDoc<T>(document);
+    }
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Polecat, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(string id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Polecat, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(Guid id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Polecat, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(int id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting a document by id in Polecat, deleting the
+    /// underlying database row even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocById<T> HardDelete<T>(long id) where T : class => new(id);
+
+    /// <summary>
+    /// Return a side effect of "hard" deleting every document matching the provided filter,
+    /// deleting the underlying database rows even for a soft-deleted document type
+    /// </summary>
+    public static HardDeleteDocWhere<T> HardDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+        => new(expression);
+
+    /// <summary>
+    /// Return a side effect of reversing the soft deletion of every document of a
+    /// soft-deleted document type matching the provided filter
+    /// </summary>
+    public static UndoDeleteDocWhere<T> UndoDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+        => new(expression);
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Polecat while asserting that
+    /// the currently stored version matches the supplied version. Causes a ConcurrencyException
+    /// on SaveChangesAsync() if the stored version has moved on
+    /// </summary>
+    public static UpdateDocExpectedVersion<T> UpdateExpectedVersion<T>(T document, Guid version) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new UpdateDocExpectedVersion<T>(document, version);
+    }
+
+    /// <summary>
+    /// Return a side effect of updating the specified document in Polecat with a new revision.
+    /// Causes a ConcurrencyException on SaveChangesAsync() if the stored revision is greater
+    /// than or equal to the supplied revision
+    /// </summary>
+    public static UpdateDocRevision<T> UpdateRevision<T>(T document, long revision) where T : notnull
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        return new UpdateDocRevision<T>(document, revision);
+    }
+
+    /// <summary>
+    /// Return a side effect of queueing a raw SQL command to run inside the same transaction as
+    /// the rest of the session's work. "?" denotes a positional parameter
+    /// </summary>
+    public static QueueSqlCommandOp QueueSqlCommand(string sql, params object[] parameterValues)
+        => new(sql, parameterValues);
+}
+
+public class HardDeleteDoc<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public HardDeleteDoc(T document) : base(document)
+    {
+        _document = document;
+    }
+
+    public HardDeleteDoc(T document, string tenantId) : base(document, tenantId)
+    {
+        _document = document;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).HardDelete(_document);
+    }
+}
+
+public class HardDeleteDocById<T> : ITenantedPolecatOp where T : class
+{
+    private readonly object _id;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public HardDeleteDocById(object id)
+    {
+        if (id == null)
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        // Unlike Delete<T>(), Polecat's HardDelete<T>() has no object-typed overload to fall back
+        // on, so an id type it cannot dispatch would only blow up inside Execute() -- long after
+        // the handler returned a side effect that looked perfectly valid. Reject it at the point
+        // of construction, where the caller can still see it in a unit test.
+        if (id is not (string or Guid or long or int))
+        {
+            throw new ArgumentOutOfRangeException(nameof(id),
+                $"Polecat can only hard delete by string, Guid, long, or int id, but got {id.GetType().FullName}");
+        }
+
+        _id = id;
+    }
+
+    public HardDeleteDocById(object id, string tenantId) : this(id)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        switch (_id)
+        {
+            case string idAsString:
+                target.HardDelete<T>(idAsString);
+                break;
+            case Guid idAsGuid:
+                target.HardDelete<T>(idAsGuid);
+                break;
+            case long idAsLong:
+                target.HardDelete<T>(idAsLong);
+                break;
+            case int idAsInt:
+                target.HardDelete<T>(idAsInt);
+                break;
+        }
+    }
+}
+
+public class HardDeleteDocWhere<T> : ITenantedPolecatOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public HardDeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public HardDeleteDocWhere(Expression<Func<T, bool>> expression, string tenantId) : this(expression)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.HardDeleteWhere(_expression);
+    }
+}
+
+public class UndoDeleteDocWhere<T> : ITenantedPolecatOp where T : notnull
+{
+    private readonly Expression<Func<T, bool>> _expression;
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public UndoDeleteDocWhere(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public UndoDeleteDocWhere(Expression<Func<T, bool>> expression, string tenantId) : this(expression)
+    {
+        TenantId = tenantId;
+    }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.UndoDeleteWhere(_expression);
+    }
+}
+
+public class UpdateDocExpectedVersion<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public UpdateDocExpectedVersion(T document, Guid version) : base(document)
+    {
+        _document = document;
+        Version = version;
+    }
+
+    public Guid Version { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).UpdateExpectedVersion(_document, Version);
+    }
+}
+
+public class UpdateDocRevision<T> : DocumentOp where T : notnull
+{
+    private readonly T _document;
+
+    public UpdateDocRevision(T document, long revision) : base(document)
+    {
+        _document = document;
+        Revision = revision;
+    }
+
+    public long Revision { get; }
+
+    public override void Execute(IDocumentSession session)
+    {
+        ResolveSession(session).UpdateRevision(_document, Revision);
+    }
+}
+
+public class QueueSqlCommandOp : ITenantedPolecatOp
+{
+    public QueueSqlCommandOp(string sql, params object[] parameterValues)
+    {
+        Sql = sql ?? throw new ArgumentNullException(nameof(sql));
+        ParameterValues = parameterValues ?? throw new ArgumentNullException(nameof(parameterValues));
+    }
+
+    public string Sql { get; }
+
+    public object[] ParameterValues { get; }
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant.
+    /// Note that this only routes the command to that tenant's database in a
+    /// database-per-tenant setup; it does not add any tenant filtering to the SQL itself
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public void Execute(IDocumentSession session)
+    {
+        IDocumentOperations target = TenantId != null ? session.ForTenant(TenantId) : session;
+        target.QueueSqlCommand(Sql, ParameterValues);
+    }
+}

--- a/src/Persistence/Wolverine.Polecat/PolecatOps.Events.cs
+++ b/src/Persistence/Wolverine.Polecat/PolecatOps.Events.cs
@@ -1,0 +1,261 @@
+using JasperFx.Core;
+using Polecat;
+using Polecat.Events;
+
+namespace Wolverine.Polecat;
+
+/// <summary>
+/// Event store side effects beyond starting a new stream: appending to a stream that already
+/// exists, and the archive lifecycle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Appending to the stream the handler is <em>already</em> working on belongs in the aggregate
+/// handler workflow ([WriteAggregate] / IEventStream&lt;T&gt; / the Events return type), which also
+/// gives you the aggregate state and its concurrency protection. These side effects are for the
+/// other case: touching some <em>other</em> stream from a handler that has no aggregate of its own.
+/// </para>
+/// <para>
+/// <c>UnArchiveStream</c> and <c>TombstoneStream</c> have no <c>MartenOps</c> counterpart — they are
+/// Polecat's own archive-lifecycle operations. Parity with Marten is the floor here, not the
+/// ceiling: the point of checking each store's session API rather than copying the Marten file
+/// across is that it finds what each store has that the others do not.
+/// </para>
+/// </remarks>
+public static partial class PolecatOps
+{
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by Guid identity
+    /// </summary>
+    public static AppendToStream Append(Guid streamId, params object[] events) => new(streamId, events);
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by string key
+    /// </summary>
+    public static AppendToStream Append(string streamKey, params object[] events) => new(streamKey, events);
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by Guid identity,
+    /// asserting that the stream is at the supplied version or the transaction is aborted with
+    /// a ConcurrencyException
+    /// </summary>
+    public static AppendToStream Append(Guid streamId, long expectedVersion, params object[] events)
+        => new(streamId, events) { ExpectedVersion = expectedVersion };
+
+    /// <summary>
+    /// Return a side effect of appending events to an existing event stream by string key,
+    /// asserting that the stream is at the supplied version or the transaction is aborted with
+    /// a ConcurrencyException
+    /// </summary>
+    public static AppendToStream Append(string streamKey, long expectedVersion, params object[] events)
+        => new(streamKey, events) { ExpectedVersion = expectedVersion };
+
+    /// <summary>
+    /// Return a side effect of archiving an event stream by Guid identity
+    /// </summary>
+    public static ArchiveStream ArchiveStream(Guid streamId) => new(streamId);
+
+    /// <summary>
+    /// Return a side effect of archiving an event stream by string key
+    /// </summary>
+    public static ArchiveStream ArchiveStream(string streamKey) => new(streamKey);
+
+    /// <summary>
+    /// Return a side effect of reversing the archiving of an event stream by Guid identity.
+    /// Polecat-specific; there is no MartenOps counterpart
+    /// </summary>
+    public static UnArchiveStream UnArchiveStream(Guid streamId) => new(streamId);
+
+    /// <summary>
+    /// Return a side effect of reversing the archiving of an event stream by string key.
+    /// Polecat-specific; there is no MartenOps counterpart
+    /// </summary>
+    public static UnArchiveStream UnArchiveStream(string streamKey) => new(streamKey);
+
+    /// <summary>
+    /// Return a side effect of tombstoning an event stream by Guid identity.
+    /// Polecat-specific; there is no MartenOps counterpart
+    /// </summary>
+    public static TombstoneStream TombstoneStream(Guid streamId) => new(streamId);
+
+    /// <summary>
+    /// Return a side effect of tombstoning an event stream by string key.
+    /// Polecat-specific; there is no MartenOps counterpart
+    /// </summary>
+    public static TombstoneStream TombstoneStream(string streamKey) => new(streamKey);
+}
+
+/// <summary>
+/// Shared identity handling for the stream side effects: exactly one of a Guid id or a string key,
+/// neither of which may be the empty value.
+/// </summary>
+/// <remarks>
+/// The Guid/string discrimination is on <c>StreamId == Guid.Empty</c>, the same sentinel
+/// <c>StartStream&lt;T&gt;</c> uses, so an empty identity would silently take the string branch and
+/// archive nothing. Both constructors refuse it.
+/// </remarks>
+public abstract class StreamOp : ITenantedPolecatOp
+{
+    protected StreamOp(Guid streamId)
+    {
+        if (streamId == Guid.Empty)
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamId), "The stream id cannot be Guid.Empty");
+        }
+
+        StreamId = streamId;
+    }
+
+    protected StreamOp(string streamKey)
+    {
+        if (streamKey.IsEmpty())
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamKey), "The stream key cannot be null or empty");
+        }
+
+        StreamKey = streamKey;
+    }
+
+    public string StreamKey { get; } = string.Empty;
+
+    public Guid StreamId { get; }
+
+    /// <summary>
+    /// Optional tenant id. When set, the operation will be scoped to the specified tenant
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// The event operations to write through, scoped to the tenant when one is set. Polecat's
+    /// IDocumentOperations does not carry the write-side Events surface, so this resolves through
+    /// ITenantOperations / IDocumentSession rather than through IDocumentOperations.
+    /// </summary>
+    protected IEventOperations ResolveEvents(IDocumentSession session)
+        => TenantId != null ? session.ForTenant(TenantId).Events : session.Events;
+
+    public abstract void Execute(IDocumentSession session);
+}
+
+public class AppendToStream : StreamOp
+{
+    public AppendToStream(Guid streamId, params object[] events) : base(streamId)
+    {
+        Events.AddRange(events);
+    }
+
+    public AppendToStream(string streamKey, params object[] events) : base(streamKey)
+    {
+        Events.AddRange(events);
+    }
+
+    /// <summary>
+    /// Optional optimistic concurrency check. When set, Polecat will abort the transaction if
+    /// the stream is not at this version
+    /// </summary>
+    public long? ExpectedVersion { get; set; }
+
+    public List<object> Events { get; } = new();
+
+    public AppendToStream With(object @event)
+    {
+        Events.Add(@event);
+        return this;
+    }
+
+    public AppendToStream With(object[] events)
+    {
+        Events.AddRange(events);
+        return this;
+    }
+
+    public override void Execute(IDocumentSession session)
+    {
+        var target = ResolveEvents(session);
+
+        if (StreamId == Guid.Empty)
+        {
+            if (ExpectedVersion.HasValue)
+            {
+                target.Append(StreamKey, ExpectedVersion.Value, Events.ToArray());
+            }
+            else
+            {
+                target.Append(StreamKey, Events.ToArray());
+            }
+        }
+        else
+        {
+            if (ExpectedVersion.HasValue)
+            {
+                target.Append(StreamId, ExpectedVersion.Value, Events.ToArray());
+            }
+            else
+            {
+                target.Append(StreamId, Events.ToArray());
+            }
+        }
+    }
+}
+
+public class ArchiveStream : StreamOp
+{
+    public ArchiveStream(Guid streamId) : base(streamId) { }
+
+    public ArchiveStream(string streamKey) : base(streamKey) { }
+
+    public override void Execute(IDocumentSession session)
+    {
+        var target = ResolveEvents(session);
+
+        if (StreamId == Guid.Empty)
+        {
+            target.ArchiveStream(StreamKey);
+        }
+        else
+        {
+            target.ArchiveStream(StreamId);
+        }
+    }
+}
+
+public class UnArchiveStream : StreamOp
+{
+    public UnArchiveStream(Guid streamId) : base(streamId) { }
+
+    public UnArchiveStream(string streamKey) : base(streamKey) { }
+
+    public override void Execute(IDocumentSession session)
+    {
+        var target = ResolveEvents(session);
+
+        if (StreamId == Guid.Empty)
+        {
+            target.UnArchiveStream(StreamKey);
+        }
+        else
+        {
+            target.UnArchiveStream(StreamId);
+        }
+    }
+}
+
+public class TombstoneStream : StreamOp
+{
+    public TombstoneStream(Guid streamId) : base(streamId) { }
+
+    public TombstoneStream(string streamKey) : base(streamKey) { }
+
+    public override void Execute(IDocumentSession session)
+    {
+        var target = ResolveEvents(session);
+
+        if (StreamId == Guid.Empty)
+        {
+            target.TombstoneStream(StreamKey);
+        }
+        else
+        {
+            target.TombstoneStream(StreamId);
+        }
+    }
+}


### PR DESCRIPTION
The Polecat half of the follow-up #4384 named in its own "Not in this PR": `Wolverine.Polecat`
carries the same op model as `Wolverine.Marten` and had the same gaps. Per that PR's caveat, the ops
here were checked against **Polecat's own session API** rather than copied across — which is what
decided both what is here and what is deliberately missing, and it also turned up two ops Marten has
no counterpart for.

## What `PolecatOps` gains

| New op | Polecat call it reaches |
|---|---|
| `HardDelete(doc)`, `HardDelete<T>(id)`, `HardDeleteWhere<T>(filter)` | `HardDelete` / `HardDeleteWhere` |
| `UndoDeleteWhere<T>(filter)` | `UndoDeleteWhere` |
| `UpdateExpectedVersion`, `UpdateRevision` | same names |
| `QueueSqlCommand(sql, ...)` | `QueueSqlCommand` |
| `Append(streamId \| streamKey, ...)`, with an optional expected version | `Events.Append` |
| `ArchiveStream(streamId \| streamKey)` | `Events.ArchiveStream` |
| **`UnArchiveStream`**, **`TombstoneStream`** | `Events.UnArchiveStream` / `Events.TombstoneStream` |

Those last two have **no `MartenOps` counterpart** — Marten has no such session API. Parity with
Marten was the floor here, not the ceiling; checking each store's own surface rather than copying
the Marten file across is what finds them.

Plus `ITenantedPolecatOp` + `ForTenant()`, the same single tenant mechanism #4384 introduced instead
of another round of `tenantId` overloads. The pre-existing ops implement it too, so
`PolecatOps.StoreMany(items).ForTenant(t).With(oneMore)` works and keeps its concrete type.

## What Polecat does not have, so neither does this

- **`InsertObjects` / `DeleteObjects`** — no such session methods.
- **`TryUpdateRevision`** — Polecat has `UpdateRevision` only.
- **Patching** — Polecat has no `Patch<T>()` API.
- **The placeholder overload of `QueueSqlCommand`** — Polecat takes `(sql, params object[])` only.

An op whose `Execute` could only throw is worse than the absence of one.

## Two invariants at construction time, as in #4384

`HardDelete<T>()` rejects an id that is not `string`/`Guid`/`int`/`long` — Polecat has no
`object`-typed overload to fall back on — and the stream ops refuse `Guid.Empty` and an empty stream
key, because the Guid/string discrimination is on `Guid.Empty` (the sentinel `StartStream<T>` uses)
and an empty id would otherwise silently take the string branch and archive nothing.

## One implementation note

The stream ops resolve through `ITenantOperations` / `IDocumentSession` rather than through
`IDocumentOperations` the way the Marten ops do: Polecat's `IDocumentOperations` does not carry the
write-side `Events` surface, only the session and the tenant operations do. That is the whole of the
`StreamOp.ResolveEvents` base — the shape of the ops is otherwise the Marten shape.

## Tests

12 new in `PolecatTests`:

- `PolecatOps_expanded_operations` — 8 op-shape tests over the factories, the rejected id types, the
  empty-identity guards, Polecat's archive-lifecycle extras, and `ForTenant()` across every op
  including the pre-existing ones.
- `handler_actions_with_expanded_polecat_operations` — 4 integration tests driving each op through a
  real handler against SQL Server, including the soft-delete/hard-delete distinction and an
  archive → un-archive round trip.

Docs: new sections in `docs/guide/durability/polecat/operations.md`, badged 6.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
