### PR TITLE
Link retry attempts to the prior failed attempt's Activity via ActivityLink

### DIFF
--- a/src/Testing/CoreTests/ErrorHandling/RequeueContinuationTester.cs
+++ b/src/Testing/CoreTests/ErrorHandling/RequeueContinuationTester.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CoreTests.Runtime;
 using NSubstitute;
 using Shouldly;
@@ -38,5 +39,21 @@ public class RequeueContinuationTester
         var strategy = new FixedMultiplierJitter(2.0);
 
         ((IJitterable)RequeueContinuation.Instance).TrySetJitter(strategy).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task links_the_requeued_envelope_to_the_failed_attempt_activity()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        var context = Substitute.For<IEnvelopeLifecycle>();
+        context.Envelope.Returns(envelope);
+
+        var activity = new Activity("process");
+        activity.Start();
+
+        await RequeueContinuation.Instance.ExecuteAsync(context, new MockWolverineRuntime(), DateTime.Now, activity);
+
+        envelope.PreviousAttemptActivityId.ShouldBe(activity.Id);
     }
 }

--- a/src/Testing/CoreTests/ErrorHandling/RetryNowContinuationTester.cs
+++ b/src/Testing/CoreTests/ErrorHandling/RetryNowContinuationTester.cs
@@ -58,4 +58,23 @@ public class RetryNowContinuationTester
 
         ((IJitterable)RetryInlineContinuation.Instance).TrySetJitter(strategy).ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task links_the_retried_envelope_to_the_failed_attempt_activity()
+    {
+        var continuation = RetryInlineContinuation.Instance;
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Attempts = 1;
+
+        var context = Substitute.For<IEnvelopeLifecycle>();
+        context.Envelope.Returns(envelope);
+
+        var activity = new Activity("process");
+        activity.Start();
+
+        await continuation.ExecuteAsync(context, new MockWolverineRuntime(), DateTimeOffset.Now, activity);
+
+        envelope.PreviousAttemptActivityId.ShouldBe(activity.Id);
+    }
 }

--- a/src/Testing/CoreTests/ErrorHandling/ScheduledRetryContinuationTester.cs
+++ b/src/Testing/CoreTests/ErrorHandling/ScheduledRetryContinuationTester.cs
@@ -51,4 +51,42 @@ public class ScheduledRetryContinuationTester
 
         await lifecycle.Received(1).ReScheduleAsync(now.AddSeconds(10));
     }
+
+    [Fact]
+    public async Task links_the_rescheduled_envelope_to_the_failed_attempt_activity()
+    {
+        var continuation = new ScheduledRetryContinuation(TimeSpan.FromSeconds(10));
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Attempts = 1;
+
+        var lifecycle = Substitute.For<IEnvelopeLifecycle>();
+        lifecycle.Envelope.Returns(envelope);
+
+        var now = new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero);
+        var activity = new Activity("process");
+        activity.Start();
+
+        await continuation.ExecuteAsync(lifecycle, new MockWolverineRuntime(), now, activity);
+
+        envelope.PreviousAttemptActivityId.ShouldBe(activity.Id);
+    }
+
+    [Fact]
+    public async Task does_not_set_previous_attempt_activity_id_when_activity_is_null()
+    {
+        var continuation = new ScheduledRetryContinuation(TimeSpan.FromSeconds(10));
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Attempts = 1;
+
+        var lifecycle = Substitute.For<IEnvelopeLifecycle>();
+        lifecycle.Envelope.Returns(envelope);
+
+        var now = new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero);
+
+        await continuation.ExecuteAsync(lifecycle, new MockWolverineRuntime(), now, null);
+
+        envelope.PreviousAttemptActivityId.ShouldBeNull();
+    }
 }

--- a/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
+++ b/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
@@ -30,6 +30,66 @@ public class WolverineTracingTests
 
         activity.ParentId.ShouldBe(envelope.ParentId);
     }
+
+    [Fact]
+    public void links_to_the_previous_attempt_activity_when_set_on_envelope()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.PreviousAttemptActivityId = "00-25d8f5709b569a1f61bcaf79b9450ed4-f293c0545fc237a1-01";
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Wolverine")
+            .SetResourceBuilder(
+                ResourceBuilder.CreateDefault()
+                    .AddService("Wolverine", serviceVersion: "1.0"))
+            .AddConsoleExporter()
+            .Build();
+
+        using var activity = WolverineTracing.StartEnvelopeActivity("process", envelope);
+        activity.ShouldNotBeNull();
+
+        var link = activity.Links.ShouldHaveSingleItem();
+        link.Context.TraceId.ToString().ShouldBe("25d8f5709b569a1f61bcaf79b9450ed4");
+        link.Context.SpanId.ToString().ShouldBe("f293c0545fc237a1");
+    }
+
+    [Fact]
+    public void clears_previous_attempt_activity_id_after_starting_the_activity()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.PreviousAttemptActivityId = "00-25d8f5709b569a1f61bcaf79b9450ed4-f293c0545fc237a1-01";
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Wolverine")
+            .SetResourceBuilder(
+                ResourceBuilder.CreateDefault()
+                    .AddService("Wolverine", serviceVersion: "1.0"))
+            .AddConsoleExporter()
+            .Build();
+
+        using var activity = WolverineTracing.StartEnvelopeActivity("process", envelope);
+
+        envelope.PreviousAttemptActivityId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void does_not_add_links_when_previous_attempt_activity_id_is_not_set()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Wolverine")
+            .SetResourceBuilder(
+                ResourceBuilder.CreateDefault()
+                    .AddService("Wolverine", serviceVersion: "1.0"))
+            .AddConsoleExporter()
+            .Build();
+
+        using var activity = WolverineTracing.StartEnvelopeActivity("process", envelope);
+        activity.ShouldNotBeNull();
+
+        activity.Links.ShouldBeEmpty();
+    }
 }
 
 public class when_creating_an_execution_activity

--- a/src/Wolverine/Envelope.cs
+++ b/src/Wolverine/Envelope.cs
@@ -453,6 +453,17 @@ public partial class Envelope : IHasTenantId
     public string? ParentId { get; set; }
 
     /// <summary>
+    ///     The open telemetry activity id of the immediately preceding failed attempt at processing this
+    ///     envelope, if any. Set by error handling continuations that reschedule or retry an envelope
+    ///     (<see cref="Wolverine.ErrorHandling.RetryInlineContinuation"/>, <see cref="Wolverine.ErrorHandling.ScheduledRetryContinuation"/>,
+    ///     <see cref="Wolverine.ErrorHandling.RequeueContinuation"/>) so that the next attempt's activity can
+    ///     be linked back to it instead of being reparented under it. A retry does not temporally contain the
+    ///     attempt that preceded it, so OpenTelemetry's own guidance is to express that relationship with an
+    ///     <see cref="System.Diagnostics.ActivityLink"/> rather than a parent/child span.
+    /// </summary>
+    public string? PreviousAttemptActivityId { get; set; }
+
+    /// <summary>
     ///     User defined tenant identifier for multi-tenancy strategies. This is
     ///     part of metrics reporting and message correlation
     /// </summary>

--- a/src/Wolverine/EnvelopeConstants.cs
+++ b/src/Wolverine/EnvelopeConstants.cs
@@ -20,6 +20,7 @@ public static class EnvelopeConstants
     public const string AcceptedContentTypesKey = "accepted-content-types";
     public const string DeliverByKey = "deliver-by";
     public const string ParentIdKey = "parent-id";
+    public const string PreviousAttemptActivityIdKey = "previous-attempt-activity-id";
     public const string IsResponseKey = "is-response";
     public const string TenantIdKey = "tenant-id";
     public const string GroupIdKey = "group-id";

--- a/src/Wolverine/ErrorHandling/RequeueContinuation.cs
+++ b/src/Wolverine/ErrorHandling/RequeueContinuation.cs
@@ -34,6 +34,11 @@ internal class RequeueContinuation : IContinuation, IContinuationSource, IJitter
     {
         activity?.AddEvent(new ActivityEvent(WolverineTracing.EnvelopeRequeued));
 
+        if (activity != null && lifecycle.Envelope != null)
+        {
+            lifecycle.Envelope.PreviousAttemptActivityId = activity.Id;
+        }
+
         if (Delay != null)
         {
             var envelope = lifecycle.Envelope!;

--- a/src/Wolverine/ErrorHandling/RetryInlineContinuation.cs
+++ b/src/Wolverine/ErrorHandling/RetryInlineContinuation.cs
@@ -40,6 +40,11 @@ internal class RetryInlineContinuation : IContinuation, IContinuationSource, IIn
 
         activity?.AddEvent(new ActivityEvent(WolverineTracing.EnvelopeRetry));
 
+        if (activity != null && lifecycle.Envelope != null)
+        {
+            lifecycle.Envelope.PreviousAttemptActivityId = activity.Id;
+        }
+
         await lifecycle.RetryExecutionNowAsync().ConfigureAwait(false);
     }
 

--- a/src/Wolverine/ErrorHandling/ScheduledRetryContinuation.cs
+++ b/src/Wolverine/ErrorHandling/ScheduledRetryContinuation.cs
@@ -25,6 +25,12 @@ internal class ScheduledRetryContinuation : IContinuation, IContinuationSource, 
         Activity? activity)
     {
         activity?.AddEvent(new ActivityEvent(WolverineTracing.ScheduledRetry));
+
+        if (activity != null && lifecycle.Envelope != null)
+        {
+            lifecycle.Envelope.PreviousAttemptActivityId = activity.Id;
+        }
+
         var effective = _jitter?.Apply(_delay, lifecycle.Envelope?.Attempts ?? 1) ?? _delay;
         var scheduledTime = now.Add(effective);
 

--- a/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
+++ b/src/Wolverine/Runtime/Serialization/EnvelopeSerializer.cs
@@ -30,6 +30,7 @@ public static class EnvelopeSerializer
         EnvelopeConstants.AcceptedContentTypesKey,
         EnvelopeConstants.IdKey,
         EnvelopeConstants.ParentIdKey,
+        EnvelopeConstants.PreviousAttemptActivityIdKey,
         EnvelopeConstants.GroupIdKey,
         EnvelopeConstants.DeduplicationIdKey,
         EnvelopeConstants.ReplyRequestedKey,
@@ -114,6 +115,10 @@ public static class EnvelopeSerializer
 
                 case EnvelopeConstants.ParentIdKey:
                     env.ParentId = value;
+                    break;
+
+                case EnvelopeConstants.PreviousAttemptActivityIdKey:
+                    env.PreviousAttemptActivityId = value;
                     break;
 
                 case EnvelopeConstants.GroupIdKey:
@@ -403,6 +408,7 @@ public static class EnvelopeSerializer
         writer.WriteProp(ref count, EnvelopeConstants.DestinationKey, env.Destination);
         writer.WriteProp(ref count, EnvelopeConstants.SagaIdKey, env.SagaId);
         writer.WriteProp(ref count, EnvelopeConstants.ParentIdKey, env.ParentId);
+        writer.WriteProp(ref count, EnvelopeConstants.PreviousAttemptActivityIdKey, env.PreviousAttemptActivityId);
         writer.WriteProp(ref count, EnvelopeConstants.TenantIdKey, env.TenantId);
         writer.WriteProp(ref count, EnvelopeConstants.TopicNameKey, env.TopicName);
         writer.WriteProp(ref count, EnvelopeConstants.UserNameKey, env.UserName);

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -290,9 +290,20 @@ public static class WolverineTracing
     public static Activity? StartEnvelopeActivity(string spanName, Envelope envelope,
         ActivityKind kind = ActivityKind.Internal)
     {
+        ActivityLink[]? links = null;
+        if (envelope.PreviousAttemptActivityId.IsNotEmpty() &&
+            ActivityContext.TryParse(envelope.PreviousAttemptActivityId, null, out var previousAttempt))
+        {
+            links = [new ActivityLink(previousAttempt)];
+
+            // Single-use. A stale link from an attempt several retries back is not useful once this
+            // attempt has been linked to the one immediately before it.
+            envelope.PreviousAttemptActivityId = null;
+        }
+
         var activity = envelope.ParentId.IsNotEmpty()
-            ? ActivitySource.StartActivity(spanName, kind, envelope.ParentId)
-            : ActivitySource.StartActivity(spanName, kind);
+            ? ActivitySource.StartActivity(spanName, kind, envelope.ParentId, links: links)
+            : ActivitySource.StartActivity(spanName, kind, default(ActivityContext), links: links);
 
         if (activity == null)
         {

--- a/src/Wolverine/Transports/EnvelopeMapper.cs
+++ b/src/Wolverine/Transports/EnvelopeMapper.cs
@@ -117,6 +117,7 @@ public abstract class EnvelopeMapper<TIncoming, TOutgoing> : IEnvelopeMapper<TIn
         MapPropertyToHeader(x => x.Id, EnvelopeConstants.IdKey);
         MapPropertyToHeader(x => x.ConversationId, EnvelopeConstants.ConversationIdKey);
         MapPropertyToHeader(x => x.ParentId!, EnvelopeConstants.ParentIdKey);
+        MapPropertyToHeader(x => x.PreviousAttemptActivityId!, EnvelopeConstants.PreviousAttemptActivityIdKey);
         MapPropertyToHeader(x => x.ContentType!, EnvelopeConstants.ContentTypeKey);
         MapPropertyToHeader(x => x.Source!, EnvelopeConstants.SourceKey);
         MapPropertyToHeader(x => x.ReplyRequested!, EnvelopeConstants.ReplyRequestedKey);


### PR DESCRIPTION
## Problem

Closes #4398.

When a message fails and is retried — inline, on a delay, or requeued — the next attempt's
`Activity` is only ever a sibling of the failed attempt's `Activity`; both are parented off the
same `Envelope.ParentId` from the original inbound context. There's nothing that lets you jump
from "attempt 1 failed" to "attempt 2, which is what happened next" in a trace backend. The only
trace of the retry today is an `ActivityEvent` added to the *failed* attempt's own span
(`wolverine.envelope.retried` / `.rescheduled` / `.requeued`), which is a dead end rather than a
forward pointer.

## Why not just reparent under the failed attempt?

That's the obvious first fix, and it's what we shipped as a local workaround before writing this
PR: set `envelope.ParentId = activity.Id` before retrying. It looked right in the trace UI, but
it's the wrong relationship per the [OpenTelemetry messaging semantic
conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/) —
parent/child is supposed to mean temporal containment, and a retry's span does not live inside
the span of the attempt that failed before it (for `ScheduledRetryContinuation` there can be
minutes between them). The convention's answer for "related but not containing" is
`ActivityLink`. MassTransit (`MT-Activity-Propagation: "Link"` header on redelivery) and Brighter
(`BrighterTracer.GetMessagePumpLinks`) both already do this for the same scenario.

## What this changes

Adds `Envelope.PreviousAttemptActivityId`, wired through the exact same plumbing `ParentId`
already uses:

- `EnvelopeConstants.PreviousAttemptActivityIdKey` — new wire header key, alongside
  `ParentIdKey`.
- `EnvelopeSerializer` — read/write in the binary envelope format (durable storage +
  native-transport round-trip), and added to `ReservedHeaderKeys`.
- `EnvelopeMapper<TIncoming,TOutgoing>` — one `MapPropertyToHeader` line, so every transport
  mapper (Rabbit, Kafka, Azure Service Bus, SQS, ...) picks it up automatically with no
  per-transport changes.
- `WolverineTracing.StartEnvelopeActivity` — if the envelope carries a
  `PreviousAttemptActivityId`, parses it with `ActivityContext.TryParse` and passes it as an
  `ActivityLink` to `ActivitySource.StartActivity`, *in addition to* the existing
  `ParentId`-based parent (which is left untouched — it still correctly represents the original
  inbound context, not the retry chain). The field is cleared immediately after being consumed,
  so it's single-use: a link should point at the attempt immediately before it, not an
  arbitrarily stale one from several retries back.
- `RetryInlineContinuation`, `ScheduledRetryContinuation`, `RequeueContinuation` — each stamps
  `lifecycle.Envelope.PreviousAttemptActivityId = activity.Id` from the failed attempt's
  `Activity`, right next to the existing `activity?.AddEvent(...)` call, before retrying /
  rescheduling / requeuing.

Piggybacking on `ParentId`'s existing infrastructure rather than inventing a new mechanism means
this survives everything `ParentId` already survives: a durable reschedule picked up by a
different process/node via the inbox, and round-tripping over every external transport, with a
one-line change per concern rather than one per transport.

## Open question for maintainers

Right now this is single-use — only the immediately preceding attempt gets linked, not the whole
retry chain. That matches what MassTransit/Brighter do and keeps the wire payload bounded, but if
you'd rather see every prior attempt linked (`List<ActivityLink>` accumulated across retries), I
can rework it that way instead — wanted to raise the tradeoff rather than assume.

## Testing

- New unit tests: `WolverineTracingTests` (link is added when `PreviousAttemptActivityId` is set,
  cleared after being consumed, absent when not set), plus one test per continuation
  (`RetryNowContinuationTester`, `ScheduledRetryContinuationTester`, `RequeueContinuationTester`)
  confirming each stamps `PreviousAttemptActivityId` from the passed-in `Activity`, and that
  `ScheduledRetryContinuation` leaves it null when no `Activity` is available.
- Full `CoreTests` suite: 2909 passed, 2 pre-existing/unrelated skips, 0 failed.
