### PR TITLE
GH-4395: [SlicePattern] declares a message-handler slice's pattern the code cannot derive

### DIFF
--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -414,6 +414,33 @@ or a cron-scheduled message is an `Automation`, a gRPC RPC is a `Command`, an in
 slice a `Translation`, and a slice whose command is an event another slice emits is promoted to `Automation`
 because the assembled model says so.
 
+### Declaring the pattern of a message handler
+
+That still leaves a gap. A message handler whose message has *no* producer anywhere in the model -- it comes in
+from another service over a broker, or from a hosted service, or from a controller that isn't a Wolverine
+endpoint -- carries no pattern at all, and those are usually exactly the slices you most want colored in. If you
+know the answer, say so on the handler with `[SlicePattern]`, the same way `[Emits]` names events:
+
+```cs
+[SlicePattern(SlicePattern.Command)]
+public static IssueAssigned Handle(AssignIssue command, IssueRepository issues)
+{
+    // ...
+}
+```
+
+Put it on the handler method, or on the handler type when every method of it has the same pattern. A declaration
+on the method wins over one on the type.
+
+::: tip
+`[SlicePattern]` only fills a gap. An HTTP route, a gRPC RPC, a schedule and an inbound external system all
+derive the pattern from the trigger itself, and the attribute won't override any of them. On a plain message
+handler it *does* take precedence over the `Automation` promotion for a message another slice cascades, because
+a cascaded message can also arrive from outside the model, and that's precisely the question you're answering.
+Like `[Emits]`, it's purely diagnostic, and a stale declaration shows up as a disagreement with a declared model
+rather than going unnoticed.
+:::
+
 ### Meeting a declared model
 
 A declared model — a curated board file, an overlay — names a slice for the behaviour: `ConfirmAppointment`.

--- a/src/Testing/CoreTests/Acceptance/event_model_slice_pattern_attribute_4395.cs
+++ b/src/Testing/CoreTests/Acceptance/event_model_slice_pattern_attribute_4395.cs
@@ -1,0 +1,210 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Wolverine.Configuration;
+using Wolverine.Configuration.EventModeling;
+using Wolverine.Persistence.EventSourcing;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace CoreTests.Acceptance.EventModel4395;
+
+// GH-4395: after GH-4387 a message-handler slice whose message has no producer in the model -- it comes from
+// another service, a hosted service, a controller -- carries no Pattern at all. "The code cannot say" and
+// "nobody can say" were producing the same output. [SlicePattern] lets the handler say it, next to the code.
+public class slice_pattern_attribute_4395
+{
+    private static HandlerChain chainFor<THandler>(System.Linq.Expressions.Expression<Action<THandler>> expression)
+        => HandlerChain.For(expression, new HandlerGraph());
+
+    [Fact]
+    public void a_declared_pattern_is_claimed_for_a_message_handler()
+    {
+        EventModelRoles.ForHandlerChain(chainFor<AssignTicketHandler>(x => AssignTicketHandler.Handle(null!)))
+            .Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void without_a_declaration_the_pattern_stays_unclaimed()
+    {
+        EventModelRoles.ForHandlerChain(chainFor<CloseTicketHandler>(x => CloseTicketHandler.Handle(null!)))
+            .Pattern.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_declaration_on_the_handler_type_applies_to_its_methods()
+    {
+        EventModelRoles.ForHandlerChain(chainFor<TicketAutomationHandler>(x => TicketAutomationHandler.Handle((TicketEscalated)null!)))
+            .Pattern.ShouldBe(SlicePattern.Automation);
+    }
+
+    [Fact]
+    public void a_declaration_on_the_method_wins_over_the_handler_type()
+    {
+        EventModelRoles.ForHandlerChain(chainFor<TicketAutomationHandler>(x => TicketAutomationHandler.Handle((TicketImported)null!)))
+            .Pattern.ShouldBe(SlicePattern.Translation);
+    }
+
+    [Fact]
+    public void the_quickstart_shape_now_colours_every_slice()
+    {
+        // OpenTicket arrives from outside the model and is declared; TicketOpened is cascaded by it and is
+        // still promoted by the model-wide rule, exactly as before
+        var open = EventModelRoles.ForHandlerChain(chainFor<OpenTicketHandler>(x => OpenTicketHandler.Handle(null!)));
+        var react = EventModelRoles.ForHandlerChain(chainFor<TicketOpenedHandler>(x => TicketOpenedHandler.Handle(null!)));
+
+        var model = WolverineEventModelSource.FinishModel(new EventModelDescriptor("app", new[] { open, react }));
+
+        model.Slices.Single(x => x.Name == nameof(OpenTicket)).Pattern.ShouldBe(SlicePattern.Command);
+        model.Slices.Single(x => x.Name == nameof(TicketOpened)).Pattern.ShouldBe(SlicePattern.Automation);
+    }
+
+    [Fact]
+    public void a_declaration_is_not_promoted_by_the_cascade_inference()
+    {
+        // AssignTicket is cascaded by a sibling slice, which would make it an Automation -- but it is also sent
+        // from outside the model, and the handler says so. The declaration answers the question the rule guesses at.
+        var escalate = EventModelRoles.ForHandlerChain(chainFor<EscalateTicketHandler>(x => EscalateTicketHandler.Handle(null!)));
+        escalate.PublishedMessages.Select(x => x.Name).ShouldBe(new[] { nameof(AssignTicket) });
+
+        var assign = EventModelRoles.ForHandlerChain(chainFor<AssignTicketHandler>(x => AssignTicketHandler.Handle(null!)));
+
+        var model = WolverineEventModelSource.FinishModel(new EventModelDescriptor("app", new[] { escalate, assign }));
+
+        model.Slices.Single(x => x.Name == nameof(AssignTicket)).Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void a_declaration_does_not_override_a_schedule()
+    {
+        EventModelRoles.ForHandlerChain(chainFor<TicketReminderHandler>(x => TicketReminderHandler.Handle(null!)))
+            .Pattern.ShouldBe(SlicePattern.Automation);
+    }
+
+    [Fact]
+    public void a_declaration_does_not_override_an_http_route()
+    {
+        var chain = chainFor<TicketAutomationHandler>(x => TicketAutomationHandler.Handle((TicketEscalated)null!));
+
+        var query = EventModelRoles.Describe(chain,
+            new EventModelSliceSeed("GET /tickets", TriggerKind.Http, null, null, typeof(TicketAutomationHandler))
+            {
+                IsQuery = true
+            });
+        query.Pattern.ShouldBe(SlicePattern.View);
+
+        var post = EventModelRoles.Describe(chain,
+            new EventModelSliceSeed("POST /tickets", TriggerKind.Http, null, null, typeof(TicketAutomationHandler)));
+        post.Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void a_declaration_does_not_override_a_grpc_rpc()
+    {
+        var slice = EventModelRoles.ForHandlerChain(chainFor<TicketAutomationHandler>(x => TicketAutomationHandler.Handle((TicketEscalated)null!)));
+        slice.Pattern.ShouldBe(SlicePattern.Automation);
+
+        var manifest = new StubGrpcManifest(new GrpcEndpointDescriptor("Tickets", "Escalate",
+            typeof(TicketEscalated), null, typeof(TicketAutomationHandler),
+            GrpcServiceDiscoveryMode.CodeFirst, GrpcRpcStreamKind.Unary));
+
+        var applied = WolverineEventModelSource.ApplyGrpcTriggers(new EventModelDescriptor("app", new[] { slice }), manifest);
+
+        applied.Slices.Single().Pattern.ShouldBe(SlicePattern.Command);
+    }
+
+    [Fact]
+    public void a_stale_declaration_disagrees_with_the_board_instead_of_going_unseen()
+    {
+        var derived = EventModelRoles.ForHandlerChain(chainFor<AssignTicketHandler>(x => AssignTicketHandler.Handle(null!)))
+            .WithProvenance(EventModelProvenance.Derived);
+
+        var board = (EventModelSliceDescriptor.Named(derived.Name) with
+        {
+            Pattern = SlicePattern.Automation
+        }).WithProvenance(EventModelProvenance.Declared);
+
+        var merged = board.Merge(derived);
+
+        merged.ProvenanceFor(EventModelRole.Pattern).ShouldBe(EventModelProvenance.Derived);
+        merged.Hotspots.ShouldContain(x => x.Origin == HotspotOrigin.SourceDisagreement);
+    }
+
+    private sealed class StubGrpcManifest(params GrpcEndpointDescriptor[] endpoints) : IGrpcEndpointManifest
+    {
+        public IReadOnlyList<GrpcEndpointDescriptor> Endpoints { get; } = endpoints;
+    }
+}
+
+#region sample types for GH-4395
+
+public record OpenTicket(string Title);
+
+public record TicketOpened(Guid Id);
+
+public record AssignTicket(Guid Id, string Assignee);
+
+public record EscalateTicket(Guid Id);
+
+public record CloseTicket(Guid Id);
+
+public record TicketEscalated(Guid Id);
+
+public record TicketImported(Guid Id);
+
+public record TicketReminderDue(Guid Id) : TimeoutMessage(TimeSpan.FromHours(1));
+
+public class OpenTicketHandler
+{
+    [SlicePattern(SlicePattern.Command)]
+    public static TicketOpened Handle(OpenTicket command) => new(Guid.NewGuid());
+}
+
+public class TicketOpenedHandler
+{
+    public static void Handle(TicketOpened opened)
+    {
+    }
+}
+
+public class AssignTicketHandler
+{
+    [SlicePattern(SlicePattern.Command)]
+    public static void Handle(AssignTicket command)
+    {
+    }
+}
+
+public class EscalateTicketHandler
+{
+    public static AssignTicket Handle(EscalateTicket command) => new(command.Id, "on-call");
+}
+
+public class CloseTicketHandler
+{
+    public static void Handle(CloseTicket command)
+    {
+    }
+}
+
+[SlicePattern(SlicePattern.Automation)]
+public class TicketAutomationHandler
+{
+    public static void Handle(TicketEscalated escalated)
+    {
+    }
+
+    [SlicePattern(SlicePattern.Translation)]
+    public static void Handle(TicketImported imported)
+    {
+    }
+}
+
+public class TicketReminderHandler
+{
+    [SlicePattern(SlicePattern.Command)]
+    public static void Handle(TicketReminderDue due)
+    {
+    }
+}
+
+#endregion

--- a/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
+++ b/src/Wolverine/Configuration/EventModeling/EventModelRoles.cs
@@ -217,7 +217,13 @@ public static class EventModelRoles
             // promotes a slice whose command is an event another slice emits to Automation, and an
             // inbound external system still makes the slice a Translation. Both claim the role from
             // evidence rather than from the absence of it.
-            pattern = null;
+            //
+            // GH-4395. ...unless the handler says so itself with [SlicePattern]. A message with no
+            // producer in this model -- one from another service, a hosted service, a controller -- has
+            // no evidence to promote it, and "the code cannot say" is not the same claim as "nobody can
+            // say". Only here, where nothing else answers: every branch above derives the pattern from
+            // the trigger, and a declaration does not contradict what the code does know.
+            pattern = declaredPattern(chain);
         }
 
         // GH-4181. TriggerLabel is deliberately NOT claimed here. Every structural fact a derived
@@ -387,6 +393,22 @@ public static class EventModelRoles
                 roles.ReadModels.Add(parameterType);
             }
         }
+    }
+
+    /// <summary>
+    ///     The pattern a <see cref="SlicePatternAttribute" /> declares on the chain's handler method, else on
+    ///     its handler type; null when neither does. GH-4395.
+    /// </summary>
+    private static SlicePattern? declaredPattern(IChain chain)
+    {
+        foreach (var call in chain.HandlerCalls())
+        {
+            var declared = call.Method.GetAttribute<SlicePatternAttribute>()
+                           ?? call.HandlerType.GetAttribute<SlicePatternAttribute>();
+            if (declared != null) return declared.Pattern;
+        }
+
+        return null;
     }
 
     private static Type? tryDetermineAggregateType(IChain chain)

--- a/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
+++ b/src/Wolverine/Configuration/EventModeling/WolverineEventModelSource.cs
@@ -364,7 +364,9 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
             // GH-4387: the slice behind an RPC is derived off a message handler chain, which no longer
             // claims Pattern. An RPC is an inbound request somebody made, exactly as an HTTP route is, so
             // the trigger answers the question the handler signature could not.
-            Pattern = slice.Pattern ?? SlicePattern.Command
+            // GH-4395: unconditionally, so a [SlicePattern] on the handler behind the RPC fills no gap
+            // here -- the trigger outranks a declaration, the same as an HTTP route's derived pattern does.
+            Pattern = SlicePattern.Command
         };
 
     private static EventModelSliceDescriptor grpcTriggerOnlySlice(GrpcEndpointDescriptor endpoint, PublisherOrigin origin)
@@ -411,6 +413,13 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
     ///         cascades has not thereby made the route an automation. A slice whose only producer is
     ///         <em>itself</em> is a loop, which says nothing about how the message first arrives.
     ///     </para>
+    ///     <para>
+    ///         <b>A declared pattern is never promoted.</b> <see cref="EventModelRoles.Describe" /> leaves a
+    ///         message-handler slice's pattern unclaimed unless the handler declares one with
+    ///         <c>[SlicePattern]</c> (GH-4395), so a pattern already on such a slice here is a declaration. It
+    ///         answers the very question this rule infers -- a message another slice cascades may also arrive
+    ///         from outside the model -- so it stands.
+    ///     </para>
     /// </remarks>
     public static EventModelDescriptor FinishModel(EventModelDescriptor model)
     {
@@ -439,8 +448,8 @@ public sealed class WolverineEventModelSource : IEventModelDefinitionSource
 
         EventModelSliceDescriptor promote(EventModelSliceDescriptor slice)
         {
-            if (slice.Pattern is not (null or SlicePattern.Command)) return slice;
             if (slice.TriggerKind != TriggerKind.MessageHandler) return slice;
+            if (slice.Pattern is not null) return slice; // GH-4395: declared with [SlicePattern]
             if (slice.CommandType is not { } command) return slice;
             if (!producers.TryGetValue(command.FullName, out var names)) return slice;
             if (names.All(x => string.Equals(x, slice.Name, StringComparison.Ordinal))) return slice;

--- a/src/Wolverine/Persistence/EventSourcing/SlicePatternAttribute.cs
+++ b/src/Wolverine/Persistence/EventSourcing/SlicePatternAttribute.cs
@@ -1,0 +1,54 @@
+using JasperFx.Events.EventModeling;
+
+namespace Wolverine.Persistence.EventSourcing;
+
+/// <summary>
+///     Declare the Event Modeling <see cref="SlicePattern" /> of a message handler when nothing in the
+///     code can derive it (GH-4395).
+/// </summary>
+/// <remarks>
+///     <para>
+///         A message handler's slice is a <see cref="SlicePattern.Command" /> or an
+///         <see cref="SlicePattern.Automation" /> depending on <em>why</em> the message arrived -- a person
+///         asked for it, or the system reacted to something -- and a handler signature cannot tell the two
+///         apart, so Wolverine leaves the pattern unclaimed (GH-4387). The model can answer when another slice
+///         in this application hands the message off, but a message that comes from another service over a
+///         broker, from a hosted service, or from a controller that is not a Wolverine endpoint has no
+///         producer in the model at all, and its slice carries no pattern.
+///     </para>
+///     <para>
+///         This attribute puts the fact back next to the code, the same way <see cref="EmitsAttribute" />
+///         does for event types. It is read on the <see cref="EventModelProvenance.Derived" /> rung and it
+///         is purely diagnostic: nothing about dispatch, codegen or persistence reads it, so a wrong or stale
+///         declaration costs a claim that disagrees with the board, which is exactly the drift the merge
+///         exists to surface.
+///     </para>
+///     <para>
+///         <b>It fills a gap and never overrides a trigger.</b> An HTTP route, a gRPC RPC, a schedule and an
+///         inbound external system each derive the pattern from the trigger itself, and the attribute does
+///         not contradict them. On a plain message handler it does take precedence over the model-wide
+///         inference that promotes a slice to <see cref="SlicePattern.Automation" /> because another slice
+///         cascades its message: that inference is exactly the guess the declaration is there to settle.
+///     </para>
+///     <para>
+///         Put it on the handler method, or on the handler type when every method of it has the same
+///         pattern. A declaration on the method wins over one on the type.
+///     </para>
+/// </remarks>
+/// <example>
+///     <code>
+///     [SlicePattern(SlicePattern.Command)]
+///     public static IssueAssigned Handle(AssignIssue command, IssueRepository issues)
+///     </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class SlicePatternAttribute : Attribute
+{
+    public SlicePatternAttribute(SlicePattern pattern)
+    {
+        Pattern = pattern;
+    }
+
+    /// <summary>The slice pattern this handler declares.</summary>
+    public SlicePattern Pattern { get; }
+}


### PR DESCRIPTION
Closes #4395.

## The gap

After #4387, a message-handler slice whose message has **no producer anywhere in the model** carries no `Pattern`. That covers a message from another service over a broker, one from a hosted service, or one from a controller that isn't a Wolverine endpoint. In the Quickstart shape, the slices the application receives from outside are exactly the blank ones.

## The fix

The issue proposed an opt-in declaration shaped like `[Emits]` (#4386). This adds it:

```csharp
[SlicePattern(SlicePattern.Command)]
public static IssueAssigned Handle(AssignIssue command, IssueRepository issues) { ... }
```

- `SlicePatternAttribute` lives next to `EmitsAttribute` in `Wolverine.Persistence.EventSourcing`. It goes on a method or a handler type, and the method's declaration wins.
- `EventModelRoles.Describe` reads it on the Derived rung, only in the message-handler branch where #4387 leaves `Pattern` null.
- It is purely diagnostic. A stale declaration shows up as a `SourceDisagreement` against the board, and a test covers that.
- It is deliberately **not** an inference of `Command` from "nothing produces this message". #4387 removed that guess.

## Precedence (the issue's open question, decided here)

| Where the pattern comes from | vs. `[SlicePattern]` |
| --- | --- |
| HTTP route (`GET` is View, otherwise Command) | **trigger wins**, the attribute is ignored |
| gRPC RPC is Command | **trigger wins** |
| `TimeoutMessage` or cron schedule is Automation | **trigger wins** |
| Inbound named external system is Translation | **trigger wins** (unchanged, applied later) |
| `FinishModel` promotes a cascaded message to Automation | **declaration wins** |

This follows the issue's instinct for HTTP and gRPC: the attribute fills a gap but can't contradict something the code knows. The one place a declaration outranks derivation is the cascade promotion. That rule is an inference, and a message another slice cascades can also arrive from outside the model, which is exactly what the declaration answers.

Two behavior changes follow from this table:
- **`withGrpcTrigger`** now claims `Command` unconditionally instead of `slice.Pattern ?? Command`, so a declaration on the handler behind an RPC can't override the trigger. Before this PR, the only non-null pattern that could reach that point was a scheduled message type that is also an RPC request. Its trigger kind is overwritten to `Grpc` there anyway, so `Command` is the consistent answer.
- **`FinishModel`'s promotion guard** went from `Pattern is null or Command` to `Pattern is null`. A message-handler slice only carries a pattern at that point if it was declared. CritterWatch doesn't call `FinishModel`.

The outbound-relay flip to Translation in `ApplyExternalSystems` still applies to a declared `Command` on a pure relay. A handler that only forwards to a named external system really is a translation.

## Docs

`command-line.md` has a new "Declaring the pattern of a message handler" section after the "will not claim" table.

## Tests

New `event_model_slice_pattern_attribute_4395` (10 tests): method, type, and method-over-type declarations; the no-declaration case stays null; Quickstart shape; declaration beats cascade promotion; schedule, HTTP GET/POST and gRPC all beat the declaration; stale declaration raises a `SourceDisagreement`.

Local results:
- All CoreTests event-model tests, including #4387's: 78/78 passed.
- gRPC event-model tests: 6/6 passed.
- `dotnet build wolverine.slnx -c Release -f net9.0`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj