### PR TITLE
GH-4407: owner-scoped assignment deletes, claim-if-absent, and reconciliation-sweep hardening

### DIFF
--- a/src/Persistence/MySql/Wolverine.MySql/MySqlNodePersistence.cs
+++ b/src/Persistence/MySql/Wolverine.MySql/MySqlNodePersistence.cs
@@ -300,6 +300,25 @@ internal class MySqlNodePersistence : DatabaseConstants, INodeAgentPersistence
             .ExecuteNonQueryAsync(cancellationToken);
     }
 
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        // GH-4407: insert only if nobody owns the agent yet (the duplicate-key branch is a no-op), then report
+        // whether the row is ours
+        await _dataSource.CreateCommand(
+                $"INSERT INTO {_assignmentTable} (id, node_id) VALUES (@id, @node) ON DUPLICATE KEY UPDATE id = id")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId)
+            .ExecuteNonQueryAsync(cancellationToken);
+
+        var owned = await _dataSource.CreateCommand(
+                $"SELECT COUNT(*) FROM {_assignmentTable} WHERE id = @id AND node_id = @node")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId)
+            .ExecuteScalarAsync(cancellationToken);
+
+        return Convert.ToInt64(owned) > 0;
+    }
+
     public async Task OverwriteHealthCheckTimeAsync(Guid nodeId, DateTimeOffset lastHeartbeatTime)
     {
         await _dataSource.CreateCommand($"UPDATE {_nodeTable} SET health_check = @now WHERE id = @id")

--- a/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
+++ b/src/Persistence/Oracle/Wolverine.Oracle/OracleNodePersistence.cs
@@ -285,6 +285,39 @@ internal class OracleNodePersistence : DatabaseConstants, INodeAgentPersistence
         await conn.CloseAsync();
     }
 
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
+
+        // GH-4407: insert only if nobody owns the agent yet, then report whether the row is ours
+        await using (var insert = conn.CreateCommand(
+                         $"MERGE INTO {_assignmentTable} t USING DUAL ON (t.id = :id) " +
+                         "WHEN NOT MATCHED THEN INSERT (id, node_id) VALUES (:id, :node)"))
+        {
+            insert.With("id", agentUri.ToString());
+            insert.With("node", nodeId);
+
+            try
+            {
+                await insert.ExecuteNonQueryAsync(cancellationToken);
+            }
+            catch (global::Oracle.ManagedDataAccess.Client.OracleException e) when (e.Number == 1)
+            {
+                // ORA-00001: a peer inserted between the MERGE's match and its insert, so it owns the row
+            }
+        }
+
+        await using var select = conn.CreateCommand(
+            $"SELECT COUNT(*) FROM {_assignmentTable} WHERE id = :id AND node_id = :node");
+        select.With("id", agentUri.ToString());
+        select.With("node", nodeId);
+        var owned = await select.ExecuteScalarAsync(cancellationToken);
+
+        await conn.CloseAsync();
+
+        return Convert.ToInt64(owned) > 0;
+    }
+
     public async Task OverwriteHealthCheckTimeAsync(Guid nodeId, DateTimeOffset lastHeartbeatTime)
     {
         await using var conn = await _dataSource.OpenConnectionAsync();

--- a/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.CosmosDb/Internals/CosmosDbMessageStore.NodeAgents.cs
@@ -260,14 +260,54 @@ public partial class CosmosDbMessageStore : INodeAgentPersistence
 
     public async Task RemoveAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
     {
+        // GH-4407: only this node's own claim. Deleting by id alone let a node stopping a copy it did not own
+        // delete the owner's row, which the leader then read as an unassigned agent and placed again. The
+        // delete is conditioned on the ETag of the read, so a row that changes hands in between survives.
+        var id = CosmosAgentAssignment.ToId(agentUri);
+        var partition = new PartitionKey(DocumentTypes.SystemPartition);
+
         try
         {
-            await _container.DeleteItemAsync<dynamic>(
-                CosmosAgentAssignment.ToId(agentUri), new PartitionKey(DocumentTypes.SystemPartition),
+            var existing = await _container.ReadItemAsync<CosmosAgentAssignment>(id, partition,
                 cancellationToken: cancellationToken);
+            if (existing.Resource.NodeId != nodeId.ToString())
+            {
+                return;
+            }
+
+            await _container.DeleteItemAsync<CosmosAgentAssignment>(id, partition,
+                new ItemRequestOptions { IfMatchEtag = existing.ETag }, cancellationToken);
         }
-        catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        catch (CosmosException e) when (e.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.PreconditionFailed)
         {
+            // Already gone, or it changed hands between the read and the delete -- not ours to remove
+        }
+    }
+
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        var partition = new PartitionKey(DocumentTypes.SystemPartition);
+
+        try
+        {
+            // GH-4407: create, never upsert, so a peer's existing claim is never overwritten
+            await _container.CreateItemAsync(new CosmosAgentAssignment(agentUri, nodeId), partition,
+                cancellationToken: cancellationToken);
+            return true;
+        }
+        catch (CosmosException e) when (e.StatusCode == HttpStatusCode.Conflict)
+        {
+            try
+            {
+                var existing = await _container.ReadItemAsync<CosmosAgentAssignment>(
+                    CosmosAgentAssignment.ToId(agentUri), partition, cancellationToken: cancellationToken);
+                return existing.Resource.NodeId == nodeId.ToString();
+            }
+            catch (CosmosException missing) when (missing.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Deleted again between the conflict and the read; nobody can be said to own it for us
+                return false;
+            }
         }
     }
 

--- a/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
+++ b/src/Persistence/Wolverine.Postgresql/PostgresqlNodePersistence.cs
@@ -260,6 +260,24 @@ internal class PostgresqlNodePersistence : DatabaseConstants, INodeAgentPersiste
             .ExecuteNonQueryAsync(cancellationToken);
     }
 
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        // GH-4407: insert only if nobody owns the agent yet, then report whether the row is ours
+        await _dataSource.CreateCommand(
+                $"insert into {_assignmentTable} (id, node_id) values (:id, :node) on conflict (id) do nothing;")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId)
+            .ExecuteNonQueryAsync(cancellationToken);
+
+        var owned = await _dataSource.CreateCommand(
+                $"select count(*) from {_assignmentTable} where id = :id and node_id = :node")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId)
+            .ExecuteScalarAsync(cancellationToken);
+
+        return Convert.ToInt64(owned) > 0;
+    }
+
     public async Task OverwriteHealthCheckTimeAsync(Guid nodeId, DateTimeOffset lastHeartbeatTime)
     {
         await _dataSource.CreateCommand($"update {_nodeTable} set health_check = :now where id = :id")

--- a/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
+++ b/src/Persistence/Wolverine.RavenDb/Internals/RavenDbMessageStore.NodeAgents.cs
@@ -227,10 +227,59 @@ public partial class RavenDbMessageStore : INodeAgentPersistence
 
     public async Task RemoveAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
     {
+        // GH-4407: only this node's own claim. Deleting by id alone let a node stopping a copy it did not own
+        // delete the owner's row, which the leader then read as an unassigned agent and placed again.
         using var session = _store.OpenAsyncSession();
-        session.Delete(AgentAssignment.ToId(agentUri));
+        session.Advanced.UseOptimisticConcurrency = true;
 
-        await session.SaveChangesAsync(token: cancellationToken);
+        var existing = await session.LoadAsync<AgentAssignment>(AgentAssignment.ToId(agentUri), cancellationToken);
+        if (existing == null || existing.NodeId != nodeId)
+        {
+            return;
+        }
+
+        session.Delete(existing);
+
+        try
+        {
+            await session.SaveChangesAsync(token: cancellationToken);
+        }
+        catch (ConcurrencyException)
+        {
+            // The row changed hands between the load and the delete, so it is no longer ours to remove
+        }
+    }
+
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        var id = AgentAssignment.ToId(agentUri);
+
+        using (var session = _store.OpenAsyncSession())
+        {
+            var existing = await session.LoadAsync<AgentAssignment>(id, cancellationToken);
+            if (existing != null)
+            {
+                return existing.NodeId == nodeId;
+            }
+
+            // GH-4407: an empty change vector means "only if the document does not exist yet", so a peer that
+            // claims the agent between the load and the save wins instead of being overwritten
+            await session.StoreAsync(new AgentAssignment(agentUri, nodeId), string.Empty, id, cancellationToken);
+
+            try
+            {
+                await session.SaveChangesAsync(token: cancellationToken);
+                return true;
+            }
+            catch (ConcurrencyException)
+            {
+                // Lost the race; fall through and report who did win
+            }
+        }
+
+        using var reread = _store.OpenAsyncSession();
+        var winner = await reread.LoadAsync<AgentAssignment>(id, cancellationToken);
+        return winner?.NodeId == nodeId;
     }
 
     public async Task AddAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)

