### PR TITLE
GH-4410: refuse CircuitBreaker() on a buffered local queue instead of silently ignoring it

### DIFF
--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -251,6 +251,12 @@ limit sit on the queue and wait their turn, which is exactly what you want -- th
 free and losing them is not.
 :::
 
+::: warning
+The circuit breaker depends on that durability. A local queue can only pause when it's durable, so if you set
+`DurableQueue = false`, a `CircuitBreaker()` on the callout queue stops the host from starting. See
+[circuit breakers on local queues](/guide/messaging/transports/local#circuit-breakers-on-local-queues).
+:::
+
 Some providers are stricter than that, and a per-account rate limit that only lets you have one conversation going
 at a time is not unusual. Take the queue down to strict ordering when that's the situation you're in:
 

--- a/docs/guide/messaging/listeners.md
+++ b/docs/guide/messaging/listeners.md
@@ -506,7 +506,7 @@ callback. Settings that size or shard that block therefore do nothing on an `Inl
 | `ListenerCount(n)` | ✔️ | ✔️ | ✔️ | ✔️ |
 | `ListenWithStrictOrdering()` / `ListenOnlyAtLeader()` | ✔️ (exclusivity only) | ✔️ | ✔️ | ✔️ |
 | `ExclusiveNodeWithParallelism(n)` | ✔️ exclusivity, parallelism ignored (warns) | ✔️ | ✔️ | ✔️ |
-| `CircuitBreaker()` | ✔️ | ✔️ | ✔️ | ✔️ |
+| `CircuitBreaker()` | ✔️ | ✔️ | ✔️ (a [local queue](/guide/messaging/transports/local#circuit-breakers-on-local-queues) **throws at startup**) | ✔️ |
 | [`WithInMemoryIdempotency()`](#in-memory-idempotency-guard) | ✔️ | ✔️ | ✔️ | ignored (warns) |
 
 As of Wolverine 6.30, these combinations are no longer silently accepted:
@@ -522,6 +522,11 @@ As of Wolverine 6.30, these combinations are no longer silently accepted:
   itself *is* the local execution block. A local queue that reaches `Inline` through one of the lazily
   resolved configuration points (`LocalQueueFor<T>()`, `IConfigureLocalQueue`) throws an
   `InvalidListenerConfigurationException` at bootstrap instead.
+
+As of Wolverine 6.36, `CircuitBreaker()` on a buffered (non-durable) local queue also throws an
+`InvalidListenerConfigurationException` at bootstrap. Only a durable local queue can pause, so earlier versions
+accepted the circuit breaker and then quietly kept processing every message. See
+[circuit breakers on local queues](/guide/messaging/transports/local#circuit-breakers-on-local-queues).
 
 That normalization also removes an order dependency: `.MaximumParallelMessages(20).ProcessInline()` and
 `.ProcessInline().MaximumParallelMessages(20)` now leave the endpoint in exactly the same state. The

--- a/docs/guide/messaging/transports/local.md
+++ b/docs/guide/messaging/transports/local.md
@@ -302,6 +302,29 @@ using var host = await Host.CreateDefaultBuilder()
 
 See [Durable Inbox and Outbox Messaging](/guide/durability/) for more information.
 
+## Circuit Breakers on Local Queues
+
+You can put a [circuit breaker](/guide/handlers/error-handling#circuit-breaker) on a local queue, but only on a
+durable one:
+
+```cs
+opts.LocalQueueFor<ProcessPayment>()
+    .UseDurableInbox()
+    .CircuitBreaker(cb =>
+    {
+        cb.MinimumThreshold = 10;
+        cb.FailurePercentageThreshold = 20;
+        cb.PauseTime = 5.Minutes();
+    });
+```
+
+::: warning
+A buffered local queue can't pause. As of Wolverine 6.36, `CircuitBreaker()` on a local queue that isn't
+durable stops the host from starting with an `InvalidListenerConfigurationException`. Earlier versions accepted
+the configuration and then ignored it, so the queue just kept processing -- and failing -- every message. Add
+`UseDurableInbox()` to the queue, or `opts.Policies.UseDurableLocalQueues()` for all of them.
+:::
+
 
 ## Configuring Parallelization and Execution Properties
 

--- a/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
+++ b/src/Testing/CoreTests/Configuration/listener_configuration_validation.cs
@@ -246,6 +246,66 @@ public class listener_configuration_validation
         ListenerConfigurationValidator.Validate(queue).ShouldBeEmpty();
     }
 
+    // GH-4410. Only a durable local queue ever builds a circuit breaker; a buffered one accepted the
+    // configuration and then kept processing -- and failing -- every message.
+    [Fact]
+    public void a_circuit_breaker_on_a_buffered_local_queue_is_fatal()
+    {
+        var endpoint = compiledEndpoint(opts => opts.LocalQueue("cb-buffered").CircuitBreaker(),
+            "local://cb-buffered");
+
+        endpoint.Mode.ShouldBe(EndpointMode.BufferedInMemory);
+
+        var problem = ListenerConfigurationValidator.Validate(endpoint).Single();
+
+        problem.Severity.ShouldBe(ListenerConfigurationSeverity.Fatal);
+        problem.Message.ShouldContain("CircuitBreaker()");
+        problem.Message.ShouldContain("local://cb-buffered");
+        problem.Message.ShouldContain("UseDurableInbox()");
+    }
+
+    [Fact]
+    public void a_circuit_breaker_on_a_durable_local_queue_is_still_valid()
+    {
+        var endpoint = compiledEndpoint(opts => opts.LocalQueue("cb-durable").UseDurableInbox().CircuitBreaker(),
+            "local://cb-durable");
+
+        endpoint.Mode.ShouldBe(EndpointMode.Durable);
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_circuit_breaker_on_a_local_queue_made_durable_by_policy_is_still_valid()
+    {
+        var endpoint = compiledEndpoint(opts =>
+        {
+            opts.Policies.UseDurableLocalQueues();
+            opts.LocalQueue("cb-policy").CircuitBreaker();
+        }, "local://cb-policy");
+
+        endpoint.Mode.ShouldBe(EndpointMode.Durable);
+        ListenerConfigurationValidator.Validate(endpoint).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_circuit_breaker_on_a_buffered_local_queue_stops_the_host_from_starting()
+    {
+        var ex = await Should.ThrowAsync<InvalidListenerConfigurationException>(async () =>
+        {
+            using var host = await Host.CreateDefaultBuilder().UseWolverine(opts =>
+            {
+                opts.LocalQueueFor<CircuitBreakerLocalQueueMessage>().CircuitBreaker(cb =>
+                {
+                    cb.MinimumThreshold = 1;
+                    cb.FailurePercentageThreshold = 1;
+                });
+            }).StartAsync();
+        });
+
+        ex.Message.ShouldContain("CircuitBreaker()");
+        ex.Message.ShouldContain("local queue");
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -352,3 +412,5 @@ public class listener_configuration_validation
 }
 
 public record InlineLocalQueueMessage(string Name);
+
+public record CircuitBreakerLocalQueueMessage(string Name);

--- a/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
+++ b/src/Wolverine/Configuration/ListenerConfigurationValidator.cs
@@ -109,6 +109,22 @@ internal static class ListenerConfigurationValidator
             }
         }
 
+        // GH-4410. Only DurableLocalQueue ever builds a CircuitBreaker from these options; a BufferedLocalQueue
+        // never counts a failure against them, and its IListenerCircuit pause/restart members are no-ops. The
+        // setting used to be accepted here and then do nothing at all, so the queue kept processing -- and
+        // failing -- every message while the application believed it would pause. An Inline local queue is
+        // already refused below, so only the buffered case needs saying here.
+        if (endpoint is LocalQueue && endpoint.CircuitBreakerOptions != null &&
+            endpoint.Mode == EndpointMode.BufferedInMemory)
+        {
+            yield return new ListenerConfigurationProblem(endpoint, ListenerConfigurationSeverity.Fatal,
+                $"Invalid listener configuration for {describe(endpoint)}: CircuitBreaker() was configured on a buffered, " +
+                "non-durable local queue. A local queue's circuit breaker only exists when the queue is durable -- a buffered " +
+                "local queue never counts failures against it and cannot pause, so it would keep processing (and failing) every " +
+                "message rather than stopping. Add UseDurableInbox() to this queue, or opts.Policies.UseDurableLocalQueues() for " +
+                "all of them, or remove CircuitBreaker().");
+        }
+
         if (endpoint.Mode != EndpointMode.Inline)
         {
             yield break;

--- a/src/Wolverine/Transports/Local/LocalQueueConfiguration.cs
+++ b/src/Wolverine/Transports/Local/LocalQueueConfiguration.cs
@@ -28,8 +28,10 @@ public class LocalQueueConfiguration : ListenerConfiguration<LocalQueueConfigura
     }
 
     /// <summary>
-    ///     Add circuit breaker exception handling to this local queue. This will only
-    ///     be applied if the local queue is marked as durable!!!
+    ///     Add circuit breaker exception handling to this local queue. The queue must also be durable
+    ///     (<c>UseDurableInbox()</c>, or <c>opts.Policies.UseDurableLocalQueues()</c>): a buffered local queue
+    ///     cannot pause, so as of 6.36 a circuit breaker on one stops the host from starting with an
+    ///     <see cref="InvalidListenerConfigurationException" /> rather than being silently ignored (GH-4410).
     /// </summary>
     /// <param name="configure"></param>
     /// <returns></returns>


### PR DESCRIPTION
Closes #4410. Takes **option 1** from the issue: fail fast.

## The bug

`LocalQueueConfiguration.CircuitBreaker()` sets `Endpoint.CircuitBreakerOptions` whatever the mode, but only `DurableLocalQueue` ever builds a `CircuitBreaker` from it. `BufferedLocalQueue` runs its pipeline on the runtime's executor factory, not a `CircuitBreakerTrackedExecutorFactory`, so failures are never counted. Its `IListenerCircuit.PauseAsync` / `PauseWithDrainAsync` / `StartAsync` are also no-ops. A circuit breaker on a buffered local queue was accepted and then did nothing: the queue kept processing, and failing, every message.

## The fix

`ListenerConfigurationValidator` now reports a `LocalQueue` in `BufferedInMemory` mode with `CircuitBreakerOptions` set as **Fatal**. The host stops at bootstrap with an `InvalidListenerConfigurationException` that names the queue and points at `UseDurableInbox()` / `opts.Policies.UseDurableLocalQueues()`. This follows the GH-4022 precedent: the lazily resolved `LocalQueueFor<T>()` / `IConfigureLocalQueue` paths settle the mode at `Compile()`, so bootstrap validation is the one place that sees the final mode.

- Durable local queues are unaffected, including queues made durable by `UseDurableLocalQueues()`.
- An `Inline` local queue is already refused by the existing check, so it doesn't get a second report.
- External listeners are unaffected. `ListeningAgent` honors the breaker in every mode.

### Fatal, not Warning

The validator's own rubric says Warning is for an inert setting where "the endpoint still does something reasonable". You could argue for Warning here, since the queue does still process. I went with Fatal because the issue asks for it, and because a log-only warning is how this stayed invisible. Someone who configured a breaker to stop hammering a failing dependency is relying on it. Switching to Warning is a one-word change if you'd rather not break startup for existing misconfigured apps.

### Check before release

`WolverineFx.AI`'s documented `ConfigureQueue(q => q.CircuitBreaker(...))` sample is fine with the default `DurableQueue = true`. With `DurableQueue = false` (the buffered fallback), it now fails to start where it used to silently do nothing. No test combines the two. The AI guide now says so.

## Docs
- `listeners.md` mode table: the `BufferedInMemory` cell no longer claims `CircuitBreaker()` works on a local queue. Added a 6.36 note.
- `transports/local.md`: new "Circuit Breakers on Local Queues" section.
- `ai.md`: warning next to the callout queue sample.
- `CircuitBreaker()` XML doc updated.

## Tests
New cases in `listener_configuration_validation`:
- buffered local queue with a breaker is fatal
- durable local queue with a breaker is valid
- local queue made durable by policy with a breaker is valid
- `LocalQueueFor<T>().CircuitBreaker()` stops `StartAsync`

Local results:
- Targeted CoreTests run (`listener_configuration_validation`, `LocalQueueTests`, `local_integration_specs`, `hot_tail_requeue`, `native_ack_mode_gate`): 61/61 passed.
- `dotnet build wolverine.slnx -c Release -f net9.0`: the only error was an `MSB3030` apphost copy race in `ProcessManagerViaHandlers`. That project rebuilds clean on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj