### PR TITLE
Clear the NuGet audit advisories breaking every build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,12 @@
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.5" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="3.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <!-- SourceLink 8.0.0 pulls Microsoft.Build.Tasks.Git 8.0.0 exactly, which carries
+         GHSA-23fw-v26w-5fgq. It arrives with PrivateAssets="All" from Directory.Build.props, so the
+         transitive cannot be pinned around; the SourceLink version is the only lever. 10.0.401
+         resolves it to Microsoft.Build.Tasks.Git 10.0.401; the lowest stable clear of the advisory
+         is 10.0.204, so there is no smaller step. Build-time only, nothing ships from it. -->
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" />
     <PackageVersion Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
     <PackageVersion Include="MQTTnet" Version="5.2.0.1603" />
@@ -126,7 +131,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
     <PackageVersion Include="System.ComponentModel" Version="4.3.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <!-- 10.0.7 carries a known HIGH severity advisory (NU1903). -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.12" />
     <!-- Testcontainers pulls SSH.NET [2025.1.0, ); everything through 2025.1.0 carries
          GHSA-q939-rpr3-3284. The test projects that use Testcontainers reference this directly so
          the patched version wins. -->


### PR DESCRIPTION
Fixes #4400. `main` is currently red for everyone — every CI lane fails in ~35 seconds on **restore**,
not tests.

Two newly-published advisories landed against packages we pin, and `TreatWarningsAsErrors` promotes
NuGet audit warnings to errors. One lane's log carried **56 `NU1902` and 20 `NU1903`** across six
GHSA advisories. Nothing in the repo changed to cause it: the 6.35.0 publish hours earlier was clean.

## The two bumps

| Package | From | To | Advisory |
|---|---|---|---|
| `Microsoft.SourceLink.GitHub` | 8.0.0 | **10.0.401** | `GHSA-23fw-v26w-5fgq` on its transitive `Microsoft.Build.Tasks.Git` 8.0.0 — moderate |
| `System.Security.Cryptography.Xml` | 10.0.7 | **10.0.12** | direct pin — **high** |

`Microsoft.Build.Tasks.Git` cannot be pinned around directly: `Directory.Build.props:36` references
`Microsoft.SourceLink.GitHub` for every project with `PrivateAssets="All"`, and SourceLink 8.0.0's
nuspec pulls `Build.Tasks.Git 8.0.0` exactly, so the SourceLink version is the only lever. I checked
the published nuspecs rather than assuming: 10.0.401 resolves it to `Build.Tasks.Git 10.0.401`, and
10.0.204 is the lowest stable version clear of the advisory, so there is no smaller step available.

The jump is 8.0.x → 10.0.x, which sounds larger than it is — SourceLink is a build-time-only,
`PrivateAssets="All"` dependency, so the blast radius is symbol publishing rather than anything that
ships.

Both pins carry a comment in the file's existing house style for audit-driven pins (the one above
`SSH.NET`), so the next person to wonder why these are here does not have to reconstruct it.

## Deliberately not `NuGetAudit=false`

That would silence a genuine **high**-severity finding on a crypto package when both of these have
stable upgrades available. I used it locally only to verify an unrelated change compiled while this
was blocking me.

## Verification

| Check | Before | After |
|---|---|---|
| `dotnet restore wolverine.slnx` | fails | **exit 0** |
| `NU190x` occurrences | 56 + 20 | **0** |
| `dotnet build wolverine.slnx -c Release -f net9.0` | fails | **0 warnings, 0 errors** |

## Note for reviewers

This should also turn #4399 green — its 30 red lanes are entirely this, nothing to do with its
contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)