--- a/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerNodePersistence.cs
+++ b/src/Persistence/Wolverine.SqlServer/Persistence/SqlServerNodePersistence.cs
@@ -374,6 +374,25 @@ internal class SqlServerNodePersistence : DatabaseConstants, INodeAgentPersisten
         await conn.CloseAsync();
     }
 
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        await using var conn = new SqlConnection(_settings.ConnectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        // GH-4407: insert only if nobody owns the agent yet -- UPDLOCK/HOLDLOCK so two claimants can't both pass
+        // the NOT EXISTS -- then report whether the row is ours
+        var owned = await conn.CreateCommand(
+                $"insert into {_assignmentTable} (id, node_id) select @id, @node where not exists (select 1 from {_assignmentTable} with (updlock, holdlock) where id = @id);" +
+                $"select count(*) from {_assignmentTable} where id = @id and node_id = @node;")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId)
+            .ExecuteScalarAsync(cancellationToken);
+
+        await conn.CloseAsync();
+
+        return Convert.ToInt64(owned) > 0;
+    }
+
     public Task LogRecordsAsync(params NodeRecord[] records)
     {
         if (records.Any())

--- a/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
+++ b/src/Persistence/Wolverine.Sqlite/SqliteNodePersistence.cs
@@ -310,6 +310,26 @@ internal class SqliteNodePersistence : DatabaseConstants, INodeAgentPersistence
             .ExecuteNonQueryAsync(cancellationToken);
     }
 
+    public async Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        // GH-4407: insert only if nobody owns the agent yet, then report whether the row is ours
+        await conn.CreateCommand(
+                $"insert or ignore into {_assignmentTable} (id, node_id) values (@id, @node)")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId.ToString())
+            .ExecuteNonQueryAsync(cancellationToken);
+
+        var owned = await conn.CreateCommand(
+                $"select count(*) from {_assignmentTable} where id = @id and node_id = @node")
+            .With("id", agentUri.ToString())
+            .With("node", nodeId.ToString())
+            .ExecuteScalarAsync(cancellationToken);
+
+        return Convert.ToInt64(owned) > 0;
+    }
+
     public async Task OverwriteHealthCheckTimeAsync(Guid nodeId, DateTimeOffset lastHeartbeatTime)
     {
         await using var conn = await _dataSource.OpenConnectionAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/Testing/CoreTests/Runtime/Agents/local_agent_reconciliation_sweep.cs
+++ b/src/Testing/CoreTests/Runtime/Agents/local_agent_reconciliation_sweep.cs
@@ -127,6 +127,11 @@ public class local_agent_reconciliation_sweep
 
         await tick();
         agent.StopCount.ShouldBe(1);
+
+        // GH-4407: and the owner's row goes nowhere. A stop that took it along -- on a store whose delete was
+        // not owner-scoped -- made the leader read the agent as unassigned and place it again.
+        await _persistence.DidNotReceive()
+            .RemoveAssignmentAsync(Arg.Any<Guid>(), uri, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -137,6 +142,8 @@ public class local_agent_reconciliation_sweep
 
         await _controller.StartAgentAsync(uri);
         _persistence.ClearReceivedCalls();
+        _persistence.TryClaimAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>())
+            .Returns(true);
 
         // The row vanished entirely (peer ejection cascade). Nobody else claims the agent, so the
         // running copy is the one true copy: restore the claim, never stop the work.
@@ -145,8 +152,75 @@ public class local_agent_reconciliation_sweep
         await tick(3);
 
         agent.StopCount.ShouldBe(0);
+
+        // GH-4407: through the claim-if-absent path, never the last-writer-wins upsert
         await _persistence.Received()
+            .TryClaimAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+        await _persistence.DidNotReceive()
             .AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task leaves_the_row_to_a_peer_that_claimed_it_first()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+
+        await _controller.StartAgentAsync(uri);
+        _persistence.ClearReceivedCalls();
+
+        // GH-4407: the snapshot showed no row anywhere, but a peer claimed the agent before this node's
+        // restore landed. The claim reports the loss rather than overwriting the peer's row.
+        _persistence.TryClaimAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>())
+            .Returns(false);
+        ClusterIs(Self(), Row(Guid.NewGuid(), 2));
+
+        await tick(3);
+
+        agent.StopCount.ShouldBe(0);
+        await _persistence.DidNotReceive()
+            .AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task never_starts_an_agent_again_while_its_first_start_is_still_in_flight()
+    {
+        var uri = new Uri("test-family://one");
+        var agent = _family.Add(uri);
+        agent.StartGate = new TaskCompletionSource();
+
+        // GH-4407: an agent is registered only once its start completes, so for the whole of a slow start
+        // the row says "here" and nothing is running. That is a start in flight, not a wedge.
+        var inFlight = _controller.StartAgentAsync(uri);
+        ClusterIs(Self(uri));
+
+        await tick(5);
+        agent.StartCount.ShouldBe(1);
+
+        agent.StartGate.SetResult();
+        await inFlight;
+        agent.StartCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task caps_the_actions_taken_per_tick_and_works_through_the_rest_on_later_ticks()
+    {
+        _options.Durability.MaxLocalAgentReconciliationsPerTick = 1;
+
+        var agents = new[] { "one", "two", "three" }
+            .Select(x => _family.Add(new Uri($"test-family://{x}")))
+            .ToArray();
+
+        ClusterIs(Self(agents.Select(x => x.Uri).ToArray()));
+
+        await tick(3);
+        agents.Count(x => x.StartCount == 1).ShouldBe(1);
+
+        await tick();
+        agents.Count(x => x.StartCount == 1).ShouldBe(2);
+
+        await tick();
+        agents.ShouldAllBe(x => x.StartCount == 1);
     }
 
     [Fact]
@@ -207,6 +281,8 @@ public class local_agent_reconciliation_sweep
         await tick(5);
         await _persistence.DidNotReceive()
             .AddAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
+        await _persistence.DidNotReceive()
+            .TryClaimAssignmentAsync(_options.UniqueNodeId, uri, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -282,6 +358,9 @@ public class local_agent_reconciliation_sweep
         public int StartCount { get; private set; }
         public int StopCount { get; private set; }
 
+        // When set, StartAsync does not complete until the test releases it -- a slow start in flight
+        public TaskCompletionSource? StartGate { get; set; }
+
         public Uri Uri { get; }
         public AgentStatus Status { get; private set; } = AgentStatus.Stopped;
 
@@ -289,7 +368,7 @@ public class local_agent_reconciliation_sweep
         {
             StartCount++;
             Status = AgentStatus.Running;
-            return Task.CompletedTask;
+            return StartGate?.Task ?? Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/src/Testing/Wolverine.ComplianceTests/LeadershipElectionCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/LeadershipElectionCompliance.cs
@@ -246,6 +246,120 @@ public abstract class LeadershipElectionCompliance : IAsyncLifetime
         host3.RunningAgents().ShouldContain(expected[0]);
     }
 
+    // GH-4407: the divergences the GH-3987 reconciliation sweep exists to heal, each fabricated directly on a
+    // real cluster against real storage. Every provider has to come back to exactly one copy of every agent.
+
+    private static Guid nodeIdOf(IHost host) => host.GetRuntime().Options.UniqueNodeId;
+
+    private async Task<Guid?> assignmentOwnerOfAsync(Uri agentUri)
+    {
+        var nodes = await _hosts.First().GetRuntime().Storage.Nodes.LoadAllNodesAsync(CancellationToken.None);
+        return nodes.FirstOrDefault(x => x.ActiveAgents.Contains(agentUri))?.NodeId;
+    }
+
+    private async Task settledTwoNodeClusterAsync()
+    {
+        await _originalHost.WaitUntilAssumesLeadershipAsync(10.Seconds());
+        await startHostAsync();
+        await expectExactlyOneCopyOfEachAsync(AllFakeAgents, [], 30.Seconds());
+    }
+
+    /// <summary>
+    /// Polls until <paramref name="agentUri" /> runs on exactly one node AND its assignment row names that node,
+    /// then asserts the same so a timeout reports the actual state. Deliberately does not assert WHICH node ends
+    /// up with it: the leader is free to re-place or rebalance an agent while a divergence heals, and does.
+    /// </summary>
+    private async Task expectOneCopyWithARowNamingItsNodeAsync(Uri agentUri, TimeSpan timeout)
+    {
+        using var cancellation = new CancellationTokenSource(timeout);
+        while (!cancellation.IsCancellationRequested)
+        {
+            var runners = _hosts.Where(x => x.RunningAgents().Contains(agentUri)).ToArray();
+            if (runners.Length == 1 && await assignmentOwnerOfAsync(agentUri) == nodeIdOf(runners[0]))
+            {
+                return;
+            }
+
+            await Task.Delay(250.Milliseconds());
+        }
+
+        var finalRunners = _hosts.Where(x => x.RunningAgents().Contains(agentUri)).ToArray();
+        finalRunners.Length.ShouldBe(1, $"{agentUri} should be running on exactly one node");
+        (await assignmentOwnerOfAsync(agentUri)).ShouldBe(nodeIdOf(finalRunners[0]),
+            $"The assignment row for {agentUri} should name the node running it");
+    }
+
+    [Fact]
+    public async Task a_copy_on_a_node_the_table_does_not_name_converges_to_one_copy_with_a_matching_row()
+    {
+        await settledTwoNodeClusterAsync();
+
+        var agentUri = AllFakeAgents[0];
+        var owner = FindHostRunning(agentUri);
+        var intruder = _hosts.First(x => x != owner);
+
+        // The leadership-handover duplicate: a second copy comes up on a node the table does not name.
+        // Starting it there upserts the intruder's row, so put the owner's claim straight back, leaving the
+        // intruder running a copy no row accounts for. The intruder's sweep stops it without touching the
+        // owner's row; on a store whose delete was not owner-scoped that stop took the row too and the cluster
+        // kept re-placing the agent. The store half of that is pinned deterministically by
+        // NodePersistenceCompliance.removing_an_assignment_owned_by_another_node_is_a_no_op.
+        await intruder.GetRuntime().NodeController!.StartAgentAsync(agentUri);
+        await owner.GetRuntime().Storage.Nodes.AddAssignmentAsync(nodeIdOf(owner), agentUri, CancellationToken.None);
+
+        await expectOneCopyWithARowNamingItsNodeAsync(agentUri, 30.Seconds());
+        await expectExactlyOneCopyOfEachAsync(AllFakeAgents, [], 30.Seconds());
+    }
+
+    [Fact]
+    public async Task an_agent_assigned_to_a_node_but_not_running_there_ends_up_running_again()
+    {
+        await settledTwoNodeClusterAsync();
+
+        var agentUri = AllFakeAgents[0];
+        var owner = FindHostRunning(agentUri);
+
+        // The GH-3987 wedge: the agent goes away on its owner while the owner's row stays put, so the leader
+        // reads it as placed and never places it again. The owner's own sweep restarts it -- unless the leader
+        // gets there first and re-places it, which is just as good.
+        owner.GetRuntime().NodeController!.Agents.TryRemove(agentUri, out var agent).ShouldBeTrue();
+        await agent!.StopAsync(CancellationToken.None);
+
+        await expectOneCopyWithARowNamingItsNodeAsync(agentUri, 30.Seconds());
+        await expectExactlyOneCopyOfEachAsync(AllFakeAgents, [], 30.Seconds());
+    }
+
+    [Fact]
+    public async Task a_running_agent_whose_row_is_lost_ends_up_running_once_with_a_row_naming_its_node()
+    {
+        await settledTwoNodeClusterAsync();
+
+        var agentUri = AllFakeAgents[0];
+        var owner = FindHostRunning(agentUri);
+
+        // The peer-ejection cascade: the row goes, the running copy stays. The leader now reads the agent as
+        // unplaced and may place it again while the owner's sweep restores its claim -- either way the cluster
+        // has to come back to one copy and one row naming the node that runs it.
+        await owner.GetRuntime().Storage.Nodes.RemoveAssignmentAsync(nodeIdOf(owner), agentUri, CancellationToken.None);
+
+        await expectOneCopyWithARowNamingItsNodeAsync(agentUri, 30.Seconds());
+        await expectExactlyOneCopyOfEachAsync(AllFakeAgents, [], 30.Seconds());
+    }
+
+    [Fact]
+    public async Task every_agent_runs_exactly_once_after_the_leader_dies_with_its_starts_in_flight()
+    {
+        await _originalHost.WaitUntilAssumesLeadershipAsync(10.Seconds());
+
+        // New nodes join and the leader starts rebalancing onto them -- then dies before those starts have
+        // settled, with no chance to finish or retract them. The next leader inherits whatever landed.
+        await startHostAsync();
+        await startHostAsync();
+        await shutdownHostAsync(_originalHost);
+
+        await expectExactlyOneCopyOfEachAsync(AllFakeAgents, [], 60.Seconds());
+    }
+
     /***** NEW TESTS END HERE **********************************************/
 
     [Fact]
@@ -499,11 +613,14 @@ public abstract class LeadershipElectionCompliance : IAsyncLifetime
         var nodes = runtime.Storage.Nodes;
         await nodes.LogRecordsAsync(records);
 
-        var count = 0;
-        while (count < 10)
+        // The attempt counter was never incremented, so a store that did not persist the records spun here
+        // forever -- a 40-minute hang on the SharedMemory variant -- instead of failing
+        for (var attempt = 0; attempt < 10; attempt++)
         {
             var persisted = await nodes.FetchRecentRecordsAsync(10);
             if (persisted.Count >= 4) return;
+
+            await Task.Delay(250.Milliseconds());
         }
 
         throw new Exception("No persisted node records!");

--- a/src/Testing/Wolverine.ComplianceTests/NodePersistenceCompliance.cs
+++ b/src/Testing/Wolverine.ComplianceTests/NodePersistenceCompliance.cs
@@ -220,6 +220,88 @@ public abstract class NodePersistenceCompliance : IAsyncLifetime
         persisted.ActiveAgents.OrderBy(x => x.ToString()).ShouldBe([agent3, agent2]);
     }
 
+    // GH-4407: assignment ownership. The table holds one row per agent, so these pin down who may change
+    // whose row. A delete that was not owner-scoped let a node stopping a copy it did not own take the
+    // owner's claim with it -- and nothing here used to say that was wrong.
+
+    private async Task<Guid> persistNodeAsync()
+    {
+        var node = createNode();
+        await _database.Nodes.PersistAsync(node, CancellationToken.None);
+        return node.NodeId;
+    }
+
+    private async Task<Guid?> ownerOfAsync(Uri agentUri)
+    {
+        var nodes = await _database.Nodes.LoadAllNodesAsync(CancellationToken.None);
+        return nodes.FirstOrDefault(x => x.ActiveAgents.Contains(agentUri))?.NodeId;
+    }
+
+    [Fact]
+    public async Task removing_an_assignment_owned_by_another_node_is_a_no_op()
+    {
+        var owner = await persistNodeAsync();
+        var other = await persistNodeAsync();
+        var agent = new Uri("red://one");
+
+        await _database.Nodes.AddAssignmentAsync(owner, agent, CancellationToken.None);
+
+        await _database.Nodes.RemoveAssignmentAsync(other, agent, CancellationToken.None);
+
+        (await ownerOfAsync(agent)).ShouldBe(owner);
+    }
+
+    [Fact]
+    public async Task add_assignment_moves_the_row_to_the_new_node()
+    {
+        var first = await persistNodeAsync();
+        var second = await persistNodeAsync();
+        var agent = new Uri("red://one");
+
+        await _database.Nodes.AddAssignmentAsync(first, agent, CancellationToken.None);
+        await _database.Nodes.AddAssignmentAsync(second, agent, CancellationToken.None);
+
+        (await ownerOfAsync(agent)).ShouldBe(second);
+    }
+
+    [Fact]
+    public async Task claiming_an_unowned_assignment_takes_it()
+    {
+        var node = await persistNodeAsync();
+        var agent = new Uri("red://one");
+
+        (await _database.Nodes.TryClaimAssignmentAsync(node, agent, CancellationToken.None)).ShouldBeTrue();
+
+        (await ownerOfAsync(agent)).ShouldBe(node);
+    }
+
+    [Fact]
+    public async Task claiming_an_assignment_a_peer_owns_leaves_it_alone()
+    {
+        var owner = await persistNodeAsync();
+        var claimant = await persistNodeAsync();
+        var agent = new Uri("red://one");
+
+        await _database.Nodes.AddAssignmentAsync(owner, agent, CancellationToken.None);
+
+        (await _database.Nodes.TryClaimAssignmentAsync(claimant, agent, CancellationToken.None)).ShouldBeFalse();
+
+        (await ownerOfAsync(agent)).ShouldBe(owner);
+    }
+
+    [Fact]
+    public async Task claiming_an_assignment_this_node_already_owns_succeeds()
+    {
+        var node = await persistNodeAsync();
+        var agent = new Uri("red://one");
+
+        await _database.Nodes.AddAssignmentAsync(node, agent, CancellationToken.None);
+
+        (await _database.Nodes.TryClaimAssignmentAsync(node, agent, CancellationToken.None)).ShouldBeTrue();
+
+        (await ownerOfAsync(agent)).ShouldBe(node);
+    }
+
     private int _count = 0;
     private WolverineNode createNode()
     {

--- a/src/Wolverine/DurabilitySettings.cs
+++ b/src/Wolverine/DurabilitySettings.cs
@@ -646,6 +646,16 @@ public class DurabilitySettings : IDescribeMyself
     public int LocalAgentReconciliationThreshold { get; set; } = 3;
 
     /// <summary>
+    ///     GH-4407: the most reconciliation actions (starts, stops, restored claims) one node takes on a single
+    ///     health-check tick. The sweep runs inside the serialized health check, ahead of the leader's
+    ///     assignment pass on the leader node, so after something like a leader crash on a large fleet an
+    ///     unbounded sweep could hold that pass back for as long as hundreds of agent starts take. Anything over
+    ///     the cap keeps its place and is handled on a later tick, longest-standing first. Set to 0 or a
+    ///     negative number for no cap. Default 50.
+    /// </summary>
+    public int MaxLocalAgentReconciliationsPerTick { get; set; } = 50;
+
+    /// <summary>
     ///     GH-3970: how many consecutive assignment ticks may fail to <i>build or start</i> an agent on this
     ///     node before the node releases it to a capable peer, using the same embargo as
     ///     <see cref="MaxLocalAgentRestartsBeforeRelease" />.
@@ -843,6 +853,7 @@ public class DurabilitySettings : IDescribeMyself
         desc.AddValue(nameof(MaxAssignmentSettleTime), MaxAssignmentSettleTime);
         desc.AddValue(nameof(AssignmentSettleNodeCount), AssignmentSettleNodeCount);
         desc.AddValue(nameof(LocalAgentReconciliationThreshold), LocalAgentReconciliationThreshold);
+        desc.AddValue(nameof(MaxLocalAgentReconciliationsPerTick), MaxLocalAgentReconciliationsPerTick);
         desc.AddValue(nameof(TenantCheckPeriod), TenantCheckPeriod);
         desc.AddValue(nameof(UpdateMetricsPeriod), UpdateMetricsPeriod);
         desc.AddValue(nameof(DurabilityMetricsEnabled), DurabilityMetricsEnabled);

--- a/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/MultiTenantedMessageStore.cs
@@ -604,6 +604,12 @@ public partial class MultiTenantedMessageStore : IMessageStore, IMessageInbox, I
         return Main.Nodes.AddAssignmentAsync(nodeId, agentUri, cancellationToken);
     }
 
+    Task<bool> INodeAgentPersistence.TryClaimAssignmentAsync(Guid nodeId, Uri agentUri,
+        CancellationToken cancellationToken)
+    {
+        return Main.Nodes.TryClaimAssignmentAsync(nodeId, agentUri, cancellationToken);
+    }
+
     Task<WolverineNode?> INodeAgentPersistence.LoadNodeAsync(Guid nodeId, CancellationToken cancellationToken)
     {
         return Main.Nodes.LoadNodeAsync(nodeId, cancellationToken);

--- a/src/Wolverine/Persistence/Durability/NullMessageStore.cs
+++ b/src/Wolverine/Persistence/Durability/NullMessageStore.cs
@@ -354,6 +354,12 @@ internal class NullNodeAgentPersistence : INodeAgentPersistence
         return Task.CompletedTask;
     }
 
+    // There are no rows, so there is no peer whose claim could win
+    public Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(true);
+    }
+
     public Task<WolverineNode?> LoadNodeAsync(Guid nodeId, CancellationToken cancellationToken)
     {
         return Task.FromResult(default(WolverineNode?));

--- a/src/Wolverine/Runtime/Agents/INodeAgentPersistence.cs
+++ b/src/Wolverine/Runtime/Agents/INodeAgentPersistence.cs
@@ -21,8 +21,27 @@ public interface INodeAgentPersistence
 
     Task AssignAgentsAsync(Guid nodeId, IReadOnlyList<Uri> agents, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Remove <paramref name="agentUri" />'s assignment row, but only if it belongs to <paramref name="nodeId" />.
+    /// A row another node owns must be left alone: a node stopping a copy it does not own must never take the
+    /// owner's claim with it (GH-4407).
+    /// </summary>
     Task RemoveAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Assign <paramref name="agentUri" /> to <paramref name="nodeId" />, replacing any existing row for the
+    /// agent -- the last writer wins.
+    /// </summary>
     Task AddAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// GH-4407: claim <paramref name="agentUri" /> for <paramref name="nodeId" /> only if no node owns it yet.
+    /// Unlike <see cref="AddAssignmentAsync" /> this never takes over a row a peer wrote. Returns <c>true</c>
+    /// when the row belongs to <paramref name="nodeId" /> afterwards -- inserted now, or already this node's --
+    /// and <c>false</c> when another node owns it. Deliberately has no default implementation: a store wrapper
+    /// that forwarded every other member but not this one would silently fall back to a last-writer-wins upsert.
+    /// </summary>
+    Task<bool> TryClaimAssignmentAsync(Guid nodeId, Uri agentUri, CancellationToken cancellationToken);
 
     Task<WolverineNode?> LoadNodeAsync(Guid nodeId, CancellationToken cancellationToken);
 

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.HeartBeat.cs
@@ -165,6 +165,10 @@ public partial class NodeAgentController
                 _runtime.Options.Durability.AssignedNodeNumber);
         }
 
+        // GH-4407: taken BEFORE the snapshot is read, so a stop stamped after it -- one this snapshot cannot
+        // know about -- revokes whatever the reconciliation sweep decides from it
+        var snapshotSequence = CurrentCommandSequence;
+
         var (nodes, restrictions) = await _persistence.LoadNodeAgentStateAsync(_cancellation.Token);
 
 
@@ -220,7 +224,7 @@ public partial class NodeAgentController
         {
             if (selfRowIsPersisted)
             {
-                await ReconcileLocalAgentsAsync(nodes, restrictions);
+                await ReconcileLocalAgentsAsync(nodes, restrictions, snapshotSequence);
             }
         }
         catch (Exception e)

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.Reconcile.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.Reconcile.cs
@@ -32,8 +32,15 @@ public partial class NodeAgentController
     ///     read omits it, and skips this sweep on those ticks — a fabricated empty claim list is not a
     ///     transient the consecutive-tick threshold can filter, and acting on it would stop or re-claim
     ///     agents against state that was never real.</para>
+    ///
+    ///     <para>GH-4407: every action is decided from a snapshot, so each one defers to anything newer. A
+    ///     stop stamped after <paramref name="snapshotSequence" /> wins over a start or a restored claim, a
+    ///     start already in flight here is never started again, a stopped orphan leaves the owner's row where
+    ///     it is, and a restored claim only takes a row nobody owns. Actions per tick are capped by
+    ///     <see cref="DurabilitySettings.MaxLocalAgentReconciliationsPerTick" />.</para>
     /// </summary>
-    internal async Task ReconcileLocalAgentsAsync(IReadOnlyList<WolverineNode> nodes, AgentRestrictions restrictions)
+    internal async Task ReconcileLocalAgentsAsync(IReadOnlyList<WolverineNode> nodes, AgentRestrictions restrictions,
+        long snapshotSequence)
     {
         var threshold = _runtime.Options.Durability.LocalAgentReconciliationThreshold;
         if (threshold <= 0)
@@ -67,6 +74,9 @@ public partial class NodeAgentController
             if (running.Contains(uri)) continue;
             if (_stoppingAgents.ContainsKey(uri)) continue;
 
+            // GH-4407: a start already in flight here is not missing -- it registers the moment it lands
+            if (_startingAgents.ContainsKey(uri)) continue;
+
             // An agent this node released for failing here must not be dragged back by its own stale
             // row, an operator's pause outranks the row, and a row for a scheme this deployment cannot
             // run (blue/green) is a peer's business.
@@ -85,50 +95,43 @@ public partial class NodeAgentController
             _reconcileObservations.Remove(recovered);
         }
 
+        var ready = new List<(Uri Uri, bool RunningNotClaimed, int Streak)>();
         foreach (var (uri, runningNotClaimed) in mismatches)
         {
             var count = (_reconcileObservations.TryGetValue(uri, out var previous) ? previous : 0) + 1;
             _reconcileObservations[uri] = count;
 
-            if (count < threshold)
+            if (count >= threshold)
             {
-                continue;
+                ready.Add((uri, runningNotClaimed, count));
             }
+        }
 
+        if (ready.Count == 0)
+        {
+            return;
+        }
+
+        // GH-4407: bounded per tick. Whatever the cap defers keeps its streak, which keeps growing, so ordering
+        // by streak means a deferred divergence goes ahead of newer ones on the next tick instead of starving.
+        var cap = _runtime.Options.Durability.MaxLocalAgentReconciliationsPerTick;
+        var ordered = ready.OrderByDescending(x => x.Streak).ToList();
+        var actions = cap > 0 && ordered.Count > cap ? ordered.Take(cap).ToList() : ordered;
+
+        if (actions.Count < ordered.Count)
+        {
+            _logger.LogInformation(
+                "Node {NodeNumber} is reconciling {Count} agent(s) this tick and deferring {Deferred} to the next (MaxLocalAgentReconciliationsPerTick)",
+                _runtime.Options.Durability.AssignedNodeNumber, actions.Count, ordered.Count - actions.Count);
+        }
+
+        foreach (var (uri, runningNotClaimed, _) in actions)
+        {
             _reconcileObservations.Remove(uri);
 
             try
             {
-                if (runningNotClaimed)
-                {
-                    var owner = nodes.FirstOrDefault(x =>
-                        x.NodeId != self.NodeId && x.ActiveAgents.Contains(uri));
-
-                    if (owner != null)
-                    {
-                        _logger.LogWarning(
-                            "Agent {AgentUri} is running on node {NodeNumber} but its durable assignment belongs to node {OwnerNodeNumber}; stopping the local copy",
-                            uri, _runtime.Options.Durability.AssignedNodeNumber, owner.AssignedNodeNumber);
-
-                        await StopAgentAsync(uri);
-                    }
-                    else
-                    {
-                        _logger.LogWarning(
-                            "Agent {AgentUri} is running on node {NodeNumber} with no durable assignment row anywhere; restoring this node's claim",
-                            uri, _runtime.Options.Durability.AssignedNodeNumber);
-
-                        await upsertAssignmentAsync(uri);
-                    }
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "Agent {AgentUri} is durably assigned to node {NodeNumber} but is not running here; starting it",
-                        uri, _runtime.Options.Durability.AssignedNodeNumber);
-
-                    await StartAgentAsync(uri);
-                }
+                await reconcileAgentAsync(nodes, self, uri, runningNotClaimed, snapshotSequence);
             }
             catch (Exception e)
             {
@@ -137,6 +140,54 @@ public partial class NodeAgentController
                 _logger.LogError(e, "Error reconciling agent {AgentUri} on node {NodeNumber}", uri,
                     _runtime.Options.Durability.AssignedNodeNumber);
             }
