### PR TITLE
GH-4398: link each retry attempt to the failed attempt before it

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,6 +103,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/src/Testing/CoreTests/ErrorHandling/RequeueContinuationTester.cs
+++ b/src/Testing/CoreTests/ErrorHandling/RequeueContinuationTester.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CoreTests.Runtime;
 using NSubstitute;
 using Shouldly;
@@ -38,5 +39,21 @@ public class RequeueContinuationTester
         var strategy = new FixedMultiplierJitter(2.0);
 
         ((IJitterable)RequeueContinuation.Instance).TrySetJitter(strategy).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task records_the_failed_attempt_so_the_next_attempt_can_link_to_it()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        var context = Substitute.For<IEnvelopeLifecycle>();
+        context.Envelope.Returns(envelope);
+
+        using var activity = new Activity("process").Start();
+
+        await RequeueContinuation.Instance.ExecuteAsync(context, new MockWolverineRuntime(), DateTime.Now, activity);
+
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out var previous).ShouldBeTrue();
+        previous.ShouldBe(activity.Id);
     }
 }

--- a/src/Testing/CoreTests/ErrorHandling/RetryNowContinuationTester.cs
+++ b/src/Testing/CoreTests/ErrorHandling/RetryNowContinuationTester.cs
@@ -58,4 +58,21 @@ public class RetryNowContinuationTester
 
         ((IJitterable)RetryInlineContinuation.Instance).TrySetJitter(strategy).ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task records_the_failed_attempt_so_the_next_attempt_can_link_to_it()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Attempts = 1;
+
+        var context = Substitute.For<IEnvelopeLifecycle>();
+        context.Envelope.Returns(envelope);
+
+        using var activity = new Activity("process").Start();
+
+        await RetryInlineContinuation.Instance.ExecuteAsync(context, new MockWolverineRuntime(), DateTimeOffset.Now, activity);
+
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out var previous).ShouldBeTrue();
+        previous.ShouldBe(activity.Id);
+    }
 }

--- a/src/Testing/CoreTests/ErrorHandling/ScheduledRetryContinuationTester.cs
+++ b/src/Testing/CoreTests/ErrorHandling/ScheduledRetryContinuationTester.cs
@@ -51,4 +51,39 @@ public class ScheduledRetryContinuationTester
 
         await lifecycle.Received(1).ReScheduleAsync(now.AddSeconds(10));
     }
+
+    [Fact]
+    public async Task records_the_failed_attempt_so_the_next_attempt_can_link_to_it()
+    {
+        var continuation = new ScheduledRetryContinuation(TimeSpan.FromSeconds(10));
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Attempts = 1;
+
+        var lifecycle = Substitute.For<IEnvelopeLifecycle>();
+        lifecycle.Envelope.Returns(envelope);
+
+        using var activity = new Activity("process").Start();
+
+        await continuation.ExecuteAsync(lifecycle, new MockWolverineRuntime(), DateTimeOffset.UtcNow, activity);
+
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out var previous).ShouldBeTrue();
+        previous.ShouldBe(activity.Id);
+    }
+
+    [Fact]
+    public async Task records_nothing_when_there_is_no_activity()
+    {
+        var continuation = new ScheduledRetryContinuation(TimeSpan.FromSeconds(10));
+
+        var envelope = ObjectMother.Envelope();
+        envelope.Attempts = 1;
+
+        var lifecycle = Substitute.For<IEnvelopeLifecycle>();
+        lifecycle.Envelope.Returns(envelope);
+
+        await continuation.ExecuteAsync(lifecycle, new MockWolverineRuntime(), DateTimeOffset.UtcNow, null);
+
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out _).ShouldBeFalse();
+    }
 }

--- a/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
+++ b/src/Testing/CoreTests/Runtime/WolverineTracingTests.cs
@@ -30,6 +30,63 @@ public class WolverineTracingTests
 
         activity.ParentId.ShouldBe(envelope.ParentId);
     }
+
+    [Fact]
+    public void links_to_the_previous_attempt_and_consumes_the_header()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Headers[EnvelopeConstants.PreviousAttemptActivityIdKey] =
+            "00-25d8f5709b569a1f61bcaf79b9450ed4-f293c0545fc237a1-01";
+
+        using var activity = new Activity("process").Start();
+
+        WolverineTracing.LinkToPreviousAttempt(activity, envelope);
+
+        var link = activity.Links.ShouldHaveSingleItem();
+        link.Context.TraceId.ToString().ShouldBe("25d8f5709b569a1f61bcaf79b9450ed4");
+        link.Context.SpanId.ToString().ShouldBe("f293c0545fc237a1");
+
+        // Single-use: nothing this attempt sends or schedules next may carry it onward
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void no_link_for_an_envelope_that_was_never_retried()
+    {
+        var envelope = ObjectMother.Envelope();
+
+        using var activity = new Activity("process").Start();
+
+        WolverineTracing.LinkToPreviousAttempt(activity, envelope);
+
+        activity.Links.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void drops_the_header_when_there_is_no_activity_to_link()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Headers[EnvelopeConstants.PreviousAttemptActivityIdKey] =
+            "00-25d8f5709b569a1f61bcaf79b9450ed4-f293c0545fc237a1-01";
+
+        WolverineTracing.LinkToPreviousAttempt(null, envelope);
+
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ignores_a_malformed_previous_attempt_id()
+    {
+        var envelope = ObjectMother.Envelope();
+        envelope.Headers[EnvelopeConstants.PreviousAttemptActivityIdKey] = "not-a-traceparent";
+
+        using var activity = new Activity("process").Start();
+
+        WolverineTracing.LinkToPreviousAttempt(activity, envelope);
+
+        activity.Links.ShouldBeEmpty();
+        envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out _).ShouldBeFalse();
+    }
 }
 
 public class when_creating_an_execution_activity

--- a/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
+++ b/src/Testing/OpenTelemetry/TracingTests/TracingTests.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Alba" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/Testing/OpenTelemetry/TracingTests/retry_attempt_links.cs
+++ b/src/Testing/OpenTelemetry/TracingTests/retry_attempt_links.cs
@@ -1,0 +1,300 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using JasperFx.Core;
+using OpenTelemetry.Trace;
+using Shouldly;
+using Wolverine;
+using Wolverine.ErrorHandling;
+using Wolverine.RabbitMQ;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace TracingTests;
+
+/// <summary>
+/// GH-4398. End to end through the real OpenTelemetry SDK: every Wolverine span this host produces goes
+/// through the SDK's sampler and export pipeline into an in-memory exporter, so these tests assert on what
+/// a trace backend would actually have received rather than on Activity objects poked at in isolation.
+/// </summary>
+[Collection("otel")]
+public class retry_attempt_links : IAsyncLifetime
+{
+    private const string InlineQueue = "retry-attempt-links-inline";
+    private const string BufferedQueue = "retry-attempt-links-buffered";
+
+    private readonly ExportedSpans _spans = new();
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ServiceName = "RetryAttemptLinks";
+                opts.ApplicationAssembly = GetType().Assembly;
+
+                opts.Discovery.DisableConventionalDiscovery().IncludeType<RetryLinkHandler>();
+
+                opts.OnException<RetryNowFailure>().RetryTimes(3);
+                opts.OnException<ScheduledRetryFailure>()
+                    .ScheduleRetry(50.Milliseconds(), 50.Milliseconds(), 50.Milliseconds());
+                opts.OnException<RequeueFailure>().Requeue(5);
+
+                opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
+
+                // Inline (Rabbit MQ's default) hands the receive span to the pipeline as the span the handler
+                // runs in; buffered starts a separate short receive span first and a process span later. Both
+                // are covered because they reach the pipeline by different doors.
+                opts.PublishMessage<RabbitInlineRequeue>().ToRabbitQueue(InlineQueue);
+                opts.ListenToRabbitQueue(InlineQueue);
+
+                opts.PublishMessage<RabbitBufferedRequeue>().ToRabbitQueue(BufferedQueue);
+                opts.ListenToRabbitQueue(BufferedQueue).BufferedInMemory();
+
+                opts.Services.AddOpenTelemetry()
+                    .WithTracing(tracing => tracing.AddSource("Wolverine").AddInMemoryExporter(_spans));
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task an_attempt_that_succeeds_first_time_has_no_links()
+    {
+        var attempts = await attemptsFor(new LocalRetryNow(Guid.NewGuid(), 0), 1);
+
+        attempts.Single().Links.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task retry_now_links_each_attempt_to_the_one_before_it()
+    {
+        var message = new LocalRetryNow(Guid.NewGuid(), 2);
+
+        var attempts = await attemptsFor(message, 3);
+
+        shouldBeChained(attempts);
+        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task scheduled_retry_links_each_attempt_to_the_one_before_it()
+    {
+        var message = new LocalScheduledRetry(Guid.NewGuid(), 2);
+
+        var attempts = await attemptsFor(message, 3);
+
+        shouldBeChained(attempts);
+        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task requeue_links_each_attempt_to_the_one_before_it()
+    {
+        var message = new LocalRequeue(Guid.NewGuid(), 2);
+
+        var attempts = await attemptsFor(message, 3);
+
+        shouldBeChained(attempts);
+        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
+    }
+
+    // A Rabbit MQ requeue acks the delivery and publishes a fresh copy, so the only way the next attempt can
+    // know what failed before it is a header that survived the round trip through the broker
+
+    [Fact]
+    public async Task requeue_through_an_inline_rabbitmq_listener_carries_the_link_across_the_broker()
+    {
+        var message = new RabbitInlineRequeue(Guid.NewGuid(), 1);
+
+        var attempts = await attemptsFor(message, 2, processedInsideReceiveSpan: true);
+
+        shouldBeChained(attempts);
+        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task requeue_through_a_buffered_rabbitmq_listener_links_the_process_span_not_the_receive_span()
+    {
+        var message = new RabbitBufferedRequeue(Guid.NewGuid(), 1);
+
+        var attempts = await attemptsFor(message, 2);
+
+        shouldBeChained(attempts);
+        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
+
+        // The receive span starts before the pipeline does, so it must not be the span that takes the link
+        var messageId = attempts[0].GetTagItem(WolverineTracing.MessagingMessageId)!.ToString();
+        var receives = _spans.Snapshot()
+            .Where(x => x.DisplayName == "receive" &&
+                        x.GetTagItem(WolverineTracing.MessagingMessageId)?.ToString() == messageId)
+            .ToArray();
+
+        receives.Length.ShouldBe(2);
+        receives.ShouldAllBe(x => !x.Links.Any());
+    }
+
+    private async Task<Activity[]> attemptsFor<T>(T message, int expectedAttempts,
+        bool processedInsideReceiveSpan = false) where T : notnull
+    {
+        var session = await _host
+            .TrackActivity()
+            .DoNotAssertOnExceptionsDetected()
+            .IncludeExternalTransports()
+            .Timeout(30.Seconds())
+            .SendMessageAndWaitAsync(message);
+
+        var envelope = session.MessageSucceeded.SingleEnvelope<T>();
+        var messageId = envelope.Id.ToString();
+        var spanName = processedInsideReceiveSpan ? "receive" : envelope.MessageType;
+
+        // The tracked session completes when the message succeeds, which can be a beat before the pipeline's
+        // finally stops -- and therefore exports -- the final attempt's span
+        var attempts = await _spans.WaitForAsync(
+            x => x.DisplayName == spanName &&
+                 x.GetTagItem(WolverineTracing.MessagingMessageId)?.ToString() == messageId,
+            expectedAttempts);
+
+        attempts.Length.ShouldBe(expectedAttempts);
+
+        return attempts.OrderBy(x => x.StartTimeUtc).ToArray();
+    }
+
+    private static void shouldBeChained(Activity[] attempts)
+    {
+        attempts[0].Links.ShouldBeEmpty();
+
+        for (var i = 1; i < attempts.Length; i++)
+        {
+            var link = attempts[i].Links.ShouldHaveSingleItem();
+            link.Context.TraceId.ShouldBe(attempts[i - 1].TraceId);
+            link.Context.SpanId.ShouldBe(attempts[i - 1].SpanId);
+        }
+    }
+}
+
+public record LocalRetryNow(Guid Id, int Failures);
+
+public record LocalScheduledRetry(Guid Id, int Failures);
+
+public record LocalRequeue(Guid Id, int Failures);
+
+public record RabbitInlineRequeue(Guid Id, int Failures);
+
+public record RabbitBufferedRequeue(Guid Id, int Failures);
+
+public class RetryNowFailure() : Exception("Failing so the message is retried inline");
+
+public class ScheduledRetryFailure() : Exception("Failing so the message is rescheduled");
+
+public class RequeueFailure() : Exception("Failing so the message is requeued");
+
+public class RetryLinkHandler
+{
+    private static readonly ConcurrentDictionary<Guid, int> _attempts = new();
+    private static readonly ConcurrentDictionary<Guid, bool> _sawHeader = new();
+
+    public static bool SawPreviousAttemptHeader(Guid id) => _sawHeader.ContainsKey(id);
+
+    public void Handle(LocalRetryNow message, Envelope envelope) =>
+        failUntil<RetryNowFailure>(message.Id, message.Failures, envelope);
+
+    public void Handle(LocalScheduledRetry message, Envelope envelope) =>
+        failUntil<ScheduledRetryFailure>(message.Id, message.Failures, envelope);
+
+    public void Handle(LocalRequeue message, Envelope envelope) =>
+        failUntil<RequeueFailure>(message.Id, message.Failures, envelope);
+
+    public void Handle(RabbitInlineRequeue message, Envelope envelope) =>
+        failUntil<RequeueFailure>(message.Id, message.Failures, envelope);
+
+    public void Handle(RabbitBufferedRequeue message, Envelope envelope) =>
+        failUntil<RequeueFailure>(message.Id, message.Failures, envelope);
+
+    private static void failUntil<T>(Guid id, int failures, Envelope envelope) where T : Exception, new()
+    {
+        // The pipeline consumes the header before the handler runs, so a handler -- and anything it
+        // cascades or propagates -- never sees it
+        if (envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out _))
+        {
+            _sawHeader[id] = true;
+        }
+
+        if (_attempts.AddOrUpdate(id, 1, (_, count) => count + 1) <= failures)
+        {
+            throw new T();
+        }
+    }
+}
+
+/// <summary>
+/// The in-memory exporter appends from whichever thread stopped the span; this is only a lock around a list
+/// so a test can read it while the host is still exporting.
+/// </summary>
+internal class ExportedSpans : ICollection<Activity>
+{
+    private readonly List<Activity> _inner = new();
+    private readonly object _lock = new();
+
+    public Activity[] Snapshot()
+    {
+        lock (_lock) return _inner.ToArray();
+    }
+
+    public async Task<Activity[]> WaitForAsync(Func<Activity, bool> filter, int count)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (true)
+        {
+            var matches = Snapshot().Where(filter).ToArray();
+            if (matches.Length >= count || DateTime.UtcNow > deadline) return matches;
+
+            await Task.Delay(25);
+        }
+    }
+
+    public void Add(Activity item)
+    {
+        lock (_lock) _inner.Add(item);
+    }
+
+    public void Clear()
+    {
+        lock (_lock) _inner.Clear();
+    }
+
+    public bool Contains(Activity item)
+    {
+        lock (_lock) return _inner.Contains(item);
+    }
+
+    public void CopyTo(Activity[] array, int arrayIndex)
+    {
+        lock (_lock) _inner.CopyTo(array, arrayIndex);
+    }
+
+    public bool Remove(Activity item)
+    {
+        lock (_lock) return _inner.Remove(item);
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_lock) return _inner.Count;
+        }
+    }
+
+    public bool IsReadOnly => false;
+
+    public IEnumerator<Activity> GetEnumerator() => ((IEnumerable<Activity>)Snapshot()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Testing/OpenTelemetry/TracingTests/retry_attempt_links.cs
+++ b/src/Testing/OpenTelemetry/TracingTests/retry_attempt_links.cs
@@ -17,6 +17,16 @@ namespace TracingTests;
 /// GH-4398. End to end through the real OpenTelemetry SDK: every Wolverine span this host produces goes
 /// through the SDK's sampler and export pipeline into an in-memory exporter, so these tests assert on what
 /// a trace backend would actually have received rather than on Activity objects poked at in isolation.
+///
+/// Every failure policy that gives a message another attempt runs against both shapes of listener, because
+/// they reach the handler pipeline by different doors. Inline (Rabbit MQ's default) hands the receive span
+/// to the pipeline as the span the handler runs in. Buffered starts a short receive span first and a separate
+/// process span later -- Durable does exactly the same, so Buffered stands in for both. Local queues cannot
+/// run Inline at all, so the Inline half of the matrix is Rabbit MQ's.
+///
+/// Which span an attempt "is" differs by path -- a retry-now on an Inline listener re-runs the pipeline in a
+/// new process span, and with no message store a scheduled retry comes back through the local replies queue
+/// -- so rather than guessing from span names, the handler records the span it actually ran in.
 /// </summary>
 [Collection("otel")]
 public class retry_attempt_links : IAsyncLifetime
@@ -44,14 +54,13 @@ public class retry_attempt_links : IAsyncLifetime
 
                 opts.UseRabbitMq().AutoProvision().AutoPurgeOnStartup();
 
-                // Inline (Rabbit MQ's default) hands the receive span to the pipeline as the span the handler
-                // runs in; buffered starts a separate short receive span first and a process span later. Both
-                // are covered because they reach the pipeline by different doors.
-                opts.PublishMessage<RabbitInlineRequeue>().ToRabbitQueue(InlineQueue);
-                opts.ListenToRabbitQueue(InlineQueue);
+                opts.PublishMessage<RabbitInlineAttempt>().ToRabbitQueue(InlineQueue);
+                opts.ListenToRabbitQueue(InlineQueue).ProcessInline();
 
-                opts.PublishMessage<RabbitBufferedRequeue>().ToRabbitQueue(BufferedQueue);
+                opts.PublishMessage<RabbitBufferedAttempt>().ToRabbitQueue(BufferedQueue);
                 opts.ListenToRabbitQueue(BufferedQueue).BufferedInMemory();
+
+                // LocalBufferedAttempt stays on its conventional local queue, which is buffered
 
                 opts.Services.AddOpenTelemetry()
                     .WithTracing(tracing => tracing.AddSource("Wolverine").AddInMemoryExporter(_spans));
@@ -64,85 +73,70 @@ public class retry_attempt_links : IAsyncLifetime
         _host.Dispose();
     }
 
-    [Fact]
-    public async Task an_attempt_that_succeeds_first_time_has_no_links()
+    public static TheoryData<ListenerKind, FailureKind> EveryListenerAndFailurePolicy()
     {
-        var attempts = await attemptsFor(new LocalRetryNow(Guid.NewGuid(), 0), 1);
+        var data = new TheoryData<ListenerKind, FailureKind>();
+        foreach (var listener in Enum.GetValues<ListenerKind>())
+        foreach (var failure in Enum.GetValues<FailureKind>())
+        {
+            data.Add(listener, failure);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(EveryListenerAndFailurePolicy))]
+    public async Task each_attempt_links_to_the_one_before_it(ListenerKind listener, FailureKind failure)
+    {
+        var id = Guid.NewGuid();
+
+        var (attempts, everyOtherSpan) = await attemptsFor(listener, new Attempt(id, failure, 2), 3);
+
+        attempts[0].Links.ShouldBeEmpty();
+        for (var i = 1; i < attempts.Length; i++)
+        {
+            var link = attempts[i].Links.ShouldHaveSingleItem();
+            link.Context.TraceId.ShouldBe(attempts[i - 1].TraceId);
+            link.Context.SpanId.ShouldBe(attempts[i - 1].SpanId);
+        }
+
+        // The pipeline consumes the header before the handler runs, so a handler -- and anything it cascades
+        // or propagates -- never sees it
+        RetryLinkHandler.SawPreviousAttemptHeader(id).ShouldBeFalse();
+
+        // Only the spans the handler ran in may carry the link. A buffered listener's receive span starts
+        // before the pipeline does, which is exactly the span that must not take it.
+        if (listener == ListenerKind.RabbitBuffered) everyOtherSpan.ShouldNotBeEmpty();
+        everyOtherSpan.ShouldAllBe(x => !x.Links.Any());
+    }
+
+    [Theory]
+    [InlineData(ListenerKind.LocalBuffered)]
+    [InlineData(ListenerKind.RabbitInline)]
+    [InlineData(ListenerKind.RabbitBuffered)]
+    public async Task an_attempt_that_succeeds_first_time_has_no_links(ListenerKind listener)
+    {
+        var (attempts, _) = await attemptsFor(listener, new Attempt(Guid.NewGuid(), FailureKind.RetryNow, 0), 1);
 
         attempts.Single().Links.ShouldBeEmpty();
     }
 
-    [Fact]
-    public async Task retry_now_links_each_attempt_to_the_one_before_it()
+    /// <summary>
+    /// Returns the exported span each attempt's handler ran in, in attempt order, and every other exported
+    /// span for the same message.
+    /// </summary>
+    private async Task<(Activity[] attempts, Activity[] everyOtherSpan)> attemptsFor(ListenerKind listener,
+        Attempt attempt, int expectedAttempts)
     {
-        var message = new LocalRetryNow(Guid.NewGuid(), 2);
+        object message = listener switch
+        {
+            ListenerKind.LocalBuffered => new LocalBufferedAttempt(attempt),
+            ListenerKind.RabbitInline => new RabbitInlineAttempt(attempt),
+            ListenerKind.RabbitBuffered => new RabbitBufferedAttempt(attempt),
+            _ => throw new ArgumentOutOfRangeException(nameof(listener))
+        };
 
-        var attempts = await attemptsFor(message, 3);
-
-        shouldBeChained(attempts);
-        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task scheduled_retry_links_each_attempt_to_the_one_before_it()
-    {
-        var message = new LocalScheduledRetry(Guid.NewGuid(), 2);
-
-        var attempts = await attemptsFor(message, 3);
-
-        shouldBeChained(attempts);
-        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task requeue_links_each_attempt_to_the_one_before_it()
-    {
-        var message = new LocalRequeue(Guid.NewGuid(), 2);
-
-        var attempts = await attemptsFor(message, 3);
-
-        shouldBeChained(attempts);
-        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
-    }
-
-    // A Rabbit MQ requeue acks the delivery and publishes a fresh copy, so the only way the next attempt can
-    // know what failed before it is a header that survived the round trip through the broker
-
-    [Fact]
-    public async Task requeue_through_an_inline_rabbitmq_listener_carries_the_link_across_the_broker()
-    {
-        var message = new RabbitInlineRequeue(Guid.NewGuid(), 1);
-
-        var attempts = await attemptsFor(message, 2, processedInsideReceiveSpan: true);
-
-        shouldBeChained(attempts);
-        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task requeue_through_a_buffered_rabbitmq_listener_links_the_process_span_not_the_receive_span()
-    {
-        var message = new RabbitBufferedRequeue(Guid.NewGuid(), 1);
-
-        var attempts = await attemptsFor(message, 2);
-
-        shouldBeChained(attempts);
-        RetryLinkHandler.SawPreviousAttemptHeader(message.Id).ShouldBeFalse();
-
-        // The receive span starts before the pipeline does, so it must not be the span that takes the link
-        var messageId = attempts[0].GetTagItem(WolverineTracing.MessagingMessageId)!.ToString();
-        var receives = _spans.Snapshot()
-            .Where(x => x.DisplayName == "receive" &&
-                        x.GetTagItem(WolverineTracing.MessagingMessageId)?.ToString() == messageId)
-            .ToArray();
-
-        receives.Length.ShouldBe(2);
-        receives.ShouldAllBe(x => !x.Links.Any());
-    }
-
-    private async Task<Activity[]> attemptsFor<T>(T message, int expectedAttempts,
-        bool processedInsideReceiveSpan = false) where T : notnull
-    {
         var session = await _host
             .TrackActivity()
             .DoNotAssertOnExceptionsDetected()
@@ -150,44 +144,49 @@ public class retry_attempt_links : IAsyncLifetime
             .Timeout(30.Seconds())
             .SendMessageAndWaitAsync(message);
 
-        var envelope = session.MessageSucceeded.SingleEnvelope<T>();
-        var messageId = envelope.Id.ToString();
-        var spanName = processedInsideReceiveSpan ? "receive" : envelope.MessageType;
+        session.MessageSucceeded.Envelopes().ShouldContain(x => x.Message!.GetType() == message.GetType());
+
+        var handlerSpans = RetryLinkHandler.SpansFor(attempt.Id);
+        handlerSpans.Length.ShouldBe(expectedAttempts);
 
         // The tracked session completes when the message succeeds, which can be a beat before the pipeline's
         // finally stops -- and therefore exports -- the final attempt's span
-        var attempts = await _spans.WaitForAsync(
-            x => x.DisplayName == spanName &&
-                 x.GetTagItem(WolverineTracing.MessagingMessageId)?.ToString() == messageId,
-            expectedAttempts);
+        var exported = await _spans.WaitForAsync(x => handlerSpans.Contains(x.SpanId), expectedAttempts);
+        exported.Length.ShouldBe(expectedAttempts);
 
-        attempts.Length.ShouldBe(expectedAttempts);
+        var attempts = handlerSpans.Select(spanId => exported.Single(x => x.SpanId == spanId)).ToArray();
 
-        return attempts.OrderBy(x => x.StartTimeUtc).ToArray();
-    }
+        var messageId = attempts[0].GetTagItem(WolverineTracing.MessagingMessageId)!.ToString();
+        var everyOtherSpan = _spans.Snapshot()
+            .Where(x => !handlerSpans.Contains(x.SpanId) &&
+                        x.GetTagItem(WolverineTracing.MessagingMessageId)?.ToString() == messageId)
+            .ToArray();
 
-    private static void shouldBeChained(Activity[] attempts)
-    {
-        attempts[0].Links.ShouldBeEmpty();
-
-        for (var i = 1; i < attempts.Length; i++)
-        {
-            var link = attempts[i].Links.ShouldHaveSingleItem();
-            link.Context.TraceId.ShouldBe(attempts[i - 1].TraceId);
-            link.Context.SpanId.ShouldBe(attempts[i - 1].SpanId);
-        }
+        return (attempts, everyOtherSpan);
     }
 }
 
-public record LocalRetryNow(Guid Id, int Failures);
+public enum ListenerKind
+{
+    LocalBuffered,
+    RabbitInline,
+    RabbitBuffered
+}
 
-public record LocalScheduledRetry(Guid Id, int Failures);
+public enum FailureKind
+{
+    RetryNow,
+    ScheduledRetry,
+    Requeue
+}
 
-public record LocalRequeue(Guid Id, int Failures);
+public record Attempt(Guid Id, FailureKind Failure, int Failures);
 
-public record RabbitInlineRequeue(Guid Id, int Failures);
+public record LocalBufferedAttempt(Attempt Attempt);
 
-public record RabbitBufferedRequeue(Guid Id, int Failures);
+public record RabbitInlineAttempt(Attempt Attempt);
+
+public record RabbitBufferedAttempt(Attempt Attempt);
 
 public class RetryNowFailure() : Exception("Failing so the message is retried inline");
 
@@ -197,39 +196,42 @@ public class RequeueFailure() : Exception("Failing so the message is requeued");
 
 public class RetryLinkHandler
 {
-    private static readonly ConcurrentDictionary<Guid, int> _attempts = new();
+    private static readonly ConcurrentDictionary<Guid, ConcurrentQueue<ActivitySpanId>> _spans = new();
     private static readonly ConcurrentDictionary<Guid, bool> _sawHeader = new();
 
     public static bool SawPreviousAttemptHeader(Guid id) => _sawHeader.ContainsKey(id);
 
-    public void Handle(LocalRetryNow message, Envelope envelope) =>
-        failUntil<RetryNowFailure>(message.Id, message.Failures, envelope);
+    public static ActivitySpanId[] SpansFor(Guid id) =>
+        _spans.TryGetValue(id, out var spans) ? spans.ToArray() : [];
 
-    public void Handle(LocalScheduledRetry message, Envelope envelope) =>
-        failUntil<ScheduledRetryFailure>(message.Id, message.Failures, envelope);
+    public void Handle(LocalBufferedAttempt message, Envelope envelope) => failUntil(message.Attempt, envelope);
 
-    public void Handle(LocalRequeue message, Envelope envelope) =>
-        failUntil<RequeueFailure>(message.Id, message.Failures, envelope);
+    public void Handle(RabbitInlineAttempt message, Envelope envelope) => failUntil(message.Attempt, envelope);
 
-    public void Handle(RabbitInlineRequeue message, Envelope envelope) =>
-        failUntil<RequeueFailure>(message.Id, message.Failures, envelope);
+    public void Handle(RabbitBufferedAttempt message, Envelope envelope) => failUntil(message.Attempt, envelope);
 
-    public void Handle(RabbitBufferedRequeue message, Envelope envelope) =>
-        failUntil<RequeueFailure>(message.Id, message.Failures, envelope);
-
-    private static void failUntil<T>(Guid id, int failures, Envelope envelope) where T : Exception, new()
+    private static void failUntil(Attempt attempt, Envelope envelope)
     {
-        // The pipeline consumes the header before the handler runs, so a handler -- and anything it
-        // cascades or propagates -- never sees it
         if (envelope.TryGetHeader(EnvelopeConstants.PreviousAttemptActivityIdKey, out _))
         {
-            _sawHeader[id] = true;
+            _sawHeader[attempt.Id] = true;
         }
 
-        if (_attempts.AddOrUpdate(id, 1, (_, count) => count + 1) <= failures)
+        var spans = _spans.GetOrAdd(attempt.Id, _ => new ConcurrentQueue<ActivitySpanId>());
+        spans.Enqueue(Activity.Current!.SpanId);
+
+        if (spans.Count > attempt.Failures)
         {
-            throw new T();
+            return;
         }
+
+        throw attempt.Failure switch
+        {
+            FailureKind.RetryNow => new RetryNowFailure(),
+            FailureKind.ScheduledRetry => new ScheduledRetryFailure(),
+            FailureKind.Requeue => new RequeueFailure(),
+            _ => new ArgumentOutOfRangeException(nameof(attempt))
+        };
     }
 }
 

--- a/src/Wolverine/EnvelopeConstants.cs
+++ b/src/Wolverine/EnvelopeConstants.cs
@@ -31,6 +31,15 @@ public static class EnvelopeConstants
     public const string CausationIdKey = "causation-id";
 
     /// <summary>
+    ///     The W3C id of the failed processing attempt that an error handling continuation retried, requeued or
+    ///     rescheduled. The next attempt's span carries it as an <see cref="System.Diagnostics.ActivityLink" />.
+    ///     Deliberately a loose <see cref="Envelope.Headers" /> entry rather than a mapped envelope property, so an
+    ///     envelope that is never retried pays nothing for it in any transport mapper or in the envelope
+    ///     serializer. See GH-4398.
+    /// </summary>
+    public const string PreviousAttemptActivityIdKey = "previous-attempt-activity-id";
+
+    /// <summary>
     ///     The format <see cref="Wolverine.Transports.EnvelopeMapper{TIncoming,TOutgoing}" /> uses when it writes
     ///     <see cref="DateTimeOffset" /> envelope properties (<c>time-to-send</c>, <c>deliver-by</c>) into
     ///     transport headers. It is deliberately NOT round-trippable by <c>DateTime.Parse</c> or

--- a/src/Wolverine/ErrorHandling/RequeueContinuation.cs
+++ b/src/Wolverine/ErrorHandling/RequeueContinuation.cs
@@ -33,6 +33,7 @@ internal class RequeueContinuation : IContinuation, IContinuationSource, IJitter
         Activity? activity)
     {
         activity?.AddEvent(new ActivityEvent(WolverineTracing.EnvelopeRequeued));
+        WolverineTracing.RecordPreviousAttempt(lifecycle.Envelope, activity);
 
         if (Delay != null)
         {

--- a/src/Wolverine/ErrorHandling/RetryInlineContinuation.cs
+++ b/src/Wolverine/ErrorHandling/RetryInlineContinuation.cs
@@ -39,6 +39,7 @@ internal class RetryInlineContinuation : IContinuation, IContinuationSource, IIn
         }
 
         activity?.AddEvent(new ActivityEvent(WolverineTracing.EnvelopeRetry));
+        WolverineTracing.RecordPreviousAttempt(lifecycle.Envelope, activity);
 
         await lifecycle.RetryExecutionNowAsync().ConfigureAwait(false);
     }

--- a/src/Wolverine/ErrorHandling/ScheduledRetryContinuation.cs
+++ b/src/Wolverine/ErrorHandling/ScheduledRetryContinuation.cs
@@ -25,6 +25,7 @@ internal class ScheduledRetryContinuation : IContinuation, IContinuationSource, 
         Activity? activity)
     {
         activity?.AddEvent(new ActivityEvent(WolverineTracing.ScheduledRetry));
+        WolverineTracing.RecordPreviousAttempt(lifecycle.Envelope, activity);
         var effective = _jitter?.Apply(_delay, lifecycle.Envelope?.Attempts ?? 1) ?? _delay;
         var scheduledTime = now.Add(effective);
 

--- a/src/Wolverine/Runtime/HandlerPipeline.cs
+++ b/src/Wolverine/Runtime/HandlerPipeline.cs
@@ -88,6 +88,8 @@ public class HandlerPipeline : IHandlerPipeline
                 return;
             }
 
+            WolverineTracing.LinkToPreviousAttempt(activity, envelope);
+
             var context = _contextPool.Get();
             context.ReadEnvelope(envelope, channel);
 

--- a/src/Wolverine/Runtime/WolverineTracing.cs
+++ b/src/Wolverine/Runtime/WolverineTracing.cs
@@ -304,6 +304,43 @@ public static class WolverineTracing
         return activity;
     }
 
+    /// <summary>
+    /// Called by the error handling continuations that give a failed envelope another attempt (retry now,
+    /// scheduled retry, requeue) to remember which activity failed. See GH-4398.
+    /// </summary>
+    internal static void RecordPreviousAttempt(Envelope? envelope, Activity? activity)
+    {
+        var id = activity?.Id;
+        if (envelope == null || id == null) return;
+
+        envelope.Headers[EnvelopeConstants.PreviousAttemptActivityIdKey] = id;
+    }
+
+    /// <summary>
+    /// Link the activity running this attempt back to the failed attempt before it, then drop the header so the
+    /// link is single-use and never travels onward with anything this attempt does next. A link rather than a
+    /// parent because a retry does not temporally contain the attempt that failed before it -- the OpenTelemetry
+    /// messaging conventions use a link for exactly this, as do MassTransit and Brighter.
+    ///
+    /// Runs once per message in the handler pipeline, which is the one place every attempt converges -- doing it
+    /// at span start instead would hand the link to whichever span a receiver happened to start first. The
+    /// HasHeaders guard keeps it from allocating the lazy headers dictionary on the overwhelmingly common
+    /// envelope that carries none. See GH-4398.
+    /// </summary>
+    internal static void LinkToPreviousAttempt(Activity? activity, Envelope envelope)
+    {
+        if (!envelope.HasHeaders ||
+            !envelope.Headers.Remove(EnvelopeConstants.PreviousAttemptActivityIdKey, out var previous))
+        {
+            return;
+        }
+
+        if (activity != null && ActivityContext.TryParse(previous, null, out var context))
+        {
+            activity.AddLink(new ActivityLink(context));
+        }
+    }
+
     internal static void MaybeSetTag<T>(this Activity activity, string tagName, T? value)
     {
         if (value != null)


### PR DESCRIPTION
Closes #4398. Supersedes #4402 by @outofrange-consulting, who is credited as co-author on the commits. That PR got the design right: link the next attempt to the failed one with an `ActivityLink` instead of reparenting it, which matches the [OpenTelemetry messaging conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/) and what MassTransit and Brighter do. This PR keeps that design and changes two things: where the link lands, and how it is carried.

## What changed compared with #4402

**1. The link goes on the span the handler runs in.** #4402 used up the link in `StartEnvelopeActivity`. That method serves send, receive and execute spans, and every receiver starts its `receive` span before the pipeline starts the execute span:
- `BufferedReceiver`
- `DurableReceiver`
- `NativeAckReceiver`
- `InlineReceiver`

So on a buffered, durable or NativeAck listener, the short receive span took the link and cleared it, and the process span got nothing. Here the link is attached in `HandlerPipeline.InvokeAsync(envelope, channel, activity)`, the one place every attempt goes through, using .NET 9's `Activity.AddLink`. On Inline and NativeAck listeners the receiver passes its receive span in as the processing span, so this covers those too.

**2. A loose header, not a mapped `Envelope` property, so messages that are never retried pay nothing.** A mapped property adds one more reserved-header read for every incoming message in every transport mapper, plus a new `Envelope` field and serializer work. Custom headers already round-trip through every mapper and through `EnvelopeSerializer`. The pipeline check is `HasHeaders` first, so it never creates the lazy headers dictionary. It also makes `Envelope.Reset()` pool-safe without a new line, because `_headers` is already cleared there.

The header is removed before the handler runs. So a handler, and anything it cascades or propagates with `PropagateIncomingHeadersToOutgoing`, never sees it.

## Known limitation

A durable-inbox reschedule (`RescheduleExistingEnvelopeForRetryAsync`) only `UPDATE`s the row's time, attempts and status. It does not rewrite the stored body, so the link does not survive that path. Supporting it would mean rewriting the body on every durable retry across all the message stores. That is a separate decision about cost, and this PR does not make it. The in-memory scheduler, local queues and broker requeues all carry the link.

## Tests

- **End to end: `TracingTests/retry_attempt_links`.** A real Wolverine host runs through the real OpenTelemetry SDK into `OpenTelemetry.Exporter.InMemory`, a new test-only dependency pinned to 1.15.3 like the other OTel packages. The assertions are on the spans that were actually exported.
  - **The matrix covers every failure policy on every listener shape:**

    | | Local queue (Buffered) | RabbitMQ Inline | RabbitMQ Buffered |
    |---|---|---|---|
    | Retry now | ✓ | ✓ | ✓ |
    | Scheduled retry | ✓ | ✓ | ✓ |
    | Requeue | ✓ | ✓ | ✓ |

    Inline and Buffered reach the pipeline by different routes: Inline hands its receive span over as the handler's span, while Buffered starts a separate receive span first. Durable behaves like Buffered here, so Buffered stands in for both. Local queues can't run Inline, so the Inline column is RabbitMQ.
  - **Each cell checks that:**
    - each attempt's span links to the previous attempt's span
    - no other span for that message carries a link, which is the #4402 defect
    - the handler never sees the header
  - **Attempts are identified by the span the handler actually ran in, not by span name.** A retry-now on an Inline listener reruns the pipeline in a new process span, and with no message store a scheduled retry comes back through the local `replies` queue.
  - A first attempt that succeeds has no links, on each listener.
  - **Negative control:** against `origin/main`'s `HandlerPipeline`, exactly the 9 link cells fail and the 3 first-attempt cells pass.
- **Unit tests, adapted from #4402:** each continuation records the failed attempt, and `LinkToPreviousAttempt` links, uses up the header, ignores malformed ids and handles a missing activity.
- **Local runs:**
  - `CoreTests`: 2910 passed, 2 skipped, 0 failed
  - `TracingTests`: 19 of 19 passed
  - `dotnet build wolverine.slnx -c Release -f net9.0`: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj
