### PR TITLE
GH-3987: node-side reconciliation sweep for assigned-vs-running

### DIFF
--- a/src/Testing/CoreTests/Runtime/Agents/local_agent_reconciliation_sweep.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/local_agent_reconciliation_sweep.cs
@@ -1,0 +1,259 @@
+using CoreTests.Transports;
+using JasperFx;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Wolverine.Configuration;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Agents;
+using Xunit;
+
+namespace CoreTests.Runtime.Agents;
+
+/// <summary>
+/// GH-3987: the node-side assigned-vs-running reconciliation sweep. The assignment table is keyed one
+/// row per agent, so once the two facts diverge the leader is structurally blind to it: an agent whose
+/// row names this node but which is not running here reads as "assigned" forever, and a copy running
+/// here whose row a peer overwrote is invisible to the grid. Only the node holding the divergence can
+/// see it, by comparing its own registrations against its persisted claims on the health-check tick —
+/// follower-capable, because divergence does not care who the leader is.
+///
+/// A mismatch must be observed for LocalAgentReconciliationThreshold consecutive ticks before it is
+/// acted on, so anything legitimately in flight (a start racing its own assignment row, a stop racing
+/// its row delete) clears itself without churn.
+/// </summary>
+public class local_agent_reconciliation_sweep
+{
+    private readonly WolverineOptions _options;
+    private readonly INodeAgentPersistence _persistence = Substitute.For<INodeAgentPersistence>();
+    private readonly NodeAgentController _controller;
+    private readonly FakeAgentFamily _family = new("test-family");
+
+    public local_agent_reconciliation_sweep()
+    {
+        _options = new WolverineOptions
+        {
+            ApplicationAssembly = GetType().Assembly
+        };
+        _options.Transports.NodeControlEndpoint = new FakeEndpoint("fake://self".ToUri(), EndpointRole.System);
+        _options.Durability.DurabilityAgentEnabled = false;
+
+        var runtime = Substitute.For<IWolverineRuntime>();
+        runtime.Options.Returns(_options);
+        runtime.DurabilitySettings.Returns(_options.Durability);
+        runtime.Observer.Returns(Substitute.For<IWolverineObserver>());
+
+        // The sweep must not depend on leadership, so this node stays a follower throughout.
+        _persistence.HasLeadershipLock().Returns(false);
+        _persistence.TryAttainLeadershipLockAsync(Arg.Any<CancellationToken>()).Returns(false);
+
+        _controller = new NodeAgentController(
+            runtime,
+            _persistence,
+            [_family],
+            NullLogger<NodeAgentController>.Instance,
+            CancellationToken.None);
+    }
+
+    private WolverineNode Row(Guid nodeId, int number, params Uri[] activeAgents)
+    {
+        var node = new WolverineNode
+        {
+            NodeId = nodeId,
+            AssignedNodeNumber = number,
+            ControlUri = new Uri("fake://node" + number)
+        };
+        node.ActiveAgents.AddRange(activeAgents);
+        return node;
+    }
+
+    private WolverineNode Self(params Uri[] activeAgents)
+        => Row(_options.UniqueNodeId, _options.Durability.AssignedNodeNumber, activeAgents);
+
+    private void ClusterIs(params WolverineNode[] nodes) => ClusterIs(new AgentRestrictions(), nodes);
+
+    private void ClusterIs(AgentRestrictions restrictions, params WolverineNode[] nodes)
+    {
+        foreach (var node in nodes)
+        {
+            node.LastHealthCheck = DateTimeOffset.UtcNow;
+        }
+
+        _persistence.LoadNodeAgentStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new NodeAgentState(nodes, restrictions));
+    }
+
+    private async Task tick(int times = 1)
+    {
+        for (var i = 0; i < times; i++)
+        {
+            await _controller.DoHealthChecksAsync();
+        }
+    }
+
+    [Fact]
+    public async Task starts_an_agent_that_is_durably_assigned_here_but_not_running()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        // The GH-3987 wedge: the row says this node owns the agent, but nothing is running. The leader
+        // reads this as converged forever; only this node can notice.
+        ClusterIs(Self(uri));
+
+        await tick(2);
+        agent.StartCount.ShouldBe(0);
+
+        await tick();
+        agent.StartCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task stops_a_local_copy_whose_durable_assignment_belongs_to_another_live_node()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        await _controller.StartAgentAsync(uri);
+        agent.StartCount.ShouldBe(1);
+
+        // The leadership-handover duplicate: this copy started here, but the one-row-per-agent table
+        // now names a peer (last writer wins), so this copy is an orphan nothing else will ever stop.
+        var owner = Row(Guid.NewGuid(), 2, uri);
+        ClusterIs(Self(), owner);
+
+        await tick(2);
+        agent.StopCount.ShouldBe(0);
+
+        await tick();
+        agent.StopCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task reclaims_the_row_for_a_local_copy_no_row_accounts_for_instead_of_stopping_it()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        await _controller.StartAgentAsync(uri);
+        _persistence.ClearReceivedCalls();
+
+        // The row vanished entirely (peer ejection cascade). Nobody else claims the agent, so the
+        // running copy is the one true copy: restore the claim, never stop the work.
+        ClusterIs(Self(), Row(Guid.NewGuid(), 2));
+
+        await tick(3);
+
+        agent.StopCount.ShouldBe(0);
+        await _persistence.Received()
+            .AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task a_transient_mismatch_that_heals_on_its_own_is_never_acted_on()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        // Two ticks of mismatch — one short of the threshold...
+        ClusterIs(Self(uri));
+        await tick(2);
+
+        // ...then the divergence heals on its own (the in-flight start this row belonged to landed on
+        // a peer and the row moved on). The streak must reset, not resume.
+        ClusterIs(Self(), Row(Guid.NewGuid(), 2, uri));
+        await tick();
+
+        ClusterIs(Self(uri));
+        await tick(2);
+
+        agent.StartCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task the_sweep_is_off_when_the_threshold_is_zero()
+    {
+        _options.Durability.LocalAgentReconciliationThreshold = 0;
+
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        ClusterIs(Self(uri));
+        await tick(5);
+
+        agent.StartCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_paused_agent_is_not_dragged_back_by_its_own_stale_row()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        // An operator's pause outranks the row: the assignment row survives a pause on purpose (the
+        // node still owns the agent), so the sweep must not read "assigned but not running" from it.
+        var paused = new AgentRestrictions([
+            new AgentRestriction(Guid.NewGuid(), uri, AgentRestrictionType.Paused, 0)
+        ]);
+        ClusterIs(paused, Self(uri));
+
+        await tick(5);
+
+        agent.StartCount.ShouldBe(0);
+    }
+
+    private class FakeAgentFamily : IAgentFamily
+    {
+        private readonly Dictionary<Uri, FakeAgent> _agents = new();
+
+        public FakeAgentFamily(string scheme)
+        {
+            Scheme = scheme;
+        }
+
+        public FakeAgent Add(Uri uri)
+        {
+            var agent = new FakeAgent(uri);
+            _agents[uri] = agent;
+            return agent;
+        }
+
+        public string Scheme { get; }
+
+        public ValueTask<IReadOnlyList<Uri>> AllKnownAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask<IAgent> BuildAgentAsync(Uri uri, IWolverineRuntime wolverineRuntime)
+            => ValueTask.FromResult<IAgent>(_agents[uri]);
+
+        public ValueTask<IReadOnlyList<Uri>> SupportedAgentsAsync()
+            => ValueTask.FromResult<IReadOnlyList<Uri>>(_agents.Keys.ToList());
+
+        public ValueTask EvaluateAssignmentsAsync(AssignmentGrid assignments) => ValueTask.CompletedTask;
+    }
+
+    private class FakeAgent : IAgent
+    {
+        public FakeAgent(Uri uri) => Uri = uri;
+
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+
+        public Uri Uri { get; }
+        public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            StartCount++;
+            Status = AgentStatus.Running;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCount++;
+            Status = AgentStatus.Stopped;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Agents/local_agent_reconciliation_sweep.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/local_agent_reconciliation_sweep.cs
@@ -185,6 +185,49 @@ public class local_agent_reconciliation_sweep
     }
 
     [Fact]
