### PR TITLE
GH-4403: a Wolverine gRPC client can be injected into a handler

### DIFF
--- a/docs/guide/grpc/client.md
+++ b/docs/guide/grpc/client.md
@@ -48,6 +48,14 @@ public static async Task<PongReply> Handle(PingRequest request, IPingService pin
 }
 ```
 
+::: info
+Both kinds of typed client are registered through a factory lambda, which Wolverine's code generation
+can't build inline, so a handler that takes one has to resolve it through
+[service location](/guide/codegen). `AddWolverineGrpcClient<T>()` opts the client into that for you --
+there's no need to call `opts.CodeGeneration.AlwaysUseServiceLocationFor<T>()` yourself, even with the
+default `ServiceLocationPolicy.NotAllowed` in effect.
+:::
+
 ### Code-first vs proto-first
 
 `IsCodeFirstContract` classifies `TClient` by whether it is an interface decorated with

--- a/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs
+++ b/src/Http/Wolverine.Http.Tests/CodeGeneration/service_location_assertions.cs
@@ -133,7 +133,8 @@ public class service_location_assertions
         theChain.AssertServiceLocationsAreAllowed(reports, services);
 
         theLogger.Messages.Count.ShouldBe(2);
-        theLogger.Messages.ShouldAllBe(m => m.Contains("Wolverine 6.0"));
+        // The warning points at the policy that would make this an error -- the default since 6.0
+        theLogger.Messages.ShouldAllBe(m => m.Contains("ServiceLocationPolicy.NotAllowed"));
         theLogger.Levels.ShouldAllBe(l => l == LogLevel.Warning);
     }
 
@@ -153,7 +154,7 @@ public class service_location_assertions
             theChain.AssertServiceLocationsAreAllowed(reports, services);
         });
 
-        ex.Message.ShouldContain("Wolverine 6.0");
+        ex.Message.ShouldContain("ServiceLocationPolicy.NotAllowed is in effect");
     }
     
     [Theory]

--- a/src/Wolverine.Grpc.Tests/Client/Bug_4403_handler_injecting_a_wolverine_grpc_client.cs
+++ b/src/Wolverine.Grpc.Tests/Client/Bug_4403_handler_injecting_a_wolverine_grpc_client.cs
@@ -1,0 +1,91 @@
+using GreeterProtoFirstGrpc.Messages;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using PingPongWithGrpc.Messages;
+using Shouldly;
+using Wolverine.Grpc.Client;
+using Wolverine.Tracking;
+using Xunit;
+
+namespace Wolverine.Grpc.Tests.Client;
+
+/// <summary>
+/// GH-4403. The report hosts a gRPC server and client together behind ASP.NET Core, but none of that is
+/// involved: this is a plain host with no ASP.NET, no gRPC server and no AddWolverineGrpc(), and a handler that
+/// merely takes a Wolverine gRPC client as a parameter. AddWolverineGrpcClient registers the client through an
+/// opaque lambda factory -- Microsoft's AddGrpcClient for proto-first clients, Wolverine's own for code-first --
+/// which codegen can only reach through service location, and Wolverine 6 defaults to
+/// ServiceLocationPolicy.NotAllowed. Both of the first two tests threw InvalidServiceLocationException until
+/// AddWolverineGrpcClient began opting its client into service location itself.
+/// </summary>
+public class Bug_4403_handler_injecting_a_wolverine_grpc_client
+{
+    private static async Task<IHost> hostWith(Type handlerType, Action<IServiceCollection> registerClient,
+        Action<WolverineOptions>? configure = null)
+    {
+        return await Host.CreateDefaultBuilder()
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(Bug_4403_handler_injecting_a_wolverine_grpc_client).Assembly;
+                opts.Discovery.DisableConventionalDiscovery().IncludeType(handlerType);
+                configure?.Invoke(opts);
+            })
+            .ConfigureServices(registerClient)
+            .StartAsync();
+    }
+
+    private static void protoFirstClient(IServiceCollection services)
+        => services.AddWolverineGrpcClient<Greeter.GreeterClient>(o => o.Address = new Uri("http://localhost:1"));
+
+    private static void codeFirstClient(IServiceCollection services)
+        => services.AddWolverineGrpcClient<IPingService>(o => o.Address = new Uri("http://localhost:1"));
+
+    [Fact]
+    public async Task a_handler_can_take_a_proto_first_client()
+    {
+        using var host = await hostWith(typeof(UsesProtoFirstClientHandler), protoFirstClient);
+
+        await host.InvokeMessageAndWaitAsync(new UseProtoFirstClient());
+    }
+
+    [Fact]
+    public async Task a_handler_can_take_a_code_first_client()
+    {
+        using var host = await hostWith(typeof(UsesCodeFirstClientHandler), codeFirstClient);
+
+        await host.InvokeMessageAndWaitAsync(new UseCodeFirstClient());
+    }
+
+    // The reporter's workaround, which existing applications will still carry. Opting in explicitly as well
+    // must keep working alongside the automatic registration rather than colliding with it.
+    [Fact]
+    public async Task an_explicit_opt_in_still_works_alongside_the_automatic_one()
+    {
+        using var host = await hostWith(typeof(UsesProtoFirstClientHandler), protoFirstClient,
+            opts => opts.CodeGeneration.AlwaysUseServiceLocationFor<Greeter.GreeterClient>());
+
+        await host.InvokeMessageAndWaitAsync(new UseProtoFirstClient());
+    }
+}
+
+public record UseProtoFirstClient;
+
+public record UseCodeFirstClient;
+
+public static class UsesProtoFirstClientHandler
+{
+    // Never calls the client -- there is no server. Taking it as a parameter is the whole reproduction.
+    public static void Handle(UseProtoFirstClient message, Greeter.GreeterClient client)
+    {
+        client.ShouldNotBeNull();
+    }
+}
+
+public static class UsesCodeFirstClientHandler
+{
+    public static void Handle(UseCodeFirstClient message, IPingService client)
+    {
+        client.ShouldNotBeNull();
+    }
+}

--- a/src/Wolverine.Grpc/Client/WolverineGrpcClientExtensions.cs
+++ b/src/Wolverine.Grpc/Client/WolverineGrpcClientExtensions.cs
@@ -86,6 +86,14 @@ public static class WolverineGrpcClientExtensions
         services.AddOptions<WolverineGrpcClientOptions>(name);
         services.AddOptions<WolverineGrpcCodeFirstClientOptions>(name);
 
+        // GH-4403: both registration paths below hand the client to DI as an opaque lambda factory --
+        // Microsoft's AddGrpcClient<T>() for proto-first, our own for code-first -- which Wolverine's codegen
+        // cannot construct inline. Under the default ServiceLocationPolicy.NotAllowed, every handler that took
+        // the client as a parameter failed to compile. Opting the client into service location here, at the one
+        // place it is registered, means nobody has to do it by hand. It is applied at startup like any other
+        // extension, so it works in a client-only application and in any order relative to UseWolverine().
+        services.ConfigureWolverine(opts => opts.CodeGeneration.AlwaysUseServiceLocationFor<TClient>());
+
         if (IsCodeFirstContract(typeof(TClient)))
         {
             services.TryAddSingleton<WolverineGrpcCodeFirstChannelFactory>();

--- a/src/Wolverine/Configuration/Chain.cs
+++ b/src/Wolverine/Configuration/Chain.cs
@@ -583,11 +583,11 @@ public abstract class Chain<TChain, TModifyAttribute> : IChain
                 {
                     if (report.ServiceDescriptor.IsKeyedService)
                     {
-                        logger.LogWarning("Utilizing service location for {Chain} for Service {ServiceType} ({Key}): {Reason}. This will throw in Wolverine 6.0 when ServiceLocationPolicy.NotAllowed becomes the default. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.ServiceDescriptor.ServiceKey, report.Reason);
+                        logger.LogWarning("Utilizing service location for {Chain} for Service {ServiceType} ({Key}): {Reason}. Under the default ServiceLocationPolicy.NotAllowed this is an error. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.ServiceDescriptor.ServiceKey, report.Reason);
                     }
                     else
                     {
-                        logger.LogWarning("Utilizing service location for {Chain} for Service {ServiceType}: {Reason}. This will throw in Wolverine 6.0 when ServiceLocationPolicy.NotAllowed becomes the default. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.Reason);
+                        logger.LogWarning("Utilizing service location for {Chain} for Service {ServiceType}: {Reason}. Under the default ServiceLocationPolicy.NotAllowed this is an error. See https://wolverinefx.net/guide/codegen.html", Description, report.ServiceDescriptor.ServiceType, report.Reason);
                     }
                 }
                 break;
@@ -612,7 +612,7 @@ public class InvalidServiceLocationException : Exception
     public static string ToMessage(IChain chain, ServiceLocationReport[] reports)
     {
         var writer = new StringWriter();
-        writer.WriteLine($"Found service locations while generating code for {chain.Description}, but {nameof(ServiceLocationPolicy)}.{nameof(ServiceLocationPolicy.NotAllowed)} is in effect (this will become the default in Wolverine 6.0).");
+        writer.WriteLine($"Found service locations while generating code for {chain.Description}, but {nameof(ServiceLocationPolicy)}.{nameof(ServiceLocationPolicy.NotAllowed)} is in effect (it is the default).");
         writer.WriteLine("See https://wolverinefx.net/guide/codegen.html for more information");
         writer.WriteLine("Service location(s):");
         foreach (var report in reports)


### PR DESCRIPTION
Closes #4403.

## What was actually wrong

The report hosts a gRPC server and client together behind ASP.NET Core, but **none of that is involved**. Any Wolverine handler that takes an `AddWolverineGrpcClient<T>()` client as a parameter fails to compile, in any host:

```
InvalidServiceLocationException : ... ServiceLocationPolicy.NotAllowed is in effect
Service ...ClientTestClient: The service registration ... is an 'opaque' lambda factory with the
Transient lifetime and requires service location
```

`AddWolverineGrpcClient` registers the client through a lambda factory in both of its paths, and Wolverine's code generation can't build that inline:
- **proto-first:** Microsoft's `AddGrpcClient<T>()`
- **code-first:** Wolverine's own `AddTransient(sp => ...)`

Wolverine 6 defaults to `ServiceLocationPolicy.NotAllowed`, so the handler can't be generated. The reporter's workaround, `opts.CodeGeneration.AlwaysUseServiceLocationFor<ClientTestClient>()`, was the correct one.

**The docs and the sample were affected too:**
- The docs example in `docs/guide/grpc/client.md` ("inject the typed client into any Wolverine handler") is exactly this failing case.
- The `OrderChainWithGrpc` sample the reporter followed is broken the same way: its `PlaceOrderHandler` takes an `IInventoryService` registered through `AddWolverineGrpcClient`. Without this fix, `codegen preview` on `OrderServer` fails with `InvalidServiceLocationException`; with it, `PlaceOrderHandler` generates cleanly.

Nothing in the test suite ever injected a gRPC client into a handler.

## Fix

`AddWolverineGrpcClient<T>()` now opts its own client into service location with `services.ConfigureWolverine(o => o.CodeGeneration.AlwaysUseServiceLocationFor<TClient>())`. That's the same thing the EF Core integration does for `DbContext`s registered through factories. `ConfigureWolverine` registers an extension that's applied when Wolverine's options are built at startup, before any handler compiles. So it works:
- in a client-only app that never calls `AddWolverineGrpc()`
- in either order relative to `UseWolverine()`
- alongside an app that still has the explicit workaround

Also fixed: the service-location messages in `Chain.cs` still said `NotAllowed` "will become the default in Wolverine 6.0". It's been the default since 6.0, so they now say so.

## Tests

`Wolverine.Grpc.Tests/Client/Bug_4403_handler_injecting_a_wolverine_grpc_client.cs` uses a plain `Host`, with no ASP.NET, no gRPC server and no `AddWolverineGrpc()`, and a handler that takes the client without calling it:
- a proto-first client (`Greeter.GreeterClient`) can be injected
- a code-first client (`IPingService`) can be injected
- an app that still applies `AlwaysUseServiceLocationFor<T>()` explicitly keeps working alongside the automatic opt-in

**Before the fix,** both injection tests failed with the reporter's exact exception, and the explicit workaround passed.

**Results:**
- Regression tests: 3 of 3 passing
- Full gRPC suite: 325 of 325 passing
- `dotnet build wolverine.slnx -c Release -f net9.0`: 0 Error(s), 0 Warning(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj
