### PR TITLE
Bump to 6.36.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>true</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>6.35.0</Version>
+        <Version>6.36.0</Version>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Version bump for the 6.36.0 release: GH-4395, GH-4403, GH-4398, GH-3987/GH-4407, GH-4397 and GH-4410, plus the `System.Security.Cryptography.Xml` 10.0.12 advisory fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDUrBeB4tTnKj4AExCS1nj