+    public async Task never_acts_on_the_synthetic_self_row_injected_for_a_lagging_snapshot()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        await _controller.StartAgentAsync(uri);
+        _persistence.ClearReceivedCalls();
+
+        // The snapshot omits this node entirely (read-after-write lag), so the health check injects a
+        // synthetic self whose ActiveAgents is EMPTY — a deterministic fiction the consecutive-tick
+        // threshold cannot filter. A peer's row claims the agent in that same stale snapshot: acting on
+        // it would stop the legitimate local copy. The sweep must sit these ticks out entirely.
+        ClusterIs(Row(Guid.NewGuid(), 2, uri));
+        await tick(5);
+        agent.StopCount.ShouldBe(0);
+
+        // Nor may the inverse branch fire: with no claimant anywhere in the stale snapshot, acting
+        // would re-claim the row over whatever a peer wrote after the snapshot was taken.
+        ClusterIs(Row(Guid.NewGuid(), 2));
+        await tick(5);
+        await _persistence.DidNotReceive()
+            .AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task resumes_reconciling_once_the_persisted_self_row_is_visible_again()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        // Lagging ticks first: the snapshot omits self, so nothing is observed or acted on...
+        ClusterIs(Row(Guid.NewGuid(), 2, uri));
+        await tick(5);
+        agent.StartCount.ShouldBe(0);
+
+        // ...then the persisted row comes back showing the real divergence (assigned here, not
+        // running), and the sweep proceeds on its normal threshold from genuine observations.
+        ClusterIs(Self(uri), Row(Guid.NewGuid(), 2));
+        await tick(3);
+        agent.StartCount.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task a_paused_agent_is_not_dragged_back_by_its_own_stale_row()
     {
         var uri = new Uri("test-family://one");

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -639,6 +639,13 @@ public class DurabilitySettings : IDescribeMyself
     public int MaxLocalAgentRestartsBeforeRelease { get; set; } = 3;
 
     /// <summary>
+    ///     How many consecutive health-check ticks a mismatch between this node's persisted agent
+    ///     assignments and its actually-running agents must be observed before the node reconciles
+    ///     it. Set to 0 or a negative number to disable the reconciliation sweep. Default 3.
+    /// </summary>
+    public int LocalAgentReconciliationThreshold { get; set; } = 3;
+
+    /// <summary>
     ///     GH-3970: how many consecutive assignment ticks may fail to <i>build or start</i> an agent on this
     ///     node before the node releases it to a capable peer, using the same embargo as
     ///     <see cref="MaxLocalAgentRestartsBeforeRelease" />.
@@ -835,6 +842,7 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(AssignmentSettlePeriod), AssignmentSettlePeriod);
         desc.AddValue(nameof(MaxAssignmentSettleTime), MaxAssignmentSettleTime);
         desc.AddValue(nameof(AssignmentSettleNodeCount), AssignmentSettleNodeCount);
+        desc.AddValue(nameof(LocalAgentReconciliationThreshold), LocalAgentReconciliationThreshold);
         desc.AddValue(nameof(TenantCheckPeriod), TenantCheckPeriod);
         desc.AddValue(nameof(UpdateMetricsPeriod), UpdateMetricsPeriod);
         desc.AddValue(nameof(DurabilityMetricsEnabled), DurabilityMetricsEnabled);

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -204,6 +204,20 @@ public partial class NodeAgentController
         // Do it no matter what
         await ejectStaleNodes(staleNodes);
 
+        // GH-3987: node-side assigned-vs-running reconciliation, follower-capable by design — the
+        // divergences it heals live on the node that has them, and the leader structurally cannot see
+        // them (a row with no runner looks assigned; a runner with no row is invisible to the grid).
+        // Wrapped so a fault here can never cost this node its heartbeat or its leadership lease.
+        try
+        {
+            await ReconcileLocalAgentsAsync(nodes, restrictions);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error reconciling local agents on node {NodeNumber}",
+                _runtime.Options.Durability.AssignedNodeNumber);
+        }
+
         // Detect lost leadership: we *thought* we were the leader (from a
         // previous heartbeat tick) but our underlying advisory lock has been
         // released server-side. With the AdvisoryLock.HasLock liveness ping

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -190,7 +190,8 @@ public partial class NodeAgentController
         // propagating), inject self so downstream leader-election and
         // assignment-evaluation code can find us. We rely on the next tick to
         // pick up the persisted row with its full Capabilities / ActiveAgents.
-        if (nodes.All(x => x.NodeId != selfNodeId))
+        var selfRowIsPersisted = nodes.Any(x => x.NodeId == selfNodeId);
+        if (!selfRowIsPersisted)
         {
             nodes = nodes.Concat(new[] { WolverineNode.For(_runtime.Options) }).ToList();
         }
@@ -208,9 +209,19 @@ public partial class NodeAgentController
         // divergences it heals live on the node that has them, and the leader structurally cannot see
         // them (a row with no runner looks assigned; a runner with no row is invisible to the grid).
         // Wrapped so a fault here can never cost this node its heartbeat or its leadership lease.
+        //
+        // Gated on the snapshot actually containing this node's PERSISTED row. The synthetic self
+        // injected above carries an empty ActiveAgents list — a deterministic fiction, not a lagging
+        // reading — so the consecutive-tick threshold cannot filter it: every synthetic tick would
+        // count every local agent as "running but unclaimed", and after the threshold the sweep would
+        // stop copies whose claim the stale snapshot attributes elsewhere, or re-claim rows over a
+        // peer's newer write. The sweep only ever compares against durable truth it has actually seen.
         try
         {
-            await ReconcileLocalAgentsAsync(nodes, restrictions);
+            if (selfRowIsPersisted)
+            {
+                await ReconcileLocalAgentsAsync(nodes, restrictions);
+            }
         }
         catch (Exception e)
         {

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.Reconcile.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.Reconcile.cs
@@ -26,6 +26,12 @@ public partial class NodeAgentController
     ///     </list>
     ///     The existing local sweep (<see cref="ReportFailedLocalAgentsAsync" />) covers agents that are
     ///     registered but wedged/paused; this one covers registration-vs-table divergence.
+    ///
+    ///     <para>The caller must only pass a snapshot that contains this node's PERSISTED row.
+    ///     <c>DoHealthChecksInternalAsync</c> injects a synthetic self (empty ActiveAgents) when a lagging
+    ///     read omits it, and skips this sweep on those ticks — a fabricated empty claim list is not a
+    ///     transient the consecutive-tick threshold can filter, and acting on it would stop or re-claim
+    ///     agents against state that was never real.</para>
     /// </summary>
     internal async Task ReconcileLocalAgentsAsync(IReadOnlyList<WolverineNode> nodes, AgentRestrictions restrictions)
     {

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.Reconcile.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.Reconcile.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wolverine.Runtime.Agents;
+
+public partial class NodeAgentController
+{
+    // GH-3987: consecutive-tick observation streaks for local assignment discrepancies, keyed by agent
+    // Uri. Only touched from the serialized health-check path. An entry is removed the moment the
+    // discrepancy is no longer observed, so only a SUSTAINED mismatch is ever acted on — anything
+    // legitimately in flight (a start racing its assignment row, a stop racing its row delete) clears
+    // itself within a tick.
+    private readonly Dictionary<Uri, int> _reconcileObservations = new();
+
+    /// <summary>
+    ///     GH-3987: the node-side assigned-vs-running reconciliation sweep. Runs on every node on every
+    ///     health-check tick, independently of leadership. Compares what the durable assignment table
+    ///     says this node owns against what is actually registered here, and heals both directions of
+    ///     divergence the leader structurally cannot see:
+    ///     <list type="bullet">
+    ///         <item>an agent whose row says this node owns it but which is not registered here at all —
+    ///         the "assigned but not running" wedge — is started;</item>
+    ///         <item>an agent running here that no durable row accounts for is stopped if another live
+    ///         node owns the durable claim (this copy is split-brain residue the GH-2602 healer cannot
+    ///         see, since it only compares durable rows), or re-claimed by restoring this node's row if
+    ///         nobody owns it.</item>
+    ///     </list>
+    ///     The existing local sweep (<see cref="ReportFailedLocalAgentsAsync" />) covers agents that are
+    ///     registered but wedged/paused; this one covers registration-vs-table divergence.
+    /// </summary>
+    internal async Task ReconcileLocalAgentsAsync(IReadOnlyList<WolverineNode> nodes, AgentRestrictions restrictions)
+    {
+        var threshold = _runtime.Options.Durability.LocalAgentReconciliationThreshold;
+        if (threshold <= 0)
+        {
+            return;
+        }
+
+        var self = nodes.FirstOrDefault(x => x.NodeId == _runtime.Options.UniqueNodeId);
+        if (self == null)
+        {
+            // Snapshot lag; there is nothing trustworthy to compare against on this tick
+            return;
+        }
+
+        var claimed = self.ActiveAgents.Where(x => x != LeaderUri).ToHashSet();
+        var running = Agents.Keys.Where(x => x != LeaderUri).ToHashSet();
+        var paused = restrictions.FindPausedAgentUris().ToHashSet();
+
+        var mismatches = new List<(Uri Uri, bool RunningNotClaimed)>();
+
+        foreach (var uri in running)
+        {
+            if (claimed.Contains(uri)) continue;
+            if (_stoppingAgents.ContainsKey(uri)) continue;
+
+            mismatches.Add((uri, true));
+        }
+
+        foreach (var uri in claimed)
+        {
+            if (running.Contains(uri)) continue;
+            if (_stoppingAgents.ContainsKey(uri)) continue;
+
+            // An agent this node released for failing here must not be dragged back by its own stale
+            // row, an operator's pause outranks the row, and a row for a scheme this deployment cannot
+            // run (blue/green) is a peer's business.
+            if (_releasedAgents.ContainsKey(uri)) continue;
+            if (paused.Contains(uri)) continue;
+            if (!_agentFamilies.ContainsKey(uri.Scheme)) continue;
+
+            mismatches.Add((uri, false));
+        }
+
+        // Streak accounting: reset anything that healed on its own, then only act on discrepancies
+        // observed for `threshold` consecutive ticks.
+        var current = mismatches.Select(x => x.Uri).ToHashSet();
+        foreach (var recovered in _reconcileObservations.Keys.Where(x => !current.Contains(x)).ToArray())
+        {
+            _reconcileObservations.Remove(recovered);
+        }
+
+        foreach (var (uri, runningNotClaimed) in mismatches)
+        {
+            var count = (_reconcileObservations.TryGetValue(uri, out var previous) ? previous : 0) + 1;
+            _reconcileObservations[uri] = count;
+
+            if (count < threshold)
+            {
+                continue;
+            }
+
+            _reconcileObservations.Remove(uri);
+
+            try
+            {
+                if (runningNotClaimed)
+                {
+                    var owner = nodes.FirstOrDefault(x =>
+                        x.NodeId != self.NodeId && x.ActiveAgents.Contains(uri));
+
+                    if (owner != null)
+                    {
+                        _logger.LogWarning(
+                            "Agent {AgentUri} is running on node {NodeNumber} but its durable assignment belongs to node {OwnerNodeNumber}; stopping the local copy",
+                            uri, _runtime.Options.Durability.AssignedNodeNumber, owner.AssignedNodeNumber);
+
+                        await StopAgentAsync(uri);
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "Agent {AgentUri} is running on node {NodeNumber} with no durable assignment row anywhere; restoring this node's claim",
+                            uri, _runtime.Options.Durability.AssignedNodeNumber);
+
+                        await upsertAssignmentAsync(uri);
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Agent {AgentUri} is durably assigned to node {NodeNumber} but is not running here; starting it",
+                        uri, _runtime.Options.Durability.AssignedNodeNumber);
+
+                    await StartAgentAsync(uri);
+                }
+            }
+            catch (Exception e)
+            {
+                // One agent's failure must not take down the sweep; a failed start is already counted
+                // and escalated by the _failedStarts / release machinery.
+                _logger.LogError(e, "Error reconciling agent {AgentUri} on node {NodeNumber}", uri,
+                    _runtime.Options.Durability.AssignedNodeNumber);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I pulled this out of #4297 which I'll rebase or discard later.

This compares the agents assigned to the node to the agents actually running on the node and starts or stops them accordingly. In that sim repo I was able to reproduce agents duplicating even with the [settle gate on](https://github.com/mlh758/wolverine-churn-simulator/blob/master/RESULTS.md#2026-09-09--first-duplicate-observed-gh-4367-settle-gate).

This won't completely eliminate agents getting duplicated but it does cause the situation to heal in [this result](https://github.com/mlh758/wolverine-churn-simulator/blob/master/RESULTS.md#2026-09-09--mlh758gh-3987-3959-fixes-converges-8-duplicates-8-healed-0-persisted).

The mechanism seems to be the leader issuing agent start commands and then being shut down with those commands in flight. The new leader starts and issues its own start commands before the destination writes out that it has the agent. Since `node_assignments` is one row per agent, the cluster appears to have converged which is what I think is preventing #2607 3rd layer from fixing this on its own.

A more in depth fix might be to have the leader write the commands to disk immediately once it's ready to issue them, and then send the commands to other nodes. If it crashes the reconcile process this introduces will still have those nodes picking up their agents as assigned. I would need to test that out more though.

Guardrails against churn: a mismatch must persist for LocalAgentReconciliationThreshold consecutive
ticks (default 3, ~30 s; 0 disables) so anything legitimately in flight clears itself; a local copy is
stopped only when another live node owns the durable claim, while a running copy with no row anywhere
gets its claim restored instead; pauses, released agents, in-flight stops, and schemes this deployment
can't run are exempt. Unit tests cover all of these.

