### PR TITLE
Make the natural-key handler fixtures re-runnable

### DIFF
--- a/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs
+++ b/src/Persistence/MartenTests/AggregateHandlerWorkflow/natural_key_aggregate_handler_workflow.cs
@@ -45,6 +45,16 @@ public class natural_key_aggregate_handler_workflow : PostgresqlContext, IAsyncL
         });
 
         _store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        // Every test below claims a hardcoded natural key. A natural key identifies ONE stream, so
+        // without this the fixture passes exactly once against a given database and every rerun fails
+        // with DuplicateNaturalKeyException -- the guard firing correctly on a mapping the previous run
+        // left behind. Invisible in CI, which gets a fresh database, and thoroughly misleading locally:
+        // it reads as a regression in the natural-key workflow itself.
+        //
+        // DeleteAllEventDataAsync clears the mapping table too: Marten's NaturalKeyTable carries a real
+        // foreign key to mt_streams, so truncating streams cascades into it.
+        await _store.Advanced.Clean.DeleteAllEventDataAsync();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs
+++ b/src/Persistence/PolecatTests/natural_key_aggregate_handler_workflow.cs
@@ -46,6 +46,16 @@ public class natural_key_aggregate_handler_workflow : IAsyncLifetime
         // Ensure the Polecat event store schema is created
         var store = (DocumentStore)_store;
         await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Every test below claims a hardcoded natural key. A natural key identifies ONE stream, so
+        // without this the fixture passes exactly once against a given database and every rerun fails
+        // with DuplicateNaturalKeyException -- the guard firing correctly on a mapping the previous run
+        // left behind. Invisible in CI, which gets a fresh database, and thoroughly misleading locally:
+        // it reads as a regression in the natural-key workflow itself.
+        //
+        // CleanAllEventDataAsync clears the mapping table too: Polecat deletes every pc_natural_key_%
+        // table ahead of streams, because SQL Server has no cascading truncate to lean on.
+        await store.Advanced.CleanAllEventDataAsync();
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
`MartenTests.AggregateHandlerWorkflow.natural_key_aggregate_handler_workflow` and its
`PolecatTests` twin each pass **exactly once** against a given database. Every rerun fails all three
tests with:

```
JasperFx.Events.DuplicateNaturalKeyException : The natural key 'ORD-WOL-001' is already mapped to a
different stream for aggregate type 'NkOrderAggregate'.
```

Both fixtures claim hardcoded keys (`ORD-WOL-001/002/003`, `ORD-PC-001/002/003`) and never cleared
the store, so the mapping row from the previous run is still there — pointing at a stream that no
longer exists. The exception is the duplicate guard working correctly on stale data.

## Why it is worth fixing rather than living with

Invisible in CI, which gets a fresh database every time. Locally it is actively misleading: it fired
twice during the 6.35.0 release verification, once while validating Marten 9.32.0 → 9.32.1 (#4393)
and once while validating Polecat 5.23.0 → 5.24.0, and both times three failures in the natural-key
workflow of the store being bumped read exactly like a regression in that store. Both times the store
was innocent. Establishing that meant inspecting `mt_natural_key_nkorderaggregate` /
`pc_natural_key_pcnkorderaggregate` by hand and finding the three leftover rows.

## The fix is one call per fixture

Nothing upstream needed changing — all three stores already clear these tables on a clean, each in
the way its database allows:

| Store | How |
|---|---|
| Marten | `NaturalKeyTable` carries real FKs to `mt_streams`, so `TRUNCATE … CASCADE` reaches it |
| Polecat | deletes every `pc_natural_key_%` table ahead of streams — SQL Server has no cascading truncate |
| Fisher | lists them explicitly in its ordered delete (fisher#40) |

Fisher's comment could be describing this PR:

> They carry no foreign key, so their position is free — but leaving them behind is not: a cleaned
> store would still refuse the next stream to claim a key it had already seen, which is the duplicate
> guard firing on data that is gone.

The fixtures just never called any of it. So: `Advanced.Clean.DeleteAllEventDataAsync()` in the
Marten fixture and `Advanced.CleanAllEventDataAsync()` in the Polecat one, each matching the idiom
already used elsewhere in that test project, with a comment explaining why it is load-bearing rather
than tidiness.

## Verification

Each class run **twice in a row against the same database with no cleanup in between** — which is
precisely what used to fail:

| | run 1 | run 2 |
|---|---|---|
| `MartenTests` | 3/3 | 3/3 |
| `PolecatTests` | 3/3 | 3/3 |

## Unrelated, but noticed here

A fresh restore on this branch — and on unmodified `main`, checked by stashing — now fails with
**`NU1902`**: `Microsoft.Build.Tasks.Git` 8.0.0 has a newly-published moderate advisory, promoted to
an error by `TreatWarningsAsErrors`. It hits 8 projects. It is not caused by this change and it will
hit any fresh restore, so CI may go red on it independently of this PR. I built with
`-p:NuGetAudit=false` to verify the change itself. Worth its own issue if CI confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)