### PR TITLE
GH-4397: count every batched member per pipeline, not just listener arrivals

### DIFF
--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -253,6 +253,44 @@ that refers to the original message is completely processed. See [Durability and
 settlement](#durability-and-message-settlement) above for the full settlement model and why a durable listener
 is required for guaranteed delivery.
 
+<!-- DRAFT (GH-4397): wording for Jeremy to review before merge -->
+## Waiting for batches to finish <Badge type="tip" text="6.35" />
+
+Let's say you've got an integration test that causes some batched messages, and before the next test resets
+the database you want to be sure every one of those batches has actually run. Otherwise a batch sitting out its
+`TriggerTime` can fire *after* the reset and fail against data that's no longer there.
+
+Wolverine keeps a running count of every member message that's somewhere inside a batching pipeline -- waiting
+to be batched, sitting in an assembled batch, or executing in your batch handler -- and you can ask for it through
+`BatchingPendingCounts` on the Wolverine runtime:
+
+```csharp
+var counts = host.GetRuntime().BatchingPendingCounts;
+
+// Members of BatchMessagesOf<Item>() that haven't finished yet, however they arrived
+var pending = counts.PendingForBatchedMessage<Item>();
+
+// Or across every batching pipeline in the application
+var total = counts.TotalPendingBatchMembers;
+```
+
+A member is released when the batch it belongs to reaches its terminal, success or failure, so a count of
+zero means the batch handler has finished (including committing its transaction if you're using transactional
+middleware).
+
+::: warning
+A member is only counted once the batching processor picks it up from the element type's local queue. Right after
+you publish, the count can still read zero because the message hasn't gotten there yet, so wait for the count to
+go up before you wait for it to come back down -- or just use a [tracked session](/guide/testing), which handles
+all of this for you.
+:::
+
+::: info
+`BatchingPendingCounts.PendingFor(Uri)` is a different number. It only counts members that arrived through a
+specific transport listener, because it exists to feed that listener's back-pressure. Members you publish
+in-process, including cascading messages, never show up there.
+:::
+
 ## Message expiration (`DeliverBy` / `DeliverWithin`) <Badge type="tip" text="6.26" />
 
 Batched messages honor member-level [message expiration](/guide/messages) the same way unbatched messages do,

--- a/docs/guide/handlers/batching.md
+++ b/docs/guide/handlers/batching.md
@@ -253,7 +253,6 @@ that refers to the original message is completely processed. See [Durability and
 settlement](#durability-and-message-settlement) above for the full settlement model and why a durable listener
 is required for guaranteed delivery.
 
-<!-- DRAFT (GH-4397): wording for Jeremy to review before merge -->
 ## Waiting for batches to finish <Badge type="tip" text="6.35" />
 
 Let's say you've got an integration test that causes some batched messages, and before the next test resets

--- a/src/Persistence/MartenTests/batch_processing.cs
+++ b/src/Persistence/MartenTests/batch_processing.cs
@@ -101,6 +101,82 @@ public class batch_processing
     }
 
     [Fact]
+    public async Task pending_count_covers_locally_published_members_on_durable_local_queues()
+    {
+        // GH-4397, the reporter's shape: in-process publishes onto durable local queues. Those members have
+        // no listener, so only the per-pipeline count sees them, and it must not reach zero until the batch
+        // handler's transaction has committed.
+        using var theHost = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Services.AddMarten(m =>
+                {
+                    m.DisableNpgsqlLogging = true;
+                    m.DatabaseSchemaName = "batch_pending";
+                    m.Connection(Servers.PostgresConnectionString);
+                }).IntegrateWithWolverine();
+
+                opts.Policies.AutoApplyTransactions();
+                opts.Policies.UseDurableLocalQueues();
+
+                opts.BatchMessagesOf<BatchItem>(batching =>
+                {
+                    batching.TriggerTime = 1.Seconds();
+                    batching.BatchSize = 8;
+                }).Sequential();
+
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(BatchItemHandler));
+                opts.Durability.Mode = DurabilityMode.Solo;
+            }).StartAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        await theHost.CleanAllMartenDataAsync();
+        await theHost.ResetResourceState(cancellation: TestContext.Current.CancellationToken);
+
+        var counts = theHost.GetRuntime().BatchingPendingCounts;
+        var items = new[]
+        {
+            new BatchItem("one", Guid.NewGuid()),
+            new BatchItem("two", Guid.NewGuid()),
+            new BatchItem("three", Guid.NewGuid())
+        };
+
+        var bus = theHost.MessageBus();
+        foreach (var item in items)
+        {
+            await bus.PublishAsync(item);
+        }
+
+        await waitUntil(() => counts.PendingForBatchedMessage<BatchItem>() == items.Length,
+            "every published member to be counted as pending");
+
+        await waitUntil(() => counts.PendingForBatchedMessage<BatchItem>() == 0,
+            "the batch to reach its terminal");
+
+        // Zero means the batch handler ran AND its transaction committed
+        using var session = theHost.DocumentStore().LightweightSession();
+        var ids = items.Select(x => x.Id).ToArray();
+        var stored = await session.Query<BatchItem>().Where(x => x.Id.IsOneOf(ids))
+            .CountAsync(token: TestContext.Current.CancellationToken);
+
+        stored.ShouldBe(items.Length);
+    }
+
+    private static async Task waitUntil(Func<bool> condition, string description)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"Timed out waiting for {description}");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+
+    [Fact]
     public async Task end_to_end_with_tenancy()
     {
         using var theHost = await Host.CreateDefaultBuilder()

--- a/src/Testing/CoreTests/Acceptance/batching_pending_counts_for_local_members.cs
+++ b/src/Testing/CoreTests/Acceptance/batching_pending_counts_for_local_members.cs
@@ -1,0 +1,128 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Microsoft.Extensions.Hosting;
+using System.Collections.Concurrent;
+using Wolverine.Runtime;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace CoreTests.Acceptance;
+
+/// <summary>
+/// GH-4397. Members published in-process -- here, cascaded from another handler -- have no listener, so the
+/// listener-keyed back-pressure count never sees them. The per-pipeline count has to, because "has every
+/// batch this test caused finished?" is exactly what an integration test harness needs to ask.
+/// </summary>
+public class batching_pending_counts_for_local_members : IAsyncLifetime
+{
+    private IHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _host = await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.Discovery.DisableConventionalDiscovery()
+                    .IncludeType(typeof(StartEnrollmentsHandler))
+                    .IncludeType(typeof(PendingEnrollmentBatchHandler));
+
+                // Well past the time it takes to observe the members as pending, so the batch fires on its
+                // trigger time rather than racing the assertions
+                opts.BatchMessagesOf<PendingEnrollment>(batching =>
+                {
+                    batching.BatchSize = 100;
+                    batching.TriggerTime = 1.Seconds();
+                }).Sequential();
+            }).StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task a_cascaded_member_is_pending_until_its_batch_handler_has_finished()
+    {
+        var counts = _host.GetRuntime().BatchingPendingCounts;
+        var id = Guid.NewGuid();
+
+        counts.PendingForBatchedMessage<PendingEnrollment>().ShouldBe(0);
+
+        await _host.MessageBus().PublishAsync(new StartEnrollments(id, 3));
+
+        await waitUntil(() => counts.PendingForBatchedMessage<PendingEnrollment>() == 3,
+            "all three cascaded members to be counted as pending");
+
+        counts.TotalPendingBatchMembers.ShouldBe(3);
+
+        // The back-pressure view is unchanged: none of these members came through a listener
+        var elementQueue = _host.GetRuntime().RoutingFor(typeof(PendingEnrollment)).Routes.Single()
+            .As<Wolverine.Runtime.Routing.MessageRoute>().Sender.Destination;
+        counts.PendingFor(elementQueue).ShouldBe(0);
+
+        await waitUntil(() => counts.PendingForBatchedMessage<PendingEnrollment>() == 0,
+            "the batch to reach its terminal");
+
+        // Zero only once the batch handler has finished -- and while it ran, its members were still pending
+        PendingEnrollmentBatchHandler.Finished(id).ShouldBeTrue();
+        PendingEnrollmentBatchHandler.PendingSeenWhileExecuting(id).ShouldBe(3);
+        counts.TotalPendingBatchMembers.ShouldBe(0);
+    }
+
+    private static async Task waitUntil(Func<bool> condition, string description)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"Timed out waiting for {description}");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+}
+
+public record StartEnrollments(Guid Id, int Count);
+
+public record PendingEnrollment(Guid Id, int Number);
+
+public static class StartEnrollmentsHandler
+{
+    public static OutgoingMessages Handle(StartEnrollments command)
+    {
+        var messages = new OutgoingMessages();
+        for (var i = 0; i < command.Count; i++)
+        {
+            messages.Add(new PendingEnrollment(command.Id, i));
+        }
+
+        return messages;
+    }
+}
+
+public static class PendingEnrollmentBatchHandler
+{
+    private static readonly ConcurrentDictionary<Guid, int> _pendingWhileExecuting = new();
+    private static readonly ConcurrentDictionary<Guid, bool> _finished = new();
+
+    public static int PendingSeenWhileExecuting(Guid id) => _pendingWhileExecuting.GetValueOrDefault(id);
+
+    public static bool Finished(Guid id) => _finished.ContainsKey(id);
+
+    public static async Task Handle(PendingEnrollment[] enrollments, IWolverineRuntime runtime)
+    {
+        var id = enrollments[0].Id;
+        _pendingWhileExecuting[id] = runtime.As<WolverineRuntime>().BatchingPendingCounts
+            .PendingForBatchedMessage<PendingEnrollment>();
+
+        // Long enough that a count released at the start of execution, rather than at the terminal,
+        // would be caught by the test's wait for zero
+        await Task.Delay(250);
+
+        _finished[id] = true;
+    }
+}

--- a/src/Testing/CoreTests/Runtime/Batching/BatchingPendingCountsTests.cs
+++ b/src/Testing/CoreTests/Runtime/Batching/BatchingPendingCountsTests.cs
@@ -106,6 +106,145 @@ public class BatchingPendingCountsTests
         counts.PendingFor(Address).ShouldBe(1);
     }
 
+    // GH-4397 — the per-pipeline count, which does not care where a member came from
+
+    private const string BatchType = "pending-item-batch";
+
+    [Fact]
+    public void pipeline_counts_every_member_including_local_sends()
+    {
+        var counts = new BatchingPendingCounts();
+        var pipeline = counts.RegisterPipeline(typeof(PendingItem), BatchType);
+
+        // What BatchingProcessor does per member: one from a listener, one published locally
+        var remote = envelopeFrom(Address);
+        counts.Increment(remote.Listener!.Address);
+        pipeline.Increment();
+
+        var local = new Envelope(new PendingItem("local"));
+        counts.Increment(local.Listener?.Address);
+        pipeline.Increment();
+
+        counts.PendingForBatchedMessage<PendingItem>().ShouldBe(2);
+        counts.TotalPendingBatchMembers.ShouldBe(2);
+
+        // The listener count keeps its back-pressure meaning: only what arrived through that listener
+        counts.PendingFor(Address).ShouldBe(1);
+    }
+
+    [Fact]
+    public void settling_a_counted_batch_releases_its_members_once()
+    {
+        var counts = new BatchingPendingCounts();
+        var pipeline = counts.RegisterPipeline(typeof(PendingItem), BatchType);
+        pipeline.Increment();
+        pipeline.Increment();
+        pipeline.Increment(); // a third member still waiting in the batching channel
+
+        var batch = countedBatch(new Envelope(new PendingItem("one")), new Envelope(new PendingItem("two")));
+
+        counts.SettleBatch(batch);
+        counts.SettleBatch(batch);
+
+        counts.PendingForBatchedMessage(typeof(PendingItem)).ShouldBe(1);
+    }
+
+    [Fact]
+    public void a_batch_nobody_counted_releases_nothing()
+    {
+        var counts = new BatchingPendingCounts();
+        var pipeline = counts.RegisterPipeline(typeof(PendingItem), BatchType);
+        pipeline.Increment();
+        pipeline.Increment();
+
+        var uncounted = new Envelope(new PendingItem[1], [new Envelope(new PendingItem("one"))])
+        {
+            MessageType = BatchType
+        };
+
+        counts.SettleBatch(uncounted);
+
+        counts.PendingForBatchedMessage<PendingItem>().ShouldBe(2);
+    }
+
+    [Fact]
+    public void a_replayed_batch_is_pending_until_its_own_terminal()
+    {
+        var counts = new BatchingPendingCounts();
+        counts.RegisterPipeline(typeof(PendingItem), BatchType);
+
+        var reduced = new Envelope(new PendingItem[2],
+            [new Envelope(new PendingItem("one")), new Envelope(new PendingItem("two"))])
+        {
+            MessageType = BatchType
+        };
+
+        counts.CountReplayedBatch(reduced);
+        counts.PendingForBatchedMessage<PendingItem>().ShouldBe(2);
+
+        counts.SettleBatch(reduced);
+        counts.PendingForBatchedMessage<PendingItem>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void a_replayed_batch_for_an_unregistered_pipeline_is_not_counted()
+    {
+        var counts = new BatchingPendingCounts();
+
+        var reduced = new Envelope(new PendingItem[1], [new Envelope(new PendingItem("one"))])
+        {
+            MessageType = "nothing-registered-this"
+        };
+
+        counts.CountReplayedBatch(reduced);
+        counts.SettleBatch(reduced);
+
+        counts.TotalPendingBatchMembers.ShouldBe(0);
+    }
+
+    [Fact]
+    public void pipeline_count_clamps_at_zero()
+    {
+        var counts = new BatchingPendingCounts();
+        var pipeline = counts.RegisterPipeline(typeof(PendingItem), BatchType);
+
+        pipeline.Decrement();
+        counts.PendingForBatchedMessage<PendingItem>().ShouldBe(0);
+
+        pipeline.Increment();
+        counts.SettleBatch(countedBatch(new Envelope(new PendingItem("one")), new Envelope(new PendingItem("two"))));
+        counts.PendingForBatchedMessage<PendingItem>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void registering_the_same_pipeline_twice_shares_one_counter()
+    {
+        // BatchingProcessor can be built more than once under a startup race
+        var counts = new BatchingPendingCounts();
+
+        var first = counts.RegisterPipeline(typeof(PendingItem), BatchType);
+        var second = counts.RegisterPipeline(typeof(PendingItem), BatchType);
+
+        second.ShouldBeSameAs(first);
+    }
+
+    [Fact]
+    public void an_element_type_with_no_pipeline_has_nothing_pending()
+    {
+        new BatchingPendingCounts().PendingForBatchedMessage<string>().ShouldBe(0);
+    }
+
+    private static Envelope countedBatch(params Envelope[] members)
+    {
+        return new Envelope(new PendingItem[members.Length], members)
+        {
+            MessageType = BatchType,
+            BatchPipelineCounted = true
+        };
+    }
+
+    public record PendingItem(string Name);
+
     private static Envelope envelopeFrom(Uri address)
     {
         return new Envelope(new object()) { Listener = new StubListener(address) };

--- a/src/Wolverine/Envelope.Internals.cs
+++ b/src/Wolverine/Envelope.Internals.cs
@@ -152,7 +152,16 @@ public partial class Envelope
     /// drive the pending count negative.
     /// </summary>
     internal bool BatchPendingSettled { get; set; }
-    
+
+    /// <summary>
+    /// GH-4397 — true on a grouped batch envelope whose members were counted into their batching
+    /// pipeline's total in <see cref="Runtime.Batching.BatchingPendingCounts"/>, so its terminal releases
+    /// them. Set by whoever built the batch and counted it: <c>BatchingProcessor</c> for assembled batches
+    /// and expired-member carriers, <c>BatchReplay</c> for a reduced batch. A batch nobody counted must
+    /// not subtract members it never added.
+    /// </summary>
+    internal bool BatchPipelineCounted { get; set; }
+
     [JsonIgnore]
     internal bool HasBeenAcked { get; set; }
 
@@ -608,6 +617,7 @@ public partial class Envelope
         Failure = null;
         Batch = null;
         BatchPendingSettled = false;
+        BatchPipelineCounted = false;
         HasBeenAcked = false;
         AckAttempts = 0;
         WireTap = null;

--- a/src/Wolverine/Runtime/Batching/ApplyItemContinuation.cs
+++ b/src/Wolverine/Runtime/Batching/ApplyItemContinuation.cs
@@ -197,6 +197,19 @@ internal static class BatchReplay
             GroupId = batchEnvelope.GroupId
         };
 
-        await queue.EnqueueAsync(reduced).ConfigureAwait(false);
+        // GH-4397 — a reduced batch is still work its pipeline owes, so it counts as pending until its own
+        // terminal. The original batch's terminal releases the original members; these are new ones.
+        var pendingCounts = (runtime as WolverineRuntime)?.BatchingPendingCounts;
+        pendingCounts?.CountReplayedBatch(reduced);
+
+        try
+        {
+            await queue.EnqueueAsync(reduced).ConfigureAwait(false);
+        }
+        catch
+        {
+            pendingCounts?.SettleBatch(reduced);
+            throw;
+        }
     }
 }

--- a/src/Wolverine/Runtime/Batching/BatchingPendingCounts.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingPendingCounts.cs
@@ -1,17 +1,25 @@
 using System.Collections.Concurrent;
+using ImTools;
 
 namespace Wolverine.Runtime.Batching;
 
 /// <summary>
-/// CritterWatch#942 — tracks, per originating listener address, how many member envelopes are
-/// somewhere inside a message-batching pipeline: posted into a <see cref="BatchingProcessor{T}"/>'s
-/// batching channel, waiting in a grouped batch on the (deliberately unbounded, GH-3287) local
-/// execution queue, or executing in a batch handler that hasn't reached its terminal yet.
+/// Tracks how many member envelopes are somewhere inside a message-batching pipeline: posted into a
+/// <see cref="BatchingProcessor{T}"/>'s batching channel, waiting in a grouped batch on the (deliberately
+/// unbounded, GH-3287) local execution queue, or executing in a batch handler that hasn't reached its
+/// terminal yet. It keeps two independent counts of the same members:
+/// <list type="bullet">
+/// <item><see cref="PendingFor"/> — per originating <b>listener address</b>, for back-pressure (CritterWatch#942).
+/// Only members that arrived through a transport listener are counted.</item>
+/// <item><see cref="PendingForBatchedMessage{T}"/> / <see cref="TotalPendingBatchMembers"/> — per
+/// <b>batching pipeline</b>, counting every member however it arrived, local publishes and cascades
+/// included (GH-4397). Use these to ask "is a batch of T still pending or executing?".</item>
+/// </list>
 /// </summary>
 /// <remarks>
 /// <para>
-/// Without this, <c>BatchMessagesOf</c> severs the back-pressure chain: the transport listener's
-/// bounded receive block — the only stage <see cref="Transports.BackPressureAgent"/> watches —
+/// Without the listener count, <c>BatchMessagesOf</c> severs the back-pressure chain: the transport
+/// listener's bounded receive block — the only stage <see cref="Transports.BackPressureAgent"/> watches —
 /// always drains instantly into the batching channel and onward to the unbounded local queue, so
 /// <c>QueueCount</c> reads near zero while the real backlog (with every member's payload and
 /// deserialized message graph pinned via <see cref="Envelope.Batch"/>) grows without bound. That is
@@ -23,18 +31,28 @@ namespace Wolverine.Runtime.Batching;
 /// batching pipeline is deep — restoring the bounded-memory behavior per-message handling had,
 /// without bounding any local queue (which would deadlock self-cascading handlers, GH-3287) and
 /// without ever blocking a local publisher: envelopes with no <see cref="Envelope.Listener"/>
-/// (local sends and cascades) are not counted.
+/// (local sends and cascades) are not counted there. That is exactly why the listener count cannot
+/// answer "is a batch still in flight" for in-process publishes, and why the pipeline count exists.
 /// </para>
 /// <para>
-/// Increment happens per member in <see cref="BatchingProcessor{T}.HandleAsync"/>; settlement
+/// Both counts increment per member in <see cref="BatchingProcessor{T}.HandleAsync"/>; settlement
 /// happens once per grouped batch envelope at its terminal — the <c>CompleteAsync</c> batch
 /// branches in <c>BufferedReceiver</c>/<c>DurableReceiver</c> — guarded by
-/// <c>Envelope.BatchPendingSettled</c> so a double-complete can't drive the count negative.
+/// <c>Envelope.BatchPendingSettled</c> so a double-complete can't drive either count negative. The
+/// pipeline count only releases batches marked <c>Envelope.BatchPipelineCounted</c> by whoever counted
+/// them, because a reduced batch replayed by <c>ApplyItemException</c> carries new member envelopes the
+/// original batch's terminal has already released.
 /// </para>
 /// </remarks>
 public class BatchingPendingCounts
 {
     private readonly ConcurrentDictionary<Uri, long> _pending = new();
+
+    // GH-4397. Registered once per BatchingProcessor at bootstrap and read on every batch terminal, so
+    // ImHashMap: lock-free, non-allocating lookups, copy-on-write registration under the lock.
+    private readonly object _registrationLock = new();
+    private ImHashMap<string, BatchPipelineCounter> _pipelinesByBatchType = ImHashMap<string, BatchPipelineCounter>.Empty;
+    private ImHashMap<Type, BatchPipelineCounter> _pipelinesByElementType = ImHashMap<Type, BatchPipelineCounter>.Empty;
 
     public void Increment(Uri? listenerAddress)
     {
@@ -63,12 +81,130 @@ public class BatchingPendingCounts
         {
             Decrement(member.Listener?.Address);
         }
+
+        if (batchEnvelope.BatchPipelineCounted && findPipeline(batchEnvelope) is { } pipeline)
+        {
+            pipeline.Release(batchEnvelope.Batch.Length);
+        }
     }
 
-    /// <summary>How many member envelopes received at this listener address are still pending inside a batching pipeline.</summary>
+    /// <summary>
+    /// How many member envelopes received at this <b>listener</b> address are still pending inside a
+    /// batching pipeline. Members published in-process (local sends and cascades) have no listener and are
+    /// never counted here — this is the back-pressure view. To ask whether a batch is still in flight
+    /// regardless of where its members came from, use <see cref="PendingForBatchedMessage{T}"/>.
+    /// </summary>
     public int PendingFor(Uri listenerAddress)
     {
         if (!_pending.TryGetValue(listenerAddress, out var count)) return 0;
-        return count > int.MaxValue ? int.MaxValue : (int)count;
+        return clamp(count);
+    }
+
+    /// <summary>
+    /// How many members of the <c>BatchMessagesOf&lt;T&gt;()</c> pipeline for element type
+    /// <typeparamref name="T"/> are still waiting to be batched, waiting as an assembled batch, or executing
+    /// in the batch handler — however they arrived. Zero means every batch that pipeline was given has
+    /// reached its terminal.
+    /// </summary>
+    public int PendingForBatchedMessage<T>() => PendingForBatchedMessage(typeof(T));
+
+    /// <inheritdoc cref="PendingForBatchedMessage{T}"/>
+    public int PendingForBatchedMessage(Type elementType)
+    {
+        return _pipelinesByElementType.TryFind(elementType, out var pipeline) ? clamp(pipeline.Count) : 0;
+    }
+
+    /// <summary>
+    /// How many members are pending across every batching pipeline in this application, however they
+    /// arrived. Zero means no batch anywhere is waiting or executing.
+    /// </summary>
+    public int TotalPendingBatchMembers
+    {
+        get
+        {
+            long total = 0;
+            foreach (var entry in _pipelinesByBatchType.Enumerate())
+            {
+                total += entry.Value.Count;
+            }
+
+            return clamp(total);
+        }
+    }
+
+    /// <summary>
+    /// Get or create the counter for one batching pipeline. Idempotent, because a BatchingProcessor can be
+    /// built more than once under a startup race and every build must share the one count.
+    /// </summary>
+    internal BatchPipelineCounter RegisterPipeline(Type elementType, string batchMessageTypeName)
+    {
+        lock (_registrationLock)
+        {
+            if (!_pipelinesByBatchType.TryFind(batchMessageTypeName, out var pipeline))
+            {
+                pipeline = new BatchPipelineCounter();
+                _pipelinesByBatchType = _pipelinesByBatchType.AddOrUpdate(batchMessageTypeName, pipeline);
+            }
+
+            if (!_pipelinesByElementType.TryFind(elementType, out _))
+            {
+                _pipelinesByElementType = _pipelinesByElementType.AddOrUpdate(elementType, pipeline);
+            }
+
+            return pipeline;
+        }
+    }
+
+    /// <summary>
+    /// Count a reduced batch replayed onto its pipeline's queue (<c>ApplyItemException</c>,
+    /// <c>IsolateBatchMembers</c>) as pending until its own terminal settles it.
+    /// </summary>
+    internal void CountReplayedBatch(Envelope reducedBatch)
+    {
+        if (reducedBatch.Batch == null || findPipeline(reducedBatch) is not { } pipeline) return;
+
+        pipeline.Add(reducedBatch.Batch.Length);
+        reducedBatch.BatchPipelineCounted = true;
+    }
+
+    private BatchPipelineCounter? findPipeline(Envelope batchEnvelope)
+    {
+        return batchEnvelope.MessageType != null &&
+               _pipelinesByBatchType.TryFind(batchEnvelope.MessageType, out var pipeline)
+            ? pipeline
+            : null;
+    }
+
+    private static int clamp(long count) => count > int.MaxValue ? int.MaxValue : (int)count;
+}
+
+/// <summary>
+/// GH-4397 — one batching pipeline's count of pending members. Held directly by its
+/// <see cref="BatchingProcessor{T}"/> so the per-member increment is a single interlocked add.
+/// </summary>
+internal sealed class BatchPipelineCounter
+{
+    private long _count;
+
+    public long Count => Interlocked.Read(ref _count);
+
+    public void Increment() => Interlocked.Increment(ref _count);
+
+    public void Decrement() => Release(1);
+
+    public void Add(int members) => Interlocked.Add(ref _count, members);
+
+    /// <summary>Subtract, clamping at zero so a release for members never counted can't wedge it below reality.</summary>
+    public void Release(int members)
+    {
+        var current = Interlocked.Read(ref _count);
+        while (true)
+        {
+            var next = current > members ? current - members : 0;
+            var observed = Interlocked.CompareExchange(ref _count, next, current);
+            if (observed == current) return;
+
+            current = observed;
+        }
     }
 }

--- a/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
+++ b/src/Wolverine/Runtime/Batching/BatchingProcessor.cs
@@ -14,6 +14,9 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
 
     private readonly BatchingPendingCounts? _pendingCounts;
 
+    // GH-4397 — this pipeline's own count of every member, however it arrived
+    private readonly BatchPipelineCounter? _pipeline;
+
     private readonly IBatchExecutionQueues _queues;
 
     private readonly ILogger? _logger;
@@ -31,6 +34,10 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
         _pendingCounts = pendingCounts;
         _logger = logger;
         Chain = chain ?? throw new ArgumentOutOfRangeException(nameof(chain));
+
+        // Keyed by the batch chain's TypeName because that is what every batch envelope this processor
+        // assembles carries as its MessageType, so a terminal can find the counter without a new field
+        _pipeline = pendingCounts?.RegisterPipeline(typeof(T), chain.TypeName);
 
         _options = options;
         Batcher = batcher ?? throw new ArgumentNullException(nameof(batcher));
@@ -69,6 +76,10 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
         // grouped batch envelope at its terminal (BatchingPendingCounts.SettleBatch).
         _pendingCounts?.Increment(envelope.Listener?.Address);
 
+        // GH-4397 — and count it against this pipeline no matter where it came from, so a caller can ask
+        // whether any batch of T is still pending or executing -- local publishes and cascades included
+        _pipeline?.Increment();
+
         try
         {
             await _batchingBlock.PostAsync(envelope).ConfigureAwait(false);
@@ -76,6 +87,7 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
         catch
         {
             _pendingCounts?.Decrement(envelope.Listener?.Address);
+            _pipeline?.Decrement();
             throw;
         }
     }
@@ -102,6 +114,7 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
             carrier.Destination = carrierQueue.Uri;
             carrier.MessageType = Chain!.TypeName;
             carrier.SentAt = DateTimeOffset.UtcNow;
+            carrier.BatchPipelineCounted = _pipeline != null;
 
             await carrierQueue.EnqueueAsync(carrier);
         }
@@ -116,6 +129,7 @@ public class BatchingProcessor<T> : MessageHandler, IAsyncDisposable
             grouped.Destination = queue.Uri;
             grouped.MessageType = Chain!.TypeName;
             grouped.SentAt = DateTimeOffset.UtcNow;
+            grouped.BatchPipelineCounted = _pipeline != null;
 
             // GH-3898 — whole-batch backstop for expiry that elapses while the assembled batch waits
             // on the (deliberately unbounded, GH-3287) execution queue. Only the LATEST member expiry


### PR DESCRIPTION
Closes #4397. Reported by @carcer.

## Diagnosis

`BatchingPendingCounts.PendingFor(uri)` returning 0 for in-process local-queue members is by design, but nothing gave the reporter an alternative. The counter was added for CritterWatch#942 to feed transport back-pressure:
- It keys each member by the listener it arrived through (`envelope.Listener?.Address`).
- It deliberately skips members with no listener. Local publishes and cascades never have one.

So for the reporter's setup the dictionary really does stay empty. Even a member that arrived through a transport would be counted under the listener's URI, not the local queue URI they queried. The listener view can't answer the question a test harness needs answered: is a batch of `T` still pending or executing?

## Fix

This adds a second count of the same members, per batching pipeline, however they arrived.

- **Counting.** `BatchingProcessor<T>` registers a counter at construction, keyed by its batch chain's `TypeName`, and adds one per member in `HandleAsync`. Registration is idempotent, so a startup build race shares a single counter.
- **Releasing.** Only batch envelopes marked `Envelope.BatchPipelineCounted` can release the count:
  - assembled batches
  - expired-member carriers
  - reduced batches replayed by `ApplyItemException` / `IsolateBatchMembers`. `BatchReplay` now counts these as pending until they finish.

  The marking matters because a replayed batch carries new member envelopes whose originals the first batch has already released. Subtracting for an unmarked batch would double-count, and zero-clamping would hide it as a count that reads too low.
- **Settling.** `SettleBatch` releases the pipeline count at the same point that settles the listener count, and the same `BatchPendingSettled` flag stops it happening twice.
- **New API.** `PendingForBatchedMessage<T>()` / `PendingForBatchedMessage(Type)` and `TotalPendingBatchMembers`. `PendingFor(uri)` keeps its back-pressure meaning; its XML docs now say so and point to the new API.
- **Separated-mode fan-out.** Nothing to change: `FanoutMessageHandler` re-sends the batch *message*, so the copies carry no `Batch` and only the original envelope settles.

**Cost:** one `Interlocked.Increment` per batched member (the processor holds its counter directly) and one `ImHashMap` lookup per finished batch. Unbatched messages pay nothing.

**Known gap (documented):** a member is counted from the moment the batching processor takes it off the element type's local queue. Right after a publish the count can still read zero, so a harness should wait for the count to go up before waiting for it to come back down, or use a tracked session.

## Tests

- **Unit tests (`BatchingPendingCountsTests`):**
  - local members are counted per pipeline but not per listener
  - a batch releases its members once, and an unmarked batch releases nothing
  - a replayed batch stays pending until it finishes, and one for an unknown pipeline is ignored
  - the count clamps at zero
  - registration is idempotent
- **Acceptance (`batching_pending_counts_for_local_members`):** cascaded members stay pending while the batch handler runs, and read zero only after it has finished. **Negative control:** with `origin/main`'s `BatchingProcessor`, the test times out waiting for the members to be counted.
- **Marten (`batch_processing.pending_count_covers_locally_published_members_on_durable_local_queues`):** the reporter's setup, `UseDurableLocalQueues` plus Marten. Zero means the batch's transaction committed.
- **Local runs:**
  - CoreTests: 2911 passed, 2 skipped, 0 failed
  - MartenTests `batch_processing`: 3 of 3 passed
  - `dotnet build wolverine.slnx -c Release -f net9.0`: 0 errors

## Docs

`docs/guide/handlers/batching.md` gains a **"Waiting for batches to finish"** section. The wording has been reviewed and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj

