### PR TITLE
Bump to 6.35.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.34.0</Version>
+        <Version>6.35.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Version bump for the 6.35.0 release. One line in `Directory.Build.props`, which is the single version
source for all ~38 `WolverineFx.*` packages.

## What is in 6.35.0

| PR | Change |
|---|---|
| [#4384](https://github.com/JasperFx/wolverine/pull/4384) | `MartenOps` closes the gap with Marten's own `IDocumentOperations` — hard deletes, soft-delete reversal, mixed batches, revision-checked updates, patching, raw SQL, stream append/archive, and `ForTenant()` (thanks @erdtsieck) |
| [#4392](https://github.com/JasperFx/wolverine/pull/4392) | `PolecatOps` parity, plus `UnArchiveStream` / `TombstoneStream`, which Marten has no counterpart for |
| [#4391](https://github.com/JasperFx/wolverine/pull/4391) | `FisherOps` parity, including patching and `TryUpdateRevision` |
| [#4388](https://github.com/JasperFx/wolverine/pull/4388) | GH-4385/4386/4387 — a declared Event Model now merges with the code it describes: slices join on handler type, `[Emits]` names events a signature cannot carry, and `Pattern` is left unclaimed where a message handler cannot answer it |
| [#4390](https://github.com/JasperFx/wolverine/pull/4390) | GH-4383 — an endpoint-metadata seam for Wolverine-mapped gRPC services, so `[Authorize]` can come off the wire contract (reported by @ArieGato) |
| [#4389](https://github.com/JasperFx/wolverine/pull/4389) | JasperFx 2.66.1 |
| [#4393](https://github.com/JasperFx/wolverine/pull/4393) | Marten 9.32.1, Polecat 5.24.0, Fisher 1.2.0 — the stores onto the same JasperFx line |

## Behaviour changes worth reading before upgrading

**A plain message-handler slice no longer reports `pattern: "Command"`** in `event-model` output or
the `ServiceCapabilities` snapshot (#4388). A handler signature cannot tell a Command from an
Automation, so the role is left unclaimed and a declaration wins it. `Pattern` is still derived
wherever the code answers the question — HTTP routes, gRPC RPCs, schedules, external systems, and any
slice whose command is an event or cascaded message another slice produces.

## Upstream releases cut for this

- Polecat [v5.24.0](https://github.com/JasperFx/polecat/releases/tag/v5.24.0) — [polecat#571](https://github.com/JasperFx/polecat/pull/571)
- Fisher [v1.2.0](https://github.com/JasperFx/fisher/releases/tag/v1.2.0) — [fisher#229](https://github.com/JasperFx/fisher/pull/229)

Both carry [jasperfx#796](https://github.com/JasperFx/jasperfx/pull/796), the shared fix for
polecat#557 and fisher#203: a filtered async shard catching up over a compacted stream from a null
snapshot folded only what was appended after compaction and persisted an aggregate missing everything
before it, silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)