### PR TITLE
Bump the store pins onto the JasperFx 2.66.1 line

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,13 +49,13 @@
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
     <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
-    <PackageVersion Include="Marten" Version="9.32.0" />
+    <PackageVersion Include="Marten" Version="9.32.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-    <PackageVersion Include="Polecat" Version="5.23.0" />
-    <PackageVersion Include="Fisher" Version="1.1.0" />
+    <PackageVersion Include="Polecat" Version="5.24.0" />
+    <PackageVersion Include="Fisher" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Marten.AspNetCore" Version="9.32.0" />
-    <PackageVersion Include="Marten.Newtonsoft" Version="9.32.0" />
+    <PackageVersion Include="Marten.AspNetCore" Version="9.32.1" />
+    <PackageVersion Include="Marten.Newtonsoft" Version="9.32.1" />
     <PackageVersion Include="MemoryPack" Version="1.21.3" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.15" />


### PR DESCRIPTION
The last piece of the 6.35 lockstep. #4389 moved Wolverine onto JasperFx 2.66.1; this moves the three
stores it loads onto the same line.

| Package | From | To | Built against |
|---|---|---|---|
| `Marten`, `Marten.AspNetCore`, `Marten.Newtonsoft` | 9.32.0 | **9.32.1** | JasperFx 2.66.0 |
| `Polecat` | 5.23.0 | **5.24.0** | JasperFx **2.66.1** |
| `Fisher` | 1.1.0 | **1.2.0** | JasperFx **2.66.1** |

Marten's three pins move together: leaving `Marten.AspNetCore` or `Marten.Newtonsoft` on 9.32.0 would
drag 9.32.0 back in transitively.

## Why this is not just tidiness

A store rolls forward at runtime, so the old pins would have *worked*. But a store's own floor is what
a consumer resolves against, and 2.66.1 is not a cosmetic patch for these two:
[jasperfx#796](https://github.com/JasperFx/jasperfx/pull/796) appends `Compacted<TDoc>` to a
single-stream projection's declared event types in `JasperFxSingleStreamProjectionBase`, which is the
shared fix for **polecat#557** and **fisher#203** — a filtered async shard catching up over a
compacted stream from a null snapshot folded only what was appended *after* compaction and persisted
an aggregate missing everything before it, silently.

Polecat 5.24.0 and Fisher 1.2.0 were cut for this:

- [polecat#571](https://github.com/JasperFx/polecat/pull/571) → [v5.24.0](https://github.com/JasperFx/polecat/releases/tag/v5.24.0)
- [fisher#229](https://github.com/JasperFx/fisher/pull/229) → [v1.2.0](https://github.com/JasperFx/fisher/releases/tag/v1.2.0)

Both nuspecs were checked on nuget.org rather than assumed: each depends on `JasperFx 2.66.1`, from
the merge commit its release was tagged at.

## Verification

Against the **published** packages, on this branch rebased onto current `main` (`403f4162`, so the
tree includes all seven merges that make up 6.35):

| Check | Result |
|---|---|
| `dotnet build wolverine.slnx -c Release -f net9.0` | 0 warnings, 0 errors |
| `MartenTests` | 663 passed, 0 failed |
| `PolecatTests` | 306 passed, 2 skipped, 0 failed |
| `FisherTests` | 46 passed, 0 failed |

⚠️ Two of those numbers needed a second look, and the reason is worth recording. `MartenTests` first
came back 3 failed and `PolecatTests` 3 failed, all six in `natural_key_aggregate_handler_workflow`,
throwing `DuplicateNaturalKeyException`. Against a bump of exactly those stores, that reads like a
regression in the natural-key workflow. It is not: both fixtures seed hardcoded natural keys
(`ORD-WOL-001…`, `ORD-PC-001…`) and never reset their schema, so they pass once against a given
database and fail on every rerun — invisible in CI, which gets fresh databases. Inspecting the
mapping tables showed exactly three leftover rows in each, from my own earlier runs; deleting them
made all six pass. Tracked separately rather than patched into a release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