+        }
+    }
+
+    private async Task reconcileAgentAsync(IReadOnlyList<WolverineNode> nodes, WolverineNode self, Uri uri,
+        bool runningNotClaimed, long snapshotSequence)
+    {
+        var nodeNumber = _runtime.Options.Durability.AssignedNodeNumber;
+
+        if (!runningNotClaimed)
+        {
+            _logger.LogWarning(
+                "Agent {AgentUri} is durably assigned to node {NodeNumber} but is not running here; starting it",
+                uri, nodeNumber);
+
+            // GH-4407: through the revocation guard, so a stop that landed after this snapshot was read wins
+            await StartAgentGuardedAsync(uri, snapshotSequence);
+            return;
+        }
+
+        // A stop that landed after the snapshot has already changed the picture this decision was made from
+        if (isRevokedSince(uri, snapshotSequence))
+        {
+            return;
+        }
+
+        var owner = nodes.FirstOrDefault(x => x.NodeId != self.NodeId && x.ActiveAgents.Contains(uri));
+        if (owner != null)
+        {
+            _logger.LogWarning(
+                "Agent {AgentUri} is running on node {NodeNumber} but its durable assignment belongs to node {OwnerNodeNumber}; stopping the local copy",
+                uri, nodeNumber, owner.AssignedNodeNumber);
+
+            // GH-4407: the row is the owner's claim, so this stop must leave it where it is
+            await stopAgentAsync(uri, removeAssignment: false);
+            return;
+        }
+
+        _logger.LogWarning(
+            "Agent {AgentUri} is running on node {NodeNumber} with no durable assignment row anywhere; restoring this node's claim",
+            uri, nodeNumber);
+
+        // GH-4407: only if it is still unowned. A peer may have claimed it since the snapshot was read, and an
+        // upsert here would take the row out from under that peer.
+        if (!await claimAssignmentAsync(uri))
+        {
+            _logger.LogInformation(
+                "Agent {AgentUri} was claimed by another node before node {NodeNumber} could restore its own claim; leaving the row to its owner",
+                uri, nodeNumber);
         }
     }
 }

--- a/src/Wolverine/Runtime/Agents/NodeAgentController.cs
+++ b/src/Wolverine/Runtime/Agents/NodeAgentController.cs
@@ -189,6 +189,12 @@ public partial class NodeAgentController
     // tells the two apart.
     private readonly ConcurrentDictionary<Uri, byte> _stoppingAgents = new();
 
+    // GH-4407: agents whose start is currently in flight on this node. StartAgentAsync only registers an agent
+    // once its (possibly retried) start completes, and the wedged-restart path deregisters it first, so for
+    // the whole start the agent reads as "assigned here but not running" to the reconciliation sweep.
+    // Membership here keeps the sweep from starting it a second time.
+    private readonly ConcurrentDictionary<Uri, byte> _startingAgents = new();
+
     internal long CurrentCommandSequence => Volatile.Read(ref _commandSequence);
 
     private bool isRevokedSince(Uri agentUri, long sequence)
@@ -349,6 +355,8 @@ public partial class NodeAgentController
                 "Agent {AgentUri} is still registered on node {NodeNumber} but its shard is stopped; restarting it",
                 agentUri, _runtime.Options.Durability.AssignedNodeNumber);
 
+            // GH-4407: marked before the registration disappears, so the sweep never sees a gap
+            _startingAgents[agentUri] = default;
             Agents.TryRemove(agentUri, out _);
             try
             {
@@ -360,10 +368,13 @@ public partial class NodeAgentController
             }
         }
 
-        IAgent agent;
+        _startingAgents[agentUri] = default;
         try
         {
-            agent = await startWithRetriesAsync(agentUri);
+            var agent = await startWithRetriesAsync(agentUri);
+
+            // Registered before the in-flight marker is released, so there is no moment the agent is neither
+            Agents[agentUri] = agent;
         }
         catch (Exception e)
         {
@@ -375,8 +386,10 @@ public partial class NodeAgentController
             _failedStarts.AddOrUpdate(agentUri, _ => new FailedStartRecord(1, e), (_, existing) => existing.Next(e));
             throw;
         }
-
-        Agents[agentUri] = agent;
+        finally
+        {
+            _startingAgents.TryRemove(agentUri, out _);
+        }
 
         // GH-3638: a start that succeeded supersedes whatever failure was last reported for this agent, so
         // a later failure alerts again instead of being swallowed as a duplicate of the old one.
@@ -480,7 +493,22 @@ public partial class NodeAgentController
         }
     }
 
-    public async Task StopAgentAsync(Uri agentUri)
+    // GH-4407: claim agentUri for this node only if no node owns it yet, and report whether the row is this
+    // node's afterwards. Like upsertAssignmentAsync, registers the node row first so the assignment's FK holds.
+    private async Task<bool> claimAssignmentAsync(Uri agentUri)
+    {
+        await ensureLocalNodeRegisteredAsync(_cancellation.Token);
+        return await _persistence.TryClaimAssignmentAsync(_runtime.Options.UniqueNodeId, agentUri,
+            _cancellation.Token);
+    }
+
+    public Task StopAgentAsync(Uri agentUri) => stopAgentAsync(agentUri, removeAssignment: true);
+
+    // GH-4407: removeAssignment is false only for the reconciliation sweep stopping a copy whose row another
+    // node owns. That row is the owner's claim, not this node's, so the stop must leave it alone -- on a store
+    // whose delete was not owner-scoped, taking it along made the leader read the agent as unassigned and
+    // place it again, which started the next duplicate.
+    private async Task stopAgentAsync(Uri agentUri, bool removeAssignment)
     {
         // GH-3748: stamped before the attempt, so even a stop that finds nothing running revokes any
         // deferred start still queued or in flight for this agent. See StartAgentGuardedAsync.
@@ -518,16 +546,19 @@ public partial class NodeAgentController
                 }
             }
 
-            try
+            if (removeAssignment)
             {
-                await _persistence.RemoveAssignmentAsync(_runtime.Options.UniqueNodeId, agentUri,
-                    _cancellation.Token);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e,
-                    "Error trying to remove the assignment of agent {AgentUri} to Node {NodeId} in persistence",
-                    agentUri, _runtime.Options.UniqueNodeId);
+                try
+                {
+                    await _persistence.RemoveAssignmentAsync(_runtime.Options.UniqueNodeId, agentUri,
+                        _cancellation.Token);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e,
+                        "Error trying to remove the assignment of agent {AgentUri} to Node {NodeId} in persistence",
+                        agentUri, _runtime.Options.UniqueNodeId);
+                }
             }
         }
         finally


### PR DESCRIPTION
Closes #4407. These are the follow-ups from reviewing #4404, the node-side reconciliation sweep for #3987.

## 1. RavenDB and Cosmos DB no longer delete other nodes' assignment rows

On the SQL providers, `RemoveAssignmentAsync` only deletes a row the calling node owns (`where id = @id and node_id = @node`). **RavenDB and Cosmos DB deleted by agent id alone.** #4404's orphan-stop branch calls `StopAgentAsync` exactly when another node owns the row, so on those stores it deleted the owner's row. The leader then saw the agent as unassigned and placed it again, creating a new duplicate that the next sweep would stop, deleting that row too.

- **The orphan stop leaves assignment rows alone.** `StopAgentAsync(uri)` keeps its behaviour; the sweep calls a private `stopAgentAsync(uri, removeAssignment: false)`. This fixes the problem for every provider.
- **RavenDB and Cosmos DB deletes are now owner-scoped.** RavenDB loads the row and deletes it only if the `NodeId` matches, with optimistic concurrency. Cosmos reads the row and deletes it only if the node matches, conditional on the ETag. A row that changes hands in between survives.

## 2. Restoring a claim no longer overwrites a newer one

Adds `INodeAgentPersistence.TryClaimAssignmentAsync(nodeId, agentUri)`. It inserts a row only if no node owns the agent, and returns whether the row belongs to the caller afterwards. The sweep uses it instead of the last-writer-wins `AddAssignmentAsync` when it restores a claim for a running copy, so a peer that claimed the agent after the snapshot keeps it.

- **SQL providers:** a race-safe insert-if-absent for each dialect: Postgres `on conflict do nothing`, SQL Server `not exists` under `updlock, holdlock`, MySQL `on duplicate key` as a no-op, Oracle `merge ... when not matched` (tolerating ORA-00001), SQLite `insert or ignore`. Each is followed by a `count(*)` on `id` and `node_id` to check ownership.
- **RavenDB:** a create-only store (empty change vector), re-reading to see who won if it loses the race.
- **Cosmos DB:** `CreateItemAsync`, reading on conflict.
- **Wrappers:** `MultiTenantedMessageStore` forwards the new member explicitly, and `NullMessageStore` returns true.
- **Deliberately no default implementation.** The multi-tenant store implements the interface explicitly and forwards every member. With a default, a wrapper that forwarded everything but this one would silently fall back to an upsert. Anyone implementing `INodeAgentPersistence` outside this repo will need to add the method.

## 3. A cap on reconciliation actions per health check

New `DurabilitySettings.MaxLocalAgentReconciliationsPerTick`, default 50; 0 or less means no cap. The sweep runs inside the serialized health check, before the leader's assignment pass on the leader node, so after something like a leader crash on a large fleet an unbounded sweep could hold that pass back. Deferred divergences keep their streak count and are handled on later ticks, oldest first.

## 4. Sweep starts respect stop revocations and starts still in progress

- **Revocation:** the command sequence is captured *before* the health check reads its snapshot. The sweep starts agents through `StartAgentGuardedAsync(uri, snapshotSequence)`, and skips restoring a claim if a stop has arrived since. A stop the snapshot couldn't have known about always wins.
- **Starts in progress:** a `_startingAgents` set tracks them, the way `_stoppingAgents` tracks stops. The marker is set before the wedged-restart path deregisters the agent and released only after registration, so the sweep never sees a slow start as "assigned here but not running" and starts it again.

## 5. Compliance coverage for assignment ownership and divergence

**`NodePersistenceCompliance`**, run for every provider:
- `removing_an_assignment_owned_by_another_node_is_a_no_op`, the regression test for item 1
- `add_assignment_moves_the_row_to_the_new_node`, documenting last-writer-wins
- `claiming_an_unowned_assignment_takes_it`
- `claiming_an_assignment_a_peer_owns_leaves_it_alone`
- `claiming_an_assignment_this_node_already_owns_succeeds`

**`LeadershipElectionCompliance`**, run against real hosts and real storage on every leadership suite. Each scenario fakes a divergence, then requires exactly one copy of every agent, and for the agent under test a row naming the node that runs it:
- a duplicate copy on a node the table doesn't name
- an agent assigned to a node but not running there
- a running agent whose row was deleted
- the leader dying while its start commands are still in flight

The scenarios deliberately don't assert *which* node ends up with the agent. The leader may legitimately re-place or rebalance it while the divergence heals, and in practice it does.

Also fixed: `persist_and_load_node_records` never advanced its retry counter, so on the SharedMemory variant it spun forever. That was a 40-minute hang locally; SlowTests only runs on manual dispatch, so CI never saw it. It now makes 10 attempts with a delay between them, and on SharedMemory it now fails fast rather than hanging (details under Verification).

## Verification

- `dotnet build wolverine.slnx -c Release -f net9.0`: 0 errors, 0 warnings
- CoreTests `Runtime.Agents`: 386 of 386. New unit tests cover: the orphan stop never calls `RemoveAssignmentAsync`, restoring goes through the claim and never the upsert, a peer winning the claim race keeps the row, a start in progress is never started again, and the per-tick cap works through a backlog over later ticks.
- `NodePersistenceCompliance`, all passing:
  - Postgres 18/18
  - SQL Server 18/18
  - MySQL 17/17
  - Oracle 17/17
  - SQLite 17/17
  - RavenDB 19/19
- **RavenDB negative control:** with only the old delete-by-id `RemoveAssignmentAsync` swapped back in, `removing_an_assignment_owned_by_another_node_is_a_no_op` fails (1 of 1), and passes again once the fix is restored.
- **Leadership suites:** all four new scenarios pass on MySQL, Oracle, Postgres, RavenDB (both variants), SQL Server, RabbitMQ and SharedMemory. The only failures were `singular_agent_is_only_running_on_one` (below) and SharedMemory's `persist_and_load_node_records`, which predates this PR and now fails fast instead of hanging.
- **`singular_agent_is_only_running_on_one`:** a known flake in the leadership suites (see #3451 for the CosmosDB occurrence). It failed with two copies in three suite runs on this branch, and in 1 of 5 isolated Oracle runs against 0 of 5 on the #4404 baseline. **In every failing run the reconciliation sweep took no action at all**, and every behaviour this PR changes on the SQL providers goes through a sweep action, so it isn't involved. Each failing log instead shows the leader re-placing a start that hadn't been confirmed yet (`Node 1 confirmed 0 of 5 requested agents; ... remain unconfirmed`), then `simple:///` starting on two nodes. A larger interleaved A/B is running; its numbers will follow as a comment.
- **Not run locally:** Cosmos DB (needs the emulator) and Azure Service Bus. CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